### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Proletariat CLI v2 - Multi-agent development orchestration",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Bump version to 0.3.2 for npm publish.

## After Merge
```bash
cd apps/cli
npm publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)