### PR TITLE
feat(TKT-773): add missing agent remove command

### DIFF
--- a/apps/cli/src/commands/agent/index.ts
+++ b/apps/cli/src/commands/agent/index.ts
@@ -56,6 +56,7 @@ export default class Agent extends PMOCommand {
         { name: '📋 List all agents', value: 'list', command: 'prlt agent list --machine' },
         { name: '📊 Show status', value: 'status', command: 'prlt agent status --machine' },
         { name: '📂 Visit directory', value: 'visit', command: 'prlt agent visit --machine' },
+        { name: '🗑️  Remove agent', value: 'remove', command: 'prlt agent remove --machine' },
         // Management group
         { name: '👔 Manage staff agents', value: 'staff', command: 'prlt agent staff --machine' },
         { name: '⏱️  Manage temp agents', value: 'temp', command: 'prlt agent temp --machine' },
@@ -95,6 +96,12 @@ export default class Agent extends PMOCommand {
         case 'visit': {
           const { default: VisitCommand } = await import('./visit.js');
           const cmd = new VisitCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'remove': {
+          const { default: RemoveCommand } = await import('./remove.js');
+          const cmd = new RemoveCommand([], this.config);
           await cmd.run();
           break;
         }

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -1,0 +1,189 @@
+import { Args, Flags } from '@oclif/core';
+import inquirer from 'inquirer';
+import { colors, format } from '../../lib/colors.js';
+import {
+  getWorkspaceInfo,
+  removeAgentsFromWorkspace
+} from '../../lib/agents/commands.js';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputErrorAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../lib/prompt-json.js';
+
+export default class Remove extends PMOCommand {
+  static description = 'Remove an agent from the workspace';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> camry',
+    '<%= config.bin %> <%= command.id %>',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Agent name to remove',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    json: Flags.boolean({
+      description: 'Output prompt configuration as JSON (for AI agents/scripts)',
+      default: false,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(Remove);
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags);
+
+    // Helper to handle errors in JSON mode
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('agent remove', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Get workspace information
+    const workspaceInfo = getWorkspaceInfo();
+
+    if (workspaceInfo.agents.length === 0) {
+      if (jsonMode) {
+        outputErrorAsJson('NO_AGENTS', 'No agents to remove.', createMetadata('agent remove', flags));
+        return;
+      }
+      this.log(colors.warning('No agents to remove.'));
+      return;
+    }
+
+    let agentName = args.name;
+
+    // Interactive mode if no agent specified
+    if (!agentName) {
+      // Group agents by type
+      const staffAgents = workspaceInfo.agents.filter(a => a.type === 'persistent');
+      const tempAgents = workspaceInfo.agents.filter(a => a.type === 'ephemeral');
+
+      // Build choices with command field for JSON mode
+      const agentChoices: Array<{ name: string; value: string; command?: string }> = [];
+
+      for (const agent of staffAgents) {
+        agentChoices.push({ name: `👔 ${agent.name}`, value: agent.name, command: `prlt agent remove ${agent.name} --machine` });
+      }
+
+      for (const agent of tempAgents) {
+        agentChoices.push({ name: `⏱️  ${agent.name}`, value: agent.name, command: `prlt agent remove ${agent.name} --machine` });
+      }
+
+      agentChoices.push({ name: 'Cancel', value: 'cancel' });
+
+      const selectMessage = 'Select agent to remove:';
+
+      // In JSON mode, output agent selection prompt
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'name', selectMessage, agentChoices),
+          createMetadata('agent remove', flags)
+        );
+        return;
+      }
+
+      const { selected } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'selected',
+          message: selectMessage,
+          choices: [
+            ...agentChoices.slice(0, -1),
+            new inquirer.Separator(),
+            { name: '❌ ' + agentChoices[agentChoices.length - 1].name, value: agentChoices[agentChoices.length - 1].value }
+          ]
+        }
+      ]);
+
+      if (selected === 'cancel') {
+        this.log(colors.textMuted('Operation cancelled.'));
+        return;
+      }
+
+      agentName = selected;
+    }
+
+    // Validate agent exists
+    const agent = workspaceInfo.agents.find((a) => a.name === agentName);
+    if (!agent) {
+      return handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available agents: ${workspaceInfo.agents.map((a) => a.name).join(', ')}`);
+    }
+
+    const agentsToRemove = [agentName!];
+
+    // Build choices once, use for both JSON and interactive modes
+    const confirmChoices = [
+      { name: 'No, cancel', value: 'false' },
+      { name: 'Yes, remove agent', value: 'true' },
+    ];
+    const confirmMessage = `Are you sure you want to remove agent "${agentName!}"? This will delete its worktree.`;
+
+    // Confirm removal
+    // In JSON mode, output confirmation prompt
+    if (jsonMode) {
+      outputPromptAsJson(
+        buildPromptConfig('list', 'confirmed', confirmMessage, confirmChoices),
+        createMetadata('agent remove', flags)
+      );
+      return;
+    }
+
+    const { confirm } = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'confirm',
+        message: confirmMessage,
+        choices: [
+          { name: '❌ ' + confirmChoices[0].name, value: false },
+          { name: '⚠️  ' + confirmChoices[1].name, value: true }
+        ],
+        default: 0 // Default to "No, cancel"
+      }
+    ]);
+
+    if (!confirm) {
+      this.log(colors.textMuted('Removal cancelled.'));
+      return;
+    }
+
+    // Remove agents
+    this.log(colors.primary(`Removing agent "${agentName!}"...`));
+
+    const { removed, failed } = await removeAgentsFromWorkspace(workspaceInfo, agentsToRemove);
+
+    // Show results for each agent
+    for (const name of agentsToRemove) {
+      if (removed.includes(name)) {
+        this.log(format.success(`Agent ${name} removed`));
+      } else if (failed.includes(name)) {
+        this.log(format.error(`Failed to remove agent ${name}`));
+      }
+    }
+
+    // Summary
+    if (removed.length > 0) {
+      this.log(format.success(`\nSuccessfully removed ${removed.length} agent(s): ${removed.join(', ')}`));
+    }
+    if (failed.length > 0) {
+      this.log(format.error(`\nFailed to remove ${failed.length} agent(s): ${failed.join(', ')}`));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Created `src/commands/agent/remove.ts` as a top-level agent subcommand that handles removing any agent (both staff/persistent and temp/ephemeral)
- Updated `src/commands/agent/index.ts` to add 'remove' to the interactive menu choices and switch statement
- Modeled after `staff/remove.ts` but operates on all agent types with proper grouping (👔 staff, ⏱️ temp)

## Test plan
- [x] All agent remove tests in `agent-commands.test.ts` pass
- [x] All agent remove tests in `agent.test.ts` pass
- [x] `prlt agent remove --help` shows proper help text
- [x] Build succeeds with no TypeScript errors

Fixes TKT-773

🤖 Generated with [Claude Code](https://claude.com/claude-code)