### PR TITLE
TKT-039: Implement event-based hooks for auto-spawn

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -24,7 +24,8 @@
     "ink": "^5.0.1",
     "ink-select-input": "^6.0.0",
     "inquirer": "^8.2.5",
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@oclif/prettier-config": "^0.2.1",

--- a/apps/cli/src/commands/hooks/disable.ts
+++ b/apps/cli/src/commands/hooks/disable.ts
@@ -1,0 +1,84 @@
+import { Command, Args } from '@oclif/core';
+import { styles } from '../../lib/styles.js';
+import { findPMO } from '../../lib/pmo/find-pmo.js';
+import { getWorkspaceDbPath } from '../../lib/pmo/sync-manager.js';
+import { findWorkspaceFromPMO } from '../../lib/pmo/hooks-integration.js';
+import {
+  loadAllHooks,
+  saveHookToDatabase,
+  Hook,
+} from '../../lib/hooks/index.js';
+import Database from 'better-sqlite3';
+
+export default class HooksDisable extends Command {
+  static description = 'Disable a hook';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> auto_spawn_ready',
+    '<%= config.bin %> <%= command.id %> log_ticket_created',
+  ];
+
+  static args = {
+    hookId: Args.string({
+      description: 'Hook ID to disable',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(HooksDisable);
+    const hookId = args.hookId;
+
+    // Find PMO and workspace
+    const pmoPath = findPMO();
+    if (!pmoPath) {
+      this.error('PMO not found. Run "prlt pmo init" first.');
+    }
+
+    const workspacePath = findWorkspaceFromPMO(pmoPath);
+    const dbPath = getWorkspaceDbPath(pmoPath);
+
+    // Load hooks
+    let db: Database.Database;
+    try {
+      db = new Database(dbPath);
+    } catch (error) {
+      this.error('Could not open workspace database.');
+    }
+
+    const hooks = loadAllHooks(workspacePath, db);
+
+    // Find the hook
+    const hook = hooks.find(h => h.id === hookId);
+    if (!hook) {
+      db.close();
+      this.error(`Hook not found: ${hookId}`);
+    }
+
+    if (!hook.enabled) {
+      db.close();
+      this.log(styles.muted(`Hook "${hookId}" is already disabled.`));
+      return;
+    }
+
+    // For YAML hooks, we need to save the disabled state to database
+    // Database hooks override YAML hooks with the same ID
+    const updatedHook: Hook = {
+      ...hook,
+      enabled: false,
+      source: 'database',
+      updatedAt: new Date(),
+    };
+
+    saveHookToDatabase(db, updatedHook);
+    db.close();
+
+    this.log(styles.success(`\n✅ Disabled hook: ${hookId}`));
+
+    if (hook.source === 'yaml') {
+      this.log('');
+      this.log(styles.muted('Note: This override is stored in the database.'));
+      this.log(styles.muted('To permanently disable, edit hooks.yaml directly.'));
+    }
+  }
+}

--- a/apps/cli/src/commands/hooks/enable.ts
+++ b/apps/cli/src/commands/hooks/enable.ts
@@ -1,0 +1,84 @@
+import { Command, Args } from '@oclif/core';
+import { styles } from '../../lib/styles.js';
+import { findPMO } from '../../lib/pmo/find-pmo.js';
+import { getWorkspaceDbPath } from '../../lib/pmo/sync-manager.js';
+import { findWorkspaceFromPMO } from '../../lib/pmo/hooks-integration.js';
+import {
+  loadAllHooks,
+  saveHookToDatabase,
+  Hook,
+} from '../../lib/hooks/index.js';
+import Database from 'better-sqlite3';
+
+export default class HooksEnable extends Command {
+  static description = 'Enable a hook';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> auto_spawn_ready',
+    '<%= config.bin %> <%= command.id %> log_ticket_created',
+  ];
+
+  static args = {
+    hookId: Args.string({
+      description: 'Hook ID to enable',
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(HooksEnable);
+    const hookId = args.hookId;
+
+    // Find PMO and workspace
+    const pmoPath = findPMO();
+    if (!pmoPath) {
+      this.error('PMO not found. Run "prlt pmo init" first.');
+    }
+
+    const workspacePath = findWorkspaceFromPMO(pmoPath);
+    const dbPath = getWorkspaceDbPath(pmoPath);
+
+    // Load hooks
+    let db: Database.Database;
+    try {
+      db = new Database(dbPath);
+    } catch (error) {
+      this.error('Could not open workspace database.');
+    }
+
+    const hooks = loadAllHooks(workspacePath, db);
+
+    // Find the hook
+    const hook = hooks.find(h => h.id === hookId);
+    if (!hook) {
+      db.close();
+      this.error(`Hook not found: ${hookId}`);
+    }
+
+    if (hook.enabled) {
+      db.close();
+      this.log(styles.muted(`Hook "${hookId}" is already enabled.`));
+      return;
+    }
+
+    // For YAML hooks, we need to save the enabled state to database
+    // Database hooks override YAML hooks with the same ID
+    const updatedHook: Hook = {
+      ...hook,
+      enabled: true,
+      source: 'database',
+      updatedAt: new Date(),
+    };
+
+    saveHookToDatabase(db, updatedHook);
+    db.close();
+
+    this.log(styles.success(`\n✅ Enabled hook: ${hookId}`));
+
+    if (hook.source === 'yaml') {
+      this.log('');
+      this.log(styles.muted('Note: This override is stored in the database.'));
+      this.log(styles.muted('To permanently enable, edit hooks.yaml directly.'));
+    }
+  }
+}

--- a/apps/cli/src/commands/hooks/index.ts
+++ b/apps/cli/src/commands/hooks/index.ts
@@ -1,0 +1,23 @@
+import { Command } from '@oclif/core';
+
+export default class HooksIndex extends Command {
+  static description = 'Manage event-based hooks for automation';
+
+  static examples = [
+    '<%= config.bin %> hooks list',
+    '<%= config.bin %> hooks test ticket.moved --to-column Ready',
+    '<%= config.bin %> hooks init',
+  ];
+
+  async run(): Promise<void> {
+    this.log('Available hooks commands:');
+    this.log('');
+    this.log('  hooks list     - List all registered hooks');
+    this.log('  hooks test     - Test a hook by simulating an event');
+    this.log('  hooks init     - Create a hooks.yaml template');
+    this.log('  hooks enable   - Enable a hook');
+    this.log('  hooks disable  - Disable a hook');
+    this.log('');
+    this.log('Run "prlt hooks --help" for more information on a command.');
+  }
+}

--- a/apps/cli/src/commands/hooks/init.ts
+++ b/apps/cli/src/commands/hooks/init.ts
@@ -1,0 +1,76 @@
+import { Command, Flags } from '@oclif/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { styles } from '../../lib/styles.js';
+import { findPMO } from '../../lib/pmo/find-pmo.js';
+import { findWorkspaceFromPMO } from '../../lib/pmo/hooks-integration.js';
+import { ensureHooksYamlExists, generateHooksTemplate } from '../../lib/hooks/index.js';
+
+export default class HooksInit extends Command {
+  static description = 'Create a hooks.yaml template file';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --force',
+  ];
+
+  static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Overwrite existing hooks.yaml',
+    }),
+    print: Flags.boolean({
+      description: 'Print template to stdout instead of creating file',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(HooksInit);
+
+    // Print mode
+    if (flags.print) {
+      this.log(generateHooksTemplate());
+      return;
+    }
+
+    // Find PMO and workspace
+    const pmoPath = findPMO();
+    if (!pmoPath) {
+      this.error('PMO not found. Run "prlt pmo init" first.');
+    }
+
+    const workspacePath = findWorkspaceFromPMO(pmoPath);
+    const hooksPath = path.join(workspacePath, '.proletariat', 'hooks.yaml');
+
+    // Check if file exists
+    if (fs.existsSync(hooksPath) && !flags.force) {
+      this.error(`hooks.yaml already exists at ${hooksPath}. Use --force to overwrite.`);
+    }
+
+    // Ensure directory exists
+    const dir = path.dirname(hooksPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    // Write template
+    fs.writeFileSync(hooksPath, generateHooksTemplate());
+
+    this.log(styles.success(`\n✅ Created hooks.yaml at ${hooksPath}`));
+    this.log('');
+    this.log(styles.muted('Edit the file to configure your hooks.'));
+    this.log(styles.muted('See documentation for available events, conditions, and actions.'));
+    this.log('');
+    this.log(styles.muted('Available events:'));
+    this.log(styles.muted('  - ticket.created, ticket.moved, ticket.updated'));
+    this.log(styles.muted('  - ticket.status_changed, ticket.deleted, ticket.completed'));
+    this.log(styles.muted('  - epic.created, epic.updated, epic.status_changed, epic.deleted'));
+    this.log(styles.muted('  - work.started, work.completed'));
+    this.log('');
+    this.log(styles.muted('Available actions:'));
+    this.log(styles.muted('  - spawn_agent: Auto-spawn agent to work on ticket'));
+    this.log(styles.muted('  - shell: Run a shell command'));
+    this.log(styles.muted('  - log: Log a message'));
+    this.log(styles.muted('  - webhook: Send HTTP request'));
+  }
+}

--- a/apps/cli/src/commands/hooks/list.ts
+++ b/apps/cli/src/commands/hooks/list.ts
@@ -1,0 +1,157 @@
+import { Command, Flags } from '@oclif/core';
+import * as path from 'path';
+import { styles } from '../../lib/styles.js';
+import { findPMO } from '../../lib/pmo/find-pmo.js';
+import { getWorkspaceDbPath } from '../../lib/pmo/sync-manager.js';
+import { findWorkspaceFromPMO } from '../../lib/pmo/hooks-integration.js';
+import { loadAllHooks, Hook } from '../../lib/hooks/index.js';
+import Database from 'better-sqlite3';
+
+export default class HooksList extends Command {
+  static description = 'List all registered hooks';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --event ticket.moved',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static flags = {
+    event: Flags.string({
+      char: 'e',
+      description: 'Filter by event type',
+    }),
+    enabled: Flags.boolean({
+      description: 'Only show enabled hooks',
+    }),
+    disabled: Flags.boolean({
+      description: 'Only show disabled hooks',
+    }),
+    json: Flags.boolean({
+      description: 'Output as JSON',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(HooksList);
+
+    // Find PMO and workspace
+    const pmoPath = findPMO();
+    if (!pmoPath) {
+      this.error('PMO not found. Run "prlt pmo init" first.');
+    }
+
+    const workspacePath = findWorkspaceFromPMO(pmoPath);
+    const dbPath = getWorkspaceDbPath(pmoPath);
+
+    // Load hooks
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath);
+    } catch {
+      // Database not available
+    }
+
+    const hooks = loadAllHooks(workspacePath, db);
+    db?.close();
+
+    // Apply filters
+    let filteredHooks = hooks;
+
+    if (flags.event) {
+      filteredHooks = filteredHooks.filter(h => h.event === flags.event);
+    }
+
+    if (flags.enabled) {
+      filteredHooks = filteredHooks.filter(h => h.enabled);
+    }
+
+    if (flags.disabled) {
+      filteredHooks = filteredHooks.filter(h => !h.enabled);
+    }
+
+    // Output
+    if (flags.json) {
+      this.log(JSON.stringify(filteredHooks, null, 2));
+      return;
+    }
+
+    if (filteredHooks.length === 0) {
+      this.log(styles.muted('No hooks found.'));
+      this.log('');
+      this.log(styles.muted('Create hooks.yaml with: prlt hooks init'));
+      return;
+    }
+
+    this.log(styles.header(`\nRegistered Hooks (${filteredHooks.length})`));
+    this.log('');
+
+    for (const hook of filteredHooks) {
+      this.printHook(hook);
+    }
+  }
+
+  private printHook(hook: Hook): void {
+    const status = hook.enabled
+      ? styles.success('●')
+      : styles.muted('○');
+
+    const source = hook.source === 'yaml'
+      ? styles.muted('[yaml]')
+      : styles.muted('[db]');
+
+    this.log(`${status} ${styles.emphasis(hook.name)} ${source}`);
+    this.log(`  Event: ${styles.info(hook.event)}`);
+
+    if (hook.description) {
+      this.log(`  ${styles.muted(hook.description)}`);
+    }
+
+    // Show conditions
+    if (hook.conditions && hook.conditions.length > 0) {
+      this.log(`  Conditions:`);
+      for (const cond of hook.conditions) {
+        this.log(`    - ${cond.field} ${cond.operator} ${JSON.stringify(cond.value)}`);
+      }
+    }
+
+    // Show actions
+    this.log(`  Actions:`);
+    for (const action of hook.actions) {
+      this.log(`    - ${action.type}${this.formatActionDetails(action)}`);
+    }
+
+    if (hook.priority !== undefined) {
+      this.log(`  Priority: ${hook.priority}`);
+    }
+
+    if (hook.projectId) {
+      this.log(`  Project: ${hook.projectId}`);
+    }
+
+    this.log('');
+  }
+
+  private formatActionDetails(action: Hook['actions'][0]): string {
+    switch (action.type) {
+      case 'spawn_agent':
+        const parts: string[] = [];
+        if (action.strategy) parts.push(`strategy=${action.strategy}`);
+        if (action.agent) parts.push(`agent=${action.agent}`);
+        if (action.limit) parts.push(`limit=${action.limit}`);
+        return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+
+      case 'shell':
+        return ` "${action.command}"`;
+
+      case 'log':
+        return ` "${action.message}"`;
+
+      case 'webhook':
+        return ` ${action.method || 'POST'} ${action.url}`;
+
+      default:
+        return '';
+    }
+  }
+}

--- a/apps/cli/src/commands/hooks/test.ts
+++ b/apps/cli/src/commands/hooks/test.ts
@@ -1,0 +1,321 @@
+import { Command, Args, Flags } from '@oclif/core';
+import * as path from 'path';
+import { styles } from '../../lib/styles.js';
+import { findPMO } from '../../lib/pmo/find-pmo.js';
+import { getWorkspaceDbPath } from '../../lib/pmo/sync-manager.js';
+import { findWorkspaceFromPMO } from '../../lib/pmo/hooks-integration.js';
+import {
+  initializeHooks,
+  HooksManager,
+  HookEventName,
+  HookEventPayload,
+  TicketCreatedPayload,
+  TicketMovedPayload,
+  TicketStatusChangedPayload,
+  HookExecutionResult,
+} from '../../lib/hooks/index.js';
+import { Ticket, TicketStatus } from '../../lib/pmo/types.js';
+import Database from 'better-sqlite3';
+
+export default class HooksTest extends Command {
+  static description = 'Test hooks by simulating an event';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> ticket.created',
+    '<%= config.bin %> <%= command.id %> ticket.moved --from-column Backlog --to-column Ready',
+    '<%= config.bin %> <%= command.id %> ticket.status_changed --to-status in_progress',
+    '<%= config.bin %> <%= command.id %> ticket.moved --dry-run',
+  ];
+
+  static args = {
+    event: Args.string({
+      description: 'Event to simulate',
+      required: true,
+      options: [
+        'ticket.created',
+        'ticket.moved',
+        'ticket.updated',
+        'ticket.status_changed',
+        'ticket.deleted',
+        'ticket.completed',
+        'epic.created',
+        'epic.updated',
+        'epic.status_changed',
+        'epic.deleted',
+        'work.started',
+        'work.completed',
+      ],
+    }),
+  };
+
+  static flags = {
+    'ticket-id': Flags.string({
+      description: 'Ticket ID for the simulated event',
+      default: 'TEST-001',
+    }),
+    'ticket-title': Flags.string({
+      description: 'Ticket title for the simulated event',
+      default: 'Test Ticket',
+    }),
+    'from-column': Flags.string({
+      description: 'Source column (for ticket.moved)',
+      default: 'Backlog',
+    }),
+    'to-column': Flags.string({
+      description: 'Target column (for ticket.moved)',
+      default: 'Ready',
+    }),
+    'from-status': Flags.string({
+      description: 'Previous status (for ticket.status_changed)',
+      options: ['backlog', 'ready', 'in_progress', 'blocked', 'review', 'done', 'cancelled'],
+    }),
+    'to-status': Flags.string({
+      description: 'New status (for ticket.status_changed)',
+      options: ['backlog', 'ready', 'in_progress', 'blocked', 'review', 'done', 'cancelled'],
+      default: 'in_progress',
+    }),
+    project: Flags.string({
+      description: 'Project ID for the event',
+      default: 'default',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Show what would happen without executing actions',
+      default: false,
+    }),
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'Show detailed output',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(HooksTest);
+    const event = args.event as HookEventName;
+
+    // Find PMO and workspace
+    const pmoPath = findPMO();
+    if (!pmoPath) {
+      this.error('PMO not found. Run "prlt pmo init" first.');
+    }
+
+    const workspacePath = findWorkspaceFromPMO(pmoPath);
+    const dbPath = getWorkspaceDbPath(pmoPath);
+
+    // Load hooks
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath);
+    } catch {
+      // Database not available
+    }
+
+    const manager = initializeHooks({
+      workspacePath,
+      pmoPath,
+      db,
+      log: (msg) => this.log(styles.muted(`  ${msg}`)),
+    });
+
+    db?.close();
+
+    // Build mock payload
+    const payload = this.buildMockPayload(event, flags);
+
+    this.log(styles.header(`\nSimulating event: ${event}`));
+    this.log('');
+
+    if (flags.verbose) {
+      this.log(styles.muted('Payload:'));
+      this.log(styles.muted(JSON.stringify(payload, null, 2)));
+      this.log('');
+    }
+
+    // Get hooks that would match
+    const hooks = manager.getHooksForEvent(event);
+    const enabledHooks = hooks.filter(h => h.enabled);
+
+    this.log(`Found ${enabledHooks.length} enabled hooks for this event:`);
+    for (const hook of enabledHooks) {
+      const matches = manager.evaluateConditions(hook.conditions || [], payload);
+      const matchStatus = matches ? styles.success('✓ matches') : styles.warning('✗ conditions not met');
+      this.log(`  - ${hook.name}: ${matchStatus}`);
+    }
+    this.log('');
+
+    if (flags['dry-run']) {
+      this.log(styles.warning('Dry run - no actions executed'));
+      return;
+    }
+
+    // Execute hooks
+    this.log(styles.header('Executing hooks...'));
+    this.log('');
+
+    const results = await manager.emit(event, payload);
+
+    // Show results
+    this.printResults(results, flags.verbose);
+  }
+
+  private buildMockPayload(event: HookEventName, flags: Record<string, unknown>): HookEventPayload {
+    const now = new Date();
+    const projectId = flags.project as string;
+
+    // Build mock ticket
+    const mockTicket: Ticket = {
+      id: flags['ticket-id'] as string,
+      title: flags['ticket-title'] as string,
+      description: 'Test ticket description',
+      status: (flags['to-status'] as TicketStatus) || 'backlog',
+      column: flags['to-column'] as string,
+      priority: 'MEDIUM',
+      category: 'test',
+      subtasks: [],
+      metadata: {},
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Build payload based on event type
+    switch (event) {
+      case 'ticket.created':
+        return {
+          timestamp: now,
+          projectId,
+          ticket: mockTicket,
+        } as TicketCreatedPayload;
+
+      case 'ticket.moved':
+        return {
+          timestamp: now,
+          projectId,
+          ticket: mockTicket,
+          fromColumn: flags['from-column'] as string,
+          toColumn: flags['to-column'] as string,
+        } as TicketMovedPayload;
+
+      case 'ticket.status_changed':
+        return {
+          timestamp: now,
+          projectId,
+          ticket: mockTicket,
+          fromStatus: flags['from-status'] as TicketStatus | undefined,
+          toStatus: flags['to-status'] as TicketStatus,
+        } as TicketStatusChangedPayload;
+
+      case 'ticket.updated':
+        return {
+          timestamp: now,
+          projectId,
+          ticket: mockTicket,
+          changes: { status: flags['to-status'] as TicketStatus },
+          previousValues: { status: flags['from-status'] as TicketStatus | undefined },
+        };
+
+      case 'ticket.deleted':
+        return {
+          timestamp: now,
+          projectId,
+          ticketId: mockTicket.id,
+          ticket: mockTicket,
+        };
+
+      case 'ticket.completed':
+        return {
+          timestamp: now,
+          projectId,
+          ticket: { ...mockTicket, status: 'done' as TicketStatus },
+        };
+
+      case 'work.started':
+        return {
+          timestamp: now,
+          projectId,
+          ticketId: mockTicket.id,
+          agentName: 'test-agent',
+          executionId: 'test-execution-001',
+        };
+
+      case 'work.completed':
+        return {
+          timestamp: now,
+          projectId,
+          ticketId: mockTicket.id,
+          agentName: 'test-agent',
+          executionId: 'test-execution-001',
+          success: true,
+        };
+
+      default:
+        // Generic payload for epic events
+        return {
+          timestamp: now,
+          projectId,
+          epic: {
+            id: 'TEST-EPIC-001',
+            projectId,
+            title: 'Test Epic',
+            status: 'active' as const,
+            position: 0,
+            createdAt: now,
+            updatedAt: now,
+          },
+        } as HookEventPayload;
+    }
+  }
+
+  private printResults(results: HookExecutionResult[], verbose: boolean): void {
+    if (results.length === 0) {
+      this.log(styles.muted('No hooks executed.'));
+      return;
+    }
+
+    let successCount = 0;
+    let failedCount = 0;
+    let skippedCount = 0;
+
+    for (const result of results) {
+      if (result.skipped) {
+        skippedCount++;
+        if (verbose) {
+          this.log(`${styles.muted('○')} ${result.hook.name} (skipped)`);
+        }
+        continue;
+      }
+
+      const icon = result.success ? styles.success('✓') : styles.error('✗');
+      const duration = `${result.duration}ms`;
+
+      this.log(`${icon} ${result.hook.name} (${duration})`);
+
+      if (result.success) {
+        successCount++;
+      } else {
+        failedCount++;
+      }
+
+      // Show action results
+      for (const actionResult of result.actionResults) {
+        const actionIcon = actionResult.success
+          ? styles.success('  ✓')
+          : styles.error('  ✗');
+        this.log(`${actionIcon} ${actionResult.action.type}`);
+
+        if (!actionResult.success && actionResult.error) {
+          this.log(styles.error(`    Error: ${actionResult.error}`));
+        }
+
+        if (verbose && actionResult.output) {
+          this.log(styles.muted(`    Output: ${JSON.stringify(actionResult.output)}`));
+        }
+      }
+    }
+
+    this.log('');
+    this.log(styles.header('Summary:'));
+    this.log(`  Executed: ${successCount + failedCount}`);
+    this.log(`  ${styles.success('Success')}: ${successCount}`);
+    this.log(`  ${styles.error('Failed')}: ${failedCount}`);
+    this.log(`  ${styles.muted('Skipped')}: ${skippedCount}`);
+  }
+}

--- a/apps/cli/src/lib/hooks/actions/index.ts
+++ b/apps/cli/src/lib/hooks/actions/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Hook Actions
+ *
+ * Main entry point for action execution.
+ * Routes action types to their specific executors.
+ */
+
+import {
+  HookAction,
+  HookExecutionContext,
+  SpawnAgentAction,
+  ShellAction,
+  LogAction,
+  WebhookAction,
+  NotifyAction,
+} from '../types.js'
+import { executeSpawnAction } from './spawn.js'
+import { executeShellAction } from './shell.js'
+import { executeLogAction } from './log.js'
+import { executeWebhookAction } from './webhook.js'
+
+/**
+ * Execute a hook action based on its type
+ */
+export async function executeAction(
+  action: HookAction,
+  context: HookExecutionContext
+): Promise<unknown> {
+  switch (action.type) {
+    case 'spawn_agent':
+      return executeSpawnAction(action as SpawnAgentAction, context)
+
+    case 'shell':
+      return executeShellAction(action as ShellAction, context)
+
+    case 'log':
+      return executeLogAction(action as LogAction, context)
+
+    case 'webhook':
+      return executeWebhookAction(action as WebhookAction, context)
+
+    case 'notify':
+      // Notify is a placeholder for future implementation
+      context.log(`[WARN] Notify action not yet implemented: ${(action as NotifyAction).channel}`)
+      return {
+        success: false,
+        error: 'Notify action not yet implemented',
+      }
+
+    default:
+      throw new Error(`Unknown action type: ${(action as HookAction).type}`)
+  }
+}
+
+// Re-export individual action executors for direct use
+export { executeSpawnAction } from './spawn.js'
+export { executeShellAction } from './shell.js'
+export { executeLogAction } from './log.js'
+export { executeWebhookAction } from './webhook.js'
+export { interpolateTemplate, getNestedValue, formatValue } from './utils.js'

--- a/apps/cli/src/lib/hooks/actions/log.ts
+++ b/apps/cli/src/lib/hooks/actions/log.ts
@@ -1,0 +1,57 @@
+/**
+ * Log Action
+ *
+ * Outputs log messages when hooks fire.
+ */
+
+import { LogAction, HookExecutionContext } from '../types.js'
+import { interpolateTemplate } from './utils.js'
+
+export interface LogResult {
+  message: string
+  level: string
+}
+
+/**
+ * Execute a log action
+ */
+export async function executeLogAction(
+  action: LogAction,
+  context: HookExecutionContext
+): Promise<LogResult> {
+  const { payload, log } = context
+
+  // Interpolate message with payload values
+  const message = interpolateTemplate(action.message, payload)
+  const level = action.level || 'info'
+
+  // Format message with level prefix
+  const prefix = getLogPrefix(level)
+  const formattedMessage = `${prefix} ${message}`
+
+  // Output via context log function
+  log(formattedMessage)
+
+  return {
+    message,
+    level,
+  }
+}
+
+/**
+ * Get log level prefix
+ */
+function getLogPrefix(level: string): string {
+  switch (level) {
+    case 'debug':
+      return '[DEBUG]'
+    case 'info':
+      return '[INFO]'
+    case 'warn':
+      return '[WARN]'
+    case 'error':
+      return '[ERROR]'
+    default:
+      return '[LOG]'
+  }
+}

--- a/apps/cli/src/lib/hooks/actions/shell.ts
+++ b/apps/cli/src/lib/hooks/actions/shell.ts
@@ -1,0 +1,185 @@
+/**
+ * Shell Action
+ *
+ * Executes shell commands when hooks fire.
+ */
+
+import { spawn, SpawnOptions } from 'child_process'
+import * as path from 'path'
+import { ShellAction, HookExecutionContext } from '../types.js'
+import { interpolateTemplate } from './utils.js'
+
+export interface ShellResult {
+  success: boolean
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  error?: string
+}
+
+/**
+ * Execute a shell action
+ */
+export async function executeShellAction(
+  action: ShellAction,
+  context: HookExecutionContext
+): Promise<ShellResult> {
+  const { payload, workspacePath, log } = context
+
+  // Interpolate command with payload values
+  const command = interpolateTemplate(action.command, payload)
+
+  // Determine working directory
+  const cwd = action.cwd
+    ? path.resolve(workspacePath, action.cwd)
+    : workspacePath
+
+  // Build environment
+  const env = {
+    ...process.env,
+    ...action.env,
+    // Add useful context variables
+    PRLT_WORKSPACE: workspacePath,
+    PRLT_EVENT: context.event,
+    PRLT_HOOK_ID: context.hook.id,
+    PRLT_HOOK_NAME: context.hook.name,
+  }
+
+  // If running in background, don't wait for completion
+  if (action.background) {
+    return executeBackgroundShell(command, cwd, env, log)
+  }
+
+  // Execute command and wait for completion
+  return executeBlockingShell(command, cwd, env, action.timeout, log)
+}
+
+/**
+ * Execute shell command in background (fire-and-forget)
+ */
+function executeBackgroundShell(
+  command: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  log: (msg: string) => void
+): ShellResult {
+  const options: SpawnOptions = {
+    cwd,
+    env,
+    shell: true,
+    detached: true,
+    stdio: 'ignore',
+  }
+
+  try {
+    const child = spawn(command, [], options)
+    child.unref()
+
+    log(`Started background command: ${command}`)
+
+    return {
+      success: true,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+    }
+  } catch (error) {
+    return {
+      success: false,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * Execute shell command and wait for completion
+ */
+function executeBlockingShell(
+  command: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  timeout?: number,
+  log?: (msg: string) => void
+): Promise<ShellResult> {
+  return new Promise((resolve) => {
+    const options: SpawnOptions = {
+      cwd,
+      env,
+      shell: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+
+    const child = spawn(command, [], options)
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    // Set up timeout if specified
+    let timeoutId: NodeJS.Timeout | undefined
+    if (timeout && timeout > 0) {
+      timeoutId = setTimeout(() => {
+        timedOut = true
+        child.kill('SIGTERM')
+        // Force kill after 5 seconds if SIGTERM doesn't work
+        setTimeout(() => {
+          if (!child.killed) {
+            child.kill('SIGKILL')
+          }
+        }, 5000)
+      }, timeout)
+    }
+
+    child.stdout?.on('data', (data) => {
+      stdout += data.toString()
+    })
+
+    child.stderr?.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    child.on('close', (exitCode) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+
+      if (timedOut) {
+        resolve({
+          success: false,
+          exitCode: exitCode ?? null,
+          stdout,
+          stderr,
+          error: `Command timed out after ${timeout}ms`,
+        })
+      } else {
+        const success = exitCode === 0
+        if (!success && log) {
+          log(`Shell command failed with exit code ${exitCode}: ${command}`)
+        }
+        resolve({
+          success,
+          exitCode: exitCode ?? null,
+          stdout,
+          stderr,
+        })
+      }
+    })
+
+    child.on('error', (error) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+
+      resolve({
+        success: false,
+        exitCode: null,
+        stdout,
+        stderr,
+        error: error.message,
+      })
+    })
+  })
+}

--- a/apps/cli/src/lib/hooks/actions/spawn.ts
+++ b/apps/cli/src/lib/hooks/actions/spawn.ts
@@ -1,0 +1,153 @@
+/**
+ * Spawn Agent Action
+ *
+ * Executes the spawn_agent action which triggers auto-spawn
+ * for tickets when hooks fire.
+ */
+
+import Database from 'better-sqlite3'
+import { SpawnAgentAction, HookExecutionContext, TicketMovedPayload, TicketCreatedPayload } from '../types.js'
+import { SQLiteStorage } from '../../pmo/storage-sqlite.js'
+import { ExecutionStorage } from '../../execution/storage.js'
+import { getWorkspaceInfo } from '../../agents/commands.js'
+import { spawnAgentForTicket, selectAgent, getAvailableAgents } from '../../execution/spawner.js'
+import { getDatabasePath, openWorkspaceDatabase } from '../../database/index.js'
+import { Ticket } from '../../pmo/types.js'
+
+export interface SpawnResult {
+  spawned: boolean
+  agentName?: string
+  executionId?: string
+  ticketId?: string
+  error?: string
+}
+
+/**
+ * Execute a spawn_agent action
+ */
+export async function executeSpawnAction(
+  action: SpawnAgentAction,
+  context: HookExecutionContext
+): Promise<SpawnResult> {
+  const { payload, workspacePath, pmoPath, log } = context
+
+  // Get ticket from payload - different events have different payload structures
+  let ticket: Ticket | undefined
+
+  if ('ticket' in payload) {
+    ticket = (payload as TicketMovedPayload | TicketCreatedPayload).ticket
+  }
+
+  if (!ticket) {
+    return {
+      spawned: false,
+      error: 'No ticket found in event payload',
+    }
+  }
+
+  try {
+    // Open database
+    const dbPath = getDatabasePath(workspacePath)
+    const db = openWorkspaceDatabase(workspacePath)
+
+    // Get workspace info
+    const workspaceInfo = getWorkspaceInfo()
+    if (!workspaceInfo) {
+      db.close()
+      return {
+        spawned: false,
+        ticketId: ticket.id,
+        error: 'Could not get workspace info',
+      }
+    }
+
+    // Initialize storage instances
+    const storage = new SQLiteStorage(dbPath, payload.projectId)
+    const executionStorage = new ExecutionStorage(db)
+
+    // Check if ticket already has a running execution
+    const runningExec = executionStorage.getRunningExecution(ticket.id)
+    if (runningExec) {
+      await storage.close()
+      db.close()
+      return {
+        spawned: false,
+        ticketId: ticket.id,
+        error: `Ticket already has running execution: ${runningExec.id}`,
+      }
+    }
+
+    // Get available agents
+    const availableAgents = action.agent
+      ? [action.agent]
+      : getAvailableAgents(workspaceInfo, executionStorage)
+
+    if (availableAgents.length === 0) {
+      await storage.close()
+      db.close()
+      return {
+        spawned: false,
+        ticketId: ticket.id,
+        error: 'No agents available',
+      }
+    }
+
+    // Select agent using strategy
+    const strategy = action.strategy || 'round-robin'
+    const agentName = action.agent || selectAgent(strategy, availableAgents, executionStorage)
+
+    if (!agentName) {
+      await storage.close()
+      db.close()
+      return {
+        spawned: false,
+        ticketId: ticket.id,
+        error: 'Could not select an agent',
+      }
+    }
+
+    // Spawn agent for ticket
+    const spawnResult = await spawnAgentForTicket(
+      ticket,
+      agentName,
+      storage,
+      executionStorage,
+      workspaceInfo,
+      db,
+      pmoPath,
+      {
+        environment: action.environment,
+        displayMode: action.displayMode,
+        skipPermissions: action.skipPermissions,
+        createPR: action.createPR,
+        log,
+      }
+    )
+
+    await storage.close()
+    db.close()
+
+    if (spawnResult.success) {
+      log(`Hook spawned agent ${agentName} for ticket ${ticket.id}`)
+      return {
+        spawned: true,
+        agentName,
+        executionId: spawnResult.executionId,
+        ticketId: ticket.id,
+      }
+    } else {
+      return {
+        spawned: false,
+        agentName,
+        ticketId: ticket.id,
+        error: spawnResult.error || 'Spawn failed',
+      }
+    }
+  } catch (error) {
+    return {
+      spawned: false,
+      ticketId: ticket?.id,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/apps/cli/src/lib/hooks/actions/utils.ts
+++ b/apps/cli/src/lib/hooks/actions/utils.ts
@@ -1,0 +1,80 @@
+/**
+ * Action Utilities
+ *
+ * Shared utilities for action executors.
+ */
+
+import { HookEventPayload } from '../types.js'
+
+/**
+ * Interpolate a template string with values from the payload.
+ * Supports {{field}} and {{object.field}} syntax.
+ *
+ * Examples:
+ *   "Ticket {{ticket.id}} created" + {ticket: {id: "TKT-001"}}
+ *   => "Ticket TKT-001 created"
+ */
+export function interpolateTemplate(template: string, payload: HookEventPayload): string {
+  return template.replace(/\{\{([^}]+)\}\}/g, (match, path) => {
+    const value = getNestedValue(payload, path.trim())
+    if (value === undefined || value === null) {
+      return match // Keep original placeholder if value not found
+    }
+    if (typeof value === 'object') {
+      return JSON.stringify(value)
+    }
+    return String(value)
+  })
+}
+
+/**
+ * Get a nested value from an object using dot notation.
+ *
+ * Examples:
+ *   getNestedValue({a: {b: 1}}, "a.b") => 1
+ *   getNestedValue({ticket: {id: "TKT-001"}}, "ticket.id") => "TKT-001"
+ */
+export function getNestedValue(obj: unknown, path: string): unknown {
+  const parts = path.split('.')
+  let current: unknown = obj
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined
+    }
+    if (typeof current !== 'object') {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[part]
+  }
+
+  return current
+}
+
+/**
+ * Format a value for display in logs/messages.
+ */
+export function formatValue(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined'
+  }
+  if (value === null) {
+    return 'null'
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(formatValue).join(', ')}]`
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}

--- a/apps/cli/src/lib/hooks/actions/webhook.ts
+++ b/apps/cli/src/lib/hooks/actions/webhook.ts
@@ -1,0 +1,91 @@
+/**
+ * Webhook Action
+ *
+ * Sends HTTP requests when hooks fire.
+ */
+
+import { WebhookAction, HookExecutionContext } from '../types.js'
+import { interpolateTemplate } from './utils.js'
+
+export interface WebhookResult {
+  success: boolean
+  statusCode?: number
+  responseBody?: string
+  error?: string
+}
+
+/**
+ * Execute a webhook action
+ */
+export async function executeWebhookAction(
+  action: WebhookAction,
+  context: HookExecutionContext
+): Promise<WebhookResult> {
+  const { payload, log } = context
+
+  // Interpolate URL with payload values
+  const url = interpolateTemplate(action.url, payload)
+  const method = action.method || 'POST'
+
+  // Build headers
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'proletariat-hooks/1.0',
+    ...action.headers,
+  }
+
+  // Build body - interpolate if provided, otherwise use payload
+  let body: string | undefined
+  if (action.body) {
+    body = interpolateTemplate(action.body, payload)
+  } else if (method !== 'GET') {
+    body = JSON.stringify(payload)
+  }
+
+  // Set up timeout with AbortController
+  const controller = new AbortController()
+  const timeout = action.timeout || 30000
+  const timeoutId = setTimeout(() => controller.abort(), timeout)
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: method !== 'GET' ? body : undefined,
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+
+    const responseBody = await response.text()
+
+    if (response.ok) {
+      log(`Webhook sent successfully to ${url}`)
+      return {
+        success: true,
+        statusCode: response.status,
+        responseBody,
+      }
+    } else {
+      log(`Webhook failed with status ${response.status}: ${url}`)
+      return {
+        success: false,
+        statusCode: response.status,
+        responseBody,
+        error: `HTTP ${response.status}: ${response.statusText}`,
+      }
+    }
+  } catch (error) {
+    clearTimeout(timeoutId)
+
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    const isTimeout = error instanceof Error && error.name === 'AbortError'
+
+    log(`Webhook error: ${errorMessage}`)
+
+    return {
+      success: false,
+      error: isTimeout ? `Request timed out after ${timeout}ms` : errorMessage,
+    }
+  }
+}

--- a/apps/cli/src/lib/hooks/index.ts
+++ b/apps/cli/src/lib/hooks/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Event-Based Hooks System
+ *
+ * Main entry point for the hooks system.
+ * Re-exports all types and provides initialization functions.
+ */
+
+import Database from 'better-sqlite3'
+import {
+  HooksManager,
+  getHooksManager,
+  resetHooksManager,
+  isHooksManagerInitialized,
+} from './manager.js'
+import { loadAllHooks, ensureHooksYamlExists, generateHooksTemplate } from './loader.js'
+
+// Re-export types
+export * from './types.js'
+
+// Re-export manager
+export {
+  HooksManager,
+  getHooksManager,
+  resetHooksManager,
+  isHooksManagerInitialized,
+} from './manager.js'
+
+// Re-export loader functions
+export {
+  loadHooksFromYaml,
+  loadHooksFromDatabase,
+  loadAllHooks,
+  saveHookToDatabase,
+  deleteHookFromDatabase,
+  getHookFromDatabase,
+  validateHook,
+  generateHooksTemplate,
+  ensureHooksYamlExists,
+} from './loader.js'
+
+// Re-export actions
+export { executeAction } from './actions/index.js'
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+/**
+ * Initialize the hooks system for a workspace.
+ * Loads hooks from YAML and database, and registers them with the manager.
+ */
+export function initializeHooks(options: {
+  workspacePath: string
+  pmoPath: string
+  db?: Database.Database
+  log?: (message: string) => void
+}): HooksManager {
+  const { workspacePath, pmoPath, db, log = () => {} } = options
+
+  // Create or get the hooks manager
+  const manager = new HooksManager({
+    workspacePath,
+    pmoPath,
+    log,
+  })
+
+  // Load hooks from all sources
+  const hooks = loadAllHooks(workspacePath, db)
+
+  // Register hooks with manager
+  manager.registerHooks(hooks)
+
+  log(`Loaded ${hooks.length} hooks`)
+
+  return manager
+}
+
+/**
+ * Initialize hooks if not already initialized, or return existing manager.
+ * Safe to call multiple times.
+ */
+export function ensureHooksInitialized(options: {
+  workspacePath: string
+  pmoPath: string
+  db?: Database.Database
+  log?: (message: string) => void
+}): HooksManager {
+  if (isHooksManagerInitialized()) {
+    return getHooksManager()
+  }
+  return initializeHooks(options)
+}

--- a/apps/cli/src/lib/hooks/loader.ts
+++ b/apps/cli/src/lib/hooks/loader.ts
@@ -1,0 +1,436 @@
+/**
+ * Hooks Loader
+ *
+ * Loads hook definitions from YAML files and database.
+ * Supports loading from:
+ * - .proletariat/hooks.yaml (workspace-level)
+ * - Database workspace_settings table (for dynamic hooks)
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import * as yaml from 'yaml'
+import Database from 'better-sqlite3'
+import {
+  Hook,
+  HooksYamlConfig,
+  HookYamlDefinition,
+  HookEventName,
+  HookAction,
+  HookCondition,
+} from './types.js'
+import { slugify } from '../pmo/utils.js'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const HOOKS_YAML_FILENAME = 'hooks.yaml'
+const HOOKS_DB_KEY_PREFIX = 'hooks.'
+
+// =============================================================================
+// YAML Loading
+// =============================================================================
+
+/**
+ * Load hooks from YAML file
+ */
+export function loadHooksFromYaml(workspacePath: string): Hook[] {
+  const hooksPath = path.join(workspacePath, '.proletariat', HOOKS_YAML_FILENAME)
+
+  if (!fs.existsSync(hooksPath)) {
+    return []
+  }
+
+  try {
+    const content = fs.readFileSync(hooksPath, 'utf-8')
+    const config = yaml.parse(content) as HooksYamlConfig
+
+    if (!config || !config.hooks || !Array.isArray(config.hooks)) {
+      return []
+    }
+
+    const defaults = config.defaults || {}
+
+    return config.hooks.map((def, index) =>
+      yamlDefinitionToHook(def, index, defaults)
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to load hooks from ${hooksPath}: ${message}`)
+  }
+}
+
+/**
+ * Convert a YAML hook definition to a Hook object
+ */
+function yamlDefinitionToHook(
+  def: HookYamlDefinition,
+  index: number,
+  defaults: HooksYamlConfig['defaults']
+): Hook {
+  // Generate ID from name or use index-based ID
+  const id = slugify(def.name) || `hook-${index}`
+
+  // Apply defaults to spawn_agent actions
+  const actions = def.actions.map(action => {
+    if (action.type === 'spawn_agent' && defaults?.spawn_agent) {
+      return {
+        ...defaults.spawn_agent,
+        ...action,
+        type: 'spawn_agent' as const,
+      }
+    }
+    return action
+  })
+
+  return {
+    id,
+    name: def.name,
+    description: def.description,
+    event: def.event,
+    conditions: def.conditions || [],
+    actions,
+    enabled: def.enabled ?? defaults?.enabled ?? true,
+    priority: def.priority,
+    source: 'yaml',
+    projectId: def.project,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+}
+
+// =============================================================================
+// Database Loading
+// =============================================================================
+
+/**
+ * Load hooks from database workspace_settings table
+ */
+export function loadHooksFromDatabase(db: Database.Database): Hook[] {
+  const hooks: Hook[] = []
+
+  // Get all hook settings from database
+  const rows = db
+    .prepare(`SELECT key, value FROM workspace_settings WHERE key LIKE ?`)
+    .all(`${HOOKS_DB_KEY_PREFIX}%`) as Array<{ key: string; value: string }>
+
+  for (const row of rows) {
+    try {
+      const hookData = JSON.parse(row.value) as Hook
+      hooks.push({
+        ...hookData,
+        source: 'database',
+      })
+    } catch {
+      // Skip invalid JSON entries
+      continue
+    }
+  }
+
+  return hooks
+}
+
+/**
+ * Save a hook to the database
+ */
+export function saveHookToDatabase(db: Database.Database, hook: Hook): void {
+  const key = `${HOOKS_DB_KEY_PREFIX}${hook.id}`
+  const value = JSON.stringify({
+    ...hook,
+    updatedAt: new Date(),
+  })
+
+  db.prepare(`
+    INSERT INTO workspace_settings (key, value)
+    VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(key, value)
+}
+
+/**
+ * Delete a hook from the database
+ */
+export function deleteHookFromDatabase(db: Database.Database, hookId: string): boolean {
+  const key = `${HOOKS_DB_KEY_PREFIX}${hookId}`
+  const result = db
+    .prepare(`DELETE FROM workspace_settings WHERE key = ?`)
+    .run(key)
+  return result.changes > 0
+}
+
+/**
+ * Get a single hook from the database
+ */
+export function getHookFromDatabase(db: Database.Database, hookId: string): Hook | null {
+  const key = `${HOOKS_DB_KEY_PREFIX}${hookId}`
+  const row = db
+    .prepare(`SELECT value FROM workspace_settings WHERE key = ?`)
+    .get(key) as { value: string } | undefined
+
+  if (!row) {
+    return null
+  }
+
+  try {
+    return {
+      ...JSON.parse(row.value),
+      source: 'database',
+    } as Hook
+  } catch {
+    return null
+  }
+}
+
+// =============================================================================
+// Combined Loading
+// =============================================================================
+
+/**
+ * Load all hooks from both YAML and database
+ * Database hooks take precedence over YAML hooks with the same ID
+ */
+export function loadAllHooks(workspacePath: string, db?: Database.Database): Hook[] {
+  const hooks = new Map<string, Hook>()
+
+  // Load YAML hooks first (lower precedence)
+  const yamlHooks = loadHooksFromYaml(workspacePath)
+  for (const hook of yamlHooks) {
+    hooks.set(hook.id, hook)
+  }
+
+  // Load database hooks (higher precedence - can override YAML)
+  if (db) {
+    const dbHooks = loadHooksFromDatabase(db)
+    for (const hook of dbHooks) {
+      hooks.set(hook.id, hook)
+    }
+  }
+
+  return Array.from(hooks.values())
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/**
+ * Validate a hook definition
+ */
+export function validateHook(hook: Partial<Hook>): { valid: boolean; errors: string[] } {
+  const errors: string[] = []
+
+  if (!hook.name || typeof hook.name !== 'string') {
+    errors.push('Hook must have a name')
+  }
+
+  if (!hook.event || !isValidEventName(hook.event)) {
+    errors.push(`Invalid event name: ${hook.event}`)
+  }
+
+  if (!hook.actions || !Array.isArray(hook.actions) || hook.actions.length === 0) {
+    errors.push('Hook must have at least one action')
+  } else {
+    for (let i = 0; i < hook.actions.length; i++) {
+      const actionErrors = validateAction(hook.actions[i])
+      for (const error of actionErrors) {
+        errors.push(`Action ${i + 1}: ${error}`)
+      }
+    }
+  }
+
+  if (hook.conditions) {
+    for (let i = 0; i < hook.conditions.length; i++) {
+      const conditionErrors = validateCondition(hook.conditions[i])
+      for (const error of conditionErrors) {
+        errors.push(`Condition ${i + 1}: ${error}`)
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  }
+}
+
+/**
+ * Check if an event name is valid
+ */
+function isValidEventName(event: string): event is HookEventName {
+  const validEvents: HookEventName[] = [
+    'ticket.created',
+    'ticket.moved',
+    'ticket.updated',
+    'ticket.status_changed',
+    'ticket.deleted',
+    'ticket.completed',
+    'epic.created',
+    'epic.updated',
+    'epic.status_changed',
+    'epic.deleted',
+    'work.started',
+    'work.completed',
+  ]
+  return validEvents.includes(event as HookEventName)
+}
+
+/**
+ * Validate an action
+ */
+function validateAction(action: HookAction): string[] {
+  const errors: string[] = []
+
+  if (!action.type) {
+    errors.push('Action must have a type')
+    return errors
+  }
+
+  switch (action.type) {
+    case 'spawn_agent':
+      // spawn_agent doesn't require additional fields
+      break
+
+    case 'shell':
+      if (!action.command) {
+        errors.push('Shell action must have a command')
+      }
+      break
+
+    case 'log':
+      if (!action.message) {
+        errors.push('Log action must have a message')
+      }
+      break
+
+    case 'notify':
+      if (!action.channel) {
+        errors.push('Notify action must have a channel')
+      }
+      if (!action.message) {
+        errors.push('Notify action must have a message')
+      }
+      break
+
+    case 'webhook':
+      if (!action.url) {
+        errors.push('Webhook action must have a URL')
+      }
+      break
+
+    default:
+      errors.push(`Unknown action type: ${(action as HookAction).type}`)
+  }
+
+  return errors
+}
+
+/**
+ * Validate a condition
+ */
+function validateCondition(condition: HookCondition): string[] {
+  const errors: string[] = []
+
+  if (!condition.field) {
+    errors.push('Condition must have a field')
+  }
+
+  if (!condition.operator) {
+    errors.push('Condition must have an operator')
+  } else {
+    const validOperators = [
+      'equals', 'not_equals', 'contains', 'not_contains',
+      'starts_with', 'ends_with', 'matches', 'in', 'not_in'
+    ]
+    if (!validOperators.includes(condition.operator)) {
+      errors.push(`Invalid operator: ${condition.operator}`)
+    }
+  }
+
+  if (condition.value === undefined) {
+    errors.push('Condition must have a value')
+  }
+
+  return errors
+}
+
+// =============================================================================
+// Template Generation
+// =============================================================================
+
+/**
+ * Generate a template hooks.yaml file
+ */
+export function generateHooksTemplate(): string {
+  const template: HooksYamlConfig = {
+    version: 1,
+    defaults: {
+      enabled: true,
+      spawn_agent: {
+        strategy: 'round-robin',
+        environment: 'devcontainer',
+        displayMode: 'terminal',
+      },
+    },
+    hooks: [
+      {
+        name: 'auto_spawn_ready',
+        description: 'Auto-spawn agent when ticket moves to Ready column',
+        event: 'ticket.moved',
+        conditions: [
+          {
+            field: 'toColumn',
+            operator: 'equals',
+            value: 'Ready',
+          },
+        ],
+        actions: [
+          {
+            type: 'spawn_agent',
+            strategy: 'round-robin',
+            limit: 1,
+          },
+        ],
+        enabled: true,
+        priority: 10,
+      },
+      {
+        name: 'log_ticket_created',
+        description: 'Log when a new ticket is created',
+        event: 'ticket.created',
+        actions: [
+          {
+            type: 'log',
+            message: 'New ticket created: {{ticket.id}} - {{ticket.title}}',
+            level: 'info',
+          },
+        ],
+        enabled: true,
+      },
+    ],
+  }
+
+  return yaml.stringify(template, {
+    indent: 2,
+    lineWidth: 100,
+  })
+}
+
+/**
+ * Create a hooks.yaml file if it doesn't exist
+ */
+export function ensureHooksYamlExists(workspacePath: string): boolean {
+  const hooksDir = path.join(workspacePath, '.proletariat')
+  const hooksPath = path.join(hooksDir, HOOKS_YAML_FILENAME)
+
+  if (fs.existsSync(hooksPath)) {
+    return false
+  }
+
+  if (!fs.existsSync(hooksDir)) {
+    fs.mkdirSync(hooksDir, { recursive: true })
+  }
+
+  fs.writeFileSync(hooksPath, generateHooksTemplate())
+  return true
+}

--- a/apps/cli/src/lib/hooks/manager.ts
+++ b/apps/cli/src/lib/hooks/manager.ts
@@ -1,0 +1,463 @@
+/**
+ * Hooks Manager
+ *
+ * Central registry and executor for event-based hooks.
+ * Manages hook registration, event emission, condition evaluation,
+ * and action execution.
+ */
+
+import {
+  Hook,
+  HookEventName,
+  HookEventPayload,
+  HookEventMap,
+  HookCondition,
+  HookAction,
+  HookExecutionResult,
+  HookActionResult,
+  HookExecutionContext,
+  ConditionOperator,
+} from './types.js'
+import { executeAction } from './actions/index.js'
+
+// =============================================================================
+// HooksManager Class
+// =============================================================================
+
+export class HooksManager {
+  private hooks: Map<string, Hook> = new Map()
+  private eventHooks: Map<HookEventName, Set<string>> = new Map()
+  private workspacePath: string
+  private pmoPath: string
+  private log: (message: string) => void
+  private enabled: boolean = true
+
+  constructor(options: {
+    workspacePath: string
+    pmoPath: string
+    log?: (message: string) => void
+  }) {
+    this.workspacePath = options.workspacePath
+    this.pmoPath = options.pmoPath
+    this.log = options.log || (() => {})
+  }
+
+  // ===========================================================================
+  // Registration
+  // ===========================================================================
+
+  /**
+   * Register a hook with the manager
+   */
+  registerHook(hook: Hook): void {
+    // Store hook by ID
+    this.hooks.set(hook.id, hook)
+
+    // Index by event for fast lookup
+    if (!this.eventHooks.has(hook.event)) {
+      this.eventHooks.set(hook.event, new Set())
+    }
+    this.eventHooks.get(hook.event)!.add(hook.id)
+  }
+
+  /**
+   * Register multiple hooks at once
+   */
+  registerHooks(hooks: Hook[]): void {
+    for (const hook of hooks) {
+      this.registerHook(hook)
+    }
+  }
+
+  /**
+   * Unregister a hook by ID
+   */
+  unregisterHook(hookId: string): boolean {
+    const hook = this.hooks.get(hookId)
+    if (!hook) {
+      return false
+    }
+
+    // Remove from event index
+    const eventHooks = this.eventHooks.get(hook.event)
+    if (eventHooks) {
+      eventHooks.delete(hookId)
+    }
+
+    // Remove from registry
+    this.hooks.delete(hookId)
+    return true
+  }
+
+  /**
+   * Clear all registered hooks
+   */
+  clearHooks(): void {
+    this.hooks.clear()
+    this.eventHooks.clear()
+  }
+
+  /**
+   * Get all registered hooks
+   */
+  getHooks(): Hook[] {
+    return Array.from(this.hooks.values())
+  }
+
+  /**
+   * Get a specific hook by ID
+   */
+  getHook(hookId: string): Hook | undefined {
+    return this.hooks.get(hookId)
+  }
+
+  /**
+   * Get hooks for a specific event
+   */
+  getHooksForEvent(event: HookEventName): Hook[] {
+    const hookIds = this.eventHooks.get(event)
+    if (!hookIds) {
+      return []
+    }
+    return Array.from(hookIds)
+      .map(id => this.hooks.get(id)!)
+      .filter(hook => hook !== undefined)
+  }
+
+  // ===========================================================================
+  // Global Enable/Disable
+  // ===========================================================================
+
+  /**
+   * Enable the hooks system globally
+   */
+  enable(): void {
+    this.enabled = true
+  }
+
+  /**
+   * Disable the hooks system globally
+   */
+  disable(): void {
+    this.enabled = false
+  }
+
+  /**
+   * Check if hooks are enabled
+   */
+  isEnabled(): boolean {
+    return this.enabled
+  }
+
+  // ===========================================================================
+  // Event Emission
+  // ===========================================================================
+
+  /**
+   * Emit an event and execute matching hooks
+   */
+  async emit<E extends HookEventName>(
+    event: E,
+    payload: HookEventMap[E]
+  ): Promise<HookExecutionResult[]> {
+    // If hooks are disabled globally, return empty results
+    if (!this.enabled) {
+      return []
+    }
+
+    const results: HookExecutionResult[] = []
+    const hooks = this.getHooksForEvent(event)
+
+    // Sort by priority (lower = first)
+    const sortedHooks = hooks.sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))
+
+    for (const hook of sortedHooks) {
+      const result = await this.executeHook(hook, event, payload)
+      results.push(result)
+    }
+
+    return results
+  }
+
+  // ===========================================================================
+  // Hook Execution
+  // ===========================================================================
+
+  /**
+   * Execute a single hook
+   */
+  private async executeHook(
+    hook: Hook,
+    event: HookEventName,
+    payload: HookEventPayload
+  ): Promise<HookExecutionResult> {
+    const startTime = Date.now()
+
+    // Check if hook is enabled
+    if (!hook.enabled) {
+      return {
+        hook,
+        event,
+        payload,
+        conditionsMatched: false,
+        skipped: true,
+        actionResults: [],
+        success: true,
+        duration: Date.now() - startTime,
+        executedAt: new Date(),
+      }
+    }
+
+    // Check if hook is scoped to a specific project
+    const eventProjectId = (payload as { projectId?: string }).projectId
+    if (hook.projectId && eventProjectId && hook.projectId !== eventProjectId) {
+      return {
+        hook,
+        event,
+        payload,
+        conditionsMatched: false,
+        skipped: true,
+        actionResults: [],
+        success: true,
+        duration: Date.now() - startTime,
+        executedAt: new Date(),
+      }
+    }
+
+    // Evaluate conditions
+    const conditionsMatched = this.evaluateConditions(hook.conditions || [], payload)
+
+    if (!conditionsMatched) {
+      return {
+        hook,
+        event,
+        payload,
+        conditionsMatched: false,
+        skipped: true,
+        actionResults: [],
+        success: true,
+        duration: Date.now() - startTime,
+        executedAt: new Date(),
+      }
+    }
+
+    // Execute actions
+    const context: HookExecutionContext = {
+      event,
+      payload,
+      hook,
+      workspacePath: this.workspacePath,
+      pmoPath: this.pmoPath,
+      log: this.log,
+    }
+
+    const actionResults: HookActionResult[] = []
+    let allActionsSucceeded = true
+
+    for (const action of hook.actions) {
+      const actionResult = await this.executeAction(action, context)
+      actionResults.push(actionResult)
+      if (!actionResult.success) {
+        allActionsSucceeded = false
+      }
+    }
+
+    return {
+      hook,
+      event,
+      payload,
+      conditionsMatched: true,
+      skipped: false,
+      actionResults,
+      success: allActionsSucceeded,
+      duration: Date.now() - startTime,
+      executedAt: new Date(),
+    }
+  }
+
+  /**
+   * Execute a single action
+   */
+  private async executeAction(
+    action: HookAction,
+    context: HookExecutionContext
+  ): Promise<HookActionResult> {
+    const startTime = Date.now()
+
+    try {
+      const output = await executeAction(action, context)
+      return {
+        success: true,
+        action,
+        output,
+        duration: Date.now() - startTime,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        action,
+        error: error instanceof Error ? error.message : String(error),
+        duration: Date.now() - startTime,
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Condition Evaluation
+  // ===========================================================================
+
+  /**
+   * Evaluate all conditions against a payload
+   * Returns true if ALL conditions match (AND logic)
+   */
+  evaluateConditions(conditions: HookCondition[], payload: HookEventPayload): boolean {
+    if (conditions.length === 0) {
+      return true
+    }
+
+    for (const condition of conditions) {
+      if (!this.evaluateCondition(condition, payload)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * Evaluate a single condition against a payload
+   */
+  private evaluateCondition(condition: HookCondition, payload: HookEventPayload): boolean {
+    const actualValue = this.getFieldValue(condition.field, payload)
+    return this.compareValues(actualValue, condition.operator, condition.value)
+  }
+
+  /**
+   * Get a field value from the payload using dot notation
+   * e.g., "ticket.priority" or "toColumn"
+   */
+  private getFieldValue(field: string, payload: HookEventPayload): unknown {
+    const parts = field.split('.')
+    let value: unknown = payload
+
+    for (const part of parts) {
+      if (value === null || value === undefined) {
+        return undefined
+      }
+      value = (value as Record<string, unknown>)[part]
+    }
+
+    return value
+  }
+
+  /**
+   * Compare values using the specified operator
+   */
+  private compareValues(
+    actual: unknown,
+    operator: ConditionOperator,
+    expected: string | string[] | number | boolean
+  ): boolean {
+    switch (operator) {
+      case 'equals':
+        return actual === expected
+
+      case 'not_equals':
+        return actual !== expected
+
+      case 'contains':
+        if (typeof actual === 'string' && typeof expected === 'string') {
+          return actual.includes(expected)
+        }
+        if (Array.isArray(actual) && (typeof expected === 'string' || typeof expected === 'number' || typeof expected === 'boolean')) {
+          return actual.includes(expected)
+        }
+        return false
+
+      case 'not_contains':
+        if (typeof actual === 'string' && typeof expected === 'string') {
+          return !actual.includes(expected)
+        }
+        if (Array.isArray(actual) && (typeof expected === 'string' || typeof expected === 'number' || typeof expected === 'boolean')) {
+          return !actual.includes(expected)
+        }
+        return true
+
+      case 'starts_with':
+        if (typeof actual === 'string' && typeof expected === 'string') {
+          return actual.startsWith(expected)
+        }
+        return false
+
+      case 'ends_with':
+        if (typeof actual === 'string' && typeof expected === 'string') {
+          return actual.endsWith(expected)
+        }
+        return false
+
+      case 'matches':
+        if (typeof actual === 'string' && typeof expected === 'string') {
+          try {
+            return new RegExp(expected).test(actual)
+          } catch {
+            return false
+          }
+        }
+        return false
+
+      case 'in':
+        if (Array.isArray(expected)) {
+          // Cast expected to any[] to allow comparison with any type
+          return (expected as unknown[]).includes(actual)
+        }
+        return false
+
+      case 'not_in':
+        if (Array.isArray(expected)) {
+          // Cast expected to any[] to allow comparison with any type
+          return !(expected as unknown[]).includes(actual)
+        }
+        return true
+
+      default:
+        return false
+    }
+  }
+}
+
+// =============================================================================
+// Singleton Instance
+// =============================================================================
+
+let globalHooksManager: HooksManager | null = null
+
+/**
+ * Get or create the global hooks manager instance
+ */
+export function getHooksManager(options?: {
+  workspacePath: string
+  pmoPath: string
+  log?: (message: string) => void
+}): HooksManager {
+  if (!globalHooksManager && options) {
+    globalHooksManager = new HooksManager(options)
+  }
+  if (!globalHooksManager) {
+    throw new Error('HooksManager not initialized. Call with options first.')
+  }
+  return globalHooksManager
+}
+
+/**
+ * Reset the global hooks manager (for testing)
+ */
+export function resetHooksManager(): void {
+  globalHooksManager = null
+}
+
+/**
+ * Check if hooks manager is initialized
+ */
+export function isHooksManagerInitialized(): boolean {
+  return globalHooksManager !== null
+}

--- a/apps/cli/src/lib/hooks/storage-hooks.ts
+++ b/apps/cli/src/lib/hooks/storage-hooks.ts
@@ -1,0 +1,303 @@
+/**
+ * Storage Hooks Integration
+ *
+ * Provides event emission for PMO storage operations.
+ * This module wraps storage operations to emit hooks events
+ * without modifying the core storage implementation.
+ */
+
+import {
+  TicketCreatedPayload,
+  TicketMovedPayload,
+  TicketUpdatedPayload,
+  TicketStatusChangedPayload,
+  TicketDeletedPayload,
+  TicketCompletedPayload,
+  EpicCreatedPayload,
+  EpicUpdatedPayload,
+  EpicStatusChangedPayload,
+  EpicDeletedPayload,
+} from './types.js'
+import { HooksManager } from './manager.js'
+import { Ticket, Epic, TicketStatus, EpicStatus } from '../pmo/types.js'
+
+// =============================================================================
+// Ticket Events
+// =============================================================================
+
+/**
+ * Emit ticket.created event
+ */
+export async function emitTicketCreated(
+  manager: HooksManager,
+  ticket: Ticket,
+  projectId: string
+): Promise<void> {
+  const payload: TicketCreatedPayload = {
+    timestamp: new Date(),
+    projectId,
+    ticket,
+  }
+  await manager.emit('ticket.created', payload)
+}
+
+/**
+ * Emit ticket.moved event
+ */
+export async function emitTicketMoved(
+  manager: HooksManager,
+  ticket: Ticket,
+  fromColumn: string,
+  toColumn: string,
+  projectId: string
+): Promise<void> {
+  const payload: TicketMovedPayload = {
+    timestamp: new Date(),
+    projectId,
+    ticket,
+    fromColumn,
+    toColumn,
+  }
+  await manager.emit('ticket.moved', payload)
+}
+
+/**
+ * Emit ticket.updated event
+ */
+export async function emitTicketUpdated(
+  manager: HooksManager,
+  ticket: Ticket,
+  changes: Partial<Ticket>,
+  previousValues: Partial<Ticket>,
+  projectId: string
+): Promise<void> {
+  const payload: TicketUpdatedPayload = {
+    timestamp: new Date(),
+    projectId,
+    ticket,
+    changes,
+    previousValues,
+  }
+  await manager.emit('ticket.updated', payload)
+}
+
+/**
+ * Emit ticket.status_changed event
+ */
+export async function emitTicketStatusChanged(
+  manager: HooksManager,
+  ticket: Ticket,
+  fromStatus: TicketStatus | undefined,
+  toStatus: TicketStatus,
+  projectId: string
+): Promise<void> {
+  const payload: TicketStatusChangedPayload = {
+    timestamp: new Date(),
+    projectId,
+    ticket,
+    fromStatus,
+    toStatus,
+  }
+  await manager.emit('ticket.status_changed', payload)
+}
+
+/**
+ * Emit ticket.deleted event
+ */
+export async function emitTicketDeleted(
+  manager: HooksManager,
+  ticketId: string,
+  ticket: Ticket,
+  projectId: string
+): Promise<void> {
+  const payload: TicketDeletedPayload = {
+    timestamp: new Date(),
+    projectId,
+    ticketId,
+    ticket,
+  }
+  await manager.emit('ticket.deleted', payload)
+}
+
+/**
+ * Emit ticket.completed event
+ */
+export async function emitTicketCompleted(
+  manager: HooksManager,
+  ticket: Ticket,
+  projectId: string
+): Promise<void> {
+  const payload: TicketCompletedPayload = {
+    timestamp: new Date(),
+    projectId,
+    ticket,
+  }
+  await manager.emit('ticket.completed', payload)
+}
+
+// =============================================================================
+// Epic Events
+// =============================================================================
+
+/**
+ * Emit epic.created event
+ */
+export async function emitEpicCreated(
+  manager: HooksManager,
+  epic: Epic,
+  projectId: string
+): Promise<void> {
+  const payload: EpicCreatedPayload = {
+    timestamp: new Date(),
+    projectId,
+    epic,
+  }
+  await manager.emit('epic.created', payload)
+}
+
+/**
+ * Emit epic.updated event
+ */
+export async function emitEpicUpdated(
+  manager: HooksManager,
+  epic: Epic,
+  changes: Partial<Epic>,
+  previousValues: Partial<Epic>,
+  projectId: string
+): Promise<void> {
+  const payload: EpicUpdatedPayload = {
+    timestamp: new Date(),
+    projectId,
+    epic,
+    changes,
+    previousValues,
+  }
+  await manager.emit('epic.updated', payload)
+}
+
+/**
+ * Emit epic.status_changed event
+ */
+export async function emitEpicStatusChanged(
+  manager: HooksManager,
+  epic: Epic,
+  fromStatus: EpicStatus | undefined,
+  toStatus: EpicStatus,
+  projectId: string
+): Promise<void> {
+  const payload: EpicStatusChangedPayload = {
+    timestamp: new Date(),
+    projectId,
+    epic,
+    fromStatus,
+    toStatus,
+  }
+  await manager.emit('epic.status_changed', payload)
+}
+
+/**
+ * Emit epic.deleted event
+ */
+export async function emitEpicDeleted(
+  manager: HooksManager,
+  epicId: string,
+  epic: Epic,
+  projectId: string
+): Promise<void> {
+  const payload: EpicDeletedPayload = {
+    timestamp: new Date(),
+    projectId,
+    epicId,
+    epic,
+  }
+  await manager.emit('epic.deleted', payload)
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Check if a status indicates completion
+ */
+export function isCompletedStatus(status: TicketStatus): boolean {
+  return status === 'done' || status === 'cancelled'
+}
+
+/**
+ * Determine which events to emit based on changes
+ */
+export function determineTicketEvents(
+  originalTicket: Ticket | null,
+  changes: Partial<Ticket>
+): {
+  emitUpdated: boolean
+  emitStatusChanged: boolean
+  emitCompleted: boolean
+  emitMoved: boolean
+  fromStatus?: TicketStatus
+  toStatus?: TicketStatus
+  fromColumn?: string
+  toColumn?: string
+} {
+  const result = {
+    emitUpdated: Object.keys(changes).length > 0,
+    emitStatusChanged: false,
+    emitCompleted: false,
+    emitMoved: false,
+    fromStatus: undefined as TicketStatus | undefined,
+    toStatus: undefined as TicketStatus | undefined,
+    fromColumn: undefined as string | undefined,
+    toColumn: undefined as string | undefined,
+  }
+
+  // Check for status change
+  if (changes.status && originalTicket?.status !== changes.status) {
+    result.emitStatusChanged = true
+    result.fromStatus = originalTicket?.status
+    result.toStatus = changes.status
+
+    // Check if completed
+    if (isCompletedStatus(changes.status) && (!originalTicket || !isCompletedStatus(originalTicket.status))) {
+      result.emitCompleted = true
+    }
+  }
+
+  // Check for column change
+  if (changes.column && originalTicket?.column !== changes.column) {
+    result.emitMoved = true
+    result.fromColumn = originalTicket?.column
+    result.toColumn = changes.column
+  }
+
+  return result
+}
+
+/**
+ * Determine which events to emit for epic changes
+ */
+export function determineEpicEvents(
+  originalEpic: Epic | null,
+  changes: Partial<Epic>
+): {
+  emitUpdated: boolean
+  emitStatusChanged: boolean
+  fromStatus?: EpicStatus
+  toStatus?: EpicStatus
+} {
+  const result = {
+    emitUpdated: Object.keys(changes).length > 0,
+    emitStatusChanged: false,
+    fromStatus: undefined as EpicStatus | undefined,
+    toStatus: undefined as EpicStatus | undefined,
+  }
+
+  // Check for status change
+  if (changes.status && originalEpic?.status !== changes.status) {
+    result.emitStatusChanged = true
+    result.fromStatus = originalEpic?.status
+    result.toStatus = changes.status
+  }
+
+  return result
+}

--- a/apps/cli/src/lib/hooks/types.ts
+++ b/apps/cli/src/lib/hooks/types.ts
@@ -1,0 +1,415 @@
+/**
+ * Event-Based Hooks System Types
+ *
+ * Defines events that can trigger hooks, conditions for filtering,
+ * and actions that can be executed when hooks fire.
+ */
+
+import { Ticket, TicketStatus, Epic, EpicStatus } from '../pmo/types.js'
+
+// =============================================================================
+// Event Types
+// =============================================================================
+
+/**
+ * All supported event names.
+ * These events are emitted by the PMO system when entities change.
+ */
+export type HookEventName =
+  | 'ticket.created'
+  | 'ticket.moved'
+  | 'ticket.updated'
+  | 'ticket.status_changed'
+  | 'ticket.deleted'
+  | 'ticket.completed'
+  | 'epic.created'
+  | 'epic.updated'
+  | 'epic.status_changed'
+  | 'epic.deleted'
+  | 'work.started'
+  | 'work.completed'
+
+/**
+ * Base event payload - all events include these fields
+ */
+export interface BaseEventPayload {
+  /** When the event occurred */
+  timestamp: Date
+  /** Project ID where the event occurred */
+  projectId: string
+}
+
+/**
+ * Ticket-related event payloads
+ */
+export interface TicketCreatedPayload extends BaseEventPayload {
+  ticket: Ticket
+}
+
+export interface TicketMovedPayload extends BaseEventPayload {
+  ticket: Ticket
+  fromColumn: string
+  toColumn: string
+}
+
+export interface TicketUpdatedPayload extends BaseEventPayload {
+  ticket: Ticket
+  changes: Partial<Ticket>
+  previousValues: Partial<Ticket>
+}
+
+export interface TicketStatusChangedPayload extends BaseEventPayload {
+  ticket: Ticket
+  fromStatus: TicketStatus | undefined
+  toStatus: TicketStatus
+}
+
+export interface TicketDeletedPayload extends BaseEventPayload {
+  ticketId: string
+  ticket: Ticket  // Snapshot before deletion
+}
+
+export interface TicketCompletedPayload extends BaseEventPayload {
+  ticket: Ticket
+}
+
+/**
+ * Epic-related event payloads
+ */
+export interface EpicCreatedPayload extends BaseEventPayload {
+  epic: Epic
+}
+
+export interface EpicUpdatedPayload extends BaseEventPayload {
+  epic: Epic
+  changes: Partial<Epic>
+  previousValues: Partial<Epic>
+}
+
+export interface EpicStatusChangedPayload extends BaseEventPayload {
+  epic: Epic
+  fromStatus: EpicStatus | undefined
+  toStatus: EpicStatus
+}
+
+export interface EpicDeletedPayload extends BaseEventPayload {
+  epicId: string
+  epic: Epic  // Snapshot before deletion
+}
+
+/**
+ * Work-related event payloads
+ */
+export interface WorkStartedPayload extends BaseEventPayload {
+  ticketId: string
+  agentName: string
+  executionId: string
+}
+
+export interface WorkCompletedPayload extends BaseEventPayload {
+  ticketId: string
+  agentName: string
+  executionId: string
+  success: boolean
+}
+
+/**
+ * Union of all event payloads
+ */
+export type HookEventPayload =
+  | TicketCreatedPayload
+  | TicketMovedPayload
+  | TicketUpdatedPayload
+  | TicketStatusChangedPayload
+  | TicketDeletedPayload
+  | TicketCompletedPayload
+  | EpicCreatedPayload
+  | EpicUpdatedPayload
+  | EpicStatusChangedPayload
+  | EpicDeletedPayload
+  | WorkStartedPayload
+  | WorkCompletedPayload
+
+/**
+ * Map event names to their payload types
+ */
+export interface HookEventMap {
+  'ticket.created': TicketCreatedPayload
+  'ticket.moved': TicketMovedPayload
+  'ticket.updated': TicketUpdatedPayload
+  'ticket.status_changed': TicketStatusChangedPayload
+  'ticket.deleted': TicketDeletedPayload
+  'ticket.completed': TicketCompletedPayload
+  'epic.created': EpicCreatedPayload
+  'epic.updated': EpicUpdatedPayload
+  'epic.status_changed': EpicStatusChangedPayload
+  'epic.deleted': EpicDeletedPayload
+  'work.started': WorkStartedPayload
+  'work.completed': WorkCompletedPayload
+}
+
+// =============================================================================
+// Condition Types
+// =============================================================================
+
+/**
+ * Comparison operators for conditions
+ */
+export type ConditionOperator =
+  | 'equals'
+  | 'not_equals'
+  | 'contains'
+  | 'not_contains'
+  | 'starts_with'
+  | 'ends_with'
+  | 'matches'  // regex match
+  | 'in'       // value is in array
+  | 'not_in'   // value is not in array
+
+/**
+ * A single condition that must be met for the hook to fire
+ */
+export interface HookCondition {
+  /** Field path to check (e.g., "toColumn", "ticket.priority", "ticket.category") */
+  field: string
+  /** Comparison operator */
+  operator: ConditionOperator
+  /** Value(s) to compare against */
+  value: string | string[] | number | boolean
+}
+
+// =============================================================================
+// Action Types
+// =============================================================================
+
+/**
+ * Types of actions that can be executed by hooks
+ */
+export type HookActionType = 'spawn_agent' | 'shell' | 'log' | 'notify' | 'webhook'
+
+/**
+ * Base action configuration
+ */
+export interface BaseHookAction {
+  type: HookActionType
+}
+
+/**
+ * Spawn agent action - triggers auto-spawn for tickets
+ */
+export interface SpawnAgentAction extends BaseHookAction {
+  type: 'spawn_agent'
+  /** Agent selection strategy */
+  strategy?: 'round-robin' | 'least-busy' | 'random'
+  /** Specific agent to use (overrides strategy) */
+  agent?: string
+  /** Maximum number of agents to spawn (per hook execution) */
+  limit?: number
+  /** Execution environment */
+  environment?: 'host' | 'devcontainer' | 'docker'
+  /** Display mode */
+  displayMode?: 'terminal' | 'tmux' | 'background' | 'foreground'
+  /** Skip permission checks */
+  skipPermissions?: boolean
+  /** Create PR when work is ready */
+  createPR?: boolean
+}
+
+/**
+ * Shell command action - runs a shell command
+ */
+export interface ShellAction extends BaseHookAction {
+  type: 'shell'
+  /** Command to execute */
+  command: string
+  /** Working directory (relative to workspace) */
+  cwd?: string
+  /** Environment variables */
+  env?: Record<string, string>
+  /** Timeout in milliseconds */
+  timeout?: number
+  /** Run in background (don't wait for completion) */
+  background?: boolean
+}
+
+/**
+ * Log action - writes to log output
+ */
+export interface LogAction extends BaseHookAction {
+  type: 'log'
+  /** Message template (can use {{field}} placeholders) */
+  message: string
+  /** Log level */
+  level?: 'info' | 'warn' | 'error' | 'debug'
+}
+
+/**
+ * Notify action - sends notifications (placeholder for future)
+ */
+export interface NotifyAction extends BaseHookAction {
+  type: 'notify'
+  /** Notification channel */
+  channel: 'slack' | 'email' | 'desktop'
+  /** Message template */
+  message: string
+  /** Additional channel-specific options */
+  options?: Record<string, unknown>
+}
+
+/**
+ * Webhook action - sends HTTP request
+ */
+export interface WebhookAction extends BaseHookAction {
+  type: 'webhook'
+  /** URL to send request to */
+  url: string
+  /** HTTP method */
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH'
+  /** Request headers */
+  headers?: Record<string, string>
+  /** Request body template (JSON string with placeholders) */
+  body?: string
+  /** Timeout in milliseconds */
+  timeout?: number
+}
+
+/**
+ * Union of all action types
+ */
+export type HookAction =
+  | SpawnAgentAction
+  | ShellAction
+  | LogAction
+  | NotifyAction
+  | WebhookAction
+
+// =============================================================================
+// Hook Definition
+// =============================================================================
+
+/**
+ * A single hook definition
+ */
+export interface Hook {
+  /** Unique identifier for the hook */
+  id: string
+  /** Human-readable name */
+  name: string
+  /** Description of what this hook does */
+  description?: string
+  /** Event that triggers this hook */
+  event: HookEventName
+  /** Conditions that must be met (all must match - AND logic) */
+  conditions?: HookCondition[]
+  /** Actions to execute when conditions are met */
+  actions: HookAction[]
+  /** Whether the hook is enabled */
+  enabled: boolean
+  /** Priority (lower = runs first) */
+  priority?: number
+  /** Source of the hook definition */
+  source: 'yaml' | 'database'
+  /** Project ID this hook is scoped to (null = all projects) */
+  projectId?: string
+  /** Creation timestamp */
+  createdAt?: Date
+  /** Last updated timestamp */
+  updatedAt?: Date
+}
+
+// =============================================================================
+// Hook Configuration (YAML format)
+// =============================================================================
+
+/**
+ * YAML configuration file structure for .proletariat/hooks.yaml
+ */
+export interface HooksYamlConfig {
+  /** Schema version for future compatibility */
+  version?: number
+  /** Default settings for all hooks */
+  defaults?: {
+    /** Default enabled state */
+    enabled?: boolean
+    /** Default spawn_agent settings */
+    spawn_agent?: Partial<SpawnAgentAction>
+  }
+  /** Hook definitions */
+  hooks: HookYamlDefinition[]
+}
+
+/**
+ * Hook definition as it appears in YAML
+ */
+export interface HookYamlDefinition {
+  name: string
+  description?: string
+  event: HookEventName
+  conditions?: HookCondition[]
+  actions: HookAction[]
+  enabled?: boolean
+  priority?: number
+  project?: string  // Project ID scope
+}
+
+// =============================================================================
+// Hook Execution
+// =============================================================================
+
+/**
+ * Result of executing a hook action
+ */
+export interface HookActionResult {
+  /** Whether the action succeeded */
+  success: boolean
+  /** Action that was executed */
+  action: HookAction
+  /** Error message if failed */
+  error?: string
+  /** Output/result data from the action */
+  output?: unknown
+  /** Execution duration in milliseconds */
+  duration?: number
+}
+
+/**
+ * Result of executing a hook
+ */
+export interface HookExecutionResult {
+  /** Hook that was executed */
+  hook: Hook
+  /** Event that triggered the hook */
+  event: HookEventName
+  /** Event payload */
+  payload: HookEventPayload
+  /** Whether all conditions matched */
+  conditionsMatched: boolean
+  /** Whether the hook was skipped (disabled or conditions not met) */
+  skipped: boolean
+  /** Results of each action */
+  actionResults: HookActionResult[]
+  /** Overall success (all actions succeeded) */
+  success: boolean
+  /** Total execution duration in milliseconds */
+  duration: number
+  /** Timestamp of execution */
+  executedAt: Date
+}
+
+/**
+ * Hook execution context - passed to action executors
+ */
+export interface HookExecutionContext {
+  /** Event that triggered the hook */
+  event: HookEventName
+  /** Event payload */
+  payload: HookEventPayload
+  /** Hook being executed */
+  hook: Hook
+  /** Workspace path */
+  workspacePath: string
+  /** PMO path */
+  pmoPath: string
+  /** Logging function */
+  log: (message: string) => void
+}

--- a/apps/cli/src/lib/pmo/hooks-integration.ts
+++ b/apps/cli/src/lib/pmo/hooks-integration.ts
@@ -1,0 +1,293 @@
+/**
+ * Hooks Integration for PMO
+ *
+ * Provides hooks-aware wrappers for PMO storage operations.
+ * Commands can use these functions to automatically emit events
+ * when tickets/epics are created, updated, moved, or deleted.
+ */
+
+import * as path from 'path'
+import {
+  HooksManager,
+  initializeHooks,
+  isHooksManagerInitialized,
+  getHooksManager,
+} from '../hooks/index.js'
+import {
+  emitTicketCreated,
+  emitTicketMoved,
+  emitTicketUpdated,
+  emitTicketStatusChanged,
+  emitTicketDeleted,
+  emitTicketCompleted,
+  emitEpicCreated,
+  emitEpicUpdated,
+  emitEpicStatusChanged,
+  emitEpicDeleted,
+  determineTicketEvents,
+  determineEpicEvents,
+  isCompletedStatus,
+} from '../hooks/storage-hooks.js'
+import { SQLiteStorage } from './storage-sqlite.js'
+import { Ticket, Epic, TicketStatus, EpicStatus } from './types.js'
+import Database from 'better-sqlite3'
+
+// =============================================================================
+// Hooks Manager Initialization
+// =============================================================================
+
+/**
+ * Get or initialize the hooks manager for a workspace.
+ * Safe to call multiple times - will return existing manager if initialized.
+ */
+export function getOrInitHooksManager(options: {
+  workspacePath: string
+  pmoPath: string
+  db?: Database.Database
+  log?: (message: string) => void
+}): HooksManager | null {
+  const { workspacePath, pmoPath, db, log = () => {} } = options
+
+  try {
+    if (isHooksManagerInitialized()) {
+      return getHooksManager()
+    }
+    return initializeHooks({ workspacePath, pmoPath, db, log })
+  } catch {
+    // Hooks initialization failed - return null to indicate hooks are not available
+    return null
+  }
+}
+
+// =============================================================================
+// Hooks-Aware Storage Operations
+// =============================================================================
+
+/**
+ * Create a ticket and emit hooks event
+ */
+export async function createTicketWithHooks(
+  storage: SQLiteStorage,
+  ticketData: Partial<Ticket>,
+  hooksManager: HooksManager | null
+): Promise<Ticket> {
+  const ticket = await storage.createTicket(ticketData)
+  const projectId = storage.getCurrentProjectId()
+
+  if (hooksManager) {
+    await emitTicketCreated(hooksManager, ticket, projectId)
+  }
+
+  return ticket
+}
+
+/**
+ * Update a ticket and emit appropriate hooks events
+ */
+export async function updateTicketWithHooks(
+  storage: SQLiteStorage,
+  ticketId: string,
+  changes: Partial<Ticket>,
+  hooksManager: HooksManager | null
+): Promise<Ticket> {
+  // Get original ticket for comparison
+  const originalTicket = await storage.getTicket(ticketId)
+
+  // Perform the update
+  const updatedTicket = await storage.updateTicket(ticketId, changes)
+  const projectId = storage.getCurrentProjectId()
+
+  if (hooksManager && originalTicket) {
+    const events = determineTicketEvents(originalTicket, changes)
+
+    // Emit updated event
+    if (events.emitUpdated) {
+      const previousValues: Partial<Ticket> = {}
+      for (const key of Object.keys(changes)) {
+        previousValues[key as keyof Ticket] = originalTicket[key as keyof Ticket] as never
+      }
+      await emitTicketUpdated(hooksManager, updatedTicket, changes, previousValues, projectId)
+    }
+
+    // Emit status changed event
+    if (events.emitStatusChanged && events.toStatus) {
+      await emitTicketStatusChanged(
+        hooksManager,
+        updatedTicket,
+        events.fromStatus,
+        events.toStatus,
+        projectId
+      )
+    }
+
+    // Emit completed event
+    if (events.emitCompleted) {
+      await emitTicketCompleted(hooksManager, updatedTicket, projectId)
+    }
+  }
+
+  return updatedTicket
+}
+
+/**
+ * Move a ticket and emit hooks events
+ */
+export async function moveTicketWithHooks(
+  storage: SQLiteStorage,
+  ticketId: string,
+  targetColumn: string,
+  position: number | undefined,
+  hooksManager: HooksManager | null
+): Promise<Ticket> {
+  // Get original ticket for comparison
+  const originalTicket = await storage.getTicket(ticketId)
+  const fromColumn = originalTicket?.column || ''
+
+  // Perform the move
+  const movedTicket = await storage.moveTicket(ticketId, targetColumn, position)
+  const projectId = storage.getCurrentProjectId()
+
+  if (hooksManager && fromColumn !== targetColumn) {
+    await emitTicketMoved(hooksManager, movedTicket, fromColumn, targetColumn, projectId)
+  }
+
+  return movedTicket
+}
+
+/**
+ * Delete a ticket and emit hooks event
+ */
+export async function deleteTicketWithHooks(
+  storage: SQLiteStorage,
+  ticketId: string,
+  hooksManager: HooksManager | null
+): Promise<void> {
+  // Get ticket snapshot before deletion
+  const ticket = await storage.getTicket(ticketId)
+  const projectId = storage.getCurrentProjectId()
+
+  // Perform deletion
+  await storage.deleteTicket(ticketId)
+
+  if (hooksManager && ticket) {
+    await emitTicketDeleted(hooksManager, ticketId, ticket, projectId)
+  }
+}
+
+/**
+ * Create an epic and emit hooks event
+ */
+export async function createEpicWithHooks(
+  storage: SQLiteStorage,
+  epicData: Partial<Epic>,
+  hooksManager: HooksManager | null
+): Promise<Epic> {
+  const epic = await storage.createEpic(epicData)
+  const projectId = storage.getCurrentProjectId()
+
+  if (hooksManager) {
+    await emitEpicCreated(hooksManager, epic, projectId)
+  }
+
+  return epic
+}
+
+/**
+ * Update an epic and emit appropriate hooks events
+ */
+export async function updateEpicWithHooks(
+  storage: SQLiteStorage,
+  epicId: string,
+  changes: Partial<Epic>,
+  hooksManager: HooksManager | null
+): Promise<Epic> {
+  // Get original epic for comparison
+  const originalEpic = await storage.getEpic(epicId)
+
+  // Perform the update
+  const updatedEpic = await storage.updateEpic(epicId, changes)
+  const projectId = storage.getCurrentProjectId()
+
+  if (hooksManager && originalEpic) {
+    const events = determineEpicEvents(originalEpic, changes)
+
+    // Emit updated event
+    if (events.emitUpdated) {
+      const previousValues: Partial<Epic> = {}
+      for (const key of Object.keys(changes)) {
+        previousValues[key as keyof Epic] = originalEpic[key as keyof Epic] as never
+      }
+      await emitEpicUpdated(hooksManager, updatedEpic, changes, previousValues, projectId)
+    }
+
+    // Emit status changed event
+    if (events.emitStatusChanged && events.toStatus) {
+      await emitEpicStatusChanged(
+        hooksManager,
+        updatedEpic,
+        events.fromStatus,
+        events.toStatus,
+        projectId
+      )
+    }
+  }
+
+  return updatedEpic
+}
+
+/**
+ * Delete an epic and emit hooks event
+ */
+export async function deleteEpicWithHooks(
+  storage: SQLiteStorage,
+  epicId: string,
+  hooksManager: HooksManager | null
+): Promise<void> {
+  // Get epic snapshot before deletion
+  const epic = await storage.getEpic(epicId)
+  const projectId = storage.getCurrentProjectId()
+
+  // Perform deletion
+  await storage.deleteEpic(epicId)
+
+  if (hooksManager && epic) {
+    await emitEpicDeleted(hooksManager, epicId, epic, projectId)
+  }
+}
+
+// =============================================================================
+// Extended PMO Context with Hooks
+// =============================================================================
+
+/**
+ * Extended PMO context that includes hooks manager
+ */
+export interface PMOContextWithHooks {
+  pmoPath: string
+  storage: SQLiteStorage
+  columns: string[]
+  storageType: 'sqlite' | 'git'
+  projectId: string
+  projectName: string
+  hooksManager: HooksManager | null
+  workspacePath: string
+}
+
+/**
+ * Find workspace path from PMO path
+ * The workspace.db is at {workspace}/.proletariat/workspace.db
+ * PMO could be at {workspace}/pmo or {workspace}/repos/{repo}/pmo
+ */
+export function findWorkspaceFromPMO(pmoPath: string): string {
+  // Walk up to find .proletariat directory
+  let current = pmoPath
+  while (current !== path.dirname(current)) {
+    const proletariatPath = path.join(current, '.proletariat')
+    if (require('fs').existsSync(proletariatPath)) {
+      return current
+    }
+    current = path.dirname(current)
+  }
+  // Default to parent of PMO
+  return path.dirname(pmoPath)
+}

--- a/apps/cli/src/lib/pmo/index.ts
+++ b/apps/cli/src/lib/pmo/index.ts
@@ -43,6 +43,18 @@ export {
 export { findPMO } from './find-pmo.js';
 export { getPMOContext, type PMOContext } from './pmo-context.js';
 export {
+  getOrInitHooksManager,
+  createTicketWithHooks,
+  updateTicketWithHooks,
+  moveTicketWithHooks,
+  deleteTicketWithHooks,
+  createEpicWithHooks,
+  updateEpicWithHooks,
+  deleteEpicWithHooks,
+  findWorkspaceFromPMO,
+  type PMOContextWithHooks,
+} from './hooks-integration.js';
+export {
   PMO_TABLES,
   PMO_TABLE_SCHEMAS,
   PMO_INDEXES,

--- a/apps/cli/test/unit/hooks.test.ts
+++ b/apps/cli/test/unit/hooks.test.ts
@@ -1,0 +1,702 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import Database from 'better-sqlite3';
+import {
+  HooksManager,
+  Hook,
+  HookCondition,
+  TicketMovedPayload,
+  TicketCreatedPayload,
+  loadHooksFromYaml,
+  loadHooksFromDatabase,
+  loadAllHooks,
+  saveHookToDatabase,
+  deleteHookFromDatabase,
+  validateHook,
+  generateHooksTemplate,
+} from '../../src/lib/hooks/index.js';
+import { Ticket, TicketStatus } from '../../src/lib/pmo/types.js';
+
+describe('Hooks System', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-test-'));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // ==========================================================================
+  // HooksManager Tests
+  // ==========================================================================
+
+  describe('HooksManager', () => {
+    let manager: HooksManager;
+    const pmoPath = '/tmp/test-pmo';
+
+    beforeEach(() => {
+      manager = new HooksManager({
+        workspacePath: testDir,
+        pmoPath,
+        log: () => {},
+      });
+    });
+
+    describe('Hook Registration', () => {
+      it('registers a hook', () => {
+        const hook: Hook = {
+          id: 'test-hook',
+          name: 'Test Hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Test' }],
+          enabled: true,
+          source: 'yaml',
+        };
+
+        manager.registerHook(hook);
+
+        expect(manager.getHook('test-hook')).to.deep.equal(hook);
+      });
+
+      it('registers multiple hooks', () => {
+        const hooks: Hook[] = [
+          {
+            id: 'hook-1',
+            name: 'Hook 1',
+            event: 'ticket.created',
+            actions: [{ type: 'log', message: 'Test 1' }],
+            enabled: true,
+            source: 'yaml',
+          },
+          {
+            id: 'hook-2',
+            name: 'Hook 2',
+            event: 'ticket.moved',
+            actions: [{ type: 'log', message: 'Test 2' }],
+            enabled: true,
+            source: 'yaml',
+          },
+        ];
+
+        manager.registerHooks(hooks);
+
+        expect(manager.getHooks()).to.have.length(2);
+      });
+
+      it('unregisters a hook', () => {
+        const hook: Hook = {
+          id: 'test-hook',
+          name: 'Test Hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Test' }],
+          enabled: true,
+          source: 'yaml',
+        };
+
+        manager.registerHook(hook);
+        const result = manager.unregisterHook('test-hook');
+
+        expect(result).to.be.true;
+        expect(manager.getHook('test-hook')).to.be.undefined;
+      });
+
+      it('returns false when unregistering non-existent hook', () => {
+        const result = manager.unregisterHook('non-existent');
+        expect(result).to.be.false;
+      });
+
+      it('clears all hooks', () => {
+        manager.registerHook({
+          id: 'hook-1',
+          name: 'Hook 1',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Test' }],
+          enabled: true,
+          source: 'yaml',
+        });
+
+        manager.clearHooks();
+
+        expect(manager.getHooks()).to.have.length(0);
+      });
+    });
+
+    describe('Hook Lookup', () => {
+      beforeEach(() => {
+        manager.registerHooks([
+          {
+            id: 'created-hook',
+            name: 'Created Hook',
+            event: 'ticket.created',
+            actions: [{ type: 'log', message: 'Created' }],
+            enabled: true,
+            source: 'yaml',
+          },
+          {
+            id: 'moved-hook-1',
+            name: 'Moved Hook 1',
+            event: 'ticket.moved',
+            actions: [{ type: 'log', message: 'Moved 1' }],
+            enabled: true,
+            source: 'yaml',
+          },
+          {
+            id: 'moved-hook-2',
+            name: 'Moved Hook 2',
+            event: 'ticket.moved',
+            actions: [{ type: 'log', message: 'Moved 2' }],
+            enabled: true,
+            source: 'yaml',
+          },
+        ]);
+      });
+
+      it('gets hooks for specific event', () => {
+        const movedHooks = manager.getHooksForEvent('ticket.moved');
+        expect(movedHooks).to.have.length(2);
+      });
+
+      it('returns empty array for event with no hooks', () => {
+        const hooks = manager.getHooksForEvent('ticket.deleted');
+        expect(hooks).to.have.length(0);
+      });
+    });
+
+    describe('Condition Evaluation', () => {
+      it('evaluates equals condition', () => {
+        const conditions: HookCondition[] = [
+          { field: 'toColumn', operator: 'equals', value: 'Ready' },
+        ];
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+          fromColumn: 'Backlog',
+          toColumn: 'Ready',
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.true;
+      });
+
+      it('evaluates not_equals condition', () => {
+        const conditions: HookCondition[] = [
+          { field: 'toColumn', operator: 'not_equals', value: 'Backlog' },
+        ];
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+          fromColumn: 'Backlog',
+          toColumn: 'Ready',
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.true;
+      });
+
+      it('evaluates nested field path', () => {
+        const conditions: HookCondition[] = [
+          { field: 'ticket.priority', operator: 'equals', value: 'HIGH' },
+        ];
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: { ...createMockTicket(), priority: 'HIGH' },
+          fromColumn: 'Backlog',
+          toColumn: 'Ready',
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.true;
+      });
+
+      it('evaluates contains condition', () => {
+        const conditions: HookCondition[] = [
+          { field: 'ticket.title', operator: 'contains', value: 'Fix' },
+        ];
+
+        const payload: TicketCreatedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: { ...createMockTicket(), title: 'Fix login bug' },
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.true;
+      });
+
+      it('evaluates in condition', () => {
+        const conditions: HookCondition[] = [
+          { field: 'toColumn', operator: 'in', value: ['Ready', 'In Progress'] },
+        ];
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+          fromColumn: 'Backlog',
+          toColumn: 'Ready',
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.true;
+      });
+
+      it('evaluates multiple conditions (AND logic)', () => {
+        const conditions: HookCondition[] = [
+          { field: 'toColumn', operator: 'equals', value: 'Ready' },
+          { field: 'ticket.priority', operator: 'equals', value: 'HIGH' },
+        ];
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: { ...createMockTicket(), priority: 'HIGH' },
+          fromColumn: 'Backlog',
+          toColumn: 'Ready',
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.true;
+      });
+
+      it('fails when one condition does not match', () => {
+        const conditions: HookCondition[] = [
+          { field: 'toColumn', operator: 'equals', value: 'Ready' },
+          { field: 'ticket.priority', operator: 'equals', value: 'HIGH' },
+        ];
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: { ...createMockTicket(), priority: 'LOW' },
+          fromColumn: 'Backlog',
+          toColumn: 'Ready',
+        };
+
+        expect(manager.evaluateConditions(conditions, payload)).to.be.false;
+      });
+
+      it('matches when no conditions are specified', () => {
+        expect(manager.evaluateConditions([], {} as any)).to.be.true;
+      });
+    });
+
+    describe('Event Emission', () => {
+      it('executes hooks for emitted event', async () => {
+        let loggedMessage = '';
+        const logManager = new HooksManager({
+          workspacePath: testDir,
+          pmoPath,
+          log: (msg) => { loggedMessage = msg; },
+        });
+
+        logManager.registerHook({
+          id: 'log-hook',
+          name: 'Log Hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Ticket created: {{ticket.id}}' }],
+          enabled: true,
+          source: 'yaml',
+        });
+
+        const payload: TicketCreatedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+        };
+
+        const results = await logManager.emit('ticket.created', payload);
+
+        expect(results).to.have.length(1);
+        expect(results[0].success).to.be.true;
+        expect(loggedMessage).to.include('TEST-001');
+      });
+
+      it('skips disabled hooks', async () => {
+        manager.registerHook({
+          id: 'disabled-hook',
+          name: 'Disabled Hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Should not run' }],
+          enabled: false,
+          source: 'yaml',
+        });
+
+        const payload: TicketCreatedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+        };
+
+        const results = await manager.emit('ticket.created', payload);
+
+        expect(results).to.have.length(1);
+        expect(results[0].skipped).to.be.true;
+      });
+
+      it('skips hooks when conditions not met', async () => {
+        manager.registerHook({
+          id: 'conditional-hook',
+          name: 'Conditional Hook',
+          event: 'ticket.moved',
+          conditions: [{ field: 'toColumn', operator: 'equals', value: 'Done' }],
+          actions: [{ type: 'log', message: 'Should not run' }],
+          enabled: true,
+          source: 'yaml',
+        });
+
+        const payload: TicketMovedPayload = {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+          fromColumn: 'Backlog',
+          toColumn: 'Ready', // Not 'Done'
+        };
+
+        const results = await manager.emit('ticket.moved', payload);
+
+        expect(results).to.have.length(1);
+        expect(results[0].conditionsMatched).to.be.false;
+        expect(results[0].skipped).to.be.true;
+      });
+
+      it('returns empty array when hooks disabled globally', async () => {
+        manager.registerHook({
+          id: 'test-hook',
+          name: 'Test Hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Test' }],
+          enabled: true,
+          source: 'yaml',
+        });
+
+        manager.disable();
+
+        const results = await manager.emit('ticket.created', {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+        });
+
+        expect(results).to.have.length(0);
+      });
+
+      it('executes hooks in priority order', async () => {
+        const executionOrder: string[] = [];
+
+        manager.registerHooks([
+          {
+            id: 'low-priority',
+            name: 'Low Priority',
+            event: 'ticket.created',
+            actions: [{ type: 'log', message: 'low' }],
+            enabled: true,
+            source: 'yaml',
+            priority: 100,
+          },
+          {
+            id: 'high-priority',
+            name: 'High Priority',
+            event: 'ticket.created',
+            actions: [{ type: 'log', message: 'high' }],
+            enabled: true,
+            source: 'yaml',
+            priority: 1,
+          },
+        ]);
+
+        const results = await manager.emit('ticket.created', {
+          timestamp: new Date(),
+          projectId: 'test',
+          ticket: createMockTicket(),
+        });
+
+        // High priority should execute first
+        expect(results[0].hook.id).to.equal('high-priority');
+        expect(results[1].hook.id).to.equal('low-priority');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Loader Tests
+  // ==========================================================================
+
+  describe('Hooks Loader', () => {
+    describe('YAML Loading', () => {
+      it('loads hooks from hooks.yaml', () => {
+        // Create test directory structure
+        const proletariatDir = path.join(testDir, '.proletariat');
+        fs.mkdirSync(proletariatDir, { recursive: true });
+
+        // Write test hooks.yaml
+        const hooksYaml = `
+version: 1
+hooks:
+  - name: test_hook
+    event: ticket.moved
+    conditions:
+      - field: toColumn
+        operator: equals
+        value: Ready
+    actions:
+      - type: log
+        message: Test message
+    enabled: true
+`;
+        fs.writeFileSync(path.join(proletariatDir, 'hooks.yaml'), hooksYaml);
+
+        const hooks = loadHooksFromYaml(testDir);
+
+        expect(hooks).to.have.length(1);
+        expect(hooks[0].name).to.equal('test_hook');
+        expect(hooks[0].event).to.equal('ticket.moved');
+        expect(hooks[0].source).to.equal('yaml');
+      });
+
+      it('returns empty array when hooks.yaml does not exist', () => {
+        const hooks = loadHooksFromYaml(testDir);
+        expect(hooks).to.have.length(0);
+      });
+
+      it('applies defaults to hooks', () => {
+        const proletariatDir = path.join(testDir, '.proletariat');
+        fs.mkdirSync(proletariatDir, { recursive: true });
+
+        const hooksYaml = `
+version: 1
+defaults:
+  enabled: false
+  spawn_agent:
+    strategy: least-busy
+hooks:
+  - name: test_hook
+    event: ticket.created
+    actions:
+      - type: spawn_agent
+`;
+        fs.writeFileSync(path.join(proletariatDir, 'hooks.yaml'), hooksYaml);
+
+        const hooks = loadHooksFromYaml(testDir);
+
+        expect(hooks[0].enabled).to.be.false;
+        expect(hooks[0].actions[0]).to.have.property('strategy', 'least-busy');
+      });
+    });
+
+    describe('Database Loading', () => {
+      let db: Database.Database;
+      let dbPath: string;
+
+      beforeEach(() => {
+        dbPath = path.join(testDir, 'test.db');
+        db = new Database(dbPath);
+        db.exec(`
+          CREATE TABLE workspace_settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+          )
+        `);
+      });
+
+      afterEach(() => {
+        db.close();
+      });
+
+      it('loads hooks from database', () => {
+        const hook: Hook = {
+          id: 'db-hook',
+          name: 'Database Hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Test' }],
+          enabled: true,
+          source: 'database',
+        };
+
+        saveHookToDatabase(db, hook);
+
+        const hooks = loadHooksFromDatabase(db);
+
+        expect(hooks).to.have.length(1);
+        expect(hooks[0].name).to.equal('Database Hook');
+        expect(hooks[0].source).to.equal('database');
+      });
+
+      it('deletes hook from database', () => {
+        const hook: Hook = {
+          id: 'to-delete',
+          name: 'To Delete',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Test' }],
+          enabled: true,
+          source: 'database',
+        };
+
+        saveHookToDatabase(db, hook);
+        const deleted = deleteHookFromDatabase(db, 'to-delete');
+
+        expect(deleted).to.be.true;
+        expect(loadHooksFromDatabase(db)).to.have.length(0);
+      });
+    });
+
+    describe('Combined Loading', () => {
+      it('database hooks override YAML hooks with same ID', () => {
+        // Create YAML hook
+        const proletariatDir = path.join(testDir, '.proletariat');
+        fs.mkdirSync(proletariatDir, { recursive: true });
+
+        // Use 'shared-hook' as name so it slugifies to 'shared-hook' as ID
+        const hooksYaml = `
+hooks:
+  - name: shared-hook
+    event: ticket.created
+    actions:
+      - type: log
+        message: YAML version
+    enabled: true
+`;
+        fs.writeFileSync(path.join(proletariatDir, 'hooks.yaml'), hooksYaml);
+
+        // Create database hook with same ID (matching the slugified name)
+        const dbPath = path.join(testDir, 'test.db');
+        const db = new Database(dbPath);
+        db.exec(`
+          CREATE TABLE workspace_settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+          )
+        `);
+
+        const dbHook: Hook = {
+          id: 'shared-hook',  // Must match slugified name from YAML
+          name: 'shared-hook',
+          event: 'ticket.created',
+          actions: [{ type: 'log', message: 'Database version' }],
+          enabled: false,
+          source: 'database',
+        };
+        saveHookToDatabase(db, dbHook);
+
+        // Load all hooks
+        const hooks = loadAllHooks(testDir, db);
+        db.close();
+
+        // Should only have one hook, the database version
+        expect(hooks).to.have.length(1);
+        expect(hooks[0].enabled).to.be.false;
+        expect(hooks[0].actions[0]).to.have.property('message', 'Database version');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Validation Tests
+  // ==========================================================================
+
+  describe('Hook Validation', () => {
+    it('validates valid hook', () => {
+      const hook: Partial<Hook> = {
+        name: 'Valid Hook',
+        event: 'ticket.created',
+        actions: [{ type: 'log', message: 'Test' }],
+      };
+
+      const result = validateHook(hook);
+
+      expect(result.valid).to.be.true;
+      expect(result.errors).to.have.length(0);
+    });
+
+    it('requires name', () => {
+      const hook: Partial<Hook> = {
+        event: 'ticket.created',
+        actions: [{ type: 'log', message: 'Test' }],
+      };
+
+      const result = validateHook(hook);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors).to.include('Hook must have a name');
+    });
+
+    it('requires valid event', () => {
+      const hook: Partial<Hook> = {
+        name: 'Invalid Event Hook',
+        event: 'invalid.event' as any,
+        actions: [{ type: 'log', message: 'Test' }],
+      };
+
+      const result = validateHook(hook);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(e => e.includes('Invalid event name'))).to.be.true;
+    });
+
+    it('requires at least one action', () => {
+      const hook: Partial<Hook> = {
+        name: 'No Actions Hook',
+        event: 'ticket.created',
+        actions: [],
+      };
+
+      const result = validateHook(hook);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors).to.include('Hook must have at least one action');
+    });
+
+    it('validates shell action requires command', () => {
+      const hook: Partial<Hook> = {
+        name: 'Invalid Shell Hook',
+        event: 'ticket.created',
+        actions: [{ type: 'shell' } as any],
+      };
+
+      const result = validateHook(hook);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(e => e.includes('Shell action must have a command'))).to.be.true;
+    });
+  });
+
+  // ==========================================================================
+  // Template Generation Tests
+  // ==========================================================================
+
+  describe('Template Generation', () => {
+    it('generates valid YAML template', () => {
+      const template = generateHooksTemplate();
+
+      expect(template).to.include('version:');
+      expect(template).to.include('hooks:');
+      expect(template).to.include('auto_spawn_ready');
+      expect(template).to.include('ticket.moved');
+    });
+  });
+});
+
+// ==========================================================================
+// Helper Functions
+// ==========================================================================
+
+function createMockTicket(): Ticket {
+  return {
+    id: 'TEST-001',
+    title: 'Test Ticket',
+    description: 'Test description',
+    status: 'backlog' as TicketStatus,
+    column: 'Backlog',
+    priority: 'MEDIUM',
+    category: 'test',
+    subtasks: [],
+    metadata: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "apps/cli": {
       "name": "@chrismcdermut/prlt",
-      "version": "2.0.0-alpha.4",
+      "version": "2.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -26,10 +26,12 @@
         "better-sqlite3": "^9.2.2",
         "chalk": "^4.1.2",
         "chokidar": "^5.0.0",
+        "gray-matter": "^4.0.3",
         "ink": "^5.0.1",
         "ink-select-input": "^6.0.0",
         "inquirer": "^8.2.5",
-        "react": "^18.0.0"
+        "react": "^18.0.0",
+        "yaml": "^2.3.4"
       },
       "bin": {
         "prlt": "bin/run.js"
@@ -7548,7 +7550,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7663,6 +7664,18 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/external-editor": {
@@ -8177,6 +8190,43 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -8806,6 +8856,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -9876,6 +9935,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/leven": {
@@ -13914,6 +13982,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -14233,7 +14314,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
@@ -14344,6 +14424,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -15135,6 +15224,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
## Summary

Resolves TKT-039: Implement event-based hooks for auto-spawn

## Description

Add hooks system that triggers on events like ticket.created, ticket.moved, ticket.status_changed. Hooks would fire inline when CLI commands run (no server needed). Config via .proletariat/hooks.yaml or workspace settings. Use cases: auto-spawn when ticket enters Ready column, notify on status changes, etc.

## Changes

- 53ab476 feat: implement event-based hooks system for auto-spawn

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
