### PR TITLE
fix(TKT-605): fix session ID mismatch causing sessions to not display

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -754,8 +754,9 @@ export async function runDevcontainer(
     }
 
     // Set sessionId when using tmux inside the container
+    // Use buildSessionName to match the actual tmux session name format: {ticketId}-{action}-{agentName}
     if (result.success && sessionManager === 'tmux') {
-      const sessionId = context.ticketId.replace(/[^a-zA-Z0-9-]/g, '-')
+      const sessionId = buildSessionName(context)
       result.sessionId = sessionId
 
       // For terminal display mode, verify the tmux session was actually created
@@ -767,7 +768,7 @@ export async function runDevcontainer(
         // Check if tmux session exists inside the container
         try {
           const checkResult = execSync(
-            `docker exec ${containerId} tmux has-session -t ${sessionId} 2>&1`,
+            `docker exec ${containerId} tmux has-session -t "${sessionId}" 2>&1`,
             { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
           )
           // Session exists - success


### PR DESCRIPTION
## Summary
- Fixed bug where `prlt session` showed no active sessions even when agents were running
- The sessionId stored in the database didn't match the actual tmux session name format
- Changed to use `buildSessionName(context)` which generates the correct format: `{ticketId}-{action}-{agentName}`

## Root Cause
In `runDevcontainer()`, the sessionId was set to just the sanitized ticket ID (e.g., "TKT-347"), but the tmux session was created with the full name format (e.g., "TKT-347-implement-altman"). This mismatch caused the session verification in `list.ts` to fail.

## Test plan
- [ ] Start work on a ticket with devcontainer environment
- [ ] Run `prlt session list` and verify the session is shown
- [ ] Verify session can be attached with `prlt session attach`

🤖 Generated with [Claude Code](https://claude.com/claude-code)