### PR TITLE
feat(TKT-119): Local dev testing workflow (pnpm scripts + PRLT_HOME)

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -17,6 +17,7 @@ import {
   ExecutionConfig,
   DEFAULT_EXECUTION_CONFIG,
 } from './types.js'
+import { getLogsDir, getScriptsDir } from '../paths.js'
 
 // =============================================================================
 // Executor Commands
@@ -213,7 +214,7 @@ export async function runBackground(
   }
 
   // Create logs directory
-  const logsDir = path.join(os.homedir(), '.proletariat', 'logs')
+  const logsDir = getLogsDir()
   fs.mkdirSync(logsDir, { recursive: true })
 
   const logPath = path.join(logsDir, `work-${context.ticketId}-${Date.now()}.log`)
@@ -249,9 +250,7 @@ function createTmuxScript(
   skipPermissions: boolean
 ): { scriptPath: string; promptPath: string } {
   // Write prompt to separate file to avoid shell escaping issues
-  const baseDir = context.hqPath
-    ? path.join(context.hqPath, '.proletariat', 'scripts')
-    : path.join(os.homedir(), '.proletariat', 'scripts')
+  const baseDir = getScriptsDir(context.hqPath)
   fs.mkdirSync(baseDir, { recursive: true })
 
   const timestamp = Date.now()
@@ -401,10 +400,8 @@ export async function runTerminal(
   const { cmd } = getExecutorCommand(executor, prompt, skipPermissions)
 
   // Write command to temp script to avoid shell escaping issues
-  // Use HQ .proletariat/scripts if available, otherwise fallback to home dir
-  const baseDir = context.hqPath
-    ? path.join(context.hqPath, '.proletariat', 'scripts')
-    : path.join(os.homedir(), '.proletariat', 'scripts')
+  // Use HQ .proletariat/scripts if available, otherwise fallback to PRLT_HOME
+  const baseDir = getScriptsDir(context.hqPath)
   fs.mkdirSync(baseDir, { recursive: true })
 
   const timestamp = Date.now()
@@ -898,10 +895,8 @@ async function runDevcontainerInTerminal(
   const terminalApp = config.terminal.app
 
   // Write command to temp script to avoid shell escaping issues
-  // Use HQ .proletariat/scripts if available, otherwise fallback to home dir
-  const baseDir = context.hqPath
-    ? path.join(context.hqPath, '.proletariat', 'scripts')
-    : path.join(os.homedir(), '.proletariat', 'scripts')
+  // Use HQ .proletariat/scripts if available, otherwise fallback to PRLT_HOME
+  const baseDir = getScriptsDir(context.hqPath)
   fs.mkdirSync(baseDir, { recursive: true })
   const scriptPath = path.join(baseDir, `exec-${context.ticketId}-${Date.now()}.sh`)
 
@@ -1025,7 +1020,7 @@ async function runDevcontainerInBackground(
   devcontainerCmd: string
 ): Promise<RunnerResult> {
   // Create logs directory
-  const logsDir = path.join(os.homedir(), '.proletariat', 'logs')
+  const logsDir = getLogsDir()
   fs.mkdirSync(logsDir, { recursive: true })
 
   const logPath = path.join(logsDir, `work-${context.ticketId}-${Date.now()}.log`)
@@ -1063,9 +1058,7 @@ async function runDevcontainerInTmux(
     execSync('which tmux', { stdio: 'pipe' })
 
     // Write command to temp script to avoid shell escaping issues
-    const baseDir = context.hqPath
-      ? path.join(context.hqPath, '.proletariat', 'scripts')
-      : path.join(os.homedir(), '.proletariat', 'scripts')
+    const baseDir = getScriptsDir(context.hqPath)
     fs.mkdirSync(baseDir, { recursive: true })
     const scriptPath = path.join(baseDir, `exec-${context.ticketId}-${Date.now()}.sh`)
 

--- a/apps/cli/src/lib/paths.ts
+++ b/apps/cli/src/lib/paths.ts
@@ -1,0 +1,61 @@
+/**
+ * Path Resolution Utilities
+ *
+ * Centralizes all path resolution for the .proletariat directory.
+ * Supports PRLT_HOME environment variable to override the default location,
+ * enabling isolated testing and multi-agent development workflows.
+ *
+ * Resolution order: PRLT_HOME env var > ~/.proletariat
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Get the global proletariat home directory.
+ *
+ * This is the root directory for:
+ * - Global config (config.json)
+ * - Logs directory
+ * - Scripts directory
+ *
+ * @returns The path to the proletariat home directory
+ *
+ * @example
+ * // Default: ~/.proletariat
+ * // With PRLT_HOME=/tmp/test: /tmp/test
+ */
+export function getPrltHome(): string {
+  return process.env.PRLT_HOME || path.join(os.homedir(), '.proletariat');
+}
+
+/**
+ * Get the global config file path.
+ *
+ * @returns Path to the global config.json
+ */
+export function getGlobalConfigPath(): string {
+  return path.join(getPrltHome(), 'config.json');
+}
+
+/**
+ * Get the global logs directory path.
+ *
+ * @returns Path to the logs directory
+ */
+export function getLogsDir(): string {
+  return path.join(getPrltHome(), 'logs');
+}
+
+/**
+ * Get the global scripts directory path.
+ *
+ * @param hqPath Optional HQ path to use instead of global location
+ * @returns Path to the scripts directory
+ */
+export function getScriptsDir(hqPath?: string): string {
+  if (hqPath) {
+    return path.join(hqPath, '.proletariat', 'scripts');
+  }
+  return path.join(getPrltHome(), 'scripts');
+}

--- a/apps/cli/src/lib/pmo/find-pmo.ts
+++ b/apps/cli/src/lib/pmo/find-pmo.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import Database from 'better-sqlite3';
 import { findHQRoot, isValidHQ } from '../workspace.js';
+import { getGlobalConfigPath } from '../paths.js';
 
 /**
  * Resolve PMO path from stored value.
@@ -155,7 +156,7 @@ export function findPMO(): string | null {
   }
 
   // Check global config for default PMO
-  const globalConfigPath = path.join(process.env.HOME || '', '.proletariat', 'config.json');
+  const globalConfigPath = getGlobalConfigPath();
   if (fs.existsSync(globalConfigPath)) {
     try {
       const config = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));

--- a/apps/cli/src/lib/workspace.ts
+++ b/apps/cli/src/lib/workspace.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import chalk from 'chalk';
+import { getGlobalConfigPath } from './paths.js';
 
 /**
  * Central workspace resolution utilities.
@@ -65,7 +66,7 @@ export function findHQRootWithSource(startDir: string = process.cwd()): Workspac
   }
 
   // 3. Check global config for default workspace
-  const globalConfigPath = path.join(process.env.HOME || '', '.proletariat', 'config.json');
+  const globalConfigPath = getGlobalConfigPath();
   if (fs.existsSync(globalConfigPath)) {
     try {
       const config = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));

--- a/docs/CODE-REVIEW.md
+++ b/docs/CODE-REVIEW.md
@@ -69,6 +69,78 @@ pnpm test
 pnpm prlt <command>
 ```
 
+## Local Development Testing
+
+When dogfooding prlt to build prlt with multiple agent worktrees on different feature branches, you need isolation to prevent database conflicts. The CLI supports the `PRLT_HOME` environment variable to override the default `.proletariat` directory location.
+
+### Quick Local Testing
+
+Test your local build with the shared database:
+
+```bash
+# Run from anywhere in the workspace - pnpm finds root automatically
+pnpm prlt ticket list
+pnpm prlt work start TKT-XXX
+```
+
+### Isolated Testing (No Conflicts)
+
+For testing without affecting the shared database:
+
+```bash
+# Uses an ephemeral database in /tmp
+pnpm prlt:test init my-test-workspace
+pnpm prlt:test ticket create "Test ticket"
+```
+
+### Manual Isolation
+
+Override the `.proletariat` directory location manually:
+
+```bash
+# All data goes to /tmp/my-test instead of ~/.proletariat
+PRLT_HOME=/tmp/my-test pnpm prlt ticket create "Isolated test"
+
+# Or for persistent test databases
+export PRLT_HOME=/tmp/prlt-dev
+pnpm prlt init my-dev-hq
+pnpm prlt ticket list
+```
+
+### Multi-Agent/Branch Development
+
+When multiple agents are building prlt on different branches:
+
+1. Each agent can use a unique `PRLT_HOME` to avoid database conflicts
+2. The global `prlt` command always uses `~/.proletariat` (shared HQ)
+3. Local `pnpm prlt` uses the local build but respects `PRLT_HOME`
+
+```bash
+# Agent 1 on branch feature-a
+export PRLT_HOME=/tmp/prlt-agent1
+pnpm prlt:test init test-hq
+
+# Agent 2 on branch feature-b (different terminal)
+export PRLT_HOME=/tmp/prlt-agent2
+pnpm prlt:test init test-hq
+```
+
+### Environment Variable Reference
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `PRLT_HOME` | Override global `.proletariat` directory | `~/.proletariat` |
+| `PRLT_HQ_PATH` | Specify HQ workspace location | Auto-detected from cwd |
+
+`PRLT_HOME` affects:
+- Global config (`config.json`)
+- Logs directory
+- Scripts directory
+
+`PRLT_HQ_PATH` affects:
+- Workspace discovery (skips directory tree walk)
+- PMO resolution
+
 ### Native Module Issues
 
 If you see errors like `dlopen(...better_sqlite3.node...): not a mach-o file`:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "push:cli:force": "git push cli-public `git subtree split --prefix=apps/cli HEAD`:main --force",
     "pull:cli": "git subtree pull --prefix=apps/cli cli-public main --squash",
     "prlt": "node apps/cli/bin/run.js",
-    "prlt:isolated": "PRLT_HQ_PATH=/tmp/prlt-test-$RANDOM node apps/cli/bin/run.js",
+    "prlt:test": "PRLT_HOME=/tmp/prlt-test-$$ node apps/cli/bin/run.js",
     "test": "pnpm -r test",
     "test:cli": "pnpm --filter @proletariat/cli test"
   }


### PR DESCRIPTION
## Summary

- Add `PRLT_HOME` environment variable support to override the default `.proletariat` directory location
- Add `pnpm prlt` and `pnpm prlt:test` scripts for local development
- Document the isolated testing workflow for multi-agent development

## Changes

- **New utility module** (`apps/cli/src/lib/paths.ts`): Centralizes path resolution with `PRLT_HOME` support
- **runners.ts**: Updated to use `getLogsDir()` and `getScriptsDir()` for logs and scripts directories
- **find-pmo.ts** & **workspace.ts**: Updated to use `getGlobalConfigPath()` for global config resolution
- **package.json**: Added `prlt:test` script with ephemeral database isolation
- **Documentation**: Added comprehensive "Local Development Testing" section to docs/CODE-REVIEW.md

## Test plan

- [x] Verified `getPrltHome()` returns default `~/.proletariat` when `PRLT_HOME` not set
- [x] Verified `getPrltHome()` returns custom path when `PRLT_HOME` is set
- [x] Verified `getLogsDir()` and `getScriptsDir()` respect `PRLT_HOME`
- [x] Verified `pnpm prlt` runs local CLI build
- [x] Build succeeds with no TypeScript errors

## Ticket

[TKT-119](https://github.com/chrismcdermut/proletariat/issues/TKT-119) - Local dev testing workflow (pnpm scripts + PRLT_HOME)

🤖 Generated with [Claude Code](https://claude.com/claude-code)