### PR TITLE
refactor(TKT-345): Consolidate priority system to P0-P3

### DIFF
--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 import { autoExportToBoard, PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import { updateEpicTicketsSection } from '../../lib/pmo/epic-files.js';
-import { TicketTemplate } from '../../lib/pmo/types.js';
+import { TicketTemplate, PRIORITIES, PRIORITY_LABELS } from '../../lib/pmo/types.js';
 import {
   shouldOutputJson,
   outputPromptAsJson,
@@ -46,7 +46,7 @@ export default class TicketCreate extends PMOCommand {
     priority: Flags.string({
       char: 'p',
       description: 'Ticket priority',
-      options: ['URGENT', 'HIGH', 'MEDIUM', 'LOW'],
+      options: [...PRIORITIES],
     }),
     category: Flags.string({
       description: 'Ticket category (e.g., bug, feature, refactor)',
@@ -298,10 +298,7 @@ export default class TicketCreate extends PMOCommand {
         message: 'Priority:',
         choices: [
           { name: 'None', value: undefined },
-          { name: 'URGENT', value: 'URGENT' },
-          { name: 'HIGH', value: 'HIGH' },
-          { name: 'MEDIUM', value: 'MEDIUM' },
-          { name: 'LOW', value: 'LOW' },
+          ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
         ],
         default: flags.priority || template?.defaultPriority,
       },

--- a/apps/cli/src/commands/ticket/edit.ts
+++ b/apps/cli/src/commands/ticket/edit.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 import inquirer from 'inquirer';
 import { autoExportToBoard, PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { PRIORITIES, PRIORITY_LABELS } from '../../lib/pmo/types.js';
 import { styles } from '../../lib/styles.js';
 import {
   shouldOutputJson,
@@ -42,7 +43,7 @@ export default class TicketEdit extends PMOCommand {
     priority: Flags.string({
       char: 'p',
       description: 'New ticket priority',
-      options: ['URGENT', 'HIGH', 'MEDIUM', 'LOW', 'none'],
+      options: [...PRIORITIES, 'none'],
     }),
     category: Flags.string({
       description: 'New ticket category',
@@ -312,10 +313,7 @@ export default class TicketEdit extends PMOCommand {
         message: 'Priority:',
         choices: [
           { name: 'None', value: '' },
-          { name: 'URGENT', value: 'URGENT' },
-          { name: 'HIGH', value: 'HIGH' },
-          { name: 'MEDIUM', value: 'MEDIUM' },
-          { name: 'LOW', value: 'LOW' },
+          ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
         ],
         default: ticket.priority || '',
       },

--- a/apps/cli/src/commands/ticket/list.ts
+++ b/apps/cli/src/commands/ticket/list.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core';
 import { Ticket, pmoBaseFlags, TicketFilter } from '../../lib/pmo/index.js';
+import { PRIORITIES } from '../../lib/pmo/types.js';
 import { getPMOContext, type PMOContext } from '../../lib/pmo/pmo-context.js';
 import {
   styles,
@@ -32,7 +33,7 @@ export default class TicketList extends Command {
     priority: Flags.string({
       char: 'p',
       description: 'Filter by priority',
-      options: ['URGENT', 'HIGH', 'MEDIUM', 'LOW'],
+      options: [...PRIORITIES],
     }),
     category: Flags.string({
       description: 'Filter by category',

--- a/apps/cli/src/commands/ticket/template/apply.ts
+++ b/apps/cli/src/commands/ticket/template/apply.ts
@@ -1,6 +1,7 @@
 import { Flags, Args } from '@oclif/core';
 import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../../lib/pmo/index.js';
+import { PRIORITIES, PRIORITY_LABELS } from '../../../lib/pmo/types.js';
 import { styles } from '../../../lib/styles.js';
 import {
   shouldOutputJson,
@@ -42,7 +43,7 @@ export default class TicketTemplateApply extends PMOCommand {
     priority: Flags.string({
       char: 'p',
       description: 'Priority (overrides template default)',
-      options: ['URGENT', 'HIGH', 'MEDIUM', 'LOW'],
+      options: [...PRIORITIES],
     }),
     category: Flags.string({
       description: 'Category (overrides template default)',
@@ -136,10 +137,7 @@ export default class TicketTemplateApply extends PMOCommand {
       const columnChoices = this.columns.map(c => ({ name: c, value: c }));
       const priorityChoices = [
         { name: 'None', value: '' },
-        { name: 'URGENT', value: 'URGENT' },
-        { name: 'HIGH', value: 'HIGH' },
-        { name: 'MEDIUM', value: 'MEDIUM' },
-        { name: 'LOW', value: 'LOW' },
+        ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
       ];
 
       // Define fields once - single source of truth for both JSON and interactive modes

--- a/apps/cli/src/commands/ticket/update.ts
+++ b/apps/cli/src/commands/ticket/update.ts
@@ -1,6 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
+import { PRIORITIES, PRIORITY_LABELS } from '../../lib/pmo/types.js';
 import { styles } from '../../lib/styles.js';
 import {
   shouldOutputJson,
@@ -40,8 +41,8 @@ export default class TicketUpdate extends PMOCommand {
     }),
     priority: Flags.string({
       char: 'p',
-      description: 'Set priority (URGENT, HIGH, MEDIUM, LOW)',
-      options: ['URGENT', 'HIGH', 'MEDIUM', 'LOW'],
+      description: 'Set priority (P0, P1, P2, P3)',
+      options: [...PRIORITIES],
     }),
     category: Flags.string({
       char: 'c',
@@ -142,10 +143,7 @@ export default class TicketUpdate extends PMOCommand {
           message: 'Set priority to:',
           choices: [
             { name: `(Keep existing: ${ticket.priority || 'none'})`, value: null },
-            { name: 'URGENT', value: 'URGENT' },
-            { name: 'HIGH', value: 'HIGH' },
-            { name: 'MEDIUM', value: 'MEDIUM' },
-            { name: 'LOW', value: 'LOW' },
+            ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
             { name: 'None (clear priority)', value: '' },
           ],
         }]);
@@ -261,10 +259,7 @@ export default class TicketUpdate extends PMOCommand {
           message: 'Set priority to:',
           choices: [
             { name: '(Keep existing)', value: null },
-            { name: 'URGENT', value: 'URGENT' },
-            { name: 'HIGH', value: 'HIGH' },
-            { name: 'MEDIUM', value: 'MEDIUM' },
-            { name: 'LOW', value: 'LOW' },
+            ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
             { name: 'None (clear priority)', value: '' },
           ],
         }]);

--- a/apps/cli/src/lib/pmo/storage/base.ts
+++ b/apps/cli/src/lib/pmo/storage/base.ts
@@ -186,6 +186,31 @@ export function runMigrations(db: Database.Database): void {
       }
     }
   }
+
+  // Migration: Convert legacy priority values (URGENT/HIGH/MEDIUM/LOW) to P0-P3
+  if (tableExists(T.tickets)) {
+    try {
+      // Convert ticket priorities
+      db.exec(`UPDATE ${T.tickets} SET priority = 'P0' WHERE priority = 'URGENT'`)
+      db.exec(`UPDATE ${T.tickets} SET priority = 'P1' WHERE priority = 'HIGH'`)
+      db.exec(`UPDATE ${T.tickets} SET priority = 'P2' WHERE priority = 'MEDIUM'`)
+      db.exec(`UPDATE ${T.tickets} SET priority = 'P3' WHERE priority = 'LOW'`)
+    } catch {
+      // Ignore errors if migration already ran
+    }
+  }
+
+  // Migration: Convert legacy priority values in ticket templates
+  if (tableExists(T.ticket_templates)) {
+    try {
+      db.exec(`UPDATE ${T.ticket_templates} SET default_priority = 'P0' WHERE default_priority = 'URGENT'`)
+      db.exec(`UPDATE ${T.ticket_templates} SET default_priority = 'P1' WHERE default_priority = 'HIGH'`)
+      db.exec(`UPDATE ${T.ticket_templates} SET default_priority = 'P2' WHERE default_priority = 'MEDIUM'`)
+      db.exec(`UPDATE ${T.ticket_templates} SET default_priority = 'P3' WHERE default_priority = 'LOW'`)
+    } catch {
+      // Ignore errors if migration already ran
+    }
+  }
 }
 
 /**
@@ -438,7 +463,7 @@ Do NOT implement the ticket - only improve its definition so it's ready to be wo
 |-------|------|--------------|----------|
 | title | string | any text | --title |
 | description | markdown | requirements, context, notes | --description |
-| priority | enum | URGENT, HIGH, MEDIUM, LOW | --priority |
+| priority | enum | P0 (critical), P1 (high), P2 (medium), P3 (low) | --priority |
 | category | enum | feature, bug, refactor, docs, test, chore, performance, ci, build, security, database, release | --category |
 | subtasks | list | task descriptions | --add-subtask (--clear-subtasks to replace) |
 | acceptanceCriteria | list | testable statements | --add-ac (--clear-ac to replace) |
@@ -455,7 +480,7 @@ Do NOT implement the ticket - only improve its definition so it's ready to be wo
 | Acceptance Criteria | --add-ac | One per criterion (testable statement) |
 | Subtasks | --add-subtask | One per subtask |
 | Complexity (S/M/L/XL) | --add-label | \`complexity:M\` or \`complexity:L\` |
-| Priority | --priority | URGENT, HIGH, MEDIUM, or LOW only |
+| Priority | --priority | P0, P1, P2, or P3 only |
 | Category | --category | feature, bug, refactor, docs, test, chore |
 | Needs clarification | --add-label | \`needs-clarification\` |
 | Ready for work | --add-label | \`ready\` |
@@ -469,7 +494,7 @@ prlt ticket edit {{TICKET_ID}} \\
 Requirements:
 - R1: Sessions expire after 30 minutes of inactivity
 - R2: Users see a warning 5 minutes before timeout" \\
-  --priority MEDIUM \\
+  --priority P2 \\
   --category feature \\
   --add-label "complexity:M" \\
   --add-ac "Sessions expire after 30 min inactivity" \\
@@ -479,7 +504,7 @@ Requirements:
 \`\`\`
 
 ## Important Rules
-- Priority must be exactly: URGENT, HIGH, MEDIUM, or LOW (not custom values)
+- Priority must be exactly: P0, P1, P2, or P3 (not custom values)
 - Use \`--add-label "complexity:S|M|L|XL"\` for complexity (not a separate field)
 - Technical notes/flagged ambiguities go in description
 - Use \`--clear-subtasks\` if replacing existing subtasks
@@ -685,7 +710,7 @@ Brief description of the bug.
 - OS:
 - Version:
 `,
-      defaultPriority: 'HIGH',
+      defaultPriority: 'P1',
       defaultCategory: 'bug',
       suggestedSubtasks: [
         { title: 'Reproduce the bug' },
@@ -712,7 +737,7 @@ As a [type of user], I want [goal] so that [benefit].
 ## Design Notes
 
 `,
-      defaultPriority: 'MEDIUM',
+      defaultPriority: 'P2',
       defaultCategory: 'feature',
       suggestedSubtasks: [
         { title: 'Design implementation approach' },
@@ -734,7 +759,7 @@ Describe what needs to be done.
 ## Context
 Any relevant context or notes.
 `,
-      defaultPriority: 'MEDIUM',
+      defaultPriority: 'P2',
       defaultCategory: 'chore',
       suggestedSubtasks: [],
     },
@@ -755,7 +780,7 @@ Why is this refactor needed?
 ## Scope
 - [ ] Files/modules to change
 `,
-      defaultPriority: 'LOW',
+      defaultPriority: 'P3',
       defaultCategory: 'refactor',
       suggestedSubtasks: [
         { title: 'Analyze current code' },
@@ -781,7 +806,7 @@ Why is this refactor needed?
 ## Target Audience
 
 `,
-      defaultPriority: 'LOW',
+      defaultPriority: 'P3',
       defaultCategory: 'docs',
       suggestedSubtasks: [
         { title: 'Draft content' },

--- a/apps/cli/src/lib/pmo/storage/helpers.ts
+++ b/apps/cli/src/lib/pmo/storage/helpers.ts
@@ -10,6 +10,7 @@ import {
   StateCategory,
   Ticket,
   Subtask,
+  normalizePriority,
 } from '../types.js'
 import {
   AcceptanceCriterionRow,
@@ -83,7 +84,7 @@ export async function rowToTicket(
     projectName: row.project_name || undefined,
     title: row.title,
     description: row.description || undefined,
-    priority: row.priority || undefined,
+    priority: normalizePriority(row.priority),
     category: row.category || undefined,
     statusId: row.status_id,
     statusName,

--- a/apps/cli/src/lib/pmo/types.ts
+++ b/apps/cli/src/lib/pmo/types.ts
@@ -73,6 +73,83 @@ export interface Epic {
 export type TicketStatus = string
 
 // =============================================================================
+// Priority Types
+// =============================================================================
+
+/**
+ * Standardized priority values: P0 (critical) through P3 (low).
+ */
+export type Priority = 'P0' | 'P1' | 'P2' | 'P3'
+
+/**
+ * Valid priority values as a const array for validation and CLI options.
+ */
+export const PRIORITIES: readonly Priority[] = ['P0', 'P1', 'P2', 'P3'] as const
+
+/**
+ * Priority display names for UI presentation.
+ */
+export const PRIORITY_LABELS: Record<Priority, string> = {
+  P0: 'P0 - Critical',
+  P1: 'P1 - High',
+  P2: 'P2 - Medium',
+  P3: 'P3 - Low',
+}
+
+/**
+ * Legacy priority values for backwards compatibility.
+ */
+export type LegacyPriority = 'URGENT' | 'HIGH' | 'MEDIUM' | 'LOW'
+
+/**
+ * Mapping from legacy priority values to new P0-P3 format.
+ */
+export const LEGACY_PRIORITY_MAP: Record<LegacyPriority, Priority> = {
+  URGENT: 'P0',
+  HIGH: 'P1',
+  MEDIUM: 'P2',
+  LOW: 'P3',
+}
+
+/**
+ * Check if a string is a valid Priority value.
+ */
+export function isValidPriority(value: string | undefined | null): value is Priority {
+  if (!value) return false
+  return (PRIORITIES as readonly string[]).includes(value)
+}
+
+/**
+ * Check if a string is a legacy priority value.
+ */
+export function isLegacyPriority(value: string | undefined | null): value is LegacyPriority {
+  if (!value) return false
+  return value in LEGACY_PRIORITY_MAP
+}
+
+/**
+ * Normalize a priority value to the new P0-P3 format.
+ * Converts legacy values (URGENT/HIGH/MEDIUM/LOW) to P0-P3.
+ * Returns undefined for invalid values.
+ */
+export function normalizePriority(value: string | undefined | null): Priority | undefined {
+  if (!value) return undefined
+
+  // Already in new format
+  if (isValidPriority(value)) {
+    return value
+  }
+
+  // Convert from legacy format
+  if (isLegacyPriority(value)) {
+    return LEGACY_PRIORITY_MAP[value]
+  }
+
+  // Unknown value
+  return undefined
+}
+
+// =============================================================================
 // Workflow Types (Two-Tier State/Status Model)
 // =============================================================================
 

--- a/apps/cli/src/lib/styles.ts
+++ b/apps/cli/src/lib/styles.ts
@@ -69,14 +69,24 @@ export function formatPriority(priority?: string): string {
   if (!priority) return '';
 
   switch (priority) {
-    case 'URGENT':
+    // New P0-P3 format
+    case 'P0':
       return styles.priorityUrgent(`[${priority}]`);
-    case 'HIGH':
+    case 'P1':
       return styles.priorityHigh(`[${priority}]`);
-    case 'MEDIUM':
+    case 'P2':
       return styles.priorityMedium(`[${priority}]`);
-    case 'LOW':
+    case 'P3':
       return styles.priorityLow(`[${priority}]`);
+    // Legacy format (for backwards compatibility during display)
+    case 'URGENT':
+      return styles.priorityUrgent('[P0]');
+    case 'HIGH':
+      return styles.priorityHigh('[P1]');
+    case 'MEDIUM':
+      return styles.priorityMedium('[P2]');
+    case 'LOW':
+      return styles.priorityLow('[P3]');
     default:
       return styles.muted(`[${priority}]`);
   }


### PR DESCRIPTION
## Summary
- Added Priority type system (`Priority`, `PRIORITIES`, `PRIORITY_LABELS`, `LegacyPriority`, `LEGACY_PRIORITY_MAP`)
- Added `normalizePriority()` and `isValidPriority()` helper functions for validation and conversion
- Updated all CLI flag options in ticket commands (create, edit, list, update, template/apply) to use P0-P3 format
- Updated all interactive prompts to show P0-P3 choices with labels (P0 - Critical, P1 - High, P2 - Medium, P3 - Low)
- Added database migration to convert legacy URGENT/HIGH/MEDIUM/LOW values to P0/P1/P2/P3
- Added `normalizePriority()` call in storage layer read operations for backwards compatibility
- Updated groom action prompt to reference P0-P3 instead of legacy priority values
- Updated `formatPriority()` in styles.ts to handle both new and legacy formats
- Updated builtin ticket template default priorities to use P0-P3

## Test plan
- [ ] Verify `prlt ticket create --help` shows P0/P1/P2/P3 as valid priority options
- [ ] Verify `prlt ticket edit --help` shows P0/P1/P2/P3 as valid priority options
- [ ] Verify `prlt ticket list --help` shows P0/P1/P2/P3 as valid priority options
- [ ] Verify `prlt ticket update --help` shows P0/P1/P2/P3 as valid priority options
- [ ] Verify interactive ticket create shows P0-P3 choices
- [ ] Verify legacy values (URGENT/HIGH/MEDIUM/LOW) are auto-converted when read from database
- [ ] Verify new tickets are stored with P0-P3 format

🤖 Generated with [Claude Code](https://claude.com/claude-code)