### PR TITLE
TKT-774: Fix gh-commands.test.ts: 8 exec calls that hang on TTY

### DIFF
--- a/apps/cli/test/e2e/gh-commands.test.ts
+++ b/apps/cli/test/e2e/gh-commands.test.ts
@@ -138,52 +138,32 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should handle missing gh CLI gracefully', () => {
-      const output = exec('gh login')
+    it('should display login command description in help', () => {
+      const output = exec('gh login --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        expect(json).to.not.be.null
-        // Should have either success or error
-        const hasValidResponse = json?.success !== undefined || json?.error !== undefined
-        expect(hasValidResponse).to.be.true
-      } else {
-        const validOutput =
-          output.includes('gh CLI not installed') ||
-          output.includes('Already authenticated') ||
-          output.includes('Starting GitHub authentication') ||
-          output.includes('brew install gh')
-        expect(validOutput).to.be.true
-      }
+      expect(output).to.contain('Login to GitHub CLI')
+      expect(output).to.contain('USAGE')
     })
 
-    it('should provide installation instructions when gh is not installed', () => {
-      const output = exec('gh login')
+    it('should reference gh CLI in login help', () => {
+      const output = exec('gh login --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        if (json?.error?.code === 'GH_NOT_INSTALLED') {
-          expect(json.error.message).to.contain('brew install gh')
-        }
-      } else if (output.includes('not installed')) {
-        expect(output).to.contain('brew install gh')
-      }
+      const hasGhReference =
+        output.includes('gh') ||
+        output.includes('GitHub')
+      expect(hasGhReference).to.be.true
     })
 
-    it('should indicate when already authenticated', () => {
-      const output = exec('gh login')
+    it('should show login-related flags or description in help', () => {
+      const output = exec('gh login --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        if (json?.success && json.result) {
-          // If authenticated, result has authenticated: true
-          if (json.result.authenticated) {
-            expect(json.result.authenticated).to.equal(true)
-          }
-        }
-      } else if (output.includes('Already authenticated')) {
-        expect(output).to.contain('gh auth login')
-      }
+      // Help output should contain relevant login info
+      const hasLoginInfo =
+        output.includes('login') ||
+        output.includes('Login') ||
+        output.includes('auth') ||
+        output.includes('USAGE')
+      expect(hasLoginInfo).to.be.true
     })
   })
 
@@ -200,82 +180,44 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should handle missing gh CLI gracefully', () => {
-      const output = exec('gh token')
+    it('should display token command description in help', () => {
+      const output = exec('gh token --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        expect(json).to.not.be.null
-        // Should have either success or error
-        const hasValidResponse = json?.success !== undefined || json?.error !== undefined
-        expect(hasValidResponse).to.be.true
-      } else {
-        const validOutput =
-          output.includes('gh CLI not installed') ||
-          output.includes('not authenticated') ||
-          output.includes('GH_TOKEN') ||
-          output.includes('brew install gh')
-        expect(validOutput).to.be.true
-      }
+      expect(output).to.contain('GH_TOKEN setup')
+      expect(output).to.contain('USAGE')
     })
 
-    it('should provide installation instructions when gh is not installed', () => {
-      const output = exec('gh token')
+    it('should reference devcontainer in token help', () => {
+      const output = exec('gh token --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        if (json?.error?.code === 'GH_NOT_INSTALLED') {
-          expect(json.error.message).to.contain('brew install gh')
-        }
-      } else if (output.includes('not installed')) {
-        expect(output).to.contain('brew install gh')
-      }
+      expect(output).to.contain('devcontainer')
     })
 
-    it('should prompt for authentication when not authenticated', () => {
-      const output = exec('gh token')
+    it('should reference GH_TOKEN in token help', () => {
+      const output = exec('gh token --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        if (json?.error?.code === 'GH_NOT_AUTHENTICATED') {
-          expect(json.error.message).to.contain('prlt gh login')
-        }
-      } else if (output.includes('not authenticated')) {
-        expect(output).to.contain('prlt gh login')
-      }
+      const hasTokenReference =
+        output.includes('GH_TOKEN') ||
+        output.includes('token')
+      expect(hasTokenReference).to.be.true
     })
 
-    it('should show GH_TOKEN setup instructions when authenticated but token not set', () => {
-      const output = exec('gh token')
+    it('should show token-related usage information in help', () => {
+      const output = exec('gh token --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        if (json?.success && json.result && json.result.ghTokenSet === false) {
-          // JSON output should have setupCommand
-          expect(json.result).to.have.property('setupCommand')
-        }
-      } else if (output.includes('GH_TOKEN not set')) {
-        const hasShellInstructions =
-          output.includes('.zshrc') ||
-          output.includes('.bashrc') ||
-          output.includes('.profile') ||
-          output.includes('export GH_TOKEN')
-        expect(hasShellInstructions).to.be.true
-      }
+      const hasUsageInfo =
+        output.includes('USAGE') ||
+        output.includes('DESCRIPTION')
+      expect(hasUsageInfo).to.be.true
     })
 
-    it('should indicate when GH_TOKEN is already set', () => {
-      const output = exec('gh token')
+    it('should reference GitHub in token help', () => {
+      const output = exec('gh token --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        if (json?.success && json.result && json.result.ghTokenSet === true) {
-          // JSON output indicates token is set
-          expect(json.result.ghTokenSet).to.equal(true)
-        }
-      } else if (output.includes('GH_TOKEN is already set')) {
-        expect(output).to.contain('devcontainers')
-      }
+      const hasGhReference =
+        output.includes('gh') ||
+        output.includes('GitHub')
+      expect(hasGhReference).to.be.true
     })
   })
 
@@ -338,39 +280,17 @@ describe('GitHub CLI Commands E2E Tests', () => {
     })
 
     it('should delegate to login command', () => {
-      const output = exec('gh login')
+      const output = exec('gh login --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        expect(json).to.not.be.null
-        // Login command returns success or error
-        const hasValidResponse = json?.success !== undefined || json?.error !== undefined
-        expect(hasValidResponse).to.be.true
-      } else {
-        const validOutput =
-          output.includes('gh CLI not installed') ||
-          output.includes('Already authenticated') ||
-          output.includes('Starting GitHub authentication')
-        expect(validOutput).to.be.true
-      }
+      expect(output).to.contain('Login to GitHub CLI')
+      expect(output).to.contain('USAGE')
     })
 
     it('should delegate to token command', () => {
-      const output = exec('gh token')
+      const output = exec('gh token --help')
 
-      if (isJsonOutput(output)) {
-        const json = parseJsonOutput(output)
-        expect(json).to.not.be.null
-        // Token command returns success or error
-        const hasValidResponse = json?.success !== undefined || json?.error !== undefined
-        expect(hasValidResponse).to.be.true
-      } else {
-        const validOutput =
-          output.includes('gh CLI not installed') ||
-          output.includes('not authenticated') ||
-          output.includes('GH_TOKEN')
-        expect(validOutput).to.be.true
-      }
+      expect(output).to.contain('GH_TOKEN setup')
+      expect(output).to.contain('USAGE')
     })
   })
 


### PR DESCRIPTION
## Summary

Resolves TKT-774: Fix gh-commands.test.ts: 8 exec calls that hang on TTY

## Description

## Problem

gh-commands.test.ts has 8 exec() calls that trigger TTY interactive prompts and will hang forever in non-TTY environments (CI, Docker agents, test runners).

## Dangerous calls

- `exec('gh login')` × 3 — triggers interactive auth prompt, hangs
- `exec('gh token')` × 5 — may trigger interactive prompt, hangs

## Fix

Add `--help` flag or provide required flags to bypass interactive prompts:

```typescript
// BEFORE (hangs):
exec('gh login')
exec('gh token')

// AFTER (safe):
exec('gh login --help')
exec('gh token --help')
// OR test with proper flags that don't trigger TTY
```

## Context

Audit of all 31 E2E test files found 700+ exec() calls. Only this file has issues. All other files follow safe practices (subcommands, --json, --force flags).

## Files to modify
- apps/cli/test/e2e/gh-commands.test.ts

## Acceptance Criteria
- [ ] All 8 bare exec calls fixed with flags
- [ ] Tests pass without hanging
- [ ] No TTY prompts triggered in test environment

## Changes

- f8c8a7d fix(TKT-774): fix bare gh login/token exec calls in gh-commands.test.ts to use --help flag, preventing TTY hangs

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
