### PR TITLE
TKT-716: Use shared base Docker image instead of per-agent builds

### DIFF
--- a/apps/cli/src/commands/agent/build-base.ts
+++ b/apps/cli/src/commands/agent/build-base.ts
@@ -1,0 +1,220 @@
+import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import { colors } from '../../lib/colors.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import {
+  isDockerRunning,
+  getPrltVersion,
+  getBaseImageTag,
+  buildBaseImage,
+} from '../../lib/execution/runners.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+
+/**
+ * Check if a Docker image exists locally.
+ */
+function imageExists(imageName: string): boolean {
+  try {
+    execSync(`docker image inspect ${imageName}`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export default class AgentBuildBase extends PMOCommand {
+  static description = 'Build the shared base Docker image for all agents'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --no-cache',
+    '<%= config.bin %> <%= command.id %> --force  # Rebuild even if exists',
+    '<%= config.bin %> <%= command.id %> --json  # JSON mode for AI agents',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    json: Flags.boolean({
+      description: 'Output prompt configuration as JSON (for AI agents/scripts)',
+      default: false,
+    }),
+    'no-cache': Flags.boolean({
+      description: 'Build without using cache',
+      default: false,
+    }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Force rebuild even if image already exists',
+      default: false,
+    }),
+  }
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false }
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(AgentBuildBase)
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags)
+
+    // Check Docker is running
+    if (!isDockerRunning()) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'DOCKER_NOT_RUNNING',
+          'Docker is not running. Please start Docker Desktop and try again.',
+          createMetadata('agent build-base', flags)
+        )
+        this.exit(1)
+      }
+      this.error('Docker is not running. Please start Docker Desktop and try again.')
+    }
+
+    const prltVersion = getPrltVersion()
+    const baseImageTag = getBaseImageTag()
+
+    // Check if image already exists
+    if (imageExists(baseImageTag) && !flags.force) {
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { imageTag: baseImageTag, version: prltVersion, status: 'exists' },
+          createMetadata('agent build-base', flags)
+        )
+        return
+      }
+      this.log(colors.success(`✓ Base image already exists: ${baseImageTag}`))
+      this.log(colors.textMuted('Use --force to rebuild'))
+      return
+    }
+
+    // Find an agent with a Dockerfile to use as template
+    const workspaceInfo = getWorkspaceInfo()
+    if (!workspaceInfo) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'NO_WORKSPACE',
+          'Not in a proletariat workspace. Run `prlt init` first.',
+          createMetadata('agent build-base', flags)
+        )
+        this.exit(1)
+      }
+      this.error('Not in a proletariat workspace. Run `prlt init` first.')
+    }
+
+    const agentDir = this.findAgentWithDockerfile(workspaceInfo.path)
+    if (!agentDir) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'NO_DOCKERFILE',
+          'No agent with Dockerfile found. Add an agent first: prlt agent staff add',
+          createMetadata('agent build-base', flags)
+        )
+        this.exit(1)
+      }
+      this.error('No agent with Dockerfile found. Add an agent first: prlt agent staff add')
+    }
+
+    this.log(colors.primary(`🔨 Building base image: ${baseImageTag}\n`))
+    this.log(colors.textSecondary(`  Version: ${prltVersion}`))
+    this.log(colors.textSecondary(`  Using Dockerfile from: ${path.relative(workspaceInfo.path, agentDir)}`))
+    this.log('')
+
+    // Build the base image
+    const buildArgs: Record<string, string> = {
+      TZ: 'America/Los_Angeles',
+      PRLT_REGISTRY: 'npm',
+      PRLT_VERSION: 'latest',
+    }
+
+    // Add --no-cache if requested
+    if (flags['no-cache']) {
+      this.log(colors.textMuted('  Building without cache...\n'))
+    }
+
+    try {
+      const success = buildBaseImage(agentDir, baseImageTag, buildArgs)
+
+      if (!success) {
+        if (jsonMode) {
+          outputErrorAsJson(
+            'BUILD_FAILED',
+            'Failed to build base image',
+            createMetadata('agent build-base', flags)
+          )
+          this.exit(1)
+        }
+        this.error('Failed to build base image. Check Docker logs for details.')
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { imageTag: baseImageTag, version: prltVersion, status: 'built' },
+          createMetadata('agent build-base', flags)
+        )
+        return
+      }
+
+      this.log('')
+      this.log(colors.success(`✓ Base image built successfully: ${baseImageTag}`))
+      this.log(colors.textMuted('All agent spawns will now use this shared image'))
+    } catch (error) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'BUILD_FAILED',
+          `Failed to build base image: ${error instanceof Error ? error.message : String(error)}`,
+          createMetadata('agent build-base', flags)
+        )
+        this.exit(1)
+      }
+      this.error(`Failed to build base image: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  /**
+   * Find an agent directory that has a Dockerfile.
+   * Looks in both staff and temp agent directories.
+   */
+  private findAgentWithDockerfile(workspacePath: string): string | null {
+    const agentsPath = path.join(workspacePath, 'agents')
+
+    // Check staff agents first
+    const staffPath = path.join(agentsPath, 'staff')
+    if (fs.existsSync(staffPath)) {
+      const staffDirs = fs.readdirSync(staffPath, { withFileTypes: true })
+        .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+
+      for (const dir of staffDirs) {
+        const dockerfilePath = path.join(staffPath, dir.name, '.devcontainer', 'Dockerfile')
+        if (fs.existsSync(dockerfilePath)) {
+          return path.join(staffPath, dir.name)
+        }
+      }
+    }
+
+    // Check temp agents
+    const tempPath = path.join(agentsPath, 'temp')
+    if (fs.existsSync(tempPath)) {
+      const tempDirs = fs.readdirSync(tempPath, { withFileTypes: true })
+        .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+
+      for (const dir of tempDirs) {
+        const dockerfilePath = path.join(tempPath, dir.name, '.devcontainer', 'Dockerfile')
+        if (fs.existsSync(dockerfilePath)) {
+          return path.join(tempPath, dir.name)
+        }
+      }
+    }
+
+    return null
+  }
+}

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -8,6 +8,7 @@ import { spawn, execSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import { fileURLToPath } from 'node:url'
 import {
   ExecutionEnvironment,
   DisplayMode,
@@ -118,6 +119,99 @@ export function configureITermTmuxWindowMode(mode: 'tab' | 'window'): void {
 // =============================================================================
 
 const CLAUDE_CREDENTIALS_VOLUME = 'claude-credentials'
+
+// Base image name for shared agent Docker images
+const BASE_IMAGE_NAME = 'prlt-agent-base'
+
+// =============================================================================
+// Base Image Management
+// =============================================================================
+
+/**
+ * Get the prlt CLI version from package.json.
+ * This is used to tag base images for version consistency.
+ */
+export function getPrltVersion(): string {
+  try {
+    // Navigate from this file to package.json
+    const currentDir = path.dirname(fileURLToPath(import.meta.url))
+    const packageJsonPath = path.join(currentDir, '..', '..', '..', 'package.json')
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+    return pkg.version
+  } catch (error) {
+    console.debug('[runners:version] Failed to read package.json:', error)
+    return 'latest'
+  }
+}
+
+/**
+ * Get the base image tag for the current prlt version.
+ * Format: prlt-agent-base:{version}
+ */
+export function getBaseImageTag(): string {
+  const version = getPrltVersion()
+  return `${BASE_IMAGE_NAME}:${version}`
+}
+
+/**
+ * Build the shared base Docker image from an agent's Dockerfile.
+ * This image is shared across all agents for the same prlt version.
+ *
+ * @param agentDir - Path to an agent directory with .devcontainer/Dockerfile
+ * @param imageTag - The tag for the base image (e.g., prlt-agent-base:0.3.17)
+ * @param buildArgs - Build arguments for the Dockerfile
+ * @returns true if build succeeded, false otherwise
+ */
+export function buildBaseImage(agentDir: string, imageTag: string, buildArgs: Record<string, string> = {}): boolean {
+  const dockerfilePath = path.join(agentDir, '.devcontainer', 'Dockerfile')
+  if (!fs.existsSync(dockerfilePath)) {
+    console.debug(`[runners:docker] Dockerfile not found at ${dockerfilePath}`)
+    return false
+  }
+
+  try {
+    // Build --build-arg flags
+    const buildArgFlags = Object.entries(buildArgs)
+      .map(([key, value]) => `--build-arg ${key}="${value}"`)
+      .join(' ')
+
+    const buildCmd = `docker build -t ${imageTag} -f "${dockerfilePath}" ${buildArgFlags} "${path.join(agentDir, '.devcontainer')}"`
+    console.debug(`[runners:docker] Building base image: ${buildCmd}`)
+    execSync(buildCmd, { stdio: 'pipe' })
+    return true
+  } catch (error) {
+    console.debug(`[runners:docker] Failed to build base image:`, error)
+    return false
+  }
+}
+
+/**
+ * Ensure the shared base image exists, building it if necessary.
+ * This is called before container creation to ensure we have a base image
+ * for the current prlt version.
+ *
+ * @param agentDir - Path to an agent directory with .devcontainer/Dockerfile
+ * @returns The base image tag if available, null if build failed
+ */
+export function ensureBaseImageExists(agentDir: string): string | null {
+  const baseImageTag = getBaseImageTag()
+
+  if (!imageExists(baseImageTag)) {
+    console.debug(`[runners:docker] Building base image ${baseImageTag}`)
+    const buildArgs: Record<string, string> = {
+      TZ: 'America/Los_Angeles',
+      PRLT_REGISTRY: 'npm',
+      PRLT_VERSION: 'latest',
+    }
+    if (!buildBaseImage(agentDir, baseImageTag, buildArgs)) {
+      return null
+    }
+  } else {
+    console.debug(`[runners:docker] Using existing base image ${baseImageTag}`)
+  }
+
+  return baseImageTag
+}
 
 /**
  * Check if the claude-credentials Docker volume exists.
@@ -1018,7 +1112,7 @@ function runContainerSetup(containerId: string, sandboxed: boolean = true): bool
 
 /**
  * Ensure a Docker container is running for the agent.
- * Builds image and creates container if needed.
+ * Uses shared base image (prlt-agent-base:{version}) instead of per-agent images.
  * Returns the container ID if successful, null otherwise.
  */
 function ensureDockerContainer(
@@ -1026,7 +1120,6 @@ function ensureDockerContainer(
   config: ExecutionConfig
 ): string | null {
   const containerName = getContainerName(context.agentName)
-  const imageName = getImageName(context.agentName)
 
   // Always create fresh container to ensure mounts are up-to-date
   // TODO: Revisit container reuse strategy - for now, fresh containers ensure
@@ -1040,22 +1133,17 @@ function ensureDockerContainer(
     }
   }
 
-  // Build image if it doesn't exist
-  if (!imageExists(imageName)) {
-    console.debug(`[runners:docker] Building image ${imageName}`)
-    const buildArgs: Record<string, string> = {
-      TZ: 'America/Los_Angeles',
-      PRLT_REGISTRY: 'npm',
-      PRLT_VERSION: 'latest',
-    }
-    if (!buildDockerImage(context.agentDir, imageName, buildArgs)) {
-      return null
-    }
+  // Use shared base image instead of per-agent images
+  // This dramatically speeds up spawning after the first build
+  const baseImageTag = ensureBaseImageExists(context.agentDir)
+  if (!baseImageTag) {
+    console.debug(`[runners:docker] Failed to ensure base image exists`)
+    return null
   }
 
-  // Create and start container
-  console.debug(`[runners:docker] Creating container ${containerName}`)
-  if (!createDockerContainer(context, containerName, imageName, config)) {
+  // Create and start container from base image with agent-specific config
+  console.debug(`[runners:docker] Creating container ${containerName} from ${baseImageTag}`)
+  if (!createDockerContainer(context, containerName, baseImageTag, config)) {
     return null
   }
 


### PR DESCRIPTION
## Summary

Resolves TKT-716: Use shared base Docker image instead of per-agent builds

## Description

## Problem
Currently each agent spawn builds a new Docker image:
```
[runners:docker] Building image prlt-agent-civic-lecun:latest
[runners:docker] Building image prlt-agent-sure-systrom:latest
```

This is slow and wasteful — the Dockerfile has no agent-specific build args.

## Solution: Version-tagged local base images

1. On spawn, check if `prlt-agent-base:{prlt-version}` exists locally
2. If not → build it once, tag as `prlt-agent-base:0.3.16`
3. If yes → skip build, reuse existing image
4. Run container from base image with agent-specific env vars/mounts

## Implementation

### 1. Add base image check to runners/docker.ts
```typescript
const prltVersion = require('../package.json').version
const baseImageTag = `prlt-agent-base:${prltVersion}`

// Check if base image exists
const imageExists = await docker.imageExists(baseImageTag)
if (!imageExists) {
  await docker.buildBaseImage(baseImageTag)
}

// Run container from base image (no per-agent build)
await docker.run(baseImageTag, { name: agentName, env: {...}, volumes: {...} })
```

### 2. Separate base Dockerfile from agent config
- Base Dockerfile: prlt, claude-code, tools (version-tagged)
- Agent config: env vars, mounts (per-container)

### 3. Optional: Add `prlt agent build-base` command
For manual pre-building or CI

## Benefits
- Spawn time: ~2min → ~5sec (after first build)
- First spawn per version: still builds (once)
- Less disk space (no duplicate images)
- Predictable versioning

## Files to modify
- apps/cli/src/lib/execution/runners/docker.ts (or wherever docker logic lives)
- Dockerfile template generation

## Changes

- 48e49e3 feat(TKT-716): use shared base Docker image instead of per-agent builds
- e320365 refactor(TKT-206): feat(TKT-206): add Drizzle ORM for type-safe database queries (#191)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
