### PR TITLE
Require explicit confirmation to run agents on host when Docker unavailable

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -97,14 +97,25 @@ export default class WorkSpawn extends Command {
   async run(): Promise<void> {
     const { flags } = await this.parse(WorkSpawn)
 
-    // Early Docker check - fail fast if Docker is needed but not running
+    // Early Docker check - prompt for confirmation if Docker not running
     if (!flags['run-on-host'] && !isDockerRunning()) {
-      this.error(
-        'Docker is not running.\n\n' +
-        'Docker is required for devcontainer execution (recommended for agent sandboxing).\n' +
-        'Please start Docker Desktop and try again.\n\n' +
-        'Alternatively, use --run-on-host to run directly on your machine (bypasses sandbox).'
-      )
+      const { confirmHostExecution } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirmHostExecution',
+          message: 'Docker is not running. Run on host without sandbox?',
+          default: false,
+        },
+      ])
+
+      if (!confirmHostExecution) {
+        // Wait for Docker to start instead of exiting
+        this.log(styles.muted('\nWaiting for Docker to start... (Ctrl+C to cancel)'))
+        while (!isDockerRunning()) {
+          await new Promise(resolve => setTimeout(resolve, 2000))
+        }
+        this.log(styles.success('Docker detected! Continuing...\n'))
+      }
     }
 
     // Get workspace info (for agent worktree paths)

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -68,6 +68,10 @@ export default class WorkWatch extends Command {
       description: 'Create PR when work is ready',
       default: false,
     }),
+    'run-on-host': Flags.boolean({
+      description: 'Run on host even if devcontainer exists (bypasses sandbox)',
+      default: false,
+    }),
   }
 
   private isRunning = true
@@ -157,13 +161,26 @@ export default class WorkWatch extends Command {
         return hasDevcontainerConfig(agentDir)
       })
 
-      // Docker check
+      // Docker check - require explicit confirmation for host execution when Docker unavailable
       const dockerRunning = isDockerRunning()
-      if (hasDevcontainer && !dockerRunning) {
-        this.warn(
-          'Docker is not running. Agents will run on host instead of devcontainer.\n' +
-          'Start Docker Desktop for sandboxed execution.'
-        )
+      if (hasDevcontainer && !dockerRunning && !flags['run-on-host']) {
+        const { confirmHostExecution } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'confirmHostExecution',
+            message: 'Docker is not running. Run on host without sandbox?',
+            default: false,
+          },
+        ])
+
+        if (!confirmHostExecution) {
+          // Wait for Docker to start instead of exiting
+          this.log(styles.muted('\nWaiting for Docker to start... (Ctrl+C to cancel)'))
+          while (!isDockerRunning()) {
+            await new Promise(resolve => setTimeout(resolve, 2000))
+          }
+          this.log(styles.success('Docker detected! Continuing...\n'))
+        }
       }
 
       // Prompt for environment and display mode if not provided

--- a/apps/cli/src/commands/works/start.ts
+++ b/apps/cli/src/commands/works/start.ts
@@ -70,6 +70,10 @@ export default class WorksStart extends Command {
       description: 'Create PR when work is ready',
       default: false,
     }),
+    'run-on-host': Flags.boolean({
+      description: 'Run on host even if devcontainer exists (bypasses sandbox)',
+      default: false,
+    }),
   }
 
   async run(): Promise<void> {
@@ -189,13 +193,26 @@ export default class WorksStart extends Command {
         return hasDevcontainerConfig(agentDir)
       })
 
-      // Docker check
+      // Docker check - require explicit confirmation for host execution when Docker unavailable
       const dockerRunning = isDockerRunning()
-      if (hasDevcontainer && !dockerRunning) {
-        this.warn(
-          'Docker is not running. Agents will run on host instead of devcontainer.\n' +
-          'Start Docker Desktop for sandboxed execution.'
-        )
+      if (hasDevcontainer && !dockerRunning && !flags['run-on-host']) {
+        const { confirmHostExecution } = await inquirer.prompt([
+          {
+            type: 'confirm',
+            name: 'confirmHostExecution',
+            message: 'Docker is not running. Run on host without sandbox?',
+            default: false,
+          },
+        ])
+
+        if (!confirmHostExecution) {
+          // Wait for Docker to start instead of exiting
+          this.log(styles.muted('\nWaiting for Docker to start... (Ctrl+C to cancel)'))
+          while (!isDockerRunning()) {
+            await new Promise(resolve => setTimeout(resolve, 2000))
+          }
+          this.log(styles.success('Docker detected! Continuing...\n'))
+        }
       }
 
       // Prompt for environment and display mode if not provided


### PR DESCRIPTION
## Summary
- When Docker is not running, `work spawn`, `work watch`, and `works start` now prompt for confirmation before running agents on host without sandbox
- Prompt defaults to 'No' to prevent accidental unsandboxed execution
- Users can bypass the prompt with `--run-on-host` flag
- Aligns behavior with existing `work start` and `work revise` commands

## Test plan
- [ ] Run `prlt work spawn` when Docker is not running - should prompt for confirmation
- [ ] Run `prlt work spawn --run-on-host` when Docker is not running - should bypass prompt
- [ ] Run `prlt work watch` when Docker is not running - should prompt for confirmation
- [ ] Run `prlt works start` when Docker is not running - should prompt for confirmation
- [ ] Decline confirmation prompt - should exit with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)