### PR TITLE
feat(TKT-409): use tmux -CC control mode for iTerm native tab integration

### DIFF
--- a/apps/cli/src/lib/execution/config.ts
+++ b/apps/cli/src/lib/execution/config.ts
@@ -23,6 +23,7 @@ const CONFIG_KEYS = {
   autoExecute: 'execution.auto_execute',
   tmuxSession: 'execution.tmux.session',
   tmuxLayout: 'execution.tmux.layout',
+  tmuxControlMode: 'execution.tmux.control_mode',
   dockerImage: 'execution.docker.image',
   dockerNetwork: 'execution.docker.network',
   dockerMemory: 'execution.docker.memory',
@@ -100,6 +101,10 @@ export function loadExecutionConfig(db: Database.Database): ExecutionConfig {
   if (tmuxLayout) {
     config.tmux = { ...config.tmux, layout: tmuxLayout as 'split' | 'window' }
   }
+  const tmuxControlMode = getSetting(db, CONFIG_KEYS.tmuxControlMode)
+  if (tmuxControlMode !== null) {
+    config.tmux = { ...config.tmux, controlMode: tmuxControlMode === 'true' }
+  }
 
   // Load docker settings
   const dockerImage = getSetting(db, CONFIG_KEYS.dockerImage)
@@ -162,6 +167,14 @@ export function saveShell(db: Database.Database, shell: Shell): void {
 }
 
 /**
+ * Save tmux control mode preference.
+ * When enabled and using iTerm, tmux -CC is used for native tab integration.
+ */
+export function saveTmuxControlMode(db: Database.Database, enabled: boolean): void {
+  setSetting(db, CONFIG_KEYS.tmuxControlMode, enabled.toString())
+}
+
+/**
  * Check if terminal app preference has been set
  */
 export function hasTerminalPreference(db: Database.Database): boolean {
@@ -201,7 +214,42 @@ export async function promptTerminalPreference(db: Database.Database): Promise<T
   // Save preference to database
   saveTerminalApp(db, terminalApp)
 
+  // If iTerm selected, prompt for control mode preference
+  if (terminalApp === 'iTerm') {
+    await promptTmuxControlModePreference(db)
+  }
+
   return terminalApp
+}
+
+/**
+ * Prompt user for tmux control mode preference (iTerm only).
+ * When enabled, tmux -CC is used for native iTerm tab/window integration.
+ */
+export async function promptTmuxControlModePreference(db: Database.Database): Promise<boolean> {
+  const { useControlMode } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'useControlMode',
+      message: 'iTerm tmux integration mode:',
+      choices: [
+        {
+          name: 'Native tabs (tmux -CC) - iTerm handles windows/scrollback natively (Recommended)',
+          value: true,
+        },
+        {
+          name: 'Standard tmux - Traditional tmux interface inside iTerm',
+          value: false,
+        },
+      ],
+      default: true,
+    },
+  ])
+
+  // Save preference to database
+  saveTmuxControlMode(db, useControlMode)
+
+  return useControlMode
 }
 
 /**

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -342,6 +342,38 @@ export async function runTmux(
     // Check if tmux is available
     execSync('which tmux', { stdio: 'pipe' })
 
+    // Determine if we should use iTerm control mode (-CC)
+    // Control mode makes iTerm handle windows/tabs natively instead of tmux's text UI
+    const useControlMode = config.terminal.app === 'iTerm' && config.tmux.controlMode
+
+    if (useControlMode) {
+      // iTerm control mode: spawn an iTerm tab running tmux -CC
+      // The -CC flag makes tmux output control commands that iTerm understands
+      // The -A flag attaches to existing session or creates new one
+      // iTerm will create native tabs for each tmux window
+      const tmuxCmd = `tmux -CC new-session -A -s ${sessionName} -n "${windowName}" -c "${context.worktreePath}" "${scriptPath}"`
+      // Escape double quotes and backslashes for AppleScript
+      const escapedCmd = tmuxCmd.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
+      execSync(`osascript -e '
+        tell application "iTerm"
+          activate
+          tell current window
+            create tab with default profile
+            tell current session
+              write text "${escapedCmd}"
+            end tell
+          end tell
+        end tell
+      '`)
+
+      return {
+        success: true,
+        sessionId: `${sessionName}:${windowName}`,
+      }
+    }
+
+    // Standard tmux mode (non-iTerm or control mode disabled)
     // Check if session exists
     let sessionExists = false
     try {
@@ -1115,6 +1147,8 @@ async function runDevcontainerInBackground(
 /**
  * Run devcontainer command in tmux pane/window.
  * Uses a temp script file to avoid shell escaping issues with complex prompts.
+ * When iTerm is the terminal app and control mode is enabled, uses tmux -CC
+ * for native iTerm tab/window integration.
  */
 async function runDevcontainerInTmux(
   context: ExecutionContext,
@@ -1153,6 +1187,39 @@ exec $SHELL
 `
     fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 })
 
+    // Determine if we should use iTerm control mode (-CC)
+    // Control mode makes iTerm handle windows/tabs natively instead of tmux's text UI
+    const useControlMode = config.terminal.app === 'iTerm' && config.tmux.controlMode
+
+    if (useControlMode) {
+      // iTerm control mode: spawn an iTerm tab running tmux -CC
+      // The -CC flag makes tmux output control commands that iTerm understands
+      // The -A flag attaches to existing session or creates new one
+      // iTerm will create native tabs for each tmux window
+      const tmuxCmd = `tmux -CC new-session -A -s ${sessionName} -n "${windowName}" '${scriptPath}'`
+      // Escape double quotes and backslashes for AppleScript
+      const escapedCmd = tmuxCmd.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
+      execSync(`osascript -e '
+        tell application "iTerm"
+          activate
+          tell current window
+            create tab with default profile
+            tell current session
+              write text "${escapedCmd}"
+            end tell
+          end tell
+        end tell
+      '`)
+
+      return {
+        success: true,
+        containerId: `devcontainer-${context.agentName}`,
+        sessionId: `${sessionName}:${windowName}`,
+      }
+    }
+
+    // Standard tmux mode (non-iTerm or control mode disabled)
     // Check if session exists
     let sessionExists = false
     try {

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -313,6 +313,7 @@ export interface ExecutionConfig {
   tmux: {
     session: string
     layout: 'split' | 'window'
+    controlMode: boolean  // Use tmux -CC for iTerm native integration
   }
   terminal: {
     app: TerminalApp
@@ -347,6 +348,7 @@ export const DEFAULT_EXECUTION_CONFIG: ExecutionConfig = {
   tmux: {
     session: 'proletariat',
     layout: 'window',
+    controlMode: true,  // Enable -CC for iTerm native integration by default
   },
   terminal: {
     app: 'Terminal',


### PR DESCRIPTION
## Summary
- When terminal=iTerm and displayMode=tmux, use `tmux -CC` (control mode) for native iTerm tab/window integration
- Each tmux pane becomes a native iTerm tab with proper scrollback
- Added config option `tmux.controlMode` to disable control mode for users who prefer standard tmux
- Uses `-A` flag for session reattachment support

## Changes
- **types.ts**: Added `controlMode: boolean` to tmux config (defaults to `true`)
- **config.ts**: Added storage and prompt for control mode preference
- **runners.ts**: Updated `runTmux()` and `runDevcontainerInTmux()` to use `-CC` flag when iTerm + control mode enabled

## Test plan
- [ ] Verify iTerm users see native tabs when spawning agents in tmux mode
- [ ] Verify non-iTerm users get standard tmux behavior
- [ ] Verify control mode can be disabled via config prompt
- [ ] Verify session reconnection works with `-A` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)