### PR TITLE
TKT-678: Agent cleanup: Option to kill container but preserve temp directory

### DIFF
--- a/apps/cli/src/commands/agent/temp/cleanup.ts
+++ b/apps/cli/src/commands/agent/temp/cleanup.ts
@@ -26,6 +26,7 @@ export default class Cleanup extends PMOCommand {
     '<%= config.bin %> <%= command.id %> --temp',
     '<%= config.bin %> <%= command.id %> --temp --dry-run',
     '<%= config.bin %> <%= command.id %> --all',
+    '<%= config.bin %> <%= command.id %> bold-bezos-1 --keep-temp',
     '<%= config.bin %> <%= command.id %> --json',
   ];
 
@@ -64,6 +65,10 @@ export default class Cleanup extends PMOCommand {
       description: 'Push unpushed commits before cleanup',
       default: false,
     }),
+    'keep-temp': Flags.boolean({
+      description: 'Kill container/sessions but preserve temp directory for inspection',
+      default: false,
+    }),
     json: Flags.boolean({
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
@@ -100,6 +105,7 @@ export default class Cleanup extends PMOCommand {
     const skipConfirm = flags.yes;
     const forceCleanup = flags.force;
     const pushFirst = flags.push;
+    const keepTemp = flags['keep-temp'];
 
     // Determine which agents to clean up
     let agentsToCleanup: string[] = [];
@@ -259,7 +265,9 @@ export default class Cleanup extends PMOCommand {
       { name: 'No, cancel', value: 'false' },
       { name: 'Yes, clean up', value: 'true' },
     ];
-    const confirmMessage = `Clean up ${agentsToCleanup.length} agent(s)? This will remove directories, containers, and tmux sessions.`;
+    const confirmMessage = keepTemp
+      ? `Stop ${agentsToCleanup.length} agent(s)? This will kill containers and tmux sessions but preserve temp directories.`
+      : `Clean up ${agentsToCleanup.length} agent(s)? This will remove directories, containers, and tmux sessions.`;
 
     // Confirm unless --yes or dry-run
     if (!skipConfirm && !dryRun) {
@@ -323,6 +331,7 @@ export default class Cleanup extends PMOCommand {
         dryRun,
         force: forceCleanup,
         pushFirst,
+        keepTemp,
       });
 
       // Handle blocked by git status - offer interactive options
@@ -387,6 +396,7 @@ export default class Cleanup extends PMOCommand {
           dryRun,
           force: action === 'force',
           pushFirst: action === 'push',
+          keepTemp,
         });
         results.push(retryResult);
         continue;
@@ -397,10 +407,12 @@ export default class Cleanup extends PMOCommand {
 
     // JSON mode: output results
     if (jsonMode) {
+      const actionWord = dryRun ? 'Would stop' : keepTemp ? 'Stopped' : 'Cleaned';
       outputSuccessAsJson(
         {
-          message: `${dryRun ? 'Would clean' : 'Cleaned'} ${results.filter(r => r.success).length} agent(s)`,
+          message: `${actionWord} ${results.filter(r => r.success).length} agent(s)`,
           dryRun,
+          keepTemp,
           cleaned: results.filter(r => r.success).map(r => r.agent),
           failed: results.filter(r => !r.success).map(r => r.agent),
           details: results.map(r => ({
@@ -424,7 +436,11 @@ export default class Cleanup extends PMOCommand {
     const failed = results.filter(r => !r.success);
 
     if (successful.length > 0) {
-      this.log(format.success(`${dryRun ? 'Would clean' : 'Cleaned'} ${successful.length} agent(s): ${successful.map(r => r.agent).join(', ')}`));
+      const actionWord = dryRun ? 'Would stop' : keepTemp ? 'Stopped' : 'Cleaned';
+      this.log(format.success(`${actionWord} ${successful.length} agent(s): ${successful.map(r => r.agent).join(', ')}`));
+      if (keepTemp) {
+        this.log(colors.textMuted('  Temp directories preserved for inspection.'));
+      }
     }
 
     if (failed.length > 0) {
@@ -442,10 +458,11 @@ export default class Cleanup extends PMOCommand {
     const totalDirs = results.reduce((sum, r) => sum + r.directoriesRemoved.length, 0);
 
     if (totalTmux > 0 || totalContainers > 0 || totalDirs > 0) {
-      this.log(colors.textMuted(`\nResources ${dryRun ? 'that would be ' : ''}cleaned:`));
+      const resourceAction = dryRun ? 'that would be ' : keepTemp ? 'stopped' : 'cleaned';
+      this.log(colors.textMuted(`\nResources ${resourceAction}:`));
       if (totalTmux > 0) this.log(colors.textMuted(`  - Tmux sessions: ${totalTmux}`));
       if (totalContainers > 0) this.log(colors.textMuted(`  - Containers: ${totalContainers}`));
-      if (totalDirs > 0) this.log(colors.textMuted(`  - Directories: ${totalDirs}`));
+      if (totalDirs > 0 && !keepTemp) this.log(colors.textMuted(`  - Directories: ${totalDirs}`));
     }
   }
 }

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -745,6 +745,8 @@ export interface CleanupOptions {
   force?: boolean;
   /** If true, push unpushed commits before cleanup */
   pushFirst?: boolean;
+  /** If true, preserve the temp directory (only kill container/sessions) */
+  keepTemp?: boolean;
 }
 
 export interface WorktreeGitStatus {
@@ -979,6 +981,7 @@ export async function cleanupAgent(
   const dryRun = options?.dryRun ?? false;
   const force = options?.force ?? false;
   const pushFirst = options?.pushFirst ?? false;
+  const keepTemp = options?.keepTemp ?? false;
 
   const result: CleanupResult = {
     agent: agentName,
@@ -1079,47 +1082,55 @@ export async function cleanupAgent(
     }
   }
 
-  // 3. Remove git worktrees for each repository
-  for (const repo of workspaceInfo.repositories) {
-    const worktreePath = path.join(agentDir, repo.name);
-    const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
+  // 3. Remove git worktrees for each repository (skip if keepTemp)
+  if (!keepTemp) {
+    for (const repo of workspaceInfo.repositories) {
+      const worktreePath = path.join(agentDir, repo.name);
+      const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
 
-    if (fs.existsSync(worktreePath) && fs.existsSync(sourceRepoPath)) {
-      if (dryRun) {
-        log(`[dry-run] Would remove worktree: ${worktreePath}`);
-      } else {
-        log(`Removing worktree: ${worktreePath}`);
-        try {
-          execSync(`git worktree remove "${worktreePath}" --force`, {
-            cwd: sourceRepoPath,
-            stdio: 'pipe'
-          });
-        } catch {
-          // If git worktree remove fails, we'll still try to remove the directory
+      if (fs.existsSync(worktreePath) && fs.existsSync(sourceRepoPath)) {
+        if (dryRun) {
+          log(`[dry-run] Would remove worktree: ${worktreePath}`);
+        } else {
+          log(`Removing worktree: ${worktreePath}`);
+          try {
+            execSync(`git worktree remove "${worktreePath}" --force`, {
+              cwd: sourceRepoPath,
+              stdio: 'pipe'
+            });
+          } catch {
+            // If git worktree remove fails, we'll still try to remove the directory
+          }
         }
       }
     }
+  } else {
+    log(`Preserving worktrees (--keep-temp)`);
   }
 
-  // 4. Remove agent directory
-  if (fs.existsSync(agentDir)) {
-    if (dryRun) {
-      log(`[dry-run] Would remove directory: ${agentDir}`);
-      result.directoriesRemoved.push(agentDir);
-    } else {
-      log(`Removing directory: ${agentDir}`);
-      try {
-        fs.rmSync(agentDir, { recursive: true, force: true });
+  // 4. Remove agent directory (skip if keepTemp)
+  if (!keepTemp) {
+    if (fs.existsSync(agentDir)) {
+      if (dryRun) {
+        log(`[dry-run] Would remove directory: ${agentDir}`);
         result.directoriesRemoved.push(agentDir);
-      } catch (error) {
-        result.errors.push(`Failed to remove directory ${agentDir}: ${error}`);
-        result.success = false;
+      } else {
+        log(`Removing directory: ${agentDir}`);
+        try {
+          fs.rmSync(agentDir, { recursive: true, force: true });
+          result.directoriesRemoved.push(agentDir);
+        } catch (error) {
+          result.errors.push(`Failed to remove directory ${agentDir}: ${error}`);
+          result.success = false;
+        }
       }
     }
+  } else {
+    log(`Preserving temp directory: ${agentDir}`);
   }
 
-  // 5. Prune worktrees
-  if (!dryRun) {
+  // 5. Prune worktrees (skip if keepTemp)
+  if (!dryRun && !keepTemp) {
     for (const repo of workspaceInfo.repositories) {
       const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
       if (fs.existsSync(sourceRepoPath)) {
@@ -1132,10 +1143,12 @@ export async function cleanupAgent(
     }
   }
 
-  // 6. Mark agent as cleaned in database (not delete)
-  if (!dryRun && result.success) {
+  // 6. Mark agent as cleaned in database (skip if keepTemp - agent can be fully cleaned later)
+  if (!dryRun && result.success && !keepTemp) {
     log(`Marking agent "${agentName}" as cleaned`);
     markAgentCleaned(workspaceInfo.path, agentName);
+  } else if (keepTemp && result.success) {
+    log(`Agent "${agentName}" container stopped but temp directory preserved`);
   }
 
   return result;


### PR DESCRIPTION
## Summary

Resolves TKT-678: Agent cleanup: Option to kill container but preserve temp directory

## Description

## Problem

When cleaning up ephemeral agents, the current behavior kills both:
1. The tmux/docker container
2. The temp directory on the host machine

Sometimes you want to kill the container but **preserve the temp directory** for debugging or inspection.

## Requirements

- R1: Agent cleanup should support granular options
- R2: User can choose to kill container only (preserve temp dir)
- R3: User can choose to kill container AND delete temp dir (current behavior)
- R4: Default behavior should remain unchanged (full cleanup)

## Proposed UX

```bash
# Full cleanup (default - current behavior)
prlt agent cleanup <agent-id>

# Kill container only, keep temp directory
prlt agent cleanup <agent-id> --keep-temp

# Or maybe flags for explicit control:
prlt agent cleanup <agent-id> --container-only
prlt agent cleanup <agent-id> --full
```

## Use Cases

1. **Debugging failed agents** - Want to inspect temp files after container dies
2. **Reviewing agent work** - Check what files were created before cleanup
3. **Recovering work** - Agent crashed but work is in temp dir

## Changes

- 52e91d2 feat(TKT-678): add --keep-temp flag to agent cleanup command

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
