### PR TITLE
TKT-704: Fix broken image URLs in README for npm

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -88,19 +88,19 @@ Spawn agents to implement, groom, or review—not just write code.
 `prlt work` guides you through project and ticket selection:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/work/work-project-select.png" alt="Project Selection" width="600">
+  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/work/work-project-select.png" alt="Project Selection" width="600">
 </p>
 
 Choose your operation—start a single agent, batch spawn, or watch a column:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/work/work-operations-menu.png" alt="Work Operations Menu" width="600">
+  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/work/work-operations-menu.png" alt="Work Operations Menu" width="600">
 </p>
 
 Select tickets to spawn, grouped by priority:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/work/work-ticket-select.png" alt="Ticket Selection" width="800">
+  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/work/work-ticket-select.png" alt="Ticket Selection" width="800">
 </p>
 
 ---
@@ -254,7 +254,7 @@ $ prlt ticket create
 View ticket details with `prlt ticket`:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/ticket/ticket-view.png" alt="Ticket View" width="600">
+  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/ticket/ticket-view.png" alt="Ticket View" width="600">
 </p>
 
 #### 2. JSON Mode (AI Agents)
@@ -386,7 +386,7 @@ Each agent works in its own branch. No conflicts.
 Monitor running agents with `prlt execution`:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/execution/execution-list.png" alt="Execution List" width="800">
+  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/execution/execution-list.png" alt="Execution List" width="800">
 </p>
 
 ```mermaid
@@ -419,7 +419,7 @@ flowchart LR
 Agent-created PRs ready for review:
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/execution/github-prs.png" alt="GitHub Pull Requests" width="800">
+  <img src="https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/execution/github-prs.png" alt="GitHub Pull Requests" width="800">
 </p>
 
 ### Command Reference


### PR DESCRIPTION
## Summary

Resolves TKT-704: Fix broken image URLs in README for npm

## Description

Images on npmjs.com/package/@proletariat/cli are broken. Current URLs point to wrong repo and path.

**Broken pattern:**
`https://raw.githubusercontent.com/chrismcdermut/proletariat/main/docs/images/...`

**Should be:**
`https://raw.githubusercontent.com/chrismcdermut/proletariat-cli/main/images/...`

**Fix:**
Update all image URLs in apps/cli/README.md to use the proletariat-cli repo and correct path.

## Changes

- e169b88 fix(TKT-704): update README image URLs for npm
- ab303fd fix(TKT-696): add missing repo worktree mounts to raw Docker runner (#171)
- 11b32d4 feat(TKT-686): add git worktree support for live file sync with host (#168)
- 47ebeeb fix(TKT-691): remove unset DEVCONTAINER from tmux script (#170)
- 3b4ff4c Release v0.3.14 (#166)
- 78f1f55 fix(TKT-677): add rule for agents to use globally installed prlt command (#164)
- 53c0d03 Release v0.3.13 - README CTA update (#163)
- 411f401 Release v0.3.12 - README consolidation and support CTA updates (#162)
- 413935d Release v0.3.11 - Agent orchestration platform messaging (#161)
- c1bd495 feat(TKT-496): Open terminal tabs in background + fix execution ID collisions (#160)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
