### PR TITLE
TKT-472: BUG: Spec Assign - No specs found

### DIFF
--- a/apps/cli/src/commands/spec/import.ts
+++ b/apps/cli/src/commands/spec/import.ts
@@ -1,0 +1,404 @@
+import { Flags, Args } from '@oclif/core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import inquirer from 'inquirer';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import { parseSpecFile, validateSpec } from '../../lib/pmo/spec-parser.js';
+import { slugify } from '../../lib/pmo/utils.js';
+import { SpecType, SpecStatus } from '../../lib/pmo/types.js';
+import { ParsedSpec } from '../../lib/pmo/spec-types.js';
+
+/**
+ * Map folder name to spec type
+ */
+function folderToSpecType(folderName: string): SpecType | undefined {
+  const typeMap: Record<string, SpecType> = {
+    product: 'product',
+    platform: 'platform',
+    infra: 'infra',
+    integrations: 'integration',
+    integration: 'integration',
+  };
+  return typeMap[folderName.toLowerCase()];
+}
+
+/**
+ * Extract spec ID from parsed spec or derive from file
+ */
+function getSpecId(parsedSpec: ParsedSpec, filePath: string): string {
+  // Prefer ID from frontmatter
+  if (parsedSpec.frontmatter.id) {
+    return parsedSpec.frontmatter.id;
+  }
+  // Fall back to slugified title
+  if (parsedSpec.title && parsedSpec.title !== 'Untitled') {
+    return slugify(parsedSpec.title);
+  }
+  // Last resort: use filename
+  const basename = path.basename(filePath, '.md');
+  return slugify(basename);
+}
+
+export default class SpecImport extends PMOCommand {
+  static description = 'Import spec markdown files into the database';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> specs/product/auth.md',
+    '<%= config.bin %> <%= command.id %> --dir specs/',
+    '<%= config.bin %> <%= command.id %> --all',
+    '<%= config.bin %> <%= command.id %> --dry-run',
+  ];
+
+  static args = {
+    file: Args.string({
+      description: 'Specific spec file to import',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    dir: Flags.string({
+      char: 'd',
+      description: 'Directory to scan for spec files',
+      default: 'specs',
+    }),
+    all: Flags.boolean({
+      char: 'a',
+      description: 'Import all spec files from directory',
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Show what would be imported without making changes',
+      default: false,
+    }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Overwrite existing specs without prompting',
+      default: false,
+    }),
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SpecImport);
+    const dryRun = flags['dry-run'];
+
+    // Find spec files to import
+    let files: string[] = [];
+
+    if (args.file) {
+      // Import specific file
+      if (!fs.existsSync(args.file)) {
+        this.error(`File not found: ${args.file}`);
+      }
+      files = [args.file];
+    } else {
+      // Scan directory for spec files
+      const specsDir = path.resolve(flags.dir);
+      if (!fs.existsSync(specsDir)) {
+        this.log(styles.warning(`\nSpecs directory not found: ${specsDir}`));
+        this.log(styles.muted('Create spec files in a specs/ directory, or use --dir to specify a different location.'));
+        return;
+      }
+
+      files = this.findSpecFiles(specsDir);
+
+      if (files.length === 0) {
+        this.log(styles.warning(`\nNo markdown files found in ${specsDir}`));
+        return;
+      }
+
+      // If not --all, let user select which files to import
+      if (!flags.all) {
+        const { selectedFiles } = await inquirer.prompt([{
+          type: 'checkbox',
+          name: 'selectedFiles',
+          message: 'Select spec files to import:',
+          choices: files.map(f => ({
+            name: path.relative(process.cwd(), f),
+            value: f,
+            checked: true,
+          })),
+        }]);
+
+        if (selectedFiles.length === 0) {
+          this.log(styles.muted('No files selected.'));
+          return;
+        }
+        files = selectedFiles;
+      }
+    }
+
+    this.log(styles.title('\n📥 Import Specs from Markdown'));
+    this.log(styles.muted('═'.repeat(60)));
+
+    if (dryRun) {
+      this.log(styles.warning('DRY RUN - No changes will be made\n'));
+    }
+
+    // Process each file
+    const results = {
+      imported: 0,
+      skipped: 0,
+      errors: 0,
+      overwritten: 0,
+    };
+
+    for (const file of files) {
+      await this.importFile(file, flags, dryRun, results);
+    }
+
+    // Summary
+    this.log(styles.muted('\n' + '═'.repeat(60)));
+    this.log(styles.emphasis('Summary:'));
+    if (results.imported > 0) {
+      this.log(styles.success(`  ✅ Imported: ${results.imported}`));
+    }
+    if (results.overwritten > 0) {
+      this.log(styles.warning(`  🔄 Overwritten: ${results.overwritten}`));
+    }
+    if (results.skipped > 0) {
+      this.log(styles.muted(`  ⏭️  Skipped: ${results.skipped}`));
+    }
+    if (results.errors > 0) {
+      this.log(styles.error(`  ❌ Errors: ${results.errors}`));
+    }
+
+    if (!dryRun && results.imported + results.overwritten > 0) {
+      this.log(styles.muted('\nView imported specs: prlt spec list'));
+    }
+  }
+
+  /**
+   * Find all markdown files in directory (recursively)
+   */
+  private findSpecFiles(dir: string): string[] {
+    const files: string[] = [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...this.findSpecFiles(fullPath));
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        // Skip README files
+        if (entry.name.toLowerCase() !== 'readme.md') {
+          files.push(fullPath);
+        }
+      }
+    }
+
+    return files;
+  }
+
+  /**
+   * Import a single spec file
+   */
+  private async importFile(
+    filePath: string,
+    flags: { force: boolean },
+    dryRun: boolean,
+    results: { imported: number; skipped: number; errors: number; overwritten: number }
+  ): Promise<void> {
+    const relativePath = path.relative(process.cwd(), filePath);
+    this.log(`\n${styles.code(relativePath)}`);
+
+    // Parse the file
+    let parsedSpec: ParsedSpec;
+    try {
+      parsedSpec = parseSpecFile(filePath);
+    } catch (error) {
+      this.log(styles.error(`  ❌ Parse error: ${(error as Error).message}`));
+      results.errors++;
+      return;
+    }
+
+    // Validate the spec
+    const validationErrors = validateSpec(parsedSpec);
+
+    // Get spec ID
+    const specId = getSpecId(parsedSpec, filePath);
+
+    // Infer type from folder structure if not in frontmatter
+    let specType = parsedSpec.frontmatter.type;
+    if (!specType) {
+      const parentDir = path.basename(path.dirname(filePath));
+      specType = folderToSpecType(parentDir);
+    }
+
+    // Log parsed info
+    this.log(styles.muted(`  ID: ${specId}`));
+    this.log(styles.muted(`  Title: ${parsedSpec.title}`));
+    if (specType) {
+      this.log(styles.muted(`  Type: ${specType}`));
+    }
+
+    // Check for validation errors (but allow missing id if we derived one)
+    const criticalErrors = validationErrors.filter(e =>
+      e !== 'Missing id in frontmatter'
+    );
+
+    if (criticalErrors.length > 0) {
+      this.log(styles.warning(`  ⚠️  Validation warnings:`));
+      for (const error of criticalErrors) {
+        this.log(styles.warning(`     - ${error}`));
+      }
+      // Only skip if missing required content sections
+      if (criticalErrors.some(e => e.includes('Missing title') || e.includes('Missing Problem') || e.includes('Missing Solution'))) {
+        this.log(styles.error(`  ❌ Skipped: Missing required sections`));
+        results.errors++;
+        return;
+      }
+    }
+
+    // Check if spec already exists
+    const existingSpec = await this.storage.getSpec(specId);
+    if (existingSpec) {
+      if (dryRun) {
+        this.log(styles.warning(`  🔄 Would overwrite existing spec`));
+        results.overwritten++;
+        return;
+      }
+
+      if (!flags.force) {
+        // Prompt for action
+        const { action } = await inquirer.prompt([{
+          type: 'list',
+          name: 'action',
+          message: `Spec "${specId}" already exists. What would you like to do?`,
+          choices: [
+            { name: 'Overwrite with imported content', value: 'overwrite' },
+            { name: 'Skip this file', value: 'skip' },
+            { name: 'Import with different ID', value: 'rename' },
+          ],
+        }]);
+
+        if (action === 'skip') {
+          this.log(styles.muted(`  ⏭️  Skipped`));
+          results.skipped++;
+          return;
+        }
+
+        if (action === 'rename') {
+          const { newId } = await inquirer.prompt([{
+            type: 'input',
+            name: 'newId',
+            message: 'Enter new spec ID:',
+            default: `${specId}-imported`,
+            validate: (input: string) => {
+              if (!input.trim()) return 'ID is required';
+              return true;
+            },
+          }]);
+
+          // Check if the new ID also exists
+          const newExisting = await this.storage.getSpec(newId);
+          if (newExisting) {
+            this.log(styles.error(`  ❌ ID "${newId}" also exists. Skipping.`));
+            results.skipped++;
+            return;
+          }
+
+          await this.createSpec(parsedSpec, newId, specType, dryRun);
+          this.log(styles.success(`  ✅ Imported as "${newId}"`));
+          results.imported++;
+          return;
+        }
+
+        // Overwrite
+        await this.updateSpec(existingSpec.id, parsedSpec, specType, dryRun);
+        this.log(styles.warning(`  🔄 Overwritten`));
+        results.overwritten++;
+        return;
+      }
+
+      // Force mode - overwrite without prompting
+      await this.updateSpec(existingSpec.id, parsedSpec, specType, dryRun);
+      this.log(styles.warning(`  🔄 Overwritten`));
+      results.overwritten++;
+      return;
+    }
+
+    // Create new spec
+    if (dryRun) {
+      this.log(styles.success(`  ✅ Would import as "${specId}"`));
+      results.imported++;
+      return;
+    }
+
+    await this.createSpec(parsedSpec, specId, specType, dryRun);
+    this.log(styles.success(`  ✅ Imported`));
+    results.imported++;
+  }
+
+  /**
+   * Create a new spec from parsed content
+   */
+  private async createSpec(
+    parsed: ParsedSpec,
+    specId: string,
+    specType: SpecType | undefined,
+    dryRun: boolean
+  ): Promise<void> {
+    if (dryRun) return;
+
+    await this.storage.createSpec({
+      id: specId,
+      title: parsed.title,
+      status: parsed.frontmatter.status || 'draft' as SpecStatus,
+      type: specType,
+      tags: parsed.frontmatter.tags,
+      problem: parsed.problem,
+      solution: parsed.solution,
+      decisions: parsed.decisions,
+      notNow: parsed.notNow,
+      uiUx: parsed.uiUx,
+      acceptanceCriteria: parsed.acceptanceCriteria,
+      openQuestions: parsed.openQuestions,
+      requirementsFunctional: parsed.requirementsFunctional,
+      requirementsTechnical: parsed.requirementsTechnical,
+      context: parsed.context,
+    });
+
+    // Handle dependencies if specified
+    if (parsed.frontmatter.depends_on && parsed.frontmatter.depends_on.length > 0) {
+      for (const depId of parsed.frontmatter.depends_on) {
+        const depSpec = await this.storage.getSpec(depId);
+        if (depSpec) {
+          await this.storage.addSpecDependency(specId, depId);
+        }
+      }
+    }
+  }
+
+  /**
+   * Update an existing spec with parsed content
+   */
+  private async updateSpec(
+    specId: string,
+    parsed: ParsedSpec,
+    specType: SpecType | undefined,
+    dryRun: boolean
+  ): Promise<void> {
+    if (dryRun) return;
+
+    await this.storage.updateSpec(specId, {
+      title: parsed.title,
+      status: parsed.frontmatter.status,
+      type: specType,
+      tags: parsed.frontmatter.tags,
+      problem: parsed.problem,
+      solution: parsed.solution,
+      decisions: parsed.decisions,
+      notNow: parsed.notNow,
+      uiUx: parsed.uiUx,
+      acceptanceCriteria: parsed.acceptanceCriteria,
+      openQuestions: parsed.openQuestions,
+      requirementsFunctional: parsed.requirementsFunctional,
+      requirementsTechnical: parsed.requirementsTechnical,
+      context: parsed.context,
+    });
+  }
+}

--- a/apps/cli/src/commands/spec/list.ts
+++ b/apps/cli/src/commands/spec/list.ts
@@ -40,8 +40,10 @@ export default class SpecList extends PMOCommand {
     });
 
     if (specs.length === 0) {
-      this.log(styles.warning('\nNo specs found'));
-      this.log(styles.muted('  Create your first spec: prlt spec create'));
+      this.log(styles.warning('\nNo specs found in database'));
+      this.log(styles.muted('  Specs are stored in the PMO database, not as markdown files.'));
+      this.log(styles.muted('  Create a new spec:    prlt spec create'));
+      this.log(styles.muted('  Import from markdown: prlt spec import'));
       return;
     }
 

--- a/apps/cli/src/commands/ticket/spec.ts
+++ b/apps/cli/src/commands/ticket/spec.ts
@@ -125,7 +125,8 @@ export default class TicketSpec extends PMOCommand {
     // Get all specs
     const specs = await this.storage.listSpecs();
     if (specs.length === 0) {
-      this.log(styles.muted('\nNo specs found.'));
+      this.log(styles.muted('\nNo specs found in database.'));
+      this.log(styles.muted('Have markdown specs? Import them: prlt spec import'));
       const actionChoices = [
         { id: 'create', name: 'Create a new spec' },
         { id: 'cancel', name: 'Cancel' },
@@ -270,7 +271,8 @@ export default class TicketSpec extends PMOCommand {
     if (!specId) {
       const specs = await this.storage.listSpecs();
       if (specs.length === 0) {
-        this.log(styles.muted('\nNo specs found. Create one with: prlt spec create'));
+        this.log(styles.muted('\nNo specs found in database.'));
+        this.log(styles.muted('Create: prlt spec create  |  Import: prlt spec import'));
         return;
       }
 

--- a/apps/cli/test/unit/spec-import.test.ts
+++ b/apps/cli/test/unit/spec-import.test.ts
@@ -1,0 +1,379 @@
+import { expect } from 'chai';
+import { parseSpecContent, validateSpec } from '../../src/lib/pmo/spec-parser.js';
+import { slugify } from '../../src/lib/pmo/utils.js';
+import { SpecType } from '../../src/lib/pmo/types.js';
+import { ParsedSpec } from '../../src/lib/pmo/spec-types.js';
+
+/**
+ * Helper functions from spec/import.ts (duplicated for testing)
+ */
+function folderToSpecType(folderName: string): SpecType | undefined {
+  const typeMap: Record<string, SpecType> = {
+    product: 'product',
+    platform: 'platform',
+    infra: 'infra',
+    integrations: 'integration',
+    integration: 'integration',
+  };
+  return typeMap[folderName.toLowerCase()];
+}
+
+function getSpecId(parsedSpec: ParsedSpec, filePath: string): string {
+  if (parsedSpec.frontmatter.id) {
+    return parsedSpec.frontmatter.id;
+  }
+  if (parsedSpec.title && parsedSpec.title !== 'Untitled') {
+    return slugify(parsedSpec.title);
+  }
+  const basename = filePath.replace(/.*\//, '').replace('.md', '');
+  return slugify(basename);
+}
+
+describe('Spec Import', () => {
+  describe('parseSpecContent', () => {
+    it('parses spec with full frontmatter', () => {
+      const content = `---
+id: my-spec
+status: active
+type: product
+tags: [core, mvp]
+depends_on: [other-spec]
+---
+
+# My Spec Title
+
+## Problem
+
+This is the problem.
+
+## Solution
+
+This is the solution.
+`;
+
+      const parsed = parseSpecContent(content, 'specs/product/my-spec.md');
+
+      expect(parsed.frontmatter.id).to.equal('my-spec');
+      expect(parsed.frontmatter.status).to.equal('active');
+      expect(parsed.frontmatter.type).to.equal('product');
+      expect(parsed.frontmatter.tags).to.deep.equal(['core', 'mvp']);
+      expect(parsed.frontmatter.depends_on).to.deep.equal(['other-spec']);
+      expect(parsed.title).to.equal('My Spec Title');
+      expect(parsed.problem).to.equal('This is the problem.');
+      expect(parsed.solution).to.equal('This is the solution.');
+    });
+
+    it('parses spec without frontmatter', () => {
+      const content = `# Auth System
+
+## Problem
+
+Users need to authenticate.
+
+## Solution
+
+Implement OAuth 2.0.
+`;
+
+      const parsed = parseSpecContent(content, 'specs/product/auth.md');
+
+      expect(parsed.frontmatter.id).to.be.undefined;
+      expect(parsed.frontmatter.status).to.be.undefined;
+      expect(parsed.title).to.equal('Auth System');
+      expect(parsed.problem).to.equal('Users need to authenticate.');
+      expect(parsed.solution).to.equal('Implement OAuth 2.0.');
+    });
+
+    it('parses nested requirements sections', () => {
+      const content = `# Feature
+
+## Problem
+
+Problem text.
+
+## Solution
+
+Solution text.
+
+## Requirements
+
+### Functional
+
+- User can login
+- User can logout
+
+### Technical
+
+- Use JWT tokens
+- Rate limit API
+`;
+
+      const parsed = parseSpecContent(content, 'specs/feature.md');
+
+      expect(parsed.requirementsFunctional).to.contain('User can login');
+      expect(parsed.requirementsFunctional).to.contain('User can logout');
+      expect(parsed.requirementsTechnical).to.contain('Use JWT tokens');
+      expect(parsed.requirementsTechnical).to.contain('Rate limit API');
+    });
+
+    it('parses all optional sections', () => {
+      const content = `---
+id: full-spec
+---
+
+# Complete Spec
+
+## Problem
+
+The problem.
+
+## Solution
+
+The solution.
+
+## Decisions
+
+- Decision 1
+- Decision 2
+
+## Not Now
+
+- Deferred feature
+
+## UI/UX
+
+- User flow here
+
+## Acceptance Criteria
+
+- [ ] Given X, when Y, then Z
+
+## Open Questions
+
+- What about edge cases?
+
+## Context
+
+Background info.
+`;
+
+      const parsed = parseSpecContent(content, 'specs/full-spec.md');
+
+      expect(parsed.decisions).to.contain('Decision 1');
+      expect(parsed.notNow).to.contain('Deferred feature');
+      expect(parsed.uiUx).to.contain('User flow here');
+      expect(parsed.acceptanceCriteria).to.contain('Given X, when Y, then Z');
+      expect(parsed.openQuestions).to.contain('What about edge cases?');
+      expect(parsed.context).to.contain('Background info');
+    });
+  });
+
+  describe('validateSpec', () => {
+    it('returns no errors for valid spec', () => {
+      const content = `---
+id: valid-spec
+---
+
+# Valid Title
+
+## Problem
+
+Valid problem.
+
+## Solution
+
+Valid solution.
+`;
+
+      const parsed = parseSpecContent(content, 'test.md');
+      const errors = validateSpec(parsed);
+
+      expect(errors).to.be.empty;
+    });
+
+    it('returns error for missing id', () => {
+      const content = `# Title
+
+## Problem
+
+Problem.
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, 'test.md');
+      const errors = validateSpec(parsed);
+
+      expect(errors).to.include('Missing id in frontmatter');
+    });
+
+    it('returns error for missing title', () => {
+      const content = `---
+id: no-title
+---
+
+## Problem
+
+Problem.
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, 'test.md');
+      const errors = validateSpec(parsed);
+
+      expect(errors).to.include('Missing title (H1 heading)');
+    });
+
+    it('returns error for missing Problem section', () => {
+      const content = `---
+id: no-problem
+---
+
+# Title
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, 'test.md');
+      const errors = validateSpec(parsed);
+
+      expect(errors).to.include('Missing Problem section');
+    });
+
+    it('returns error for missing Solution section', () => {
+      const content = `---
+id: no-solution
+---
+
+# Title
+
+## Problem
+
+Problem.
+`;
+
+      const parsed = parseSpecContent(content, 'test.md');
+      const errors = validateSpec(parsed);
+
+      expect(errors).to.include('Missing Solution section');
+    });
+
+    it('returns multiple errors for multiple issues', () => {
+      const content = `## Not a title
+`;
+
+      const parsed = parseSpecContent(content, 'test.md');
+      const errors = validateSpec(parsed);
+
+      expect(errors).to.have.lengthOf.at.least(3);
+      expect(errors).to.include('Missing id in frontmatter');
+      expect(errors).to.include('Missing title (H1 heading)');
+      expect(errors).to.include('Missing Problem section');
+    });
+  });
+
+  describe('folderToSpecType', () => {
+    it('maps product folder to product type', () => {
+      expect(folderToSpecType('product')).to.equal('product');
+    });
+
+    it('maps platform folder to platform type', () => {
+      expect(folderToSpecType('platform')).to.equal('platform');
+    });
+
+    it('maps infra folder to infra type', () => {
+      expect(folderToSpecType('infra')).to.equal('infra');
+    });
+
+    it('maps integrations folder to integration type', () => {
+      expect(folderToSpecType('integrations')).to.equal('integration');
+    });
+
+    it('maps integration folder to integration type', () => {
+      expect(folderToSpecType('integration')).to.equal('integration');
+    });
+
+    it('handles case insensitively', () => {
+      expect(folderToSpecType('Product')).to.equal('product');
+      expect(folderToSpecType('PLATFORM')).to.equal('platform');
+    });
+
+    it('returns undefined for unknown folder', () => {
+      expect(folderToSpecType('docs')).to.be.undefined;
+      expect(folderToSpecType('other')).to.be.undefined;
+    });
+  });
+
+  describe('getSpecId', () => {
+    it('uses frontmatter id when present', () => {
+      const content = `---
+id: custom-id
+---
+
+# Title
+
+## Problem
+
+Problem.
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, 'specs/my-spec.md');
+      expect(getSpecId(parsed, 'specs/my-spec.md')).to.equal('custom-id');
+    });
+
+    it('falls back to slugified title', () => {
+      const content = `# User Authentication
+
+## Problem
+
+Problem.
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, 'specs/auth.md');
+      expect(getSpecId(parsed, 'specs/auth.md')).to.equal('user-authentication');
+    });
+
+    it('falls back to filename when no title', () => {
+      const content = `## Problem
+
+Problem.
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, 'specs/my-feature.md');
+      expect(getSpecId(parsed, 'specs/my-feature.md')).to.equal('my-feature');
+    });
+
+    it('handles complex file paths', () => {
+      const content = `## Problem
+
+Problem.
+
+## Solution
+
+Solution.
+`;
+
+      const parsed = parseSpecContent(content, '/workspace/project/specs/product/my-spec.md');
+      expect(getSpecId(parsed, '/workspace/project/specs/product/my-spec.md')).to.equal('my-spec');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves TKT-472: BUG: Spec Assign - No specs found

## Description

## Problem

When running `prlt ticket spec` (or `prlt spec ticket`), the command displays 'No specs found' even when users have spec markdown files in the `specs/` directory.

## Root Cause Analysis

The spec system is **database-backed**, not file-system based:
- Specs are stored in the `pmo_specs` SQLite table
- The `specs/` directory with markdown files is for documentation/reference only
- There is no automatic sync between markdown files and the database
- Users must create specs via `prlt spec create` for them to appear

The error occurs because:
1. User has markdown spec files in `specs/` directory
2. User expects these to be recognized as 'specs'  
3. `listSpecs()` queries the empty database table
4. Returns 'No specs found' - technically correct but confusing

## Requirements

- R1: Improve UX messaging when no specs exist to clarify specs are database-managed
- R2: Add ability to import existing spec markdown files into the database
- R3: Validate import parsing against the spec-parser.ts schema (requires id, title, Problem, Solution sections)

## Technical Notes

- Relevant files:
  - `apps/cli/src/commands/ticket/spec.ts:127-147` - 'No specs found' message
  - `apps/cli/src/commands/spec/list.ts:42-45` - Similar message  
  - `apps/cli/src/lib/pmo/storage/specs.ts` - listSpecs() queries pmo_specs table
  - `apps/cli/src/lib/pmo/spec-parser.ts` - Parses markdown spec format

## Flagged Ambiguities

- Q1: Should spec import be automatic on PMO init, or manual via new command?
- Q2: What happens if imported spec ID conflicts with existing database spec?
- Q3: Should specs/ directory structure (product/, platform/, infra/, integrations/) inform the spec 'type' field?

## Changes

- d425d9c feat(TKT-472): add spec import command and improve no-specs-found UX messages

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
