### PR TITLE
feat(TKT-446): Add priority separators to ticket pickers in work spawn/start

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -415,26 +415,30 @@ export default class WorkSpawn extends PMOCommand {
           return
         }
 
-        // Group tickets by status for display
-        const ticketsByColumn = new Map<string, typeof unassignedTickets>()
+        // Group tickets by priority for display
+        const PRIORITY_ORDER = ['P0', 'P1', 'P2', 'P3', 'None']
+        const ticketsByPriority = new Map<string, typeof unassignedTickets>()
+        for (const priority of PRIORITY_ORDER) {
+          ticketsByPriority.set(priority, [])
+        }
         for (const ticket of ticketsForSelection) {
-          const col = ticket.statusName || 'No Status'
-          if (!ticketsByColumn.has(col)) {
-            ticketsByColumn.set(col, [])
+          const priority = ticket.priority || 'None'
+          if (!ticketsByPriority.has(priority)) {
+            ticketsByPriority.set(priority, [])
           }
-          ticketsByColumn.get(col)!.push(ticket)
+          ticketsByPriority.get(priority)!.push(ticket)
         }
 
-        // Build choices with column separators
+        // Build choices with priority separators
         const choices: Array<{ name: string; value: string } | inquirer.Separator> = []
-        for (const [column, tickets] of ticketsByColumn) {
-          if (manyColumn === '__ALL__') {
-            choices.push(new inquirer.Separator(`── ${column} ──`))
-          }
+        for (const priority of PRIORITY_ORDER) {
+          const tickets = ticketsByPriority.get(priority) || []
+          if (tickets.length === 0) continue
+          choices.push(new inquirer.Separator(`── ${priority} (${tickets.length}) ──`))
           for (const ticket of tickets) {
-            const priority = ticket.priority ? `[${ticket.priority}] ` : ''
+            const statusBadge = ticket.statusName ? ` [${ticket.statusName}]` : ''
             choices.push({
-              name: `${priority}${ticket.id} - ${ticket.title}`,
+              name: `[${priority}] ${ticket.id} - ${ticket.title}${statusBadge}`,
               value: ticket.id,
             })
           }

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -219,17 +219,45 @@ export default class WorkStart extends PMOCommand {
           return handleError('NO_TICKETS', 'No tickets found. Create a ticket first with "prlt ticket create".')
         }
 
-        // Build choices once, use for both JSON and interactive modes
-        const ticketChoices = allTickets.map((t) => ({
-          name: `${t.id} - ${t.title} (${t.assignee ? `assignee: ${t.assignee}` : 'unassigned'})`,
-          value: t.id,
-        }))
+        // Group tickets by priority for display
+        const PRIORITY_ORDER = ['P0', 'P1', 'P2', 'P3', 'None']
+        const ticketsByPriority = new Map<string, typeof allTickets>()
+        for (const priority of PRIORITY_ORDER) {
+          ticketsByPriority.set(priority, [])
+        }
+        for (const ticket of allTickets) {
+          const priority = ticket.priority || 'None'
+          if (!ticketsByPriority.has(priority)) {
+            ticketsByPriority.set(priority, [])
+          }
+          ticketsByPriority.get(priority)!.push(ticket)
+        }
+
+        // Build choices with priority separators
+        const ticketChoices: Array<{ name: string; value: string } | inquirer.Separator> = []
+        for (const priority of PRIORITY_ORDER) {
+          const tickets = ticketsByPriority.get(priority) || []
+          if (tickets.length === 0) continue
+          ticketChoices.push(new inquirer.Separator(`── ${priority} (${tickets.length}) ──`))
+          for (const t of tickets) {
+            const assigneeBadge = t.assignee ? ` (${t.assignee})` : ''
+            const statusBadge = t.statusName ? ` [${t.statusName}]` : ''
+            ticketChoices.push({
+              name: `[${priority}] ${t.id} - ${t.title}${statusBadge}${assigneeBadge}`,
+              value: t.id,
+            })
+          }
+        }
         const selectMessage = 'Select ticket to work on:'
 
-        // In JSON mode, output ticket selection prompt
+        // In JSON mode, output ticket selection prompt (flat list for agents)
         if (jsonMode) {
+          const flatChoices = allTickets.map((t) => ({
+            name: `[${t.priority || 'None'}] ${t.id} - ${t.title} (${t.assignee ? `assignee: ${t.assignee}` : 'unassigned'})`,
+            value: t.id,
+          }))
           outputPromptAsJson(
-            buildPromptConfig('list', 'ticketId', selectMessage, ticketChoices),
+            buildPromptConfig('list', 'ticketId', selectMessage, flatChoices),
             createMetadata('work start', flags)
           )
           db.close()


### PR DESCRIPTION
## Summary
- Group tickets by priority (P0, P1, P2, P3, None) with visual separators in `work spawn` and `work start` commands
- Show `[priority]` badge, ticket ID, title, and status in picker items
- JSON mode still outputs flat list with priority prefix for AI agents

## Test plan
- [ ] Run `prlt work spawn` and verify tickets are grouped by priority with separators
- [ ] Run `prlt work start` and verify tickets are grouped by priority with separators
- [ ] Verify JSON mode (`--json`) outputs flat list with priority prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)