### PR TITLE
feat(TKT-223): add --all flag to ticket list for cross-project viewing

### DIFF
--- a/apps/cli/src/commands/ticket/list.ts
+++ b/apps/cli/src/commands/ticket/list.ts
@@ -1,5 +1,6 @@
-import { Flags } from '@oclif/core';
-import { Ticket, PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { Command, Flags } from '@oclif/core';
+import { Ticket, pmoBaseFlags, TicketFilter } from '../../lib/pmo/index.js';
+import { getPMOContext, type PMOContext } from '../../lib/pmo/pmo-context.js';
 import {
   styles,
   formatPriority,
@@ -9,7 +10,7 @@ import {
   divider,
 } from '../../lib/styles.js';
 
-export default class TicketList extends PMOCommand {
+export default class TicketList extends Command {
   static description = 'List tickets from the PMO board';
 
   static examples = [
@@ -19,6 +20,7 @@ export default class TicketList extends PMOCommand {
     '<%= config.bin %> <%= command.id %> --category bug',
     '<%= config.bin %> <%= command.id %> --search "login"',
     '<%= config.bin %> <%= command.id %> --project mobile-app',
+    '<%= config.bin %> <%= command.id %> --all',
   ];
 
   static flags = {
@@ -47,60 +49,179 @@ export default class TicketList extends PMOCommand {
     }),
     all: Flags.boolean({
       char: 'a',
-      description: 'Show all columns (including Done)',
+      description: 'Show tickets across all projects',
       default: false,
     }),
   };
 
-  async execute(): Promise<void> {
+  async run(): Promise<void> {
     const { flags } = await this.parse(TicketList);
 
-    // Build filter
-    const filter: {
-      column?: string;
-      priority?: string;
-      category?: string;
-      search?: string;
-    } = {};
+    // When --all is set, we don't need to select a specific project
+    // Otherwise, use the normal project selection flow
+    let pmoContext: PMOContext | undefined;
 
-    if (flags.column) {
-      filter.column = flags.column;
-    }
-    if (flags.priority) {
-      filter.priority = flags.priority;
-    }
-    if (flags.category) {
-      filter.category = flags.category;
-    }
-    if (flags.search) {
-      filter.search = flags.search;
+    if (!flags.all) {
+      pmoContext = await getPMOContext({
+        projectId: flags.project,
+        logger: (msg) => this.log(styles.muted(msg)),
+        promptIfMultiple: true,
+      });
+    } else {
+      // For --all, we still need a storage connection but skip project selection entirely
+      pmoContext = await getPMOContext({
+        logger: (msg) => this.log(styles.muted(msg)),
+        skipProjectSelection: true,
+      });
     }
 
-    const tickets = await this.storage.listTickets(filter);
-    const board = await this.storage.getBoard();
+    try {
+      // Build filter
+      const filter: TicketFilter = {};
 
-    if (tickets.length === 0) {
-      this.log(styles.warning('No tickets found.'));
-      return;
-    }
+      if (flags.all) {
+        filter.allProjects = true;
+      }
+      if (flags.column) {
+        filter.column = flags.column;
+      }
+      if (flags.priority) {
+        filter.priority = flags.priority;
+      }
+      if (flags.category) {
+        filter.category = flags.category;
+      }
+      if (flags.search) {
+        filter.search = flags.search;
+      }
 
-    // Extract column names from board
-    const columns = board.columns.map(col => col.name);
+      const tickets = await pmoContext.storage.listTickets(filter);
 
-    // Output based on format
-    switch (flags.format) {
-      case 'json':
-        this.log(JSON.stringify(tickets, null, 2));
-        break;
-      case 'compact':
-        this.outputCompact(tickets, columns, flags.all);
-        break;
-      default:
-        this.outputTable(tickets, columns, flags.all);
+      if (tickets.length === 0) {
+        this.log(styles.warning('No tickets found.'));
+        return;
+      }
+
+      // Output based on format
+      if (flags.all) {
+        // Cross-project view
+        switch (flags.format) {
+          case 'json':
+            this.log(JSON.stringify(tickets, null, 2));
+            break;
+          case 'compact':
+            this.outputCrossProjectCompact(tickets);
+            break;
+          default:
+            this.outputCrossProjectTable(tickets);
+        }
+      } else {
+        // Single project view
+        const board = await pmoContext.storage.getBoard();
+        const columns = board.columns.map(col => col.name);
+
+        switch (flags.format) {
+          case 'json':
+            this.log(JSON.stringify(tickets, null, 2));
+            break;
+          case 'compact':
+            this.outputCompact(tickets, columns);
+            break;
+          default:
+            this.outputTable(tickets, columns);
+        }
+      }
+    } finally {
+      await pmoContext.storage.close();
     }
   }
 
-  private outputTable(tickets: Ticket[], columns: string[], _showAll: boolean): void {
+  private outputCrossProjectTable(tickets: Ticket[]): void {
+    // Group tickets by project, then by column
+    const byProject: Record<string, Ticket[]> = {};
+    for (const ticket of tickets) {
+      const projectName = ticket.projectName || ticket.projectId || 'Unknown';
+      if (!byProject[projectName]) {
+        byProject[projectName] = [];
+      }
+      byProject[projectName].push(ticket);
+    }
+
+    const projectNames = Object.keys(byProject).sort();
+
+    for (const projectName of projectNames) {
+      const projectTickets = byProject[projectName];
+
+      // Project header
+      this.log(styles.emphasis(`\n${projectName}`));
+      this.log(divider(60));
+
+      // Group by column within project
+      const byColumn: Record<string, Ticket[]> = {};
+      for (const ticket of projectTickets) {
+        const col = ticket.statusName || 'Unknown';
+        if (!byColumn[col]) {
+          byColumn[col] = [];
+        }
+        byColumn[col].push(ticket);
+      }
+
+      const columns = Object.keys(byColumn).sort();
+      for (const col of columns) {
+        const colTickets = byColumn[col];
+
+        const headerColor = getColumnStyle(col);
+        this.log(headerColor(`  ${getColumnEmoji(col)} ${col} (${colTickets.length})`));
+
+        colTickets.sort((a, b) => (a.position || 0) - (b.position || 0));
+
+        for (const ticket of colTickets) {
+          const priorityBadge = formatPriority(ticket.priority);
+          const categoryBadge = formatCategory(ticket.category);
+
+          this.log(`    ${styles.code(ticket.id)} ${ticket.title} ${priorityBadge} ${categoryBadge}`);
+
+          if (ticket.description) {
+            const shortDesc = ticket.description.split('\n')[0].substring(0, 55);
+            this.log(styles.muted(`       ${shortDesc}${ticket.description.length > 55 ? '...' : ''}`));
+          }
+        }
+      }
+    }
+
+    // Summary
+    this.log('\n' + divider(60));
+    this.log(styles.emphasis(`Total: ${tickets.length} ticket${tickets.length === 1 ? '' : 's'} across ${projectNames.length} project${projectNames.length === 1 ? '' : 's'}`));
+  }
+
+  private outputCrossProjectCompact(tickets: Ticket[]): void {
+    // Group tickets by project
+    const byProject: Record<string, Ticket[]> = {};
+    for (const ticket of tickets) {
+      const projectName = ticket.projectName || ticket.projectId || 'Unknown';
+      if (!byProject[projectName]) {
+        byProject[projectName] = [];
+      }
+      byProject[projectName].push(ticket);
+    }
+
+    const projectNames = Object.keys(byProject).sort();
+
+    for (const projectName of projectNames) {
+      const projectTickets = byProject[projectName];
+      this.log(styles.emphasis(`${projectName} (${projectTickets.length}):`));
+
+      projectTickets.sort((a, b) => (a.position || 0) - (b.position || 0));
+
+      for (const ticket of projectTickets) {
+        const priority = formatPriority(ticket.priority);
+        const status = ticket.statusName ? styles.muted(`[${ticket.statusName}]`) : '';
+        this.log(`  ${styles.code(ticket.id)}: ${ticket.title} ${priority} ${status}`);
+      }
+    }
+  }
+
+  private outputTable(tickets: Ticket[], columns: string[]): void {
     // Group tickets by column
     const byColumn: Record<string, Ticket[]> = {};
     for (const col of columns) {
@@ -154,7 +275,7 @@ export default class TicketList extends PMOCommand {
     this.log(styles.emphasis(`Total: ${tickets.length} ticket${tickets.length === 1 ? '' : 's'}`));
   }
 
-  private outputCompact(tickets: Ticket[], columns: string[], _showAll: boolean): void {
+  private outputCompact(tickets: Ticket[], columns: string[]): void {
     // Group by column
     const byColumn: Record<string, Ticket[]> = {};
     for (const col of columns) {

--- a/apps/cli/src/lib/pmo/pmo-context.ts
+++ b/apps/cli/src/lib/pmo/pmo-context.ts
@@ -26,6 +26,7 @@ export interface GetPMOContextOptions {
   logger?: (msg: string) => void;
   promptIfMultiple?: boolean;
   filterEmptyProjects?: boolean;  // Hide projects with no tickets (for work commands)
+  skipProjectSelection?: boolean; // For cross-project operations, skip project selection entirely
 }
 
 /**
@@ -57,6 +58,7 @@ export async function getPMOContext(
     logger: loggerOpt,
     promptIfMultiple: promptIfMultipleOpt = false,
     filterEmptyProjects = false,
+    skipProjectSelection = false,
   } = options;
   // Find PMO
   const pmoPath = findPMO();
@@ -75,7 +77,7 @@ export async function getPMOContext(
 
   // If no project ID specified, try to auto-detect from config or prompt if multiple exist
   let resolvedProjectId = projectIdOpt;
-  if (!resolvedProjectId) {
+  if (!resolvedProjectId && !skipProjectSelection) {
     // Check if there are multiple projects
     const db = new Database(dbPath);
 
@@ -121,6 +123,10 @@ export async function getPMOContext(
       }]);
       resolvedProjectId = selectedProjectId;
     }
+  } else if (skipProjectSelection && !resolvedProjectId) {
+    // For cross-project operations, use 'default' as a placeholder project ID
+    // The storage will be initialized but the project filter will be skipped in queries
+    resolvedProjectId = 'default';
   }
 
   // Detect sync mode: 'git' enables multi-machine sync via git push/pull of board.md

--- a/apps/cli/src/lib/pmo/storage-sqlite.ts
+++ b/apps/cli/src/lib/pmo/storage-sqlite.ts
@@ -1642,16 +1642,31 @@ Why is this refactor needed?
   }
 
   async listTickets(filter?: TicketFilter): Promise<Ticket[]> {
-    const projectId = this.currentProjectId
+    const params: unknown[] = []
+
+    // Build the base query - determine project scope
     let query = `
-      SELECT t.*, bt.column_id, bt.position, c.name as column_name
+      SELECT t.*, bt.column_id, bt.position, c.name as column_name, p.name as project_name
       FROM ${T.tickets} t
       LEFT JOIN ${T.board_tickets} bt ON t.id = bt.ticket_id AND t.project_id = bt.project_id
       LEFT JOIN ${T.columns} c ON bt.project_id = c.project_id AND bt.column_id = c.id
       LEFT JOIN ${T.statuses} s ON t.status_id = s.id
-      WHERE t.project_id = ?
+      LEFT JOIN ${T.projects} p ON t.project_id = p.id
+      WHERE 1=1
     `
-    const params: unknown[] = [projectId]
+
+    // Apply project scoping
+    if (filter?.allProjects) {
+      // No project filter - list all tickets across all projects
+    } else if (filter?.projectId) {
+      // Filter to a specific project
+      query += ' AND t.project_id = ?'
+      params.push(filter.projectId)
+    } else {
+      // Default: filter to current project
+      query += ' AND t.project_id = ?'
+      params.push(this.currentProjectId)
+    }
 
     if (filter?.statusId) {
       query += ' AND t.status_id = ?'
@@ -1694,7 +1709,12 @@ Why is this refactor needed?
       params.push(filter.column)
     }
 
-    query += ' ORDER BY c.position, bt.position'
+    // Order by project first when listing all projects, then by column and position
+    if (filter?.allProjects) {
+      query += ' ORDER BY p.name, c.position, bt.position'
+    } else {
+      query += ' ORDER BY c.position, bt.position'
+    }
 
     const rows = this.db.prepare(query).all(...params) as Array<{
       id: string
@@ -5317,6 +5337,8 @@ Why is this refactor needed?
 
   private async rowToTicket(row: {
     id: string
+    project_id?: string
+    project_name?: string
     title: string
     description: string | null
     priority: string | null
@@ -5393,6 +5415,8 @@ Why is this refactor needed?
       description: row.description || undefined,
       priority: row.priority || undefined,
       category: row.category || undefined,
+      projectId: row.project_id || undefined,
+      projectName: row.project_name || undefined,
       statusId: row.status_id,
       statusName,
       statusCategory,

--- a/apps/cli/src/lib/pmo/types.ts
+++ b/apps/cli/src/lib/pmo/types.ts
@@ -293,6 +293,8 @@ export interface Ticket {
   description?: string
   priority?: string
   category?: string
+  projectId?: string    // Which project this ticket belongs to
+  projectName?: string  // Resolved project name (for display in cross-project views)
 
   // Workflow state
   statusId: string            // Reference to WorkflowStatus in project's configuration
@@ -563,6 +565,8 @@ export interface TicketFilter {
   spec?: string
   epic?: string
   column?: string
+  projectId?: string          // Filter to a specific project
+  allProjects?: boolean       // If true, list tickets across all projects (ignores current project scope)
 }
 
 export interface SpecFilter {


### PR DESCRIPTION
## Summary
- Adds `--all` flag to `ticket list` command to show tickets across all projects
- Adds `projectId` and `projectName` fields to Ticket interface
- Adds `allProjects` and `projectId` fields to TicketFilter interface
- Modifies storage layer to support cross-project ticket queries
- Adds `skipProjectSelection` option to getPMOContext for cross-project operations

## Test plan
- [x] `prlt ticket list --all` shows tickets grouped by project
- [x] `prlt ticket list --all --format compact` works
- [x] `prlt ticket list --all --format json` includes projectId/projectName
- [x] `prlt ticket list --all --priority URGENT` filters work with cross-project
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)