### PR TITLE
fix(TKT-471): fix spec view SqliteError - remove legacy depends_on column from queries

### DIFF
--- a/apps/cli/src/lib/pmo/storage/helpers.ts
+++ b/apps/cli/src/lib/pmo/storage/helpers.ts
@@ -150,7 +150,8 @@ export function rowToSpec(row: SpecRow): Spec {
     status: row.status as 'draft' | 'active' | 'implemented',
     type: row.type as 'product' | 'platform' | 'infra' | 'integration' | undefined,
     tags: row.tags ? JSON.parse(row.tags) : undefined,
-    dependsOn: row.depends_on ? JSON.parse(row.depends_on) : undefined,
+    // Note: dependsOn is now handled via spec_dependencies table, not inline column
+    dependsOn: undefined,
     problem: row.problem || undefined,
     solution: row.solution || undefined,
     decisions: row.decisions || undefined,

--- a/apps/cli/src/lib/pmo/storage/specs.ts
+++ b/apps/cli/src/lib/pmo/storage/specs.ts
@@ -22,20 +22,19 @@ export class SpecStorage {
 
     this.ctx.db.prepare(`
       INSERT INTO ${T.specs} (
-        id, title, status, type, tags, depends_on,
+        id, title, status, type, tags,
         problem, solution, decisions, not_now, ui_ux,
         acceptance_criteria, open_questions,
         requirements_functional, requirements_technical,
         context, created_at, updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       spec.title || 'Untitled Spec',
       spec.status || 'draft',
       spec.type || null,
       spec.tags ? JSON.stringify(spec.tags) : null,
-      spec.dependsOn ? JSON.stringify(spec.dependsOn) : null,
       spec.problem || null,
       spec.solution || null,
       spec.decisions || null,
@@ -56,7 +55,8 @@ export class SpecStorage {
       status: spec.status || 'draft',
       type: spec.type,
       tags: spec.tags,
-      dependsOn: spec.dependsOn,
+      // Note: dependsOn is now handled via spec_dependencies table
+      dependsOn: undefined,
       problem: spec.problem,
       solution: spec.solution,
       decisions: spec.decisions,
@@ -77,7 +77,7 @@ export class SpecStorage {
    */
   async getSpec(id: string): Promise<Spec | null> {
     const row = this.ctx.db.prepare(`
-      SELECT id, title, status, type, tags, depends_on,
+      SELECT id, title, status, type, tags,
              problem, solution, decisions, not_now, ui_ux,
              acceptance_criteria, open_questions,
              requirements_functional, requirements_technical,
@@ -95,7 +95,7 @@ export class SpecStorage {
    */
   async listSpecs(filter?: SpecFilter): Promise<Spec[]> {
     let query = `
-      SELECT id, title, status, type, tags, depends_on,
+      SELECT id, title, status, type, tags,
              problem, solution, decisions, not_now, ui_ux,
              acceptance_criteria, open_questions,
              requirements_functional, requirements_technical,
@@ -156,10 +156,6 @@ export class SpecStorage {
     if (changes.tags !== undefined) {
       updates.push('tags = ?')
       params.push(JSON.stringify(changes.tags))
-    }
-    if (changes.dependsOn !== undefined) {
-      updates.push('depends_on = ?')
-      params.push(JSON.stringify(changes.dependsOn))
     }
     if (changes.problem !== undefined) {
       updates.push('problem = ?')
@@ -332,7 +328,7 @@ export class SpecStorage {
     }
 
     this.ctx.db.prepare(`
-      INSERT OR IGNORE INTO ${T.spec_dependencies} (spec_id, depends_on, created_at)
+      INSERT OR IGNORE INTO ${T.spec_dependencies} (spec_id, depends_on_spec_id, created_at)
       VALUES (?, ?, ?)
     `).run(specId, dependsOnId, Date.now())
   }
@@ -343,7 +339,7 @@ export class SpecStorage {
   async removeSpecDependency(specId: string, dependsOnId: string): Promise<void> {
     this.ctx.db.prepare(`
       DELETE FROM ${T.spec_dependencies}
-      WHERE spec_id = ? AND depends_on = ?
+      WHERE spec_id = ? AND depends_on_spec_id = ?
     `).run(specId, dependsOnId)
   }
 
@@ -352,13 +348,13 @@ export class SpecStorage {
    */
   async getSpecDependencies(specId: string): Promise<Spec[]> {
     const rows = this.ctx.db.prepare(`
-      SELECT depends_on FROM ${T.spec_dependencies} WHERE spec_id = ?
-    `).all(specId) as Array<{ depends_on: string }>
+      SELECT depends_on_spec_id FROM ${T.spec_dependencies} WHERE spec_id = ?
+    `).all(specId) as Array<{ depends_on_spec_id: string }>
 
     const specs: Spec[] = []
     for (const row of rows) {
       // eslint-disable-next-line no-await-in-loop -- Sequential lookup for relationship chain
-      const spec = await this.getSpec(row.depends_on)
+      const spec = await this.getSpec(row.depends_on_spec_id)
       if (spec) specs.push(spec)
     }
     return specs
@@ -369,7 +365,7 @@ export class SpecStorage {
    */
   async getSpecDependents(specId: string): Promise<Spec[]> {
     const rows = this.ctx.db.prepare(`
-      SELECT spec_id FROM ${T.spec_dependencies} WHERE depends_on = ?
+      SELECT spec_id FROM ${T.spec_dependencies} WHERE depends_on_spec_id = ?
     `).all(specId) as Array<{ spec_id: string }>
 
     const specs: Spec[] = []
@@ -420,7 +416,7 @@ export class SpecStorage {
    */
   async getSpecsForProject(projectId: string): Promise<Spec[]> {
     const rows = this.ctx.db.prepare(`
-      SELECT s.id, s.title, s.status, s.type, s.tags, s.depends_on,
+      SELECT s.id, s.title, s.status, s.type, s.tags,
              s.problem, s.solution, s.decisions, s.not_now, s.ui_ux,
              s.acceptance_criteria, s.open_questions,
              s.requirements_functional, s.requirements_technical,

--- a/apps/cli/src/lib/pmo/storage/types.ts
+++ b/apps/cli/src/lib/pmo/storage/types.ts
@@ -63,7 +63,7 @@ export interface SpecRow {
   status: string
   type: string | null
   tags: string | null
-  depends_on: string | null
+  depends_on?: string | null  // Legacy field, no longer used (dependencies via spec_dependencies table)
   problem: string | null
   solution: string | null
   decisions: string | null


### PR DESCRIPTION
## Summary
- Removed legacy `depends_on` column from `pmo_specs` table queries (it may not exist in all databases)
- Fixed `spec_dependencies` table queries to use correct column name `depends_on_spec_id` (matching the schema)
- Updated `SpecRow` type and `rowToSpec` helper to handle the optional/removed field

## Problem
When viewing specs with `prlt spec view`, users would get a SqliteError because queries were referencing a `depends_on` column that:
1. Doesn't exist in older databases (migration may not have run)
2. Is no longer used (dependencies are handled via the `spec_dependencies` table)

Additionally, the `spec_dependencies` table queries were using `depends_on` column name instead of the correct `depends_on_spec_id` as defined in the schema.

## Solution
- Remove `depends_on` from all `pmo_specs` SELECT, INSERT, and UPDATE queries
- Dependencies are now properly queried through the `spec_dependencies` join table
- Fixed column name references in `spec_dependencies` queries to match schema

## Test plan
- [x] Build passes (`pnpm build`)
- [ ] `prlt spec list` works
- [ ] `prlt spec view <id>` works without SqliteError

🤖 Generated with [Claude Code](https://claude.com/claude-code)