### PR TITLE
fix: include README.md in npm package

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Proletariat CLI v2 - Multi-agent development orchestration",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"
@@ -55,7 +55,8 @@
     "./bin",
     "./dist",
     "./images",
-    "./oclif.manifest.json"
+    "./oclif.manifest.json",
+    "README.md"
   ],
   "homepage": "https://github.com/chrismcdermut/proletariat-cli",
   "keywords": [


### PR DESCRIPTION
## Summary
- Add README.md to `files` array in package.json so it displays on npmjs.com
- Bump version to 0.3.3

## Test plan
- [ ] Merge and publish to npm
- [ ] Verify README appears on https://www.npmjs.com/package/@proletariat/cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)