### PR TITLE
refactor(TKT-699): DRY up ExecutionContext creation and repoWorktrees detection

### DIFF
--- a/apps/cli/src/commands/work/revise.ts
+++ b/apps/cli/src/commands/work/revise.ts
@@ -23,6 +23,7 @@ import { runExecution, isDockerRunning, isDevcontainerCliInstalled } from '../..
 import { ExecutionStorage } from '../../lib/execution/storage.js'
 import { loadExecutionConfig, getTerminalApp, getShell, hasTerminalPreference, hasShellPreference } from '../../lib/execution/config.js'
 import { hasDevcontainerConfig } from '../../lib/execution/devcontainer.js'
+import { detectRepoWorktrees, resolveWorktreePath } from '../../lib/execution/context.js'
 import {
   isGHInstalled,
   isGHAuthenticated,
@@ -242,22 +243,14 @@ export default class WorkRevise extends PMOCommand {
         this.error(`Agent directory not found at ${agentDir}.`)
       }
 
-      let worktreePath = agentDir
-      const agentContents = fs.readdirSync(agentDir)
-      const repoWorktrees = agentContents.filter(item => {
-        const itemPath = path.join(agentDir, item)
-        const gitPath = path.join(itemPath, '.git')
-        return fs.statSync(itemPath).isDirectory() && fs.existsSync(gitPath)
-      })
+      // Detect repository worktrees within agent directory
+      const repoWorktrees = detectRepoWorktrees(agentDir)
+      const worktreePath = resolveWorktreePath(agentDir, repoWorktrees)
 
-      if (repoWorktrees.length === 1) {
-        worktreePath = path.join(agentDir, repoWorktrees[0])
-      } else if (repoWorktrees.length > 1) {
-        worktreePath = agentDir
+      if (repoWorktrees.length > 1) {
         this.log(styles.muted(`   Repos: ${repoWorktrees.join(', ')}`))
-      } else {
+      } else if (repoWorktrees.length === 0) {
         this.log(styles.muted(`   No git worktree found, using current directory`))
-        worktreePath = process.cwd()
       }
 
       // Get branch from ticket metadata or current branch
@@ -277,6 +270,8 @@ export default class WorkRevise extends PMOCommand {
         worktreePath,
         branch,
         hqPath,
+        pmoPath: this.pmoPath,
+        repoWorktrees,
         // Revision-specific context
         isRevision: true,
         prFeedback: formattedFeedback,

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -39,6 +39,7 @@ import { runExecution, isDockerRunning, isGitHubTokenAvailable, isDevcontainerCl
 import { ExecutionStorage, ContainerStorage } from '../../lib/execution/storage.js'
 import { loadExecutionConfig, getTerminalApp, promptTerminalPreference, getShell, promptShellPreference, hasTerminalPreference, hasShellPreference, getOrPromptCoderName } from '../../lib/execution/config.js'
 import { hasDevcontainerConfig } from '../../lib/execution/devcontainer.js'
+import { detectRepoWorktrees, resolveWorktreePath } from '../../lib/execution/context.js'
 import { isGHInstalled, isGHAuthenticated } from '../../lib/pr/index.js'
 
 /**
@@ -587,31 +588,14 @@ export default class WorkStart extends PMOCommand {
         }
       }
 
-      // Find worktree path for agent
-      // Agent directory may contain multiple repo worktrees - use the agent dir itself
-      // so Claude can work across all repos (frontend, backend, etc.)
-      let worktreePath = agentDir
+      // Detect repository worktrees within agent directory
+      const repoWorktrees = detectRepoWorktrees(agentDir)
+      const worktreePath = resolveWorktreePath(agentDir, repoWorktrees)
 
-      // Check if agent has repository worktrees (subdirectories with .git)
-      const agentContents = fs.readdirSync(agentDir)
-      const repoWorktrees = agentContents.filter(item => {
-        const itemPath = path.join(agentDir, item)
-        const gitPath = path.join(itemPath, '.git')
-        return fs.statSync(itemPath).isDirectory() && fs.existsSync(gitPath)
-      })
-
-      if (repoWorktrees.length === 1) {
-        // Single repo - open directly in the repo worktree
-        worktreePath = path.join(agentDir, repoWorktrees[0])
-      } else if (repoWorktrees.length > 1) {
-        // Multiple repos - open in agent directory, Claude can navigate between them
-        worktreePath = agentDir
+      if (repoWorktrees.length > 1) {
         this.log(styles.muted(`   Repos: ${repoWorktrees.join(', ')}`))
-      } else {
-        // No git worktrees found - agent is a placeholder
-        // Fall back to the current working directory
+      } else if (repoWorktrees.length === 0) {
         this.log(styles.muted(`   No git worktree found for agent, using current directory`))
-        worktreePath = process.cwd()
       }
 
       // Get coder name for branch naming (prompts on first use)
@@ -756,6 +740,7 @@ export default class WorkStart extends PMOCommand {
         branch,
         hqPath,
         pmoPath: this.pmoPath,          // PMO path for container mounting
+        repoWorktrees,
         // Action context
         actionId: selectedAction?.id,
         actionName: selectedAction?.name || (customPrompt ? 'Custom' : undefined),
@@ -1750,18 +1735,9 @@ export default class WorkStart extends PMOCommand {
       throw new Error(`Agent directory not found: ${agentDir}`)
     }
 
-    // Find worktree path
-    let worktreePath = agentDir
-    const agentContents = fs.readdirSync(agentDir)
-    const repoWorktrees = agentContents.filter(item => {
-      const itemPath = path.join(agentDir, item)
-      const gitPath = path.join(itemPath, '.git')
-      return fs.statSync(itemPath).isDirectory() && fs.existsSync(gitPath)
-    })
-
-    if (repoWorktrees.length === 1) {
-      worktreePath = path.join(agentDir, repoWorktrees[0])
-    }
+    // Detect repository worktrees within agent directory
+    const repoWorktrees = detectRepoWorktrees(agentDir)
+    const worktreePath = resolveWorktreePath(agentDir, repoWorktrees)
 
     // Get coder name for branch naming (prompts on first use)
     const coderName = await getOrPromptCoderName(db)
@@ -1812,6 +1788,7 @@ export default class WorkStart extends PMOCommand {
       branch,
       hqPath: workspaceInfo.path,
       pmoPath: this.pmoPath,
+      repoWorktrees,
       createPR: flags['create-pr'] || false,
       // Use 'implement' action for batch mode
       actionId: defaultAction?.id,

--- a/apps/cli/src/lib/execution/context.ts
+++ b/apps/cli/src/lib/execution/context.ts
@@ -1,0 +1,60 @@
+/**
+ * Execution Context Utilities
+ *
+ * Shared helpers for building ExecutionContext and detecting repository worktrees.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Detect git repository worktrees within an agent directory.
+ *
+ * Scans the agent directory for subdirectories that contain a .git file or folder,
+ * indicating they are git repositories (either worktrees or clones).
+ *
+ * @param agentDir - The agent's working directory
+ * @returns Array of repository directory names found within the agent directory
+ */
+export function detectRepoWorktrees(agentDir: string): string[] {
+  if (!fs.existsSync(agentDir)) {
+    return []
+  }
+
+  const agentContents = fs.readdirSync(agentDir)
+  return agentContents.filter(item => {
+    const itemPath = path.join(agentDir, item)
+    const gitPath = path.join(itemPath, '.git')
+    try {
+      return fs.statSync(itemPath).isDirectory() && fs.existsSync(gitPath)
+    } catch {
+      // Handle permission errors or race conditions
+      return false
+    }
+  })
+}
+
+/**
+ * Determine the worktree path for an agent based on detected repositories.
+ *
+ * @param agentDir - The agent's working directory
+ * @param repoWorktrees - Array of repository names (from detectRepoWorktrees)
+ * @param fallbackPath - Path to use if no worktrees found (defaults to process.cwd())
+ * @returns The resolved worktree path
+ */
+export function resolveWorktreePath(
+  agentDir: string,
+  repoWorktrees: string[],
+  fallbackPath?: string
+): string {
+  if (repoWorktrees.length === 1) {
+    // Single repo - open directly in the repo worktree
+    return path.join(agentDir, repoWorktrees[0])
+  } else if (repoWorktrees.length > 1) {
+    // Multiple repos - use agent directory, let user navigate between them
+    return agentDir
+  } else {
+    // No git worktrees found - use fallback
+    return fallbackPath ?? process.cwd()
+  }
+}

--- a/apps/cli/src/lib/execution/spawner.ts
+++ b/apps/cli/src/lib/execution/spawner.ts
@@ -18,6 +18,7 @@ import { ExecutionStorage } from './storage.js'
 import { hasDevcontainerConfig } from './devcontainer.js'
 import { loadExecutionConfig, getOrPromptCoderName } from './config.js'
 import { runExecution, isDockerRunning, isGitHubTokenAvailable, isDevcontainerCliInstalled } from './runners.js'
+import { detectRepoWorktrees, resolveWorktreePath } from './context.js'
 import {
   DisplayMode,
   SessionManager,
@@ -272,23 +273,9 @@ export async function spawnAgentForTicket(
     }
   }
 
-  // Find worktree path for agent
-  let worktreePath = agentDir
-  const agentContents = fs.readdirSync(agentDir)
-  const repoWorktrees = agentContents.filter(item => {
-    const itemPath = path.join(agentDir, item)
-    const gitPath = path.join(itemPath, '.git')
-    return fs.statSync(itemPath).isDirectory() && fs.existsSync(gitPath)
-  })
-
-  if (repoWorktrees.length === 1) {
-    worktreePath = path.join(agentDir, repoWorktrees[0])
-  } else if (repoWorktrees.length > 1) {
-    worktreePath = agentDir
-  } else {
-    // No git worktrees found - use current directory
-    worktreePath = process.cwd()
-  }
+  // Detect repository worktrees within agent directory
+  const repoWorktrees = detectRepoWorktrees(agentDir)
+  const worktreePath = resolveWorktreePath(agentDir, repoWorktrees)
 
   // Get coder name for branch naming (prompts on first use)
   const coderName = await getOrPromptCoderName(db)


### PR DESCRIPTION
## Summary

- Created shared `detectRepoWorktrees()` and `resolveWorktreePath()` functions in `lib/execution/context.ts`
- Replaced 4 duplicate implementations across `spawner.ts`, `work/start.ts`, and `work/revise.ts`
- Added missing `repoWorktrees` field to ExecutionContext in `start.ts` and `revise.ts`

## Problem

The logic for detecting `repoWorktrees` was duplicated in 4 places:
- `spawner.ts:278-291`
- `work/start.ts:597-609` 
- `work/start.ts:1756-1763` (in `spawnSingleTicket`)
- `work/revise.ts:247-257`

This caused a bug where PR #171 (TKT-696) added `repoWorktrees` to `spawner.ts` but missed the other locations.

## Test plan

- [x] Build passes (`pnpm build`)
- [x] CLI tests pass (`./test-cli.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)