### PR TITLE
TKT-706: Bump version to 0.3.16

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Resolves TKT-706: Bump version to 0.3.16

## Description

Bump version from 0.3.15 to 0.3.16 in apps/cli/package.json

## Changes

- 10c24de chore(TKT-706): bump @proletariat/cli version to 0.3.16
- 62c7a08 fix(TKT-704): update README image URLs for npm (#176)
- b76ec3a chore(TKT-703): bump @proletariat/cli version to 0.3.15 (#175)
- 28bf697 feat(TKT-681): add setup help CTA to post-init success message (#174)
- 692289c fix(TKT-701): add PRLT_MOUNT_MODE=worktree env var to raw Docker runner (#173)
- 180f20e refactor(TKT-699): refactor: extract repoWorktrees detection into shared context.ts module (#172)
- ab303fd fix(TKT-696): add missing repo worktree mounts to raw Docker runner (#171)
- 11b32d4 feat(TKT-686): add git worktree support for live file sync with host (#168)
- 47ebeeb fix(TKT-691): remove unset DEVCONTAINER from tmux script (#170)
- 3b4ff4c Release v0.3.14 (#166)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
