### PR TITLE
feat(TKT-428): show equivalent CLI command after interactive menu selections

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -16,6 +16,7 @@ import {
   createMetadata,
   buildPromptConfig,
 } from '../../lib/prompt-json.js'
+import { CLICommandBuilder, formatCLICommandInline } from '../../lib/cli-command-builder.js'
 
 export default class WorkSpawn extends PMOCommand {
   static description = 'Spawn work for multiple tickets by column (batch mode)'
@@ -142,6 +143,9 @@ export default class WorkSpawn extends PMOCommand {
     // Parse ticket IDs from args (everything after flags)
     const ticketIdArgs = argv as string[]
 
+    // Initialize CLI command builder to track selections for equivalent command display
+    const cliBuilder = new CLICommandBuilder('prlt work spawn')
+
     // Note: Docker check is handled by work:start command when spawning each ticket
     // This allows for the interactive devcontainer/host selection with retry loop
 
@@ -255,6 +259,9 @@ export default class WorkSpawn extends PMOCommand {
           }
         }
 
+        // Track ticket IDs in CLI builder
+        cliBuilder.addArgs(ticketsToSpawn.map(t => t.id))
+
         if (ticketsToSpawn.length === 0) {
           db.close()
           return handleError('NO_VALID_TICKETS', 'No valid tickets found from provided IDs.')
@@ -335,6 +342,10 @@ export default class WorkSpawn extends PMOCommand {
         }
 
         ticketsToSpawn = unassignedTickets.filter(t => t.statusName === matchedColumn)
+
+        // Track --all and --column flags in CLI builder
+        cliBuilder.addBooleanFlag('all')
+        cliBuilder.addFlag('column', matchedColumn)
 
         if (ticketsToSpawn.length === 0) {
           db.close()
@@ -452,6 +463,9 @@ export default class WorkSpawn extends PMOCommand {
         ])
 
         ticketsToSpawn = unassignedTickets.filter(t => selectedTicketIds.includes(t.id))
+
+        // Track ticket IDs in CLI builder (use positional args for specific tickets)
+        cliBuilder.addArgs(ticketsToSpawn.map(t => t.id))
 
         this.log('')
         this.log(styles.header(`🚀 Spawn Many: ${ticketsToSpawn.length} tickets`))
@@ -845,6 +859,42 @@ export default class WorkSpawn extends PMOCommand {
         if (batchAction) {
           selectedActionDetails = await this.storage.getAction(batchAction)
         }
+      }
+
+      // Track all batch settings in CLI builder for equivalent command display
+      if (!flags['per-ticket']) {
+        // Action
+        cliBuilder.addFlagIf('action', batchAction)
+
+        // Mode (runtime mode)
+        cliBuilder.addFlagIf('mode', batchMode)
+
+        // Output mode
+        cliBuilder.addFlagIf('output', batchOutput)
+
+        // Permission mode
+        if (batchSkipPermissions) {
+          cliBuilder.addBooleanFlag('skip-permissions')
+        }
+
+        // PR creation
+        if (batchCreatePr) {
+          cliBuilder.addBooleanFlag('create-pr')
+        } else if (batchNoPr) {
+          cliBuilder.addBooleanFlag('no-pr')
+        }
+
+        // Other flags from user input
+        cliBuilder.addBooleanFlagIf('yes', true)  // Since we confirmed, add --yes for non-interactive
+        cliBuilder.addFlagIf('strategy', flags.strategy !== 'round-robin' ? flags.strategy : undefined)
+        cliBuilder.addFlagIf('limit', flags.limit)
+        cliBuilder.addBooleanFlagIf('run-on-host', batchRunOnHost)
+        cliBuilder.addFlagIf('session', flags.session !== 'tmux' ? flags.session : undefined)
+        cliBuilder.addFlagIf('executor', flags.executor)
+
+        // Display the equivalent CLI command
+        this.log(styles.muted(formatCLICommandInline(cliBuilder.toString())))
+        this.log('')
       }
 
       // Spawn each ticket

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -34,6 +34,7 @@ import { ExecutionStorage, ContainerStorage } from '../../lib/execution/storage.
 import { loadExecutionConfig, getTerminalApp, promptTerminalPreference, getShell, promptShellPreference, hasTerminalPreference, hasShellPreference, getOrPromptCoderName } from '../../lib/execution/config.js'
 import { hasDevcontainerConfig } from '../../lib/execution/devcontainer.js'
 import { isGHInstalled, isGHAuthenticated } from '../../lib/pr/index.js'
+import { CLICommandBuilder, formatCLICommandInline } from '../../lib/cli-command-builder.js'
 
 /**
  * Try to execute a git command, return true if successful
@@ -817,6 +818,28 @@ export default class WorkStart extends PMOCommand {
       }
       this.log(styles.muted(`   Worktree: ${worktreePath}`))
       this.log(styles.muted(`   Branch: ${branch}`))
+      this.log('')
+
+      // Build and display equivalent CLI command
+      const cliBuilder = new CLICommandBuilder('prlt work start')
+      cliBuilder.addArg(ticket.id)
+      cliBuilder.addFlagIf('action', context.actionId)
+      cliBuilder.addFlagIf('mode', mode)
+      if (mode === 'devcontainer' && displayMode !== 'terminal') {
+        cliBuilder.addFlag('display', displayMode)
+      }
+      cliBuilder.addFlagIf('output', outputMode !== 'interactive' ? outputMode : undefined)
+      if (!sandboxed) {
+        cliBuilder.addBooleanFlag('skip-permissions')
+      }
+      if (createPR) {
+        cliBuilder.addBooleanFlag('create-pr')
+      } else if (ghAvailable) {
+        cliBuilder.addBooleanFlag('no-pr')
+      }
+      cliBuilder.addFlagIf('executor', executor !== 'claude-code' ? executor : undefined)
+      cliBuilder.addFlagIf('agent', flags.agent)
+      this.log(styles.muted(formatCLICommandInline(cliBuilder.toString())))
       this.log('')
 
       // Add createPR to context

--- a/apps/cli/src/lib/cli-command-builder.ts
+++ b/apps/cli/src/lib/cli-command-builder.ts
@@ -1,0 +1,188 @@
+/**
+ * CLI Command Builder
+ *
+ * Tracks user selections during interactive flows and generates
+ * the equivalent CLI command with flags for scripting/automation.
+ */
+
+/**
+ * Represents a flag or argument to include in the CLI command
+ */
+interface CommandPart {
+  /** The flag name (without leading dashes) or 'arg' for positional arguments */
+  type: 'flag' | 'arg'
+  /** The flag name (e.g., 'mode', 'action') or positional value */
+  name: string
+  /** The value for the flag (undefined for boolean flags) */
+  value?: string | boolean
+}
+
+/**
+ * CLI Command Builder
+ *
+ * Tracks selections during an interactive flow and generates
+ * the equivalent CLI command string.
+ *
+ * @example
+ * ```ts
+ * const builder = new CLICommandBuilder('prlt work spawn')
+ * builder.addArg('TKT-419')
+ * builder.addFlag('action', 'implement')
+ * builder.addFlag('mode', 'devcontainer')
+ * builder.addBooleanFlag('create-pr')
+ *
+ * console.log(builder.toString())
+ * // Output: prlt work spawn TKT-419 --action implement --mode devcontainer --create-pr
+ * ```
+ */
+export class CLICommandBuilder {
+  private baseCommand: string
+  private parts: CommandPart[] = []
+
+  /**
+   * Create a new CLI command builder
+   * @param baseCommand - The base command (e.g., 'prlt work spawn')
+   */
+  constructor(baseCommand: string) {
+    this.baseCommand = baseCommand
+  }
+
+  /**
+   * Add a positional argument
+   * @param value - The argument value
+   */
+  addArg(value: string): this {
+    this.parts.push({ type: 'arg', name: value })
+    return this
+  }
+
+  /**
+   * Add multiple positional arguments
+   * @param values - The argument values
+   */
+  addArgs(values: string[]): this {
+    for (const value of values) {
+      this.addArg(value)
+    }
+    return this
+  }
+
+  /**
+   * Add a flag with a value
+   * @param name - The flag name (without leading dashes)
+   * @param value - The flag value
+   */
+  addFlag(name: string, value: string | number): this {
+    this.parts.push({ type: 'flag', name, value: String(value) })
+    return this
+  }
+
+  /**
+   * Add a boolean flag (no value)
+   * @param name - The flag name (without leading dashes)
+   */
+  addBooleanFlag(name: string): this {
+    this.parts.push({ type: 'flag', name, value: true })
+    return this
+  }
+
+  /**
+   * Conditionally add a flag if the value is truthy
+   * @param name - The flag name
+   * @param value - The flag value (only added if truthy)
+   */
+  addFlagIf(name: string, value: string | number | undefined | null): this {
+    if (value !== undefined && value !== null && value !== '') {
+      this.addFlag(name, value)
+    }
+    return this
+  }
+
+  /**
+   * Conditionally add a boolean flag if the condition is true
+   * @param name - The flag name
+   * @param condition - Whether to add the flag
+   */
+  addBooleanFlagIf(name: string, condition: boolean | undefined): this {
+    if (condition) {
+      this.addBooleanFlag(name)
+    }
+    return this
+  }
+
+  /**
+   * Check if a flag has already been added
+   * @param name - The flag name to check
+   */
+  hasFlag(name: string): boolean {
+    return this.parts.some(p => p.type === 'flag' && p.name === name)
+  }
+
+  /**
+   * Get the current count of parts (args + flags)
+   */
+  get count(): number {
+    return this.parts.length
+  }
+
+  /**
+   * Build the CLI command string
+   * @returns The complete CLI command string
+   */
+  toString(): string {
+    const parts: string[] = [this.baseCommand]
+
+    // Add positional arguments first
+    for (const part of this.parts) {
+      if (part.type === 'arg') {
+        // Quote arguments that contain spaces
+        const value = part.name.includes(' ') ? `"${part.name}"` : part.name
+        parts.push(value)
+      }
+    }
+
+    // Add flags
+    for (const part of this.parts) {
+      if (part.type === 'flag') {
+        if (part.value === true) {
+          // Boolean flag
+          parts.push(`--${part.name}`)
+        } else if (typeof part.value === 'string') {
+          // Value flag - quote values with spaces
+          const value = part.value.includes(' ') ? `"${part.value}"` : part.value
+          parts.push(`--${part.name}`, value)
+        }
+      }
+    }
+
+    return parts.join(' ')
+  }
+
+  /**
+   * Create a copy of this builder
+   */
+  clone(): CLICommandBuilder {
+    const clone = new CLICommandBuilder(this.baseCommand)
+    clone.parts = [...this.parts]
+    return clone
+  }
+}
+
+/**
+ * Format a CLI command for display with styling
+ * @param command - The CLI command string
+ * @returns Formatted command string for terminal display
+ */
+export function formatCLICommand(command: string): string {
+  // Simple box drawing for visibility
+  const line = '─'.repeat(Math.min(command.length + 4, 80))
+  return `\n┌${line}┐\nEquivalent CLI command:\n\n  ${command}\n\n└${line}┘`
+}
+
+/**
+ * Get a shorter formatted version for inline display
+ * @param command - The CLI command string
+ */
+export function formatCLICommandInline(command: string): string {
+  return `Equivalent command: ${command}`
+}

--- a/apps/cli/test/unit/cli-command-builder.test.ts
+++ b/apps/cli/test/unit/cli-command-builder.test.ts
@@ -1,0 +1,269 @@
+import { expect } from 'chai';
+import {
+  CLICommandBuilder,
+  formatCLICommand,
+  formatCLICommandInline,
+} from '../../src/lib/cli-command-builder.js';
+
+describe('cli-command-builder', () => {
+  describe('CLICommandBuilder', () => {
+    describe('constructor', () => {
+      it('creates builder with base command', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        expect(builder.toString()).to.equal('prlt work spawn');
+      });
+    });
+
+    describe('addArg', () => {
+      it('adds a positional argument', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('TKT-001');
+        expect(builder.toString()).to.equal('prlt work spawn TKT-001');
+      });
+
+      it('returns this for chaining', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        const result = builder.addArg('TKT-001');
+        expect(result).to.equal(builder);
+      });
+
+      it('quotes arguments with spaces', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('some value with spaces');
+        expect(builder.toString()).to.equal('prlt work spawn "some value with spaces"');
+      });
+    });
+
+    describe('addArgs', () => {
+      it('adds multiple positional arguments', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArgs(['TKT-001', 'TKT-002', 'TKT-003']);
+        expect(builder.toString()).to.equal('prlt work spawn TKT-001 TKT-002 TKT-003');
+      });
+
+      it('returns this for chaining', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        const result = builder.addArgs(['TKT-001']);
+        expect(result).to.equal(builder);
+      });
+    });
+
+    describe('addFlag', () => {
+      it('adds a flag with string value', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlag('mode', 'devcontainer');
+        expect(builder.toString()).to.equal('prlt work spawn --mode devcontainer');
+      });
+
+      it('adds a flag with numeric value', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlag('limit', 10);
+        expect(builder.toString()).to.equal('prlt work spawn --limit 10');
+      });
+
+      it('quotes values with spaces', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlag('column', 'In Progress');
+        expect(builder.toString()).to.equal('prlt work spawn --column "In Progress"');
+      });
+
+      it('returns this for chaining', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        const result = builder.addFlag('mode', 'terminal');
+        expect(result).to.equal(builder);
+      });
+    });
+
+    describe('addBooleanFlag', () => {
+      it('adds a boolean flag without value', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addBooleanFlag('create-pr');
+        expect(builder.toString()).to.equal('prlt work spawn --create-pr');
+      });
+
+      it('returns this for chaining', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        const result = builder.addBooleanFlag('yes');
+        expect(result).to.equal(builder);
+      });
+    });
+
+    describe('addFlagIf', () => {
+      it('adds flag when value is truthy string', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlagIf('mode', 'terminal');
+        expect(builder.toString()).to.equal('prlt work spawn --mode terminal');
+      });
+
+      it('adds flag when value is truthy number', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlagIf('limit', 5);
+        expect(builder.toString()).to.equal('prlt work spawn --limit 5');
+      });
+
+      it('does not add flag when value is undefined', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlagIf('mode', undefined);
+        expect(builder.toString()).to.equal('prlt work spawn');
+      });
+
+      it('does not add flag when value is null', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlagIf('mode', null);
+        expect(builder.toString()).to.equal('prlt work spawn');
+      });
+
+      it('does not add flag when value is empty string', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlagIf('mode', '');
+        expect(builder.toString()).to.equal('prlt work spawn');
+      });
+
+      it('returns this for chaining', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        const result = builder.addFlagIf('mode', undefined);
+        expect(result).to.equal(builder);
+      });
+    });
+
+    describe('addBooleanFlagIf', () => {
+      it('adds flag when condition is true', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addBooleanFlagIf('yes', true);
+        expect(builder.toString()).to.equal('prlt work spawn --yes');
+      });
+
+      it('does not add flag when condition is false', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addBooleanFlagIf('yes', false);
+        expect(builder.toString()).to.equal('prlt work spawn');
+      });
+
+      it('does not add flag when condition is undefined', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addBooleanFlagIf('yes', undefined);
+        expect(builder.toString()).to.equal('prlt work spawn');
+      });
+
+      it('returns this for chaining', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        const result = builder.addBooleanFlagIf('yes', true);
+        expect(result).to.equal(builder);
+      });
+    });
+
+    describe('hasFlag', () => {
+      it('returns true if flag exists', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlag('mode', 'terminal');
+        expect(builder.hasFlag('mode')).to.be.true;
+      });
+
+      it('returns true if boolean flag exists', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addBooleanFlag('yes');
+        expect(builder.hasFlag('yes')).to.be.true;
+      });
+
+      it('returns false if flag does not exist', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        expect(builder.hasFlag('mode')).to.be.false;
+      });
+    });
+
+    describe('count', () => {
+      it('returns 0 for no parts', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        expect(builder.count).to.equal(0);
+      });
+
+      it('counts args and flags', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('TKT-001');
+        builder.addFlag('mode', 'terminal');
+        builder.addBooleanFlag('yes');
+        expect(builder.count).to.equal(3);
+      });
+    });
+
+    describe('toString', () => {
+      it('builds complete command with args and flags', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('TKT-001');
+        builder.addFlag('action', 'implement');
+        builder.addFlag('mode', 'devcontainer');
+        builder.addBooleanFlag('create-pr');
+        builder.addBooleanFlag('yes');
+
+        expect(builder.toString()).to.equal(
+          'prlt work spawn TKT-001 --action implement --mode devcontainer --create-pr --yes'
+        );
+      });
+
+      it('places positional arguments before flags', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addFlag('mode', 'terminal');
+        builder.addArg('TKT-001');
+        builder.addBooleanFlag('yes');
+        builder.addArg('TKT-002');
+
+        // Args should come before flags regardless of order added
+        expect(builder.toString()).to.equal(
+          'prlt work spawn TKT-001 TKT-002 --mode terminal --yes'
+        );
+      });
+
+      it('matches ticket example command format', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('TKT-419');
+        builder.addFlag('action', 'implement');
+        builder.addFlag('mode', 'devcontainer');
+        builder.addBooleanFlag('skip-permissions');
+        builder.addBooleanFlag('create-pr');
+
+        expect(builder.toString()).to.equal(
+          'prlt work spawn TKT-419 --action implement --mode devcontainer --skip-permissions --create-pr'
+        );
+      });
+    });
+
+    describe('clone', () => {
+      it('creates a copy of the builder', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('TKT-001');
+        builder.addFlag('mode', 'terminal');
+
+        const cloned = builder.clone();
+        expect(cloned.toString()).to.equal(builder.toString());
+      });
+
+      it('changes to clone do not affect original', () => {
+        const builder = new CLICommandBuilder('prlt work spawn');
+        builder.addArg('TKT-001');
+
+        const cloned = builder.clone();
+        cloned.addBooleanFlag('yes');
+
+        expect(builder.toString()).to.equal('prlt work spawn TKT-001');
+        expect(cloned.toString()).to.equal('prlt work spawn TKT-001 --yes');
+      });
+    });
+  });
+
+  describe('formatCLICommand', () => {
+    it('formats command with box drawing', () => {
+      const result = formatCLICommand('prlt work spawn TKT-001');
+      expect(result).to.include('prlt work spawn TKT-001');
+      expect(result).to.include('Equivalent CLI command:');
+      expect(result).to.include('┌');
+      expect(result).to.include('└');
+    });
+  });
+
+  describe('formatCLICommandInline', () => {
+    it('formats command inline', () => {
+      const result = formatCLICommandInline('prlt work spawn TKT-001');
+      expect(result).to.equal('Equivalent command: prlt work spawn TKT-001');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added a CLI command builder utility to track user selections during interactive flows
- Integrated equivalent command display into `work spawn` and `work start` commands
- After completing an interactive menu flow, displays the equivalent CLI command with flags

## Example Output
After selecting options in `work spawn`:
```
Equivalent command: prlt work spawn TKT-419 --action implement --mode devcontainer --output interactive --create-pr --yes
```

## Benefits
- Users learn the CLI flags for scripting/automation
- Enables copy-paste for repeated operations
- Helps with CI/CD integration
- Teaches power users the non-interactive workflow

## Changes
- `src/lib/cli-command-builder.ts` - New utility class to build CLI command strings
- `src/commands/work/spawn.ts` - Tracks selections and displays equivalent command
- `src/commands/work/start.ts` - Tracks selections and displays equivalent command
- `test/unit/cli-command-builder.test.ts` - Unit tests (34 passing)

## Test plan
- [x] Build passes
- [x] Unit tests pass (34 tests for CLICommandBuilder)
- [ ] Manual test: Run `prlt work spawn` interactively and verify equivalent command is shown
- [ ] Manual test: Run `prlt work start` interactively and verify equivalent command is shown

Generated with [Claude Code](https://claude.com/claude-code)