### PR TITLE
feat(TKT-510): Prepare package for npm publish

### DIFF
--- a/apps/cli-old/package.json
+++ b/apps/cli-old/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@proletariat/cli",
+  "name": "@proletariat/cli-deprecated",
   "version": "0.2.0",
   "description": "Multi-agent development CLI - Orchestrate parallel coding agents via git worktrees with memorable themes for distributed development workflows",
   "main": "dist/bin/prlt.js",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@chrismcdermut/prlt",
+  "name": "@proletariat/cli",
   "description": "Proletariat CLI v2 - Multi-agent development orchestration",
-  "version": "0.1.0-alpha.10",
+  "version": "0.3.0-beta.1",
   "author": "Chris McDermut",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   },
   "bin": {
-    "prltdev": "./bin/run.js"
+    "prlt": "./bin/run.js"
   },
   "bugs": "https://github.com/chrismcdermut/proletariat-cli/issues",
   "dependencies": {
@@ -65,7 +65,7 @@
     "cursor",
     "oclif"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "main": "dist/index.js",
   "type": "module",
   "oclif": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
     },
     "apps/cli": {
       "name": "@chrismcdermut/prlt",
-      "version": "2.0.0-alpha.5",
+      "version": "0.1.0-alpha.10",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -33,7 +34,7 @@
         "react": "^18.0.0"
       },
       "bin": {
-        "prlt": "bin/run.js"
+        "prltdev": "bin/run.js"
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.0",


### PR DESCRIPTION
## Summary
- Update package name from `@chrismcdermut/prlt` to `@proletariat/cli`
- Change bin from `prltdev` to `prlt` 
- Update license from MIT to Apache-2.0
- Set version to `0.3.0-beta.1`
- Configure publishConfig for npm public access
- Rename cli-old package to `@proletariat/cli-deprecated` to avoid workspace conflict

## Test plan
- [ ] Build passes (`npm run build` in apps/cli)
- [ ] `prlt --help` shows correct version and package name
- [ ] After merge, publish with `npm publish --access public --tag beta`
- [ ] Verify install works: `npm install -g @proletariat/cli@beta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)