### PR TITLE
feat(TKT-686): Support git worktree mode for live file sync

### DIFF
--- a/apps/cli/src/commands/agent/staff/add.ts
+++ b/apps/cli/src/commands/agent/staff/add.ts
@@ -29,6 +29,7 @@ export default class Add extends Command {
     '<%= config.bin %> <%= command.id %> agent-1 agent-2',
     '<%= config.bin %> <%= command.id %> --theme billionaires',
     '<%= config.bin %> <%= command.id %> my-agent --no-container',
+    '<%= config.bin %> <%= command.id %> zeus --worktree  # Live file sync mode',
   ];
 
   static args = {
@@ -41,6 +42,11 @@ export default class Add extends Command {
   static flags = {
     'no-container': Flags.boolean({
       description: 'Skip devcontainer setup (not recommended for autonomous agents)',
+      default: false,
+    }),
+    worktree: Flags.boolean({
+      char: 'w',
+      description: 'Use git worktree mode for live file sync with host (default: clone mode for isolation)',
       default: false,
     }),
     theme: Flags.string({
@@ -305,10 +311,14 @@ export default class Add extends Command {
         agentNames = valid;
       }
 
+      // Determine mount mode: worktree flag enables worktree mode, otherwise clone (default)
+      const mountMode = flags.worktree ? 'worktree' : 'clone';
+
       // Add agents to workspace
       const addedAgents = await addAgentsToWorkspace(workspaceInfo, agentNames, {
         skipDevcontainer: flags['no-container'],
         themeId,
+        mountMode,
       });
 
       if (addedAgents.length === 0) {
@@ -326,6 +336,8 @@ export default class Add extends Command {
       if (!flags['no-container']) {
         this.log(chalk.blue('   Devcontainer config created for sandboxed execution'));
       }
+
+      this.log(chalk.blue(`   Mount mode: ${mountMode}${mountMode === 'worktree' ? ' (live file sync)' : ' (isolated)'}`));
 
     } catch (error) {
       this.error(error instanceof Error ? error.message : String(error));

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -125,6 +125,11 @@ export default class WorkSpawn extends PMOCommand {
       description: 'Bring terminal to foreground when opening new tabs (default: opens in background)',
       default: false,
     }),
+    worktree: Flags.boolean({
+      char: 'w',
+      description: 'Use git worktree mode for live file sync with host (default: clone mode for isolation)',
+      default: false,
+    }),
   }
 
   async execute(): Promise<void> {
@@ -894,6 +899,9 @@ export default class WorkSpawn extends PMOCommand {
           // IMPORTANT: Pass --project to avoid re-prompting for project selection
           // Pass --ephemeral to signal work:start should create an ephemeral agent
           const startArgs: string[] = [ticket.id, '--project', projectId, '--ephemeral']
+
+          // Pass worktree flag if set (for live file sync mode)
+          if (flags.worktree) startArgs.push('--worktree')
 
           if (flags['per-ticket']) {
             // Per-ticket mode: only pass display flag, let start prompt for the rest

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -206,6 +206,11 @@ export default class WorkStart extends PMOCommand {
       description: 'Bring terminal to foreground when opening new tabs (default: opens in background)',
       default: false,
     }),
+    worktree: Flags.boolean({
+      char: 'W',
+      description: 'Use git worktree mode for live file sync with host (default: clone mode for isolation)',
+      default: false,
+    }),
   }
 
   async execute(): Promise<void> {
@@ -375,6 +380,7 @@ export default class WorkStart extends PMOCommand {
         this.log(styles.muted('Creating ephemeral agent...'))
         const ephemeralResult = await createEphemeralAgent(workspaceInfo, {
           skipDevcontainer: flags['run-on-host'],
+          mountMode: flags.worktree ? 'worktree' : 'clone',
           log: (msg) => this.log(msg),
         })
         agentName = ephemeralResult.name
@@ -450,6 +456,7 @@ export default class WorkStart extends PMOCommand {
             this.log(styles.muted('Creating ephemeral agent...'))
             const ephemeralResult = await createEphemeralAgent(workspaceInfo, {
               skipDevcontainer: flags['run-on-host'],
+              mountMode: flags.worktree ? 'worktree' : 'clone',
               log: (msg) => this.log(msg),
             })
             agentName = ephemeralResult.name
@@ -464,6 +471,7 @@ export default class WorkStart extends PMOCommand {
           this.log(styles.muted('Creating ephemeral agent...'))
           const ephemeralResult = await createEphemeralAgent(workspaceInfo, {
             skipDevcontainer: flags['run-on-host'],
+            mountMode: flags.worktree ? 'worktree' : 'clone',
             log: (msg) => this.log(msg),
           })
           agentName = ephemeralResult.name

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -18,7 +18,8 @@ import {
   markAgentCleaned,
   discoverAgentsOnDisk,
   Agent,
-  Repository
+  Repository,
+  MountMode
 } from '../database/index.js';
 import {
   isValidAgentName,
@@ -351,10 +352,11 @@ export function validateAgentNames(agentNames: string[]): { valid: string[]; inv
 export interface AddAgentOptions {
   skipDevcontainer?: boolean;  // Skip devcontainer creation (default: false)
   themeId?: string;            // Theme ID if agent came from a theme
+  mountMode?: MountMode;       // 'clone' (default) for isolation, 'worktree' for live file sync
 }
 
 /**
- * Create agent worktrees and update database
+ * Create agent clones/worktrees and update database
  */
 export async function addAgentsToWorkspace(workspaceInfo: WorkspaceInfo, agentNames: string[], options?: AddAgentOptions): Promise<string[]> {
   // Import dynamically to avoid circular dependency
@@ -368,15 +370,16 @@ export async function addAgentsToWorkspace(workspaceInfo: WorkspaceInfo, agentNa
     return [];
   }
 
-  // Create worktrees
+  // Create clones/worktrees
   if (workspaceInfo.type === 'hq') {
     await createAgentWorktrees(workspaceInfo.agentsPath, newAgents, workspaceInfo.path, options);
   } else {
     await createAgentWorktrees(workspaceInfo.agentsPath, newAgents, undefined, options);
   }
 
-  // Add to database (with optional theme ID)
-  addAgentsToDatabase(workspaceInfo.path, newAgents, options?.themeId);
+  // Add to database (with optional theme ID and mount mode)
+  const mountMode = options?.mountMode || 'clone';
+  addAgentsToDatabase(workspaceInfo.path, newAgents, options?.themeId, mountMode);
 
   return newAgents;
 }
@@ -484,6 +487,7 @@ export async function removeAgentsFromWorkspace(workspaceInfo: WorkspaceInfo, ag
 export interface EphemeralAgentOptions {
   themeId?: string;        // Theme to pick base name from
   skipDevcontainer?: boolean;  // Skip devcontainer creation
+  mountMode?: MountMode;   // 'clone' (default) for isolation, 'worktree' for live file sync
   /**
    * Optional logger for conflict messages (e.g., when a tmux session or directory already exists)
    */
@@ -574,28 +578,63 @@ export async function createEphemeralAgent(
     fs.mkdirSync(agentDir, { recursive: true });
   }
 
-  // Create worktrees for each repository
+  // Determine mount mode (default to clone for isolation)
+  const mountMode = options?.mountMode || 'clone';
+
+  // Create clones or worktrees for each repository
   const reposPath = path.join(workspaceInfo.path, 'repos');
 
   if (fs.existsSync(reposPath) && workspaceInfo.repositories.length > 0) {
     for (const repo of workspaceInfo.repositories) {
       const sourceRepoPath = path.join(reposPath, repo.name);
-      const worktreePath = path.join(agentDir, repo.name);
+      const targetPath = path.join(agentDir, repo.name);
 
-      if (fs.existsSync(sourceRepoPath) && !fs.existsSync(worktreePath)) {
-        try {
-          // Create git worktree for the repository
-          // Don't create a branch yet - that happens in work:start
-          // Use --detach to create without a branch reference
-          execSync(`git worktree add --detach "${worktreePath}"`, {
-            cwd: sourceRepoPath,
-            stdio: 'pipe'
-          });
-        } catch {
-          // If worktree creation fails, try to just create the directory
-          // The agent can still work without a worktree (e.g., for non-git projects)
-          if (!fs.existsSync(worktreePath)) {
-            fs.mkdirSync(worktreePath, { recursive: true });
+      if (fs.existsSync(sourceRepoPath) && !fs.existsSync(targetPath)) {
+        if (mountMode === 'clone') {
+          // Clone mode: Create independent git clone
+          try {
+            execSync(`git clone "${sourceRepoPath}" "${targetPath}"`, {
+              stdio: 'pipe'
+            });
+
+            // Set up remote to track origin (if source has a remote)
+            try {
+              const originUrl = execSync('git remote get-url origin', {
+                cwd: sourceRepoPath,
+                encoding: 'utf-8',
+                stdio: ['pipe', 'pipe', 'pipe']
+              }).trim();
+              if (originUrl) {
+                execSync(`git remote set-url origin "${originUrl}"`, {
+                  cwd: targetPath,
+                  stdio: 'pipe'
+                });
+              }
+            } catch {
+              // No remote origin in source, that's ok
+            }
+          } catch {
+            // If clone fails, create the directory so agent can still work
+            if (!fs.existsSync(targetPath)) {
+              fs.mkdirSync(targetPath, { recursive: true });
+            }
+          }
+        } else {
+          // Worktree mode: Create git worktree
+          try {
+            // Create git worktree for the repository
+            // Don't create a branch yet - that happens in work:start
+            // Use --detach to create without a branch reference
+            execSync(`git worktree add --detach "${targetPath}"`, {
+              cwd: sourceRepoPath,
+              stdio: 'pipe'
+            });
+          } catch {
+            // If worktree creation fails, try to just create the directory
+            // The agent can still work without a worktree (e.g., for non-git projects)
+            if (!fs.existsSync(targetPath)) {
+              fs.mkdirSync(targetPath, { recursive: true });
+            }
           }
         }
       }
@@ -609,17 +648,19 @@ export async function createEphemeralAgent(
       createDevcontainerConfig({
         agentName,
         agentDir,
-        repoWorktrees: workspaceInfo.repositories.map(r => r.name)
+        repoWorktrees: workspaceInfo.repositories.map(r => r.name),
+        mountMode
       });
     }
   }
 
-  // Add to database
+  // Add to database with mount mode
   const agent = addEphemeralAgentToDatabase(
     workspaceInfo.path,
     agentName,
     baseName,
-    options?.themeId
+    options?.themeId,
+    mountMode
   );
 
   return {

--- a/apps/cli/src/lib/agents/index.ts
+++ b/apps/cli/src/lib/agents/index.ts
@@ -4,7 +4,7 @@ import { execSync } from 'node:child_process';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { isValidAgentName, getSuggestedAgentNames, BUILTIN_THEMES, getThemePersistentDir } from '../themes.js';
-import { getWorkspaceRepositories, getActiveTheme } from '../database/index.js';
+import { getWorkspaceRepositories, getActiveTheme, MountMode } from '../database/index.js';
 import { styles } from '../styles.js';
 import { createDevcontainerConfig } from '../execution/devcontainer.js';
 
@@ -94,37 +94,44 @@ export async function promptAgentNames(existingAgents: string[] = []): Promise<s
 
 export interface CreateAgentOptions {
   skipDevcontainer?: boolean;  // Skip devcontainer creation (default: false)
+  mountMode?: MountMode;  // 'clone' (default) for isolation, 'worktree' for live file sync
 }
 
 /**
- * Create agent worktrees (shared between HQ and workspace-only modes)
+ * Create agent repositories (shared between HQ and workspace-only modes)
+ * Supports two modes:
+ * - 'clone' (default): Creates independent git clones for better isolation
+ * - 'worktree': Creates git worktrees for live file sync with host
  */
 export async function createAgentWorktrees(workspacePath: string, agents: string[], hqPath?: string, options?: CreateAgentOptions): Promise<void> {
+  const mountMode = options?.mountMode || 'clone';
+  const modeLabel = mountMode === 'worktree' ? 'worktree' : 'clone';
+
   if (hqPath) {
-    // HQ mode - create worktrees for all repos in repos/ directory
+    // HQ mode - create repos for all repos in repos/ directory
     const reposDir = path.join(hqPath, 'repos');
-    
+
     // Get repositories from database instead of JSON config
     const repos = getWorkspaceRepositories(hqPath);
-    
+
     if (repos.length > 0) {
-      // Create worktrees for each agent across all repositories
+      // Create repos for each agent across all repositories
       for (const agent of agents) {
         const agentDir = path.join(workspacePath, agent);
-        console.log(chalk.blue(`Creating agent: ${agent}...`));
+        console.log(chalk.blue(`Creating agent: ${agent} (${modeLabel} mode)...`));
 
         try {
           // Create agent directory
           fs.mkdirSync(agentDir, { recursive: true });
 
-          // Track which repos successfully had worktrees created
-          const createdWorktrees: string[] = [];
+          // Track which repos successfully had clones/worktrees created
+          const createdRepos: string[] = [];
 
-          // Create worktrees for all repositories
+          // Create repos for all repositories
           for (const repo of repos) {
             const sourceRepo = path.join(reposDir, repo.name);
-            // Worktree directory is just the repo name (the agent name is already in the parent path)
-            const worktreeDir = path.join(agentDir, repo.name);
+            // Target directory is just the repo name (the agent name is already in the parent path)
+            const targetDir = path.join(agentDir, repo.name);
 
             if (fs.existsSync(sourceRepo)) {
               // Check if repo is empty (no commits)
@@ -140,84 +147,133 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
                 continue;
               }
 
-              console.log(styles.muted(`  Creating worktree for ${repo.name}...`));
-
-              // Fetch latest from origin to ensure we have up-to-date main
-              try {
-                execSync(`git fetch origin main`, {
-                  cwd: sourceRepo,
-                  stdio: 'pipe'
-                });
-              } catch {
-                // Ignore fetch errors (might be offline)
-                console.log(chalk.yellow(`  Warning: Could not fetch origin/main, using local state`));
-              }
-
-              // Determine the base ref to use (origin/main, main, or HEAD)
-              let baseRef = 'origin/main';
-              try {
-                execSync(`git rev-parse ${baseRef}`, { cwd: sourceRepo, stdio: 'pipe' });
-              } catch {
-                // origin/main doesn't exist, try local main
+              if (mountMode === 'clone') {
+                // Clone mode: Create independent git clone
+                console.log(styles.muted(`  Cloning ${repo.name}...`));
                 try {
-                  execSync('git rev-parse main', { cwd: sourceRepo, stdio: 'pipe' });
-                  baseRef = 'main';
-                } catch {
-                  // No main branch, use HEAD
-                  baseRef = 'HEAD';
+                  // Clone from source repo (which is itself a clone/repo)
+                  execSync(`git clone "${sourceRepo}" "${targetDir}"`, {
+                    stdio: 'pipe'
+                  });
+
+                  // Set up remote to track origin (if source has a remote)
+                  try {
+                    const originUrl = execSync('git remote get-url origin', {
+                      cwd: sourceRepo,
+                      encoding: 'utf-8',
+                      stdio: ['pipe', 'pipe', 'pipe']
+                    }).trim();
+                    if (originUrl) {
+                      execSync(`git remote set-url origin "${originUrl}"`, {
+                        cwd: targetDir,
+                        stdio: 'pipe'
+                      });
+                    }
+                  } catch {
+                    // No remote origin in source, that's ok
+                  }
+
+                  // Create and checkout agent branch
+                  const branchName = `agent-${agent}`;
+                  try {
+                    execSync(`git checkout -b ${branchName}`, {
+                      cwd: targetDir,
+                      stdio: 'pipe'
+                    });
+                  } catch {
+                    // Branch might exist, try to check it out
+                    execSync(`git checkout ${branchName}`, {
+                      cwd: targetDir,
+                      stdio: 'pipe'
+                    });
+                  }
+
+                  createdRepos.push(repo.name);
+                } catch (cloneError) {
+                  console.log(chalk.red(`  Failed to clone ${repo.name}: ${cloneError}`));
                 }
-              }
+              } else {
+                // Worktree mode: Create git worktree (legacy behavior)
+                console.log(styles.muted(`  Creating worktree for ${repo.name}...`));
 
-              // Create git worktree for the agent
-              const branchName = `agent-${agent}`;
-              try {
-                execSync(`git worktree add "${worktreeDir}" -b ${branchName} ${baseRef}`, {
-                  cwd: sourceRepo,
-                  stdio: 'inherit'
-                });
-                createdWorktrees.push(repo.name);
-              } catch {
-                // Branch might already exist, try to use it or clean up
-                console.log(chalk.yellow(`  Branch ${branchName} already exists, attempting to reuse or clean up...`));
+                // Fetch latest from origin to ensure we have up-to-date main
                 try {
-                  // Try without creating a new branch (use existing)
-                  execSync(`git worktree add "${worktreeDir}" ${branchName}`, {
+                  execSync(`git fetch origin main`, {
+                    cwd: sourceRepo,
+                    stdio: 'pipe'
+                  });
+                } catch {
+                  // Ignore fetch errors (might be offline)
+                  console.log(chalk.yellow(`  Warning: Could not fetch origin/main, using local state`));
+                }
+
+                // Determine the base ref to use (origin/main, main, or HEAD)
+                let baseRef = 'origin/main';
+                try {
+                  execSync(`git rev-parse ${baseRef}`, { cwd: sourceRepo, stdio: 'pipe' });
+                } catch {
+                  // origin/main doesn't exist, try local main
+                  try {
+                    execSync('git rev-parse main', { cwd: sourceRepo, stdio: 'pipe' });
+                    baseRef = 'main';
+                  } catch {
+                    // No main branch, use HEAD
+                    baseRef = 'HEAD';
+                  }
+                }
+
+                // Create git worktree for the agent
+                const branchName = `agent-${agent}`;
+                try {
+                  execSync(`git worktree add "${targetDir}" -b ${branchName} ${baseRef}`, {
                     cwd: sourceRepo,
                     stdio: 'inherit'
                   });
-                  createdWorktrees.push(repo.name);
+                  createdRepos.push(repo.name);
                 } catch {
-                  // If that fails too, clean up the orphaned branch and try again
+                  // Branch might already exist, try to use it or clean up
+                  console.log(chalk.yellow(`  Branch ${branchName} already exists, attempting to reuse or clean up...`));
                   try {
-                    execSync(`git branch -D ${branchName}`, {
-                      cwd: sourceRepo,
-                      stdio: 'pipe'
-                    });
-                    execSync(`git worktree add "${worktreeDir}" -b ${branchName} ${baseRef}`, {
+                    // Try without creating a new branch (use existing)
+                    execSync(`git worktree add "${targetDir}" ${branchName}`, {
                       cwd: sourceRepo,
                       stdio: 'inherit'
                     });
-                    createdWorktrees.push(repo.name);
-                  } catch (finalError) {
-                    throw new Error(`Failed to create worktree after cleanup: ${finalError}`);
+                    createdRepos.push(repo.name);
+                  } catch {
+                    // If that fails too, clean up the orphaned branch and try again
+                    try {
+                      execSync(`git branch -D ${branchName}`, {
+                        cwd: sourceRepo,
+                        stdio: 'pipe'
+                      });
+                      execSync(`git worktree add "${targetDir}" -b ${branchName} ${baseRef}`, {
+                        cwd: sourceRepo,
+                        stdio: 'inherit'
+                      });
+                      createdRepos.push(repo.name);
+                    } catch (finalError) {
+                      throw new Error(`Failed to create worktree after cleanup: ${finalError}`);
+                    }
                   }
                 }
               }
             }
           }
 
-          // Create devcontainer config for sandboxed execution (only for repos with worktrees)
+          // Create devcontainer config for sandboxed execution (only for repos with clones/worktrees)
           // Note: Agent metadata is stored in SQLite (agents table), not in config files
-          if (!options?.skipDevcontainer && createdWorktrees.length > 0) {
+          if (!options?.skipDevcontainer && createdRepos.length > 0) {
             console.log(styles.muted(`  Creating devcontainer config...`));
             createDevcontainerConfig({
               agentName: agent,
               agentDir,
-              repoWorktrees: createdWorktrees,
+              repoWorktrees: createdRepos,
+              mountMode,
             });
           }
 
-          console.log(chalk.green(`✅ Agent ${agent} created with ${createdWorktrees.length} worktree(s)`));
+          console.log(chalk.green(`✅ Agent ${agent} created with ${createdRepos.length} ${modeLabel}(s)`));
         } catch (error) {
           console.log(chalk.red(`Failed to create agent ${agent}: ${error}`));
         }
@@ -238,10 +294,10 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
 
     for (const agent of agents) {
       const agentDir = path.join(workspacePath, agent);
-      // Worktree directory is just the repo name (the agent name is already in the parent path)
-      const worktreeDir = path.join(agentDir, repoName);
-      
-      console.log(chalk.blue(`Creating agent: ${agent}...`));
+      // Target directory is just the repo name (the agent name is already in the parent path)
+      const targetDir = path.join(agentDir, repoName);
+
+      console.log(chalk.blue(`Creating agent: ${agent} (${modeLabel} mode)...`));
 
       try {
         // Check if repo is empty (no commits)
@@ -260,61 +316,107 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
         // Create agent directory
         fs.mkdirSync(agentDir, { recursive: true });
 
-        // Fetch latest from origin to ensure we have up-to-date main
-        try {
-          execSync(`git fetch origin main`, {
-            cwd: sourceRepo,
-            stdio: 'pipe'
-          });
-        } catch {
-          // Ignore fetch errors (might be offline)
-          console.log(chalk.yellow(`  Warning: Could not fetch origin/main, using local state`));
-        }
-
-        // Determine the base ref to use (origin/main, main, or HEAD)
-        let baseRef = 'origin/main';
-        try {
-          execSync(`git rev-parse ${baseRef}`, { cwd: sourceRepo, stdio: 'pipe' });
-        } catch {
-          // origin/main doesn't exist, try local main
+        if (mountMode === 'clone') {
+          // Clone mode: Create independent git clone
+          console.log(styles.muted(`  Cloning repository...`));
           try {
-            execSync('git rev-parse main', { cwd: sourceRepo, stdio: 'pipe' });
-            baseRef = 'main';
-          } catch {
-            // No main branch, use HEAD
-            baseRef = 'HEAD';
+            // Clone from source repo
+            execSync(`git clone "${sourceRepo}" "${targetDir}"`, {
+              stdio: 'pipe'
+            });
+
+            // Set up remote to track origin (if source has a remote)
+            try {
+              const originUrl = execSync('git remote get-url origin', {
+                cwd: sourceRepo,
+                encoding: 'utf-8',
+                stdio: ['pipe', 'pipe', 'pipe']
+              }).trim();
+              if (originUrl) {
+                execSync(`git remote set-url origin "${originUrl}"`, {
+                  cwd: targetDir,
+                  stdio: 'pipe'
+                });
+              }
+            } catch {
+              // No remote origin in source, that's ok
+            }
+
+            // Create and checkout agent branch
+            const branchName = `agent-${agent}`;
+            try {
+              execSync(`git checkout -b ${branchName}`, {
+                cwd: targetDir,
+                stdio: 'pipe'
+              });
+            } catch {
+              // Branch might exist, try to check it out
+              execSync(`git checkout ${branchName}`, {
+                cwd: targetDir,
+                stdio: 'pipe'
+              });
+            }
+          } catch (cloneError) {
+            throw new Error(`Failed to clone repository: ${cloneError}`);
           }
-        }
-
-        // Create git worktree for the agent
-        const branchName = `agent-${agent}`;
-        try {
-          execSync(`git worktree add "${worktreeDir}" -b ${branchName} ${baseRef}`, {
-            cwd: sourceRepo,
-            stdio: 'inherit'
-          });
-        } catch {
-          // Branch might already exist, try to use it or clean up
-          console.log(chalk.yellow(`  Branch ${branchName} already exists, attempting to reuse or clean up...`));
+        } else {
+          // Worktree mode: Create git worktree (legacy behavior)
+          // Fetch latest from origin to ensure we have up-to-date main
           try {
-            // Try without creating a new branch (use existing)
-            execSync(`git worktree add "${worktreeDir}" ${branchName}`, {
+            execSync(`git fetch origin main`, {
+              cwd: sourceRepo,
+              stdio: 'pipe'
+            });
+          } catch {
+            // Ignore fetch errors (might be offline)
+            console.log(chalk.yellow(`  Warning: Could not fetch origin/main, using local state`));
+          }
+
+          // Determine the base ref to use (origin/main, main, or HEAD)
+          let baseRef = 'origin/main';
+          try {
+            execSync(`git rev-parse ${baseRef}`, { cwd: sourceRepo, stdio: 'pipe' });
+          } catch {
+            // origin/main doesn't exist, try local main
+            try {
+              execSync('git rev-parse main', { cwd: sourceRepo, stdio: 'pipe' });
+              baseRef = 'main';
+            } catch {
+              // No main branch, use HEAD
+              baseRef = 'HEAD';
+            }
+          }
+
+          // Create git worktree for the agent
+          const branchName = `agent-${agent}`;
+          try {
+            execSync(`git worktree add "${targetDir}" -b ${branchName} ${baseRef}`, {
               cwd: sourceRepo,
               stdio: 'inherit'
             });
           } catch {
-            // If that fails too, clean up the orphaned branch and try again
+            // Branch might already exist, try to use it or clean up
+            console.log(chalk.yellow(`  Branch ${branchName} already exists, attempting to reuse or clean up...`));
             try {
-              execSync(`git branch -D ${branchName}`, {
-                cwd: sourceRepo,
-                stdio: 'pipe'
-              });
-              execSync(`git worktree add "${worktreeDir}" -b ${branchName} ${baseRef}`, {
+              // Try without creating a new branch (use existing)
+              execSync(`git worktree add "${targetDir}" ${branchName}`, {
                 cwd: sourceRepo,
                 stdio: 'inherit'
               });
-            } catch (finalError) {
-              throw new Error(`Failed to create worktree after cleanup: ${finalError}`);
+            } catch {
+              // If that fails too, clean up the orphaned branch and try again
+              try {
+                execSync(`git branch -D ${branchName}`, {
+                  cwd: sourceRepo,
+                  stdio: 'pipe'
+                });
+                execSync(`git worktree add "${targetDir}" -b ${branchName} ${baseRef}`, {
+                  cwd: sourceRepo,
+                  stdio: 'inherit'
+                });
+              } catch (finalError) {
+                throw new Error(`Failed to create worktree after cleanup: ${finalError}`);
+              }
             }
           }
         }
@@ -327,10 +429,11 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
             agentName: agent,
             agentDir,
             repoWorktrees: [repoName],
+            mountMode,
           });
         }
 
-        console.log(chalk.green(`✅ Agent ${agent} created with worktree`));
+        console.log(chalk.green(`✅ Agent ${agent} created with ${modeLabel}`));
       } catch (error) {
         console.log(chalk.red(`Failed to create agent ${agent}: ${error}`));
       }
@@ -400,15 +503,23 @@ export async function promptForAgentsWithTheme(): Promise<AgentPromptResult> {
   return { agents: selected, themeId: selectedTheme };
 }
 
+export interface AddAgentsToHQOptions {
+  mountMode?: MountMode;  // 'clone' (default) for isolation, 'worktree' for live file sync
+  themeId?: string;       // Theme ID for the agents
+}
+
 /**
  * Add agents to HQ (used by both init and agent add commands)
  */
 export async function addAgentsToHQ(
   hqPath: string,
-  agents: string[]
+  agents: string[],
+  options?: AddAgentsToHQOptions
 ): Promise<void> {
   // Import database functions for getting/adding agents
   const { getWorkspaceAgents, addAgentsToDatabase } = await import('../database/index.js');
+
+  const mountMode = options?.mountMode || 'clone';
 
   // Get existing agents from database
   const existingAgents = getWorkspaceAgents(hqPath);
@@ -428,14 +539,14 @@ export async function addAgentsToHQ(
     return;
   }
 
-  // Create worktrees (use theme-specific directory)
+  // Create repos/worktrees (use theme-specific directory)
   const activeTheme = getActiveTheme(hqPath);
   const persistentDir = getThemePersistentDir(activeTheme?.id);
   const workspacePath = path.join(hqPath, 'agents', persistentDir);
-  await createAgentWorktrees(workspacePath, newAgents, hqPath);
+  await createAgentWorktrees(workspacePath, newAgents, hqPath, { mountMode });
 
-  // Add agents to database
-  addAgentsToDatabase(hqPath, newAgents);
+  // Add agents to database with mount mode
+  addAgentsToDatabase(hqPath, newAgents, options?.themeId, mountMode);
 
   console.log(chalk.green(`\n🎉 Added ${newAgents.length} agent(s) successfully!`));
 }

--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -24,6 +24,7 @@ export interface Repository {
 
 export type AgentType = 'persistent' | 'ephemeral';
 export type AgentStatus = 'active' | 'cleaned';
+export type MountMode = 'clone' | 'worktree';
 
 export interface Agent {
   name: string;
@@ -32,6 +33,7 @@ export interface Agent {
   base_name: string | null;  // Theme name (e.g., "bezos" from "bold-bezos-1")
   theme_id: string | null;
   worktree_path: string | null;  // e.g., "agents/temp/bold-bezos-1"
+  mount_mode: MountMode;  // 'clone' (default) for isolation, 'worktree' for live file sync
   created_at: string;
   cleaned_at: string | null;  // When the agent was cleaned up
 }
@@ -110,6 +112,7 @@ CREATE TABLE IF NOT EXISTS agents (
   base_name TEXT,
   theme_id TEXT,
   worktree_path TEXT,
+  mount_mode TEXT NOT NULL DEFAULT 'clone' CHECK (mount_mode IN ('clone', 'worktree')),
   created_at TEXT NOT NULL,
   cleaned_at TEXT,
   FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
@@ -253,6 +256,16 @@ export function openWorkspaceDatabase(workspacePath: string): Database.Database 
     }
   } catch {
     // Ignore migration errors - table might not exist yet
+  }
+
+  // Migration: add mount_mode column to agents table (TKT-686)
+  try {
+    const agentsTableInfo = db.prepare("PRAGMA table_info(agents)").all() as { name: string }[];
+    if (!agentsTableInfo.some(col => col.name === 'mount_mode')) {
+      db.exec("ALTER TABLE agents ADD COLUMN mount_mode TEXT NOT NULL DEFAULT 'clone' CHECK (mount_mode IN ('clone', 'worktree'))");
+    }
+  } catch {
+    // Ignore migration errors - column might already exist
   }
 
   return db;
@@ -414,16 +427,17 @@ export function addRepositoriesToDatabase(workspacePath: string, repos: { name: 
 
 /**
  * Add agents to database (case-insensitive uniqueness)
+ * @param mountMode - 'clone' (default) for isolation, 'worktree' for live file sync
  */
-export function addAgentsToDatabase(workspacePath: string, agentNames: string[], themeId?: string): void {
+export function addAgentsToDatabase(workspacePath: string, agentNames: string[], themeId?: string, mountMode: MountMode = 'clone'): void {
   const db = openWorkspaceDatabase(workspacePath);
 
   // Check for existing agents (case-insensitive)
   const checkExisting = db.prepare('SELECT name FROM agents WHERE LOWER(name) = LOWER(?)');
 
   const insertAgent = db.prepare(`
-    INSERT OR REPLACE INTO agents (name, type, base_name, theme_id, worktree_path, created_at)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT OR REPLACE INTO agents (name, type, base_name, theme_id, worktree_path, mount_mode, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
 
   const insertWorktree = db.prepare(`
@@ -457,7 +471,7 @@ export function addAgentsToDatabase(workspacePath: string, agentNames: string[],
         : agentName;
 
       // Add agent (persistent type for manually added agents)
-      insertAgent.run(agentName, 'persistent', null, effectiveThemeId || null, agentWorktreePath, now);
+      insertAgent.run(agentName, 'persistent', null, effectiveThemeId || null, agentWorktreePath, mountMode, now);
 
       // Add worktrees for all repos
       for (const repo of repos) {
@@ -482,12 +496,14 @@ export function addAgentsToDatabase(workspacePath: string, agentNames: string[],
 
 /**
  * Add an ephemeral agent to the database
+ * @param mountMode - 'clone' (default) for isolation, 'worktree' for live file sync
  */
 export function addEphemeralAgentToDatabase(
   workspacePath: string,
   agentName: string,
   baseName: string,
-  themeId?: string
+  themeId?: string,
+  mountMode: MountMode = 'clone'
 ): Agent {
   const db = openWorkspaceDatabase(workspacePath);
 
@@ -495,9 +511,9 @@ export function addEphemeralAgentToDatabase(
   const worktreePath = `agents/temp/${agentName}`;
 
   db.prepare(`
-    INSERT INTO agents (name, type, status, base_name, theme_id, worktree_path, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
-  `).run(agentName, 'ephemeral', 'active', baseName, themeId || null, worktreePath, now);
+    INSERT INTO agents (name, type, status, base_name, theme_id, worktree_path, mount_mode, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(agentName, 'ephemeral', 'active', baseName, themeId || null, worktreePath, mountMode, now);
 
   const agent = db.prepare('SELECT * FROM agents WHERE name = ?').get(agentName) as {
     name: string;
@@ -506,6 +522,7 @@ export function addEphemeralAgentToDatabase(
     base_name: string | null;
     theme_id: string | null;
     worktree_path: string | null;
+    mount_mode: string;
     created_at: string;
     cleaned_at: string | null;
   };
@@ -519,6 +536,7 @@ export function addEphemeralAgentToDatabase(
     base_name: agent.base_name,
     theme_id: agent.theme_id,
     worktree_path: agent.worktree_path,
+    mount_mode: agent.mount_mode as MountMode,
     created_at: agent.created_at,
     cleaned_at: agent.cleaned_at,
   };
@@ -558,6 +576,7 @@ export function getWorkspaceAgents(workspacePath: string, includeCleanedUp: bool
     base_name: string | null;
     theme_id: string | null;
     worktree_path: string | null;
+    mount_mode: string | null;
     created_at: string;
     cleaned_at: string | null;
   }>;
@@ -571,6 +590,7 @@ export function getWorkspaceAgents(workspacePath: string, includeCleanedUp: bool
     base_name: row.base_name,
     theme_id: row.theme_id,
     worktree_path: row.worktree_path,
+    mount_mode: (row.mount_mode || 'clone') as MountMode,
     created_at: row.created_at,
     cleaned_at: row.cleaned_at,
   }));
@@ -604,6 +624,7 @@ export function getAgentByPath(workspacePath: string, absolutePath: string): Age
     base_name: string | null;
     theme_id: string | null;
     worktree_path: string | null;
+    mount_mode: string | null;
     created_at: string;
     cleaned_at: string | null;
   }>;
@@ -621,6 +642,7 @@ export function getAgentByPath(workspacePath: string, absolutePath: string): Age
           base_name: row.base_name,
           theme_id: row.theme_id,
           worktree_path: row.worktree_path,
+          mount_mode: (row.mount_mode || 'clone') as MountMode,
           created_at: row.created_at,
           cleaned_at: row.cleaned_at,
         };
@@ -720,10 +742,10 @@ export function discoverAgentsOnDisk(workspacePath: string): DiscoverResult {
                 WHERE LOWER(name) = LOWER(?)
               `).run(worktreePath, entry.name);
             } else {
-              // Register new agent
+              // Register new agent (default to clone mode for discovered agents)
               db.prepare(`
-                INSERT INTO agents (name, type, status, worktree_path, created_at)
-                VALUES (?, 'persistent', 'active', ?, ?)
+                INSERT INTO agents (name, type, status, worktree_path, mount_mode, created_at)
+                VALUES (?, 'persistent', 'active', ?, 'clone', ?)
               `).run(entry.name, worktreePath, now);
             }
             result.discovered.push({ name: entry.name, type: 'persistent', path: worktreePath });
@@ -753,10 +775,10 @@ export function discoverAgentsOnDisk(workspacePath: string): DiscoverResult {
                 WHERE LOWER(name) = LOWER(?)
               `).run(worktreePath, entry.name);
             } else {
-              // Register new agent
+              // Register new agent (default to clone mode for discovered agents)
               db.prepare(`
-                INSERT INTO agents (name, type, status, worktree_path, created_at)
-                VALUES (?, 'ephemeral', 'active', ?, ?)
+                INSERT INTO agents (name, type, status, worktree_path, mount_mode, created_at)
+                VALUES (?, 'ephemeral', 'active', ?, 'clone', ?)
               `).run(entry.name, worktreePath, now);
             }
             result.discovered.push({ name: entry.name, type: 'ephemeral', path: worktreePath });

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { ExecutionConfig, DEFAULT_EXECUTION_CONFIG } from './types.js'
 import { parseChannel } from '../workspace-config.js'
+import type { MountMode } from '../database/index.js'
 
 export interface DevcontainerOptions {
   agentName: string
@@ -19,6 +20,8 @@ export interface DevcontainerOptions {
   timezone?: string
   /** prlt channel: "npm", "npm:dev", "gh", "gh:dev", "mount", or version like "npm:1.2.3" */
   prltChannel?: string
+  /** Mount mode: 'clone' (default) for isolation, 'worktree' for live file sync */
+  mountMode?: MountMode
 }
 
 export interface DevcontainerJson {
@@ -57,6 +60,10 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
   const channel = parseChannel(options.prltChannel || 'npm')
   const useMount = channel.registry === 'mount'
 
+  // Determine mount mode: 'clone' (default) for isolation, 'worktree' for live file sync
+  const mountMode = options.mountMode || 'clone'
+  const useWorktrees = mountMode === 'worktree'
+
   // Build args for Dockerfile
   const buildArgs: Record<string, string> = {
     TZ: options.timezone || 'America/Los_Angeles',
@@ -73,6 +80,9 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
   if (channel.registry === 'gh') {
     buildArgs.GITHUB_TOKEN = '${localEnv:GITHUB_TOKEN}'
   }
+
+  // Pass mount mode to setup script so it can conditionally set up git wrapper
+  buildArgs.PRLT_MOUNT_MODE = mountMode
 
   const devcontainerJson: DevcontainerJson = {
     name: `Agent: ${options.agentName}`,
@@ -111,12 +121,13 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
       // PMO path can be anywhere (e.g., /hq/pmo or /hq/repos/myrepo/pmo)
       // Use PRLT_PMO_PATH env var to mount the actual location to /hq/pmo
       'source=${localEnv:PRLT_PMO_PATH},target=/hq/pmo,type=bind',
-      // Mount each repo's directory so git worktrees can resolve their parent
+      // For WORKTREE mode only: Mount each repo's directory so git worktrees can resolve their parent
       // Worktree .git files reference paths like /Users/.../repos/{repoName}/.git/worktrees/name
       // These mounts make those paths accessible inside the container at /hq/repos/{repoName}
-      ...(options.repoWorktrees || []).map(
+      // For CLONE mode: Not needed - clones are self-contained with their own .git directories
+      ...(useWorktrees ? (options.repoWorktrees || []).map(
         repoName => `source=\${localEnv:PRLT_HQ_PATH}/repos/${repoName},target=/hq/repos/${repoName},type=bind`
-      ),
+      ) : []),
       // If using "mount" channel, mount local prlt build from PRLT_REPO_PATH
       // The setup-prlt.sh script will detect /opt/prlt and configure the wrapper
       ...(useMount ? ['source=${localEnv:PRLT_REPO_PATH},target=/opt/prlt,type=bind,readonly'] : []),
@@ -131,6 +142,8 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
       // Agent identity - allows agent to know its name and host path
       PRLT_AGENT_NAME: options.agentName,
       PRLT_HOST_PATH: options.agentDir,
+      // Mount mode: 'clone' or 'worktree' - used by setup script for conditional git wrapper
+      PRLT_MOUNT_MODE: mountMode,
       // /hq/.proletariat/bin contains prlt wrapper with ESM loader for native modules
       PATH: '/hq/.proletariat/bin:/home/node/.npm-global/bin:/usr/local/bin:/usr/bin:/bin',
     },
@@ -198,8 +211,11 @@ USER root
 # Install prlt CLI from public npm
 # PRLT_REGISTRY: "npm" (install from npmjs.com) or "mount" (use host mount)
 # PRLT_VERSION: version/tag like "latest", "dev", "next", or "1.2.3"
+# PRLT_MOUNT_MODE: "clone" (default) or "worktree" - controls git wrapper setup
 ARG PRLT_REGISTRY=npm
 ARG PRLT_VERSION=latest
+ARG PRLT_MOUNT_MODE=clone
+ENV PRLT_MOUNT_MODE=\${PRLT_MOUNT_MODE}
 RUN if [ "\${PRLT_REGISTRY}" = "npm" ] || [ "\${PRLT_REGISTRY}" = "gh" ]; then \\
       echo "Installing @proletariat/cli@\${PRLT_VERSION} from npm..." && \\
       npm install -g @proletariat/cli@\${PRLT_VERSION}; \\
@@ -370,12 +386,14 @@ export function generatePrltSetupScript(): string {
   return `#!/bin/bash
 # Setup prlt CLI - rebuild native modules if using mounted version
 
-# Configure git wrapper to handle worktree path translation
+# Configure git wrapper to handle worktree path translation (WORKTREE mode only)
 # Worktree .git files contain host paths like: gitdir: /Users/.../repos/{repoName}/.git/worktrees/name
 # Inside container, the parent repos are mounted at /hq/repos/{repoName}
 #
 # We create a git wrapper that translates paths on-the-fly using GIT_DIR
 # This avoids modifying the .git file which is bind-mounted from the host
+#
+# For CLONE mode, the git wrapper is NOT needed since clones have their own .git directories
 #
 setup_git_wrapper() {
     # Create git wrapper script in user's bin directory (already in PATH before /usr/bin)
@@ -433,8 +451,13 @@ GITWRAPPER
     echo "Git wrapper installed for worktree path translation"
 }
 
-# Set up git wrapper for worktree path translation
-setup_git_wrapper
+# Set up git wrapper for worktree path translation (WORKTREE mode only)
+# For CLONE mode, clones have their own .git directories and don't need path translation
+if [ "\${PRLT_MOUNT_MODE}" = "worktree" ]; then
+    setup_git_wrapper
+else
+    echo "Clone mode detected - git wrapper not needed"
+fi
 
 # Copy Claude credentials from workspace to home (each container gets its own copy)
 if [ -f "/workspace/.claude.json" ]; then


### PR DESCRIPTION
## Summary

- Add support for using git worktrees (instead of independent clones) mounted to Docker containers
- Add `--worktree` flag to agent creation commands for opt-in worktree mode
- Default behavior is clone mode for better isolation
- Worktree mode enables live file sync with host disk

## Changes

- Add `mount_mode` column to agents table ('clone' default, 'worktree' option)
- Implement clone mode as default for agent creation (better isolation)
- Add `--worktree` flag to `prlt agent add`, `work spawn`, and `work start` commands
- Update devcontainer generation to conditionally include worktree-specific config
- Only install git wrapper script in worktree mode (not needed for clones)

## Test plan

- [x] Build passes with `pnpm build`
- [ ] Test creating agent with default clone mode
- [ ] Test creating agent with `--worktree` flag
- [ ] Test devcontainer config includes parent repo mounts only for worktree mode
- [ ] Test git wrapper script only installed for worktree mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)