### PR TITLE
feat(TKT-686): add git worktree support for live file sync with host

### DIFF
--- a/apps/cli/src/commands/agent/staff/add.ts
+++ b/apps/cli/src/commands/agent/staff/add.ts
@@ -51,8 +51,8 @@ export default class Add extends Command {
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),
-    worktree: Flags.boolean({
-      description: 'Use git worktree mode instead of clone (enables real-time file sync with host)',
+    clone: Flags.boolean({
+      description: 'Use independent git clone instead of worktree (more isolation, no real-time sync)',
       default: false,
     }),
   };
@@ -313,7 +313,7 @@ export default class Add extends Command {
       const addedAgents = await addAgentsToWorkspace(workspaceInfo, agentNames, {
         skipDevcontainer: flags['no-container'],
         themeId,
-        mountMode: flags.worktree ? 'worktree' : 'clone',
+        mountMode: flags.clone ? 'clone' : 'worktree',
       });
 
       if (addedAgents.length === 0) {

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -125,8 +125,8 @@ export default class WorkSpawn extends PMOCommand {
       description: 'Bring terminal to foreground when opening new tabs (default: opens in background)',
       default: false,
     }),
-    worktree: Flags.boolean({
-      description: 'Use git worktree mode instead of clone (enables real-time file sync with host)',
+    clone: Flags.boolean({
+      description: 'Use independent git clone instead of worktree (more isolation, no real-time sync)',
       default: false,
     }),
   }
@@ -899,8 +899,8 @@ export default class WorkSpawn extends PMOCommand {
           // Pass --ephemeral to signal work:start should create an ephemeral agent
           const startArgs: string[] = [ticket.id, '--project', projectId, '--ephemeral']
 
-          // Pass worktree flag if specified
-          if (flags.worktree) startArgs.push('--worktree')
+          // Pass clone flag if specified
+          if (flags.clone) startArgs.push('--clone')
 
           if (flags['per-ticket']) {
             // Per-ticket mode: only pass display flag, let start prompt for the rest

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -206,8 +206,8 @@ export default class WorkStart extends PMOCommand {
       description: 'Bring terminal to foreground when opening new tabs (default: opens in background)',
       default: false,
     }),
-    worktree: Flags.boolean({
-      description: 'Use git worktree mode instead of clone (enables real-time file sync with host)',
+    clone: Flags.boolean({
+      description: 'Use independent git clone instead of worktree (more isolation, no real-time sync)',
       default: false,
     }),
   }
@@ -380,7 +380,7 @@ export default class WorkStart extends PMOCommand {
         const ephemeralResult = await createEphemeralAgent(workspaceInfo, {
           skipDevcontainer: flags['run-on-host'],
           log: (msg) => this.log(msg),
-          mountMode: flags.worktree ? 'worktree' : 'clone',
+          mountMode: flags.clone ? 'clone' : 'worktree',
         })
         agentName = ephemeralResult.name
         agentWorktreePath = ephemeralResult.worktreePath
@@ -456,7 +456,7 @@ export default class WorkStart extends PMOCommand {
             const ephemeralResult = await createEphemeralAgent(workspaceInfo, {
               skipDevcontainer: flags['run-on-host'],
               log: (msg) => this.log(msg),
-              mountMode: flags.worktree ? 'worktree' : 'clone',
+              mountMode: flags.clone ? 'clone' : 'worktree',
             })
             agentName = ephemeralResult.name
             agentWorktreePath = ephemeralResult.worktreePath
@@ -471,7 +471,7 @@ export default class WorkStart extends PMOCommand {
           const ephemeralResult = await createEphemeralAgent(workspaceInfo, {
             skipDevcontainer: flags['run-on-host'],
             log: (msg) => this.log(msg),
-            mountMode: flags.worktree ? 'worktree' : 'clone',
+            mountMode: flags.clone ? 'clone' : 'worktree',
           })
           agentName = ephemeralResult.name
           agentWorktreePath = ephemeralResult.worktreePath
@@ -1700,7 +1700,7 @@ export default class WorkStart extends PMOCommand {
           ...(flags['run-on-host'] ? ['--run-on-host'] : []),
           ...(flags.force ? ['--force'] : []),
           '--permission-mode', batchPermissionMode,
-          ...((flags as { worktree?: boolean }).worktree ? ['--worktree'] : []),
+          ...((flags as { clone?: boolean }).clone ? ['--clone'] : []),
         ])
 
         successCount++

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -355,7 +355,7 @@ export type MountMode = DBMountMode;
 export interface AddAgentOptions {
   skipDevcontainer?: boolean;  // Skip devcontainer creation (default: false)
   themeId?: string;            // Theme ID if agent came from a theme
-  mountMode?: DBMountMode;     // 'worktree' = git worktree, 'clone' = independent clone (default)
+  mountMode?: DBMountMode;     // 'worktree' = git worktree (default), 'clone' = independent clone
 }
 
 /**
@@ -493,7 +493,7 @@ export interface EphemeralAgentOptions {
    * Optional logger for conflict messages (e.g., when a tmux session or directory already exists)
    */
   log?: (message: string) => void;
-  /** Mount mode: 'worktree' = git worktree, 'clone' = independent clone (default) */
+  /** Mount mode: 'worktree' = git worktree (default), 'clone' = independent clone */
   mountMode?: DBMountMode;
 }
 
@@ -583,7 +583,7 @@ export async function createEphemeralAgent(
 
   // Create worktrees/clones for each repository
   const reposPath = path.join(workspaceInfo.path, 'repos');
-  const mountMode = options?.mountMode || 'clone';
+  const mountMode = options?.mountMode || 'worktree';
 
   if (fs.existsSync(reposPath) && workspaceInfo.repositories.length > 0) {
     for (const repo of workspaceInfo.repositories) {

--- a/apps/cli/src/lib/agents/index.ts
+++ b/apps/cli/src/lib/agents/index.ts
@@ -96,7 +96,7 @@ export type MountMode = 'worktree' | 'clone';
 
 export interface CreateAgentOptions {
   skipDevcontainer?: boolean;  // Skip devcontainer creation (default: false)
-  mountMode?: MountMode;       // 'worktree' = git worktree (shared .git), 'clone' = independent clone (default)
+  mountMode?: MountMode;       // 'worktree' = git worktree (shared .git, default), 'clone' = independent clone
 }
 
 /**
@@ -117,7 +117,7 @@ function getRemoteUrl(repoPath: string): string | null {
  * - clone mode: Uses git clone (independent repo, no path translation needed)
  */
 export async function createAgentWorktrees(workspacePath: string, agents: string[], hqPath?: string, options?: CreateAgentOptions): Promise<void> {
-  const mountMode = options?.mountMode || 'clone';  // Default to clone per TKT-453
+  const mountMode = options?.mountMode || 'worktree';  // Default to worktree for real-time file sync
   const modeLabel = mountMode === 'worktree' ? 'worktree' : 'clone';
 
   if (hqPath) {

--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -112,7 +112,7 @@ CREATE TABLE IF NOT EXISTS agents (
   base_name TEXT,
   theme_id TEXT,
   worktree_path TEXT,
-  mount_mode TEXT NOT NULL DEFAULT 'clone' CHECK (mount_mode IN ('worktree', 'clone')),
+  mount_mode TEXT NOT NULL DEFAULT 'worktree' CHECK (mount_mode IN ('worktree', 'clone')),
   created_at TEXT NOT NULL,
   cleaned_at TEXT,
   FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
@@ -429,7 +429,7 @@ export function addRepositoriesToDatabase(workspacePath: string, repos: { name: 
 /**
  * Add agents to database (case-insensitive uniqueness)
  */
-export function addAgentsToDatabase(workspacePath: string, agentNames: string[], themeId?: string, mountMode: MountMode = 'clone'): void {
+export function addAgentsToDatabase(workspacePath: string, agentNames: string[], themeId?: string, mountMode: MountMode = 'worktree'): void {
   const db = openWorkspaceDatabase(workspacePath);
 
   // Check for existing agents (case-insensitive)
@@ -502,7 +502,7 @@ export function addEphemeralAgentToDatabase(
   agentName: string,
   baseName: string,
   themeId?: string,
-  mountMode: MountMode = 'clone'
+  mountMode: MountMode = 'worktree'
 ): Agent {
   const db = openWorkspaceDatabase(workspacePath);
 

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -56,7 +56,7 @@ export interface DevcontainerJson {
  */
 export function generateDevcontainerJson(options: DevcontainerOptions, config?: ExecutionConfig): DevcontainerJson {
   const cfg = config || DEFAULT_EXECUTION_CONFIG
-  const mountMode = options.mountMode || 'clone'  // Default to clone mode
+  const mountMode = options.mountMode || 'worktree'  // Default to worktree mode
 
   // Parse the channel to determine registry and version
   const channel = parseChannel(options.prltChannel || 'npm')


### PR DESCRIPTION
## Summary

This PR adds support for using git worktrees mounted to Docker containers, allowing agents to modify files that are visible on the host disk in real-time.

**Worktree mode is the default** for real-time file sync. Use `--clone` flag for independent clones with more isolation.

### Changes:
- Add `mount_mode` column to agents database with values 'worktree' or 'clone'
- **Default is worktree mode** for real-time file visibility on host
- Add `--clone` flag to opt into independent clone mode (more isolation)
- Update devcontainer generation to conditionally include parent repo mounts (only needed for worktree mode)
- Git wrapper script only installed for worktree mode (clone mode has self-contained .git directories)
- Add `--clone` flag to `agent add`, `work spawn`, and `work start` commands

### Trade-offs

**Worktree mode (default):**
- Real-time file visibility on host
- Smaller disk usage (shared .git objects)
- Faster setup (no network clone needed)
- Branch conflicts possible between host and container
- More complex container setup (path translation needed)

**Clone mode (`--clone` flag):**
- Full isolation from host
- No branch conflicts
- Larger disk usage (full .git copy)
- Slower setup (requires network clone)

## Test plan
- [ ] Test `prlt agent add agent-name` creates agent with worktree mode (default)
- [ ] Test `prlt agent add agent-name --clone` creates agent with clone mode
- [ ] Test ephemeral agent creation uses worktree mode by default
- [ ] Verify devcontainer includes parent repo mounts for worktree mode
- [ ] Verify git wrapper script installed for worktree mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)