### PR TITLE
chore(TKT-703): bump CLI version to 0.3.15

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bumps @proletariat/cli version from 0.3.14 to 0.3.15

## Tasks
- [x] Update version in apps/cli/package.json to 0.3.15
- [x] Run pnpm install to update lockfile
- [x] Commit and create PR

## Notes
This is a patch release. No changelog yet - that will come with TKT-702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)