### PR TITLE
fix(TKT-506): add tmux availability check for devcontainer execution

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -1001,6 +1001,18 @@ async function runDevcontainerInTmux(
       }
     }
 
+    // Check if tmux is available inside the container
+    try {
+      execSync(`docker exec ${actualContainerId} which tmux`, { stdio: 'pipe' })
+    } catch {
+      return {
+        success: false,
+        error: `tmux is not installed in the devcontainer. ` +
+          `Add 'tmux' to your devcontainer's Dockerfile (e.g., apt-get install -y tmux) ` +
+          `or use the default prlt devcontainer template which includes tmux.`,
+      }
+    }
+
     // Step 1: Start tmux session INSIDE the container (detached)
     // Extract the claude command from the devcontainer command
     const cmdMatch = devcontainerCmd.match(/bash -c '(.+)'$/)


### PR DESCRIPTION
## Summary
- Adds tmux availability check before attempting to create tmux session inside devcontainer
- Returns clear, actionable error message when tmux is missing
- Mirrors existing host runner tmux check pattern (line 284)

## Problem
Ephemeral agents running in custom devcontainers would fail with cryptic errors when tmux was not installed in the container image.

## Solution
Added a `which tmux` check inside the container before attempting to create the tmux session. If tmux is missing, the error message now instructs users to either:
1. Add `tmux` to their devcontainer Dockerfile
2. Use the default prlt devcontainer template (which includes tmux)

## Test plan
- [ ] Spawn agent in devcontainer WITH tmux installed - should work unchanged
- [ ] Spawn agent in devcontainer WITHOUT tmux - should show clear error message
- [ ] Verify error message includes resolution instructions

🤖 Generated with [Claude Code](https://claude.ai/code)