### PR TITLE
TKT-707: Remove redundant Changes section from PR body template

### DIFF
--- a/apps/cli/src/commands/pr/create.ts
+++ b/apps/cli/src/commands/pr/create.ts
@@ -13,7 +13,6 @@ import {
   hasBranchBeenPushed,
   pushBranch,
   hasUnpushedCommits,
-  getCommitLog,
   createPR,
   getPRForBranch,
   generatePRTitle,
@@ -218,12 +217,10 @@ export default class PRCreate extends Command {
       }
 
       if (!prBody && ticket) {
-        const commits = getCommitLog(baseBranch);
         prBody = generatePRBody({
           ticketId: ticket.id,
           ticketTitle: ticket.title,
           ticketDescription: ticket.description,
-          commits: commits.slice(0, 10), // Limit to 10 commits
         });
       }
 

--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -16,7 +16,6 @@ import {
   hasBranchBeenPushed,
   pushBranch,
   hasUnpushedCommits,
-  getCommitLog,
   createPR,
   getPRForBranch,
   generatePRTitle,
@@ -320,12 +319,10 @@ export default class WorkReady extends PMOCommand {
 
       // Generate PR content
       const prTitle = generatePRTitle(ticket.id, ticket.title);
-      const commits = getCommitLog(baseBranch);
       const prBody = generatePRBody({
         ticketId: ticket.id,
         ticketTitle: ticket.title,
         ticketDescription: ticket.description,
-        commits: commits.slice(0, 10),
       });
 
       // Create PR

--- a/apps/cli/src/lib/pr/index.ts
+++ b/apps/cli/src/lib/pr/index.ts
@@ -393,9 +393,8 @@ export function generatePRBody(options: {
   ticketId: string;
   ticketTitle: string;
   ticketDescription?: string;
-  commits?: string[];
 }): string {
-  const { ticketId, ticketTitle, ticketDescription, commits } = options;
+  const { ticketId, ticketTitle, ticketDescription } = options;
 
   const lines: string[] = [];
 
@@ -408,15 +407,6 @@ export function generatePRBody(options: {
     lines.push('## Description');
     lines.push('');
     lines.push(ticketDescription);
-    lines.push('');
-  }
-
-  if (commits && commits.length > 0) {
-    lines.push('## Changes');
-    lines.push('');
-    for (const commit of commits) {
-      lines.push(`- ${commit}`);
-    }
     lines.push('');
   }
 

--- a/apps/cli/test/unit/pr-utils.test.ts
+++ b/apps/cli/test/unit/pr-utils.test.ts
@@ -89,25 +89,10 @@ describe('PR Utils Unit Tests', () => {
       expect(body).to.not.contain('## Description');
     });
 
-    it('should include Changes section with commits', () => {
+    it('should not include Changes section', () => {
       const options = {
         ticketId: 'TKT-001',
         ticketTitle: 'Test feature',
-        commits: ['abc123 Add initial implementation', 'def456 Fix typo'],
-      };
-
-      const body = generatePRBodyMock(options);
-
-      expect(body).to.contain('## Changes');
-      expect(body).to.contain('- abc123 Add initial implementation');
-      expect(body).to.contain('- def456 Fix typo');
-    });
-
-    it('should skip Changes section when no commits', () => {
-      const options = {
-        ticketId: 'TKT-001',
-        ticketTitle: 'Test feature',
-        commits: [],
       };
 
       const body = generatePRBodyMock(options);
@@ -261,9 +246,8 @@ function generatePRBodyMock(options: {
   ticketId: string;
   ticketTitle: string;
   ticketDescription?: string;
-  commits?: string[];
 }): string {
-  const { ticketId, ticketTitle, ticketDescription, commits } = options;
+  const { ticketId, ticketTitle, ticketDescription } = options;
 
   const lines: string[] = [];
 
@@ -276,15 +260,6 @@ function generatePRBodyMock(options: {
     lines.push('## Description');
     lines.push('');
     lines.push(ticketDescription);
-    lines.push('');
-  }
-
-  if (commits && commits.length > 0) {
-    lines.push('## Changes');
-    lines.push('');
-    for (const commit of commits) {
-      lines.push(`- ${commit}`);
-    }
     lines.push('');
   }
 

--- a/specs/product/pull-requests.md
+++ b/specs/product/pull-requests.md
@@ -129,12 +129,6 @@ Resolves {TICKET-ID}: {Ticket Title}
 
 {Ticket Description}
 
-## Changes
-
-- {commit 1}
-- {commit 2}
-- ...
-
 ## Test Plan
 
 - [ ] Tests pass locally


### PR DESCRIPTION
## Summary

Resolves TKT-707: Fix changelog section in PR description generation

The "## Changes" section in auto-generated PR descriptions was redundant - it listed commit messages which GitHub already shows in the PR's Commits tab.

## Description

- Removed `commits` parameter from `generatePRBody()` function
- Removed `getCommitLog` import from `pr/create.ts` and `work/ready.ts`
- Updated unit tests to verify Changes section is not included
- Updated spec to reflect new PR body template

## Test Plan

- [x] Build passes
- [x] CLI tests pass
- [ ] Manual testing: `prlt pr create` generates PR without Changes section

🤖 Generated with [Claude Code](https://claude.com/claude-code)