### PR TITLE
TKT-714: Set up private npm registry for agent installs to get accurate download metrics

### DIFF
--- a/apps/cli/.github/workflows/onRelease.yml
+++ b/apps/cli/.github/workflows/onRelease.yml
@@ -5,7 +5,8 @@ on:
     types: [released]
 
 jobs:
-  publish:
+  # Publish to public npm (for real users)
+  publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,4 +19,26 @@ jobs:
       - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
         with:
           token: ${{ secrets.NPM_TOKEN }}
+      - run: npm run postpack
+
+  # Publish to GitHub Packages (for agents - doesn't inflate public npm stats)
+  publish-github-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@proletariat'
+      - run: npm install
+      - run: npm run build
+      - run: npm run prepack
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run postpack

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -212,12 +212,20 @@ USER node
 RUN npm install -g pnpm && npm install -g @anthropic-ai/claude-code
 USER root
 
-# Install prlt CLI from public npm
-# PRLT_REGISTRY: "npm" (install from npmjs.com) or "mount" (use host mount)
+# Install prlt CLI
+# PRLT_REGISTRY: "npm" (install from npmjs.com), "gh" (GitHub Packages), or "mount" (use host mount)
 # PRLT_VERSION: version/tag like "latest", "dev", "next", or "1.2.3"
+# Using GitHub Packages for agent builds keeps public npm download stats accurate
 ARG PRLT_REGISTRY=npm
 ARG PRLT_VERSION=latest
-RUN if [ "\${PRLT_REGISTRY}" = "npm" ] || [ "\${PRLT_REGISTRY}" = "gh" ]; then \\
+ARG GITHUB_TOKEN
+RUN if [ "\${PRLT_REGISTRY}" = "gh" ]; then \\
+      echo "Installing @proletariat/cli@\${PRLT_VERSION} from GitHub Packages..." && \\
+      echo "//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}" > ~/.npmrc && \\
+      echo "@proletariat:registry=https://npm.pkg.github.com" >> ~/.npmrc && \\
+      npm install -g @proletariat/cli@\${PRLT_VERSION} && \\
+      rm -f ~/.npmrc; \\
+    elif [ "\${PRLT_REGISTRY}" = "npm" ]; then \\
       echo "Installing @proletariat/cli@\${PRLT_VERSION} from npm..." && \\
       npm install -g @proletariat/cli@\${PRLT_VERSION}; \\
     else \\

--- a/apps/cli/src/lib/workspace-config.ts
+++ b/apps/cli/src/lib/workspace-config.ts
@@ -22,17 +22,20 @@ import * as path from 'node:path'
 /**
  * prlt channel options:
  *
- * Public npm (npmjs.com) - no auth required:
+ * Public npm (npmjs.com) - for real users:
  * - "npm": Install @proletariat/cli@latest from public npm (default)
  * - "npm:dev": Install @proletariat/cli@dev from public npm
  * - "npm:next": Install @proletariat/cli@next from public npm
  * - "npm:x.y.z": Install specific version from public npm
  *
+ * GitHub Packages - for agent containers (doesn't inflate npm download stats):
+ * - "gh": Install @proletariat/cli@latest from GitHub Packages
+ * - "gh:dev": Install @proletariat/cli@dev from GitHub Packages
+ * - "gh:x.y.z": Install specific version from GitHub Packages
+ * Requires GITHUB_TOKEN with packages:read scope
+ *
  * Local development:
  * - "mount": Mount local prlt build from PRLT_REPO_PATH
- *
- * Legacy (deprecated, now uses npm):
- * - "gh": Alias for npm (GitHub Packages no longer used)
  */
 export type PrltChannel = 'npm' | 'npm:dev' | 'npm:next' | 'gh' | 'gh:dev' | 'mount' | string
 

--- a/docs/architecture/npm-registry-setup.md
+++ b/docs/architecture/npm-registry-setup.md
@@ -1,0 +1,173 @@
+# Private NPM Registry for Agent Downloads
+
+This document describes the dual registry architecture used to separate agent installs from real user downloads.
+
+## Problem
+
+When agents install `@proletariat/cli` from public npm, they inflate download counts, making it impossible to distinguish real user adoption from internal agent usage. This makes usage analytics inaccurate.
+
+## Solution: Dual Registry Architecture
+
+```
+                          Real Users
+                              |
+                              v
+                    ┌─────────────────┐
+                    │  Public npm     │  <-- Real user installs
+                    │  (npmjs.com)    │      (accurate download stats)
+                    └─────────────────┘
+                              ^
+                              |
+                    ┌─────────────────┐
+                    │  CI/CD Release  │
+                    │  (GitHub Actions)│
+                    └─────────────────┘
+                              |
+                              v
+                    ┌─────────────────┐
+                    │ GitHub Packages │  <-- Agent installs
+                    │ (npm.pkg.github)│      (doesn't count in npm stats)
+                    └─────────────────┘
+                              ^
+                              |
+                      Agent Containers
+```
+
+## How It Works
+
+### Publishing (CI/CD)
+
+When a new version is released, GitHub Actions publishes to both registries:
+
+1. **Public npm** (for users): Uses `NPM_TOKEN` secret
+2. **GitHub Packages** (for agents): Uses built-in `GITHUB_TOKEN`
+
+See `.github/workflows/onRelease.yml` for the publish workflow.
+
+### User Installs
+
+Regular users install from public npm as usual:
+
+```bash
+npm install -g @proletariat/cli
+```
+
+This counts toward public npm download stats and reflects real adoption.
+
+### Agent Installs
+
+Agent containers use the `gh` channel to install from GitHub Packages:
+
+```bash
+# In .proletariat/config.json
+{
+  "prlt": {
+    "channel": "gh"
+  }
+}
+```
+
+This installs from GitHub Packages, which doesn't inflate public npm stats.
+
+## Configuration
+
+### Setting the Agent Channel
+
+Configure agents to use GitHub Packages in your workspace config:
+
+```bash
+# Edit .proletariat/config.json
+{
+  "type": "hq",
+  "name": "my-workspace",
+  "prlt": {
+    "channel": "gh"
+  }
+}
+```
+
+### Channel Options
+
+| Channel | Source | Use Case |
+|---------|--------|----------|
+| `npm` | Public npm (npmjs.com) | Default, for users |
+| `npm:dev` | Public npm dev tag | Testing pre-release |
+| `gh` | GitHub Packages | Agent containers |
+| `gh:dev` | GitHub Packages dev tag | Agent testing |
+| `mount` | Local build | Development |
+
+### GitHub Token Requirements
+
+Agent containers need a `GITHUB_TOKEN` with `packages:read` scope to pull from GitHub Packages:
+
+```bash
+# Set in your environment
+export GITHUB_TOKEN=ghp_xxxx
+```
+
+The token is passed to the container via the devcontainer.json build args.
+
+## Verifying Setup
+
+### Check Agent is Using GitHub Packages
+
+Inside an agent container:
+
+```bash
+# This should show GitHub Packages was used
+npm list -g @proletariat/cli
+```
+
+### Verify Public npm Stats
+
+Visit [npmjs.com/package/@proletariat/cli](https://www.npmjs.com/package/@proletariat/cli) to see download stats. These should only reflect real user installs.
+
+## Troubleshooting
+
+### Agent Can't Pull from GitHub Packages
+
+1. Check `GITHUB_TOKEN` is set and has `packages:read` scope
+2. Verify the token is passed to the container build:
+   ```bash
+   echo $GITHUB_TOKEN
+   ```
+3. Check GitHub Packages availability:
+   ```bash
+   curl -H "Authorization: Bearer $GITHUB_TOKEN" \
+     https://npm.pkg.github.com/@proletariat/cli
+   ```
+
+### Fallback to Public npm
+
+If GitHub Packages is unavailable, change the channel to `npm`:
+
+```json
+{
+  "prlt": {
+    "channel": "npm"
+  }
+}
+```
+
+This will work but will inflate npm download stats.
+
+## Development Workflow
+
+For local development, use the `mount` channel to avoid any registry:
+
+```json
+{
+  "prlt": {
+    "channel": "mount"
+  }
+}
+```
+
+This mounts your local prlt build from `PRLT_REPO_PATH`.
+
+## Related Files
+
+- `apps/cli/.github/workflows/onRelease.yml` - Publish workflow
+- `apps/cli/src/lib/execution/devcontainer.ts` - Container template with registry logic
+- `apps/cli/src/lib/workspace-config.ts` - Channel configuration types
+- `specs/infra/devcontainer.md` - Full devcontainer specification


### PR DESCRIPTION
## Summary

Resolves TKT-714: Set up private npm registry for agent installs to get accurate download metrics

## Description

## Problem

Agents constantly install `@proletariat/cli` from public npm, inflating download counts and making it impossible to distinguish real user downloads from internal agent usage. This makes usage analytics (TKT-131) inaccurate.

## Solution

Set up a private npm registry (Verdaccio) that mirrors `@proletariat/cli` for agent usage, while public npm only gets real user downloads.

## Requirements

- **R1:** Deploy Verdaccio private npm registry (self-hosted or cloud)
- **R2:** Configure agents to install from private registry
- **R3:** Auto-publish to private registry on version bumps
- **R4:** Keep public npm as primary distribution channel for users
- **R5:** Document the two-registry setup

## Implementation Options

### Option 1: Self-hosted Verdaccio (Docker)
```bash
docker run -d -p 4873:4873 verdaccio/verdaccio
```

### Option 2: Cloud-hosted (verdaccio.org, npmjs.com private, GitHub Packages)
- GitHub Packages: Free for public repos
- npmjs.com private: \/month
- Self-hosted: Free but requires maintenance

### Option 3: Conditional install in agents
```bash
# In agent Dockerfile/bootstrap
if [ "\" = "true" ]; then
  npm config set registry https://npm.proletariat.dev
fi
npm install @proletariat/cli
```

## Architecture

```
┌─────────────────┐
│  Public npm     │ ←── Real users install here
│  (public stats) │
└─────────────────┘

┌─────────────────┐
│ Private registry│ ←── Agents install here
│ (Verdaccio)     │     (doesn't count toward public stats)
└─────────────────┘
       ↑
       │ Auto-publish on release
       │
┌─────────────────┐
│  CI/CD          │
│  (GitHub Actions)│
└─────────────────┘
```

## CI/CD Integration

```yaml
# .github/workflows/publish.yml
- name: Publish to public npm
  run: npm publish --access public
  
- name: Publish to private registry
  run: |
    npm config set registry https://npm.proletariat.dev
    npm publish
```

## Agent Configuration

Update agent Dockerfile/bootstrap to use private registry:

```dockerfile
# Set private npm registry for agent builds
ENV NPM_CONFIG_REGISTRY=https://npm.proletariat.dev
RUN npm install -g @proletariat/cli
```

Or use `.npmrc`:
```
registry=https://npm.proletariat.dev
```

## Success Criteria

- [ ] Private registry deployed and accessible
- [ ] Agents install from private registry (verify in logs)
- [ ] Public npm downloads only count real users
- [ ] Auto-publish to both registries on release
- [ ] Documentation for maintaining registry
- [ ] Backup/restore strategy for private registry

## Related

- TKT-131 (Usage analytics) - accurate download counts
- TKT-132 (Error tracking) - version tracking
- TKT-693 (Universal agent container image)
- TKT-713 (Update plugin) - works with private registry

## Complexity Factors

- Need to maintain registry uptime
- Need to handle auth tokens securely
- Need to sync versions between public/private
- Agents must handle registry failover

## Estimated Cost

- Self-hosted Verdaccio: Free (\/bin/zsh/month)
- Cloud VM for hosting: \-10/month (DigitalOcean, Fly.io)
- GitHub Packages: Free for public repos
- npmjs.com private: \/month

## Changes

- 00794be feat(TKT-714): add private npm registry setup with GitHub Packages
- 3728aec chore(TKT-706): bump @proletariat/cli version to 0.3.16 (#177)
- 62c7a08 fix(TKT-704): update README image URLs for npm (#176)
- b76ec3a chore(TKT-703): bump @proletariat/cli version to 0.3.15 (#175)
- 28bf697 feat(TKT-681): add setup help CTA to post-init success message (#174)
- 692289c fix(TKT-701): add PRLT_MOUNT_MODE=worktree env var to raw Docker runner (#173)
- 180f20e refactor(TKT-699): refactor: extract repoWorktrees detection into shared context.ts module (#172)
- ab303fd fix(TKT-696): add missing repo worktree mounts to raw Docker runner (#171)
- 11b32d4 feat(TKT-686): add git worktree support for live file sync with host (#168)
- 47ebeeb fix(TKT-691): remove unset DEVCONTAINER from tmux script (#170)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
