### PR TITLE
feat(TKT-678): add --keep-temp flag to agent cleanup command

### DIFF
--- a/apps/cli/src/commands/agent/temp/cleanup.ts
+++ b/apps/cli/src/commands/agent/temp/cleanup.ts
@@ -27,6 +27,7 @@ export default class Cleanup extends PMOCommand {
     '<%= config.bin %> <%= command.id %> --temp --dry-run',
     '<%= config.bin %> <%= command.id %> --all',
     '<%= config.bin %> <%= command.id %> --json',
+    '<%= config.bin %> <%= command.id %> bold-bezos-1 --keep-temp',
   ];
 
   static args = {
@@ -62,6 +63,10 @@ export default class Cleanup extends PMOCommand {
     }),
     push: Flags.boolean({
       description: 'Push unpushed commits before cleanup',
+      default: false,
+    }),
+    'keep-temp': Flags.boolean({
+      description: 'Kill container but preserve temp directory for debugging/inspection',
       default: false,
     }),
     json: Flags.boolean({
@@ -100,6 +105,7 @@ export default class Cleanup extends PMOCommand {
     const skipConfirm = flags.yes;
     const forceCleanup = flags.force;
     const pushFirst = flags.push;
+    const keepTemp = flags['keep-temp'];
 
     // Determine which agents to clean up
     let agentsToCleanup: string[] = [];
@@ -259,7 +265,9 @@ export default class Cleanup extends PMOCommand {
       { name: 'No, cancel', value: 'false' },
       { name: 'Yes, clean up', value: 'true' },
     ];
-    const confirmMessage = `Clean up ${agentsToCleanup.length} agent(s)? This will remove directories, containers, and tmux sessions.`;
+    const confirmMessage = keepTemp
+      ? `Clean up ${agentsToCleanup.length} agent(s)? This will kill containers and tmux sessions but PRESERVE temp directories.`
+      : `Clean up ${agentsToCleanup.length} agent(s)? This will remove directories, containers, and tmux sessions.`;
 
     // Confirm unless --yes or dry-run
     if (!skipConfirm && !dryRun) {
@@ -323,6 +331,7 @@ export default class Cleanup extends PMOCommand {
         dryRun,
         force: forceCleanup,
         pushFirst,
+        keepTemp,
       });
 
       // Handle blocked by git status - offer interactive options
@@ -387,6 +396,7 @@ export default class Cleanup extends PMOCommand {
           dryRun,
           force: action === 'force',
           pushFirst: action === 'push',
+          keepTemp,
         });
         results.push(retryResult);
         continue;
@@ -401,6 +411,7 @@ export default class Cleanup extends PMOCommand {
         {
           message: `${dryRun ? 'Would clean' : 'Cleaned'} ${results.filter(r => r.success).length} agent(s)`,
           dryRun,
+          keepTemp,
           cleaned: results.filter(r => r.success).map(r => r.agent),
           failed: results.filter(r => !r.success).map(r => r.agent),
           details: results.map(r => ({
@@ -409,6 +420,8 @@ export default class Cleanup extends PMOCommand {
             tmuxSessionsKilled: r.tmuxSessionsKilled,
             containersRemoved: r.containersRemoved,
             directoriesRemoved: r.directoriesRemoved,
+            tempPreserved: r.tempPreserved,
+            preservedPath: r.preservedPath,
             errors: r.errors,
           })),
         },
@@ -440,12 +453,23 @@ export default class Cleanup extends PMOCommand {
     const totalTmux = results.reduce((sum, r) => sum + r.tmuxSessionsKilled.length, 0);
     const totalContainers = results.reduce((sum, r) => sum + r.containersRemoved.length, 0);
     const totalDirs = results.reduce((sum, r) => sum + r.directoriesRemoved.length, 0);
+    const preservedDirs = results.filter(r => r.tempPreserved);
 
-    if (totalTmux > 0 || totalContainers > 0 || totalDirs > 0) {
+    if (totalTmux > 0 || totalContainers > 0 || totalDirs > 0 || preservedDirs.length > 0) {
       this.log(colors.textMuted(`\nResources ${dryRun ? 'that would be ' : ''}cleaned:`));
       if (totalTmux > 0) this.log(colors.textMuted(`  - Tmux sessions: ${totalTmux}`));
       if (totalContainers > 0) this.log(colors.textMuted(`  - Containers: ${totalContainers}`));
       if (totalDirs > 0) this.log(colors.textMuted(`  - Directories: ${totalDirs}`));
+    }
+
+    // Show preserved directories
+    if (preservedDirs.length > 0) {
+      this.log(colors.primary(`\n📁 Preserved directories (--keep-temp):`));
+      for (const result of preservedDirs) {
+        if (result.preservedPath) {
+          this.log(colors.textMuted(`  - ${result.preservedPath}`));
+        }
+      }
     }
   }
 }

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -745,6 +745,8 @@ export interface CleanupOptions {
   force?: boolean;
   /** If true, push unpushed commits before cleanup */
   pushFirst?: boolean;
+  /** If true, keep the temp directory (only kill container/sessions) */
+  keepTemp?: boolean;
 }
 
 export interface WorktreeGitStatus {
@@ -774,6 +776,10 @@ export interface CleanupResult {
   gitStatus?: AgentGitStatus;
   /** Whether cleanup was blocked due to unsaved work */
   blockedByGit?: boolean;
+  /** Whether temp directory was preserved (--keep-temp flag) */
+  tempPreserved?: boolean;
+  /** Path to preserved temp directory (if keepTemp was used) */
+  preservedPath?: string;
 }
 
 /**
@@ -979,6 +985,7 @@ export async function cleanupAgent(
   const dryRun = options?.dryRun ?? false;
   const force = options?.force ?? false;
   const pushFirst = options?.pushFirst ?? false;
+  const keepTemp = options?.keepTemp ?? false;
 
   const result: CleanupResult = {
     agent: agentName,
@@ -1079,30 +1086,43 @@ export async function cleanupAgent(
     }
   }
 
-  // 3. Remove git worktrees for each repository
-  for (const repo of workspaceInfo.repositories) {
-    const worktreePath = path.join(agentDir, repo.name);
-    const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
+  // 3. Remove git worktrees for each repository (skip if keepTemp)
+  if (!keepTemp) {
+    for (const repo of workspaceInfo.repositories) {
+      const worktreePath = path.join(agentDir, repo.name);
+      const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
 
-    if (fs.existsSync(worktreePath) && fs.existsSync(sourceRepoPath)) {
-      if (dryRun) {
-        log(`[dry-run] Would remove worktree: ${worktreePath}`);
-      } else {
-        log(`Removing worktree: ${worktreePath}`);
-        try {
-          execSync(`git worktree remove "${worktreePath}" --force`, {
-            cwd: sourceRepoPath,
-            stdio: 'pipe'
-          });
-        } catch {
-          // If git worktree remove fails, we'll still try to remove the directory
+      if (fs.existsSync(worktreePath) && fs.existsSync(sourceRepoPath)) {
+        if (dryRun) {
+          log(`[dry-run] Would remove worktree: ${worktreePath}`);
+        } else {
+          log(`Removing worktree: ${worktreePath}`);
+          try {
+            execSync(`git worktree remove "${worktreePath}" --force`, {
+              cwd: sourceRepoPath,
+              stdio: 'pipe'
+            });
+          } catch {
+            // If git worktree remove fails, we'll still try to remove the directory
+          }
         }
       }
     }
   }
 
-  // 4. Remove agent directory
-  if (fs.existsSync(agentDir)) {
+  // 4. Remove agent directory (skip if keepTemp)
+  if (keepTemp) {
+    // Preserve temp directory - just record the path
+    if (fs.existsSync(agentDir)) {
+      result.tempPreserved = true;
+      result.preservedPath = agentDir;
+      if (dryRun) {
+        log(`[dry-run] Would preserve directory: ${agentDir}`);
+      } else {
+        log(`Preserving directory: ${agentDir}`);
+      }
+    }
+  } else if (fs.existsSync(agentDir)) {
     if (dryRun) {
       log(`[dry-run] Would remove directory: ${agentDir}`);
       result.directoriesRemoved.push(agentDir);
@@ -1118,8 +1138,8 @@ export async function cleanupAgent(
     }
   }
 
-  // 5. Prune worktrees
-  if (!dryRun) {
+  // 5. Prune worktrees (skip if keepTemp)
+  if (!dryRun && !keepTemp) {
     for (const repo of workspaceInfo.repositories) {
       const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
       if (fs.existsSync(sourceRepoPath)) {
@@ -1133,6 +1153,7 @@ export async function cleanupAgent(
   }
 
   // 6. Mark agent as cleaned in database (not delete)
+  // Note: We mark as cleaned even with keepTemp since the container is killed
   if (!dryRun && result.success) {
     log(`Marking agent "${agentName}" as cleaned`);
     markAgentCleaned(workspaceInfo.path, agentName);


### PR DESCRIPTION
## Summary

- Adds `--keep-temp` flag to `prlt agent temp cleanup` command that kills container/tmux sessions while preserving the temp directory
- Useful for debugging failed agents, reviewing agent work, or recovering crashed agent work
- Default behavior unchanged (full cleanup)

## Test plan

- [ ] Run `prlt agent temp cleanup <agent-id> --keep-temp --dry-run` and verify it shows directory would be preserved
- [ ] Run `prlt agent temp cleanup <agent-id> --keep-temp` on an actual agent and verify:
  - Container is removed
  - Tmux sessions are killed
  - Temp directory is preserved
  - Output shows the preserved directory path
- [ ] Run `prlt agent temp cleanup <agent-id>` (without flag) and verify full cleanup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)