### PR TITLE
TKT-665: Fix --json mode to work without TTY for CI/agent usage

### DIFF
--- a/apps/cli/src/commands/pmo/init.ts
+++ b/apps/cli/src/commands/pmo/init.ts
@@ -22,6 +22,7 @@ import { isGHInstalled, isGHAuthenticated, getGHUsername, isGHTokenInEnv } from 
 import {
   shouldOutputJson,
   outputPromptAsJson,
+  outputErrorAsJson,
   createMetadata,
   buildPromptConfig,
 } from '../../lib/prompt-json.js';
@@ -112,6 +113,38 @@ export default class PMOInit extends Command {
       await this.deletePMO(hqRoot!);
     }
 
+    // In JSON mode, if required flags are missing, output error with required fields
+    // Required flags: --location and --template (--name has a default)
+    if (jsonMode) {
+      const missingFlags: string[] = [];
+      if (!flags.location) missingFlags.push('--location');
+      if (!flags.template) missingFlags.push('--template');
+
+      if (missingFlags.length > 0) {
+        // Filter out 'custom' from template options since it requires interactive input
+        const templateOptions = PICKER_TEMPLATE_IDS.filter(t => t !== 'custom').join(', ');
+        outputErrorAsJson(
+          'MISSING_REQUIRED_FLAGS',
+          `Missing required flags: ${missingFlags.join(', ')}. ` +
+          `Use --location (separate or repo:name) and --template (${templateOptions}). ` +
+          `Optional: --name for board name.`,
+          createMetadata('pmo init', flags)
+        );
+        return; // outputErrorAsJson calls process.exit, but return for type safety
+      }
+
+      // 'custom' template requires interactive column input, not supported in JSON mode
+      if (flags.template === 'custom') {
+        outputErrorAsJson(
+          'CUSTOM_TEMPLATE_NOT_SUPPORTED',
+          `The 'custom' template requires interactive input for columns and is not supported in JSON mode. ` +
+          `Use one of: ${PICKER_TEMPLATE_IDS.filter(t => t !== 'custom').join(', ')}`,
+          createMetadata('pmo init', flags)
+        );
+        return;
+      }
+    }
+
     this.log(chalk.blue('🎯 Initializing PMO...\n'));
     this.log(chalk.gray('   Creates board.md and specs/ for project planning'));
     this.log(chalk.gray('   (Data stored in SQLite, synced to markdown files)\n'));
@@ -156,8 +189,9 @@ export default class PMOInit extends Command {
     // Get board name using shared prompt (or from flag)
     // Default to {hqname}-kanban pattern
     const hqName = hqRoot ? path.basename(hqRoot).replace(/-hq$/, '') : undefined;
-    const defaultBoardName = hqName ? `${hqName}-kanban` : undefined;
-    const boardName = flags.name || await promptForBoardName(defaultBoardName);
+    const defaultBoardName = hqName ? `${hqName}-kanban` : 'kanban';
+    // In JSON mode, use default if not provided (don't prompt)
+    const boardName = flags.name || (jsonMode ? defaultBoardName : await promptForBoardName(defaultBoardName));
 
     // For standalone PMO (no HQ), we need to create mini-HQ structure first
     const isStandalone = !hqRoot;

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -99,6 +99,14 @@ export default class TicketCreate extends PMOCommand {
       this.error(message);
     };
 
+    // --interactive and --json are incompatible
+    if (jsonMode && flags.interactive) {
+      return handleError(
+        'INCOMPATIBLE_FLAGS',
+        '--interactive and --json flags are incompatible. Use --json with required flags: --title, --column.'
+      );
+    }
+
     // In JSON mode without required data, output column selection prompt
     if (jsonMode && !flags.title && !flags.column) {
       // Build base command with project if specified

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -573,11 +573,76 @@ export default class WorkSpawn extends PMOCommand {
       let selectedActionDetails: Awaited<ReturnType<typeof this.storage.getAction>> | null = null
 
       if (!flags['per-ticket']) {
-        this.log(styles.header('Batch Settings (applies to all tickets)'))
-        this.log('')
+        // In JSON mode, use sensible defaults for batch settings instead of prompting
+        if (jsonMode) {
+          // Action: use provided flag or default to 'implement'
+          batchAction = flags.action || 'implement'
 
-        // Prompt for action selection first (unless explicitly provided via --action flag)
-        if (!flags.action) {
+          // Fetch action details
+          if (batchAction === 'adhoc') {
+            selectedActionDetails = {
+              id: 'adhoc',
+              name: 'Ad-hoc',
+              description: 'Unstructured exploration and debugging',
+              prompt: 'You are working on an ad-hoc session for exploration and debugging.',
+              modifiesCode: false,
+              defaultMoveToCategory: 'started',
+              isBuiltin: false,
+              createdAt: new Date(),
+            }
+          } else {
+            selectedActionDetails = await this.storage.getAction(batchAction)
+          }
+
+          const actionModifiesCode = selectedActionDetails?.modifiesCode ?? true
+
+          // Environment: use host if --run-on-host, otherwise check devcontainer readiness
+          if (!batchRunOnHost && !batchDisplay) {
+            const dockerRunning = isDockerRunning()
+            const devcontainerCliInstalled = isDevcontainerCliInstalled()
+            const devcontainerReady = dockerRunning && devcontainerCliInstalled
+
+            if (devcontainerReady) {
+              batchDisplay = 'devcontainer'
+              batchDisplayMode = 'terminal'
+              flags.session = 'tmux'
+            } else {
+              // Devcontainer not available, use host
+              batchRunOnHost = true
+              batchDisplay = 'terminal'
+            }
+          } else if (!batchDisplay) {
+            batchDisplay = 'terminal'
+          }
+
+          // Output mode
+          if (!batchOutput) {
+            batchOutput = 'interactive'
+          }
+
+          // Permissions: use 'danger' for devcontainer (sandboxed), 'safe' for host
+          if (!flags['skip-permissions']) {
+            batchPermissionMode = batchDisplay === 'devcontainer' ? 'danger' : 'safe'
+          }
+
+          // PR creation: based on action
+          if (!batchCreatePr && !batchNoPr) {
+            if (actionModifiesCode) {
+              batchCreatePr = true
+              batchNoPr = false
+            } else {
+              batchCreatePr = false
+              batchNoPr = true
+            }
+          }
+        } else {
+          // Interactive mode - prompt for settings
+          this.log(styles.header('Batch Settings (applies to all tickets)'))
+          this.log('')
+        }
+
+        // Prompt for action selection first (unless explicitly provided via --action flag or JSON mode)
+        if (!flags.action && !jsonMode) {
           // Get available actions from database
           const actions = await this.storage.listActions()
           const actionChoices = actions
@@ -626,8 +691,8 @@ export default class WorkSpawn extends PMOCommand {
         const hasExplicitSettings = flags.display || flags.output || flags['skip-permissions'] ||
           flags['create-pr'] || flags['no-pr'] || flags['run-on-host']
 
-        // Offer to use default settings if no explicit flags provided
-        if (!hasExplicitSettings) {
+        // Offer to use default settings if no explicit flags provided (interactive mode only)
+        if (!hasExplicitSettings && !jsonMode) {
           const actionName = batchAction || 'implement'
           const modifiesCode = selectedActionDetails?.modifiesCode ?? true
           const defaultsDescription = modifiesCode
@@ -670,7 +735,8 @@ export default class WorkSpawn extends PMOCommand {
         }
 
         // Prompt for environment (devcontainer vs host) if devcontainer available and not already set
-        if (hasDevcontainer && !batchRunOnHost && !batchDisplay) {
+        // Skip in JSON mode - defaults are set above
+        if (hasDevcontainer && !batchRunOnHost && !batchDisplay && !jsonMode) {
           // Check devcontainer prerequisites upfront
           const dockerRunning = isDockerRunning()
           const devcontainerCliInstalled = isDevcontainerCliInstalled()
@@ -813,7 +879,8 @@ export default class WorkSpawn extends PMOCommand {
         }
 
         // Prompt for display mode if not already set (for host mode without devcontainer)
-        if (!batchDisplay) {
+        // Skip in JSON mode - defaults are set above
+        if (!batchDisplay && !jsonMode) {
           const { selectedMode } = await inquirer.prompt([
             {
               type: 'list',
@@ -835,7 +902,8 @@ export default class WorkSpawn extends PMOCommand {
         }
 
         // Prompt for permissions mode if not explicitly set via --skip-permissions flag
-        if (!flags['skip-permissions']) {
+        // Skip in JSON mode - defaults are set above
+        if (!flags['skip-permissions'] && !jsonMode) {
           const { permissionMode } = await inquirer.prompt([
             {
               type: 'list',
@@ -853,8 +921,9 @@ export default class WorkSpawn extends PMOCommand {
 
         // Prompt for PR creation if not provided AND action modifies code
         // Skip this prompt entirely for non-code-modifying actions (like groom)
+        // Skip in JSON mode - defaults are set above
         const actionModifiesCode = selectedActionDetails?.modifiesCode ?? true
-        if (!batchCreatePr && !batchNoPr) {
+        if (!batchCreatePr && !batchNoPr && !jsonMode) {
           if (actionModifiesCode) {
             const { prChoice } = await inquirer.prompt([
               {


### PR DESCRIPTION
## Summary

Resolves TKT-665: Fix --json mode to work without TTY for CI/agent usage

## Description

## Problem
Commands with --json flag still show interactive prompts requiring TTY input.

Example:
```bash
prlt pmo init --json  # Still shows interactive prompts
```

Expected: Either fail with "missing required flags" or use sensible defaults.

## Current Behavior
- User passes --json flag
- Command still enters interactive mode
- Blocks in non-TTY environments (CI, agents)
- Requires trial-and-error to find required flags

## Expected Behavior
When --json flag is present:
1. If required flags missing: fail with JSON error listing required flags
2. If all required flags present: execute non-interactively
3. Never prompt for input

## Commands to Audit
- pmo init
- ticket create
- work spawn
- agent add
- Any command with interactive prompts

## Source
Installation review - Multiple attempts needed even with --json flag

## Changes

- 5d0b6b8 fix(TKT-665): fix --json mode to work without TTY for CI/agent usage

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
