### PR TITLE
fix(TKT-078): Agent branches now default to branching from main

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -94,6 +94,10 @@ export default class WorkSpawn extends PMOCommand {
       description: 'Do not create PR when work is ready (batch mode only)',
       default: false,
     }),
+    'from-current': Flags.boolean({
+      description: 'Create branches from current branch instead of main',
+      default: false,
+    }),
   }
 
   async execute(): Promise<void> {
@@ -586,6 +590,7 @@ export default class WorkSpawn extends PMOCommand {
             if (flags.executor) startArgs.push('--executor', flags.executor)
             if (batchRunOnHost) startArgs.push('--run-on-host')
             if (flags.force) startArgs.push('--force')
+            if (flags['from-current']) startArgs.push('--from-current')
           } else {
             // Batch mode: pass all settings to skip prompts
             if (batchMode) startArgs.push('--mode', batchMode)
@@ -596,6 +601,7 @@ export default class WorkSpawn extends PMOCommand {
             if (batchSkipPermissions) startArgs.push('--skip-permissions')
             if (batchCreatePr) startArgs.push('--create-pr')
             if (batchNoPr) startArgs.push('--no-pr')
+            if (flags['from-current']) startArgs.push('--from-current')
           }
 
           await this.config.runCommand('work:start', startArgs)

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -109,6 +109,10 @@ export default class WorkStart extends PMOCommand {
       description: 'Output mode',
       options: ['interactive', 'print'],
     }),
+    'from-current': Flags.boolean({
+      description: 'Create branch from current branch instead of main',
+      default: false,
+    }),
   }
 
   async execute(): Promise<void> {
@@ -732,6 +736,10 @@ export default class WorkStart extends PMOCommand {
 
       // Handle git branch - only if action modifies code
       let finalBranch = branch
+      // Agent branches should default to branching from origin/main, not the current branch
+      // Unless --from-current flag is set
+      let branchFromMain = !flags['from-current']
+
       if (context.modifiesCode !== false) {
         // If we have multiple repo worktrees, use the first for branch detection
         const gitRepos = repoWorktrees.length > 0
@@ -742,6 +750,7 @@ export default class WorkStart extends PMOCommand {
         if (isExistingBranch) {
           // Ticket already has a branch linked - just use it
           this.log(styles.muted(`Using existing branch: ${branch}`))
+          branchFromMain = false  // Use existing branch as-is
         } else {
           // No branch in DB - ask user if one already exists
           const { branchChoice } = await inquirer.prompt([
@@ -750,7 +759,7 @@ export default class WorkStart extends PMOCommand {
               name: 'branchChoice',
               message: `Does a branch already exist for ${ticket.id}?`,
               choices: [
-                { name: 'No, create new branch (Recommended)', value: 'create' },
+                { name: 'No, create new branch from main (Recommended)', value: 'create' },
                 { name: 'Yes, I\'ll enter the branch name', value: 'enter' },
                 { name: 'Search for matching branches', value: 'search' },
               ],
@@ -758,7 +767,8 @@ export default class WorkStart extends PMOCommand {
           ])
 
           if (branchChoice === 'enter') {
-            // User enters existing branch name
+            // User enters existing branch name - don't branch from main
+            branchFromMain = false
             const { enteredBranch } = await inquirer.prompt([
               {
                 type: 'input',
@@ -813,6 +823,8 @@ export default class WorkStart extends PMOCommand {
               ])
 
               if (selectedBranch !== '__create__') {
+                // User selected existing branch - don't branch from main
+                branchFromMain = false
                 finalBranch = selectedBranch
                 // Fetch and checkout the selected branch
                 try {
@@ -842,6 +854,15 @@ export default class WorkStart extends PMOCommand {
               continue
             }
 
+            // Fetch from origin/main if branching from main (for new branches)
+            if (branchFromMain) {
+              try {
+                execSync('git fetch origin main', { cwd: repoPath, stdio: 'pipe' })
+              } catch {
+                this.log(styles.muted(`   ${repoName}: could not fetch origin/main, using local state`))
+              }
+            }
+
             // Check if branch exists in git
             try {
               execSync(`git rev-parse --verify ${finalBranch}`, {
@@ -854,11 +875,20 @@ export default class WorkStart extends PMOCommand {
               })
               this.log(styles.muted(`   ${repoName}: checked out branch`))
             } catch {
-              execSync(`git checkout -b ${finalBranch}`, {
-                cwd: repoPath,
-                stdio: 'pipe',
-              })
-              this.log(styles.muted(`   ${repoName}: created new branch`))
+              // Branch doesn't exist - create it from the appropriate base
+              if (branchFromMain) {
+                execSync(`git checkout -b ${finalBranch} origin/main`, {
+                  cwd: repoPath,
+                  stdio: 'pipe',
+                })
+                this.log(styles.muted(`   ${repoName}: created new branch from origin/main`))
+              } else {
+                execSync(`git checkout -b ${finalBranch}`, {
+                  cwd: repoPath,
+                  stdio: 'pipe',
+                })
+                this.log(styles.muted(`   ${repoName}: created new branch`))
+              }
             }
           } catch (error) {
             this.warn(`Could not handle branch in ${repoName}: ${error instanceof Error ? error.message : error}`)

--- a/apps/cli/src/lib/execution/spawner.ts
+++ b/apps/cli/src/lib/execution/spawner.ts
@@ -49,6 +49,8 @@ export interface SpawnOptions {
   createPR?: boolean
   /** Execution config (terminal app, shell, etc.) */
   executionConfig?: ExecutionConfig
+  /** Branch from current branch instead of main (default: false, branches from main) */
+  branchFromCurrent?: boolean
   /** Logging callback */
   log?: (msg: string) => void
 }
@@ -288,6 +290,10 @@ export async function spawnAgentForTicket(
     ? repoWorktrees.map(r => path.join(agentDir, r))
     : [worktreePath]
 
+  // Determine the base branch for creating new branches
+  // Default to origin/main unless branchFromCurrent is explicitly set
+  const branchFromMain = !options.branchFromCurrent
+
   if (environment === 'devcontainer') {
     // Get container ID for this agent
     let containerId: string | null = null
@@ -315,14 +321,29 @@ export async function spawnAgentForTicket(
             continue
           }
 
+          // Fetch from origin/main if branching from main
+          if (branchFromMain) {
+            try {
+              execSync(`docker exec ${containerId} git -C "${containerRepoPath}" fetch origin main`, { stdio: 'pipe' })
+            } catch {
+              log(`Could not fetch origin/main in ${repoName}, using local state`)
+            }
+          }
+
           // Check if branch exists
           try {
             execSync(`docker exec ${containerId} git -C "${containerRepoPath}" rev-parse --verify ${branch}`, { stdio: 'pipe' })
             execSync(`docker exec ${containerId} git -C "${containerRepoPath}" checkout ${branch}`, { stdio: 'pipe' })
           } catch {
-            execSync(`docker exec ${containerId} git -C "${containerRepoPath}" checkout -b ${branch}`, { stdio: 'pipe' })
+            // Branch doesn't exist - create it from the appropriate base
+            if (branchFromMain) {
+              execSync(`docker exec ${containerId} git -C "${containerRepoPath}" checkout -b ${branch} origin/main`, { stdio: 'pipe' })
+              log(`Created branch ${branch} from origin/main in ${repoName} (inside container)`)
+            } else {
+              execSync(`docker exec ${containerId} git -C "${containerRepoPath}" checkout -b ${branch}`, { stdio: 'pipe' })
+              log(`Created branch ${branch} from current branch in ${repoName} (inside container)`)
+            }
           }
-          log(`Created branch ${branch} in ${repoName} (inside container)`)
         } catch (error) {
           log(`Could not create branch in ${repoName}: ${error instanceof Error ? error.message : error}`)
         }
@@ -341,12 +362,28 @@ export async function spawnAgentForTicket(
           continue
         }
 
+        // Fetch from origin/main if branching from main
+        if (branchFromMain) {
+          try {
+            execSync('git fetch origin main', { cwd: repoPath, stdio: 'pipe' })
+          } catch {
+            log(`Could not fetch origin/main in ${path.basename(repoPath)}, using local state`)
+          }
+        }
+
         // Check if branch exists
         try {
           execSync(`git rev-parse --verify ${branch}`, { cwd: repoPath, stdio: 'pipe' })
           execSync(`git checkout ${branch}`, { cwd: repoPath, stdio: 'pipe' })
         } catch {
-          execSync(`git checkout -b ${branch}`, { cwd: repoPath, stdio: 'pipe' })
+          // Branch doesn't exist - create it from the appropriate base
+          if (branchFromMain) {
+            execSync(`git checkout -b ${branch} origin/main`, { cwd: repoPath, stdio: 'pipe' })
+            log(`Created branch ${branch} from origin/main in ${path.basename(repoPath)}`)
+          } else {
+            execSync(`git checkout -b ${branch}`, { cwd: repoPath, stdio: 'pipe' })
+            log(`Created branch ${branch} from current branch in ${path.basename(repoPath)}`)
+          }
         }
       } catch (error) {
         log(`Could not create branch in ${path.basename(repoPath)}: ${error instanceof Error ? error.message : error}`)


### PR DESCRIPTION
## Summary
- Agent work branches are now created from `origin/main` by default instead of the current branch
- Added `--from-current` flag to explicitly branch from current branch when needed
- Updated both `spawner.ts` and `work/start.ts` to fetch from origin/main before creating new branches

## Changes
- `apps/cli/src/lib/execution/spawner.ts`: Added `branchFromCurrent` option and updated branch creation logic
- `apps/cli/src/commands/work/start.ts`: Added `--from-current` flag and updated branch creation to use origin/main
- `apps/cli/src/commands/work/spawn.ts`: Added `--from-current` flag that passes through to work:start

## Test plan
- [ ] Spawn agent work from a feature branch - verify new branch is created from origin/main
- [ ] Use `--from-current` flag - verify branch is created from current branch
- [ ] Existing branches should continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)