### PR TITLE
TKT-627: Add agent naming themes section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,31 @@ my-project/
             └── infra/
 ```
 
+### Agent Naming Themes
+
+Themes control how agents are named. Staff agents use theme names directly (e.g., `bezos`, `camry`). Ephemeral agents add an adjective prefix (e.g., `bold-bezos`, `keen-camry`). Currently ephemeral names also include a number suffix (`bold-bezos-1`), but this will be removed soon.
+
+**Built-in Themes:**
+
+| Theme | Description | Example Names |
+| --- | --- | --- |
+| `billionaires` | Tech founders & executives (default) | `musk`, `gates`, `bezos` |
+| `toyotas` | Toyota vehicle models | `camry`, `supra`, `tacoma` |
+| `companies` | Major tech companies | `stripe`, `vercel`, `linear` |
+
+> *billionaires* — Finally, they work for us.
+
+**Theme Commands:**
+
+```bash
+prlt agent themes list              # List available themes
+prlt agent themes set billionaires  # Set active theme
+prlt agent themes create mytheme    # Create custom theme
+prlt agent themes add-names mytheme # Add names to custom theme
+```
+
+Themes are selected during `prlt init`.
+
 ### Three Ways to Use Commands
 
 #### 1. Interactive (Humans)


### PR DESCRIPTION
## Summary
- Adds documentation section explaining agent naming themes feature
- Documents the three built-in themes (billionaires, toyotas, companies)
- Shows the naming pattern and example names
- Lists theme management commands

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm theme examples match actual theme names

🤖 Generated with [Claude Code](https://claude.com/claude-code)