### PR TITLE
fix: UX improvements for work menu and project selection

### DIFF
--- a/apps/cli/src/commands/work/index.ts
+++ b/apps/cli/src/commands/work/index.ts
@@ -34,22 +34,23 @@ export default class Work extends PMOCommand {
 
   async execute(): Promise<void> {
     const { flags } = await this.parse(Work);
-    // This command requires project context
-    await this.requireProject();
+    // This command requires project context - get it once and reuse
+    const projectId = await this.requireProject();
 
     // Check if JSON output mode is active
     const jsonMode = shouldOutputJson(flags);
 
     // Define choices once, use for both JSON and interactive modes
+    // Execution actions first (most common), then ownership
     const menuChoices = [
-      { name: 'Claim work (own + assign)', value: 'claim' },
-      { name: 'Assign work to agent/person', value: 'assign' },
-      { name: 'Take ownership (accountable)', value: 'own' },
       { name: 'Start work (launch single agent)', value: 'start' },
       { name: 'Spawn work (batch by column)', value: 'spawn' },
       { name: 'Watch column (auto-spawn)', value: 'watch' },
       { name: 'Mark work ready for review', value: 'ready' },
       { name: 'Mark work complete', value: 'complete' },
+      { name: 'Claim work (own + assign)', value: 'claim' },
+      { name: 'Assign work to agent/person', value: 'assign' },
+      { name: 'Take ownership (accountable)', value: 'own' },
       { name: 'Cancel', value: 'cancel' },
     ];
     const message = 'Work Operations - What would you like to do?';
@@ -69,18 +70,18 @@ export default class Work extends PMOCommand {
       name: 'action',
       message: '🔨 ' + message,
       choices: [
-        new inquirer.Separator('── Ownership ──'),
-        menuChoices[0],
-        menuChoices[1],
-        menuChoices[2],
         new inquirer.Separator('── Execution ──'),
-        menuChoices[3],
-        menuChoices[4],
-        menuChoices[5],
-        menuChoices[6],
-        menuChoices[7],
+        menuChoices[0],  // start
+        menuChoices[1],  // spawn
+        menuChoices[2],  // watch
+        menuChoices[3],  // ready
+        menuChoices[4],  // complete
+        new inquirer.Separator('── Ownership ──'),
+        menuChoices[5],  // claim
+        menuChoices[6],  // assign
+        menuChoices[7],  // own
         new inquirer.Separator('──────────────'),
-        menuChoices[8],
+        menuChoices[8],  // cancel
       ],
     }]);
 
@@ -90,7 +91,6 @@ export default class Work extends PMOCommand {
 
     // Run the selected subcommand
     // Pass --project to avoid re-prompting for project selection
-    const projectId = await this.requireProject();
     const projectArgs = ['--project', projectId];
     switch (action) {
       case 'claim':

--- a/apps/cli/src/lib/pmo/base-command.ts
+++ b/apps/cli/src/lib/pmo/base-command.ts
@@ -143,11 +143,18 @@ export abstract class PMOCommand extends Command {
     }
 
     // Multiple projects - prompt for selection
+    // Sort projects by leading number in name (e.g., "1. MVP" before "10. Infra")
+    const sortedProjects = [...filteredProjects].sort((a, b) => {
+      const numA = parseInt(a.name.match(/^(\d+)/)?.[1] || '999', 10);
+      const numB = parseInt(b.name.match(/^(\d+)/)?.[1] || '999', 10);
+      return numA - numB;
+    });
+
     const { selectedProjectId } = await inquirer.prompt([{
       type: 'list',
       name: 'selectedProjectId',
       message: 'Select project:',
-      choices: filteredProjects.map(p => ({
+      choices: sortedProjects.map(p => ({
         name: `${p.name} (${p.id})`,
         value: p.id,
       })),


### PR DESCRIPTION
## Summary
- Fix double project prompt in `prlt work` menu (was calling `requireProject()` twice)
- Sort project list numerically by leading number ("1. MVP Launch" before "10. Infrastructure")
- Reorder work menu to show Execution actions first (Start/Spawn/Watch/Ready/Complete) since those are the most common operations

## Test plan
- [ ] Run `prlt work` - should only prompt for project once, not twice
- [ ] Run `prlt work spawn` - project list should show "1. MVP Launch" first
- [ ] Run `prlt work` - Execution section should appear before Ownership section

🤖 Generated with [Claude Code](https://claude.com/claude-code)