### PR TITLE
fix: update CLI version to 0.1.4

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@proletariat/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Multi-agent development CLI - Orchestrate parallel coding agents via git worktrees with memorable themes for distributed development workflows",
   "main": "dist/bin/prlt.js",
   "bin": {

--- a/apps/cli/src/bin/prlt.ts
+++ b/apps/cli/src/bin/prlt.ts
@@ -11,6 +11,8 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import * as fs from 'fs';
+import * as path from 'path';
 
 // Import modules
 import { getAllThemes } from '../lib/themes/index.js';
@@ -24,6 +26,17 @@ import { InitOptions, ListOptions } from '../types/index.js';
 
 const program = new Command();
 
+// Get version from package.json dynamically
+function getVersion(): string {
+  try {
+    const packageJsonPath = path.join(__dirname, '../../package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.version;
+  } catch {
+    return '0.0.0'; // Fallback version if package.json can't be read
+  }
+}
+
 // Get themes for CLI setup
 const THEMES = getAllThemes();
 
@@ -31,7 +44,7 @@ const THEMES = getAllThemes();
 program
   .name('prlt')
   .description('⚒️ Simple Themed Git Worktree Manager')
-  .version('2.0.0');
+  .version(getVersion());
 
 program
   .command('init')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
-  "name": "proletariat",
-  "version": "2.0.0",
+  "name": "proletariat-workspace",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "proletariat",
-      "version": "2.0.0",
+      "name": "proletariat-workspace",
+      "version": "0.0.0",
+      "workspaces": [
+        "apps/*",
+        "packages/*"
+      ]
+    },
+    "apps/cli": {
+      "name": "@proletariat/cli",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -164,6 +172,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@proletariat/cli": {
+      "resolved": "apps/cli",
+      "link": true
     },
     "node_modules/@types/inquirer": {
       "version": "8.2.11",


### PR DESCRIPTION
## Summary
- Updated hardcoded version from 2.0.0 to 0.1.4 in CLI
- Package.json already has 0.1.4 from npm version command

## Test plan
- [x] Build succeeds
- [x] `prlt --version` shows 0.1.4
- [ ] Ready to publish to npm after merge

🤖 Generated with [Claude Code](https://claude.ai/code)