### PR TITLE
fix(TKT-515): remove stale assignee filter from work start batch mode

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -1256,16 +1256,16 @@ export default class WorkStart extends PMOCommand {
     executionStorage: ExecutionStorage,
     flags: { mode?: string; executor?: string; 'vm-host'?: string; 'run-on-host': boolean; force: boolean }
   ): Promise<void> {
-    // Get all tickets and filter to unassigned backlog/unstarted (not in progress)
+    // Get all tickets and filter to backlog/unstarted (not in progress)
     // Note: In batch mode, we use undefined to get all tickets across all projects
     const allTickets = await this.storage.listTickets(undefined)
     const backlogTickets = allTickets.filter(t =>
-      !t.assignee && (t.statusCategory === 'backlog' || t.statusCategory === 'unstarted' || !t.statusCategory)
+      t.statusCategory === 'backlog' || t.statusCategory === 'unstarted' || !t.statusCategory
     )
 
     if (backlogTickets.length === 0) {
       db.close()
-      this.log(styles.muted('No unassigned backlog tickets to start.'))
+      this.log(styles.muted('No backlog tickets to start.'))
       return
     }
 


### PR DESCRIPTION
## Summary
- Removed the `!t.assignee` filter from `work start` batch mode that was incorrectly filtering out tickets with assignee values
- Updated related comments and log messages to remove references to "unassigned"

This filter was supposed to be removed with TKT-303/TKT-425 as the assignee field is no longer used.

## Test plan
- [ ] Run `work start --batch` and verify it now includes tickets regardless of assignee field
- [ ] Verify batch mode correctly filters only by status category (backlog/unstarted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)