### PR TITLE
fix(TKT-665): Fix --json mode to work without TTY for CI/agent usage

### DIFF
--- a/apps/cli/src/lib/pmo/base-command.ts
+++ b/apps/cli/src/lib/pmo/base-command.ts
@@ -194,12 +194,21 @@ export abstract class PMOCommand extends PromptCommand {
       return numA - numB;
     });
 
+    // Auto-detect non-TTY: switch to JSON mode when no TTY present
+    const effectiveJsonMode = options?.jsonMode ?? (!process.stdin.isTTY
+      ? {
+          flags: { json: true } as JsonFlags & Record<string, unknown>,
+          commandName: this.id ?? 'unknown',
+          baseCommand: `prlt ${(this.id ?? 'unknown').replace(/:/g, ' ')}`,
+        }
+      : null);
+
     // If JSON mode is active, output project choices as JSON
-    if (options?.jsonMode && shouldOutputJson(options.jsonMode.flags)) {
+    if (effectiveJsonMode && shouldOutputJson(effectiveJsonMode.flags)) {
       const choices = sortedProjects.map(p => ({
         name: `${p.name} (${p.id})`,
         value: p.id,
-        command: `${options.jsonMode!.baseCommand} -P ${p.id} --json`,
+        command: `${effectiveJsonMode.baseCommand} -P ${p.id} --json`,
       }));
       outputPromptAsJson(
         {
@@ -208,7 +217,7 @@ export abstract class PMOCommand extends PromptCommand {
           message: 'Select project:',
           choices,
         },
-        createMetadata(options.jsonMode.commandName, options.jsonMode.flags)
+        createMetadata(effectiveJsonMode.commandName, effectiveJsonMode.flags)
       );
       // outputPromptAsJson calls process.exit, so this is unreachable
       return '';
@@ -289,6 +298,11 @@ export abstract class PMOCommand extends PromptCommand {
       cancelValue,
     } = options;
 
+    // Auto-detect non-TTY: switch to JSON mode when no TTY present
+    const effectiveJsonMode = jsonMode ?? (!process.stdin.isTTY
+      ? { flags: { json: true } as JsonFlags & Record<string, unknown>, commandName: this.id ?? 'unknown' }
+      : null);
+
     // Build choices with command field
     const choices = items.map(item => ({
       name: getName(item),
@@ -297,7 +311,7 @@ export abstract class PMOCommand extends PromptCommand {
     }));
 
     // Check for JSON mode
-    if (jsonMode && shouldOutputJson(jsonMode.flags)) {
+    if (effectiveJsonMode && shouldOutputJson(effectiveJsonMode.flags)) {
       outputPromptAsJson(
         {
           type: 'list',
@@ -305,7 +319,7 @@ export abstract class PMOCommand extends PromptCommand {
           message,
           choices,
         },
-        createMetadata(jsonMode.commandName, jsonMode.flags)
+        createMetadata(effectiveJsonMode.commandName, effectiveJsonMode.flags)
       );
       // outputPromptAsJson exits, so this is unreachable
       return null;
@@ -368,8 +382,13 @@ export abstract class PMOCommand extends PromptCommand {
   }): Promise<string> {
     const { message, fieldName, defaultValue, validate, jsonMode } = options;
 
+    // Auto-detect non-TTY: switch to JSON mode when no TTY present
+    const effectiveJsonMode = jsonMode ?? (!process.stdin.isTTY
+      ? { flags: { json: true } as JsonFlags & Record<string, unknown>, commandName: this.id ?? 'unknown', commandHint: '', example: undefined as string | undefined }
+      : null);
+
     // Check for JSON mode
-    if (jsonMode && shouldOutputJson(jsonMode.flags)) {
+    if (effectiveJsonMode && shouldOutputJson(effectiveJsonMode.flags)) {
       outputPromptAsJson(
         {
           type: 'input',
@@ -377,11 +396,11 @@ export abstract class PMOCommand extends PromptCommand {
           message,
           default: defaultValue,
           context: {
-            hint: jsonMode.commandHint,
-            example: jsonMode.example,
+            hint: effectiveJsonMode.commandHint,
+            example: effectiveJsonMode.example,
           },
         },
-        createMetadata(jsonMode.commandName, jsonMode.flags)
+        createMetadata(effectiveJsonMode.commandName, effectiveJsonMode.flags)
       );
       // outputPromptAsJson exits, so this is unreachable
       return '';

--- a/apps/cli/src/lib/prompt-command.ts
+++ b/apps/cli/src/lib/prompt-command.ts
@@ -97,6 +97,11 @@ export abstract class PromptCommand extends Command {
       commandName: string;
     } | null
   ): Promise<T> {
+    // Auto-detect non-TTY: switch to JSON mode when no TTY present
+    if (!jsonModeConfig && !process.stdin.isTTY) {
+      jsonModeConfig = { flags: { json: true }, commandName: this.id ?? 'unknown' };
+    }
+
     // Check for JSON/agent mode
     if (jsonModeConfig && isAgentMode(jsonModeConfig.flags)) {
       // Find first question that should be shown (respecting 'when' conditions)

--- a/apps/cli/test/unit/pmo-base-command.test.ts
+++ b/apps/cli/test/unit/pmo-base-command.test.ts
@@ -204,6 +204,97 @@ describe('PMO Base Command', () => {
       expect(RequireProjectCommand.projectIdValue).to.equal('test-project');
     });
   });
+
+  describe('Non-TTY auto-detection', () => {
+    let originalStdinIsTTY: boolean | undefined;
+    let originalStdoutIsTTY: boolean | undefined;
+    let originalExit: typeof process.exit;
+    let originalConsoleLog: typeof console.log;
+    let capturedOutput: string[];
+    let exitCode: number | undefined;
+
+    // Command that calls this.prompt() WITHOUT jsonModeConfig
+    class PromptWithoutConfigCommand extends PMOCommand {
+      static id = 'prompt:noconfig';
+      static flags = { ...pmoBaseFlags };
+      static capturedResult: Record<string, unknown> | null = null;
+
+      static reset() {
+        this.capturedResult = null;
+      }
+
+      async execute(): Promise<void> {
+        const result = await this.prompt([{
+          type: 'list',
+          name: 'choice',
+          message: 'Pick one:',
+          choices: [
+            { name: 'Option A', value: 'a' },
+            { name: 'Option B', value: 'b' },
+          ],
+        }]);
+        PromptWithoutConfigCommand.capturedResult = result;
+      }
+    }
+
+    beforeEach(() => {
+      originalStdinIsTTY = process.stdin.isTTY;
+      originalStdoutIsTTY = process.stdout.isTTY;
+      originalExit = process.exit;
+      originalConsoleLog = console.log;
+      capturedOutput = [];
+      exitCode = undefined;
+      PromptWithoutConfigCommand.reset();
+
+      // Capture console.log output
+      console.log = (...args: unknown[]) => {
+        capturedOutput.push(args.map(String).join(' '));
+      };
+
+      // Override process.exit to capture exit code and throw
+      process.exit = ((code?: number) => {
+        exitCode = code;
+        throw new Error(`__EXIT_${code}__`);
+      }) as typeof process.exit;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+      process.exit = originalExit;
+      console.log = originalConsoleLog;
+    });
+
+    it('should auto-switch to JSON mode when stdin is not a TTY and no jsonModeConfig provided', async () => {
+      // Simulate non-TTY environment
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+      const config = await Config.load({ root: path.join(__dirname, '../..') });
+
+      try {
+        await PromptWithoutConfigCommand.run([], config);
+        expect.fail('Should have called process.exit');
+      } catch (error: unknown) {
+        // Expected: process.exit was called by outputPromptAsJson
+        expect((error as Error).message).to.equal('__EXIT_2__');
+      }
+
+      // Should have exited with EXIT_NEEDS_INPUT (2)
+      expect(exitCode).to.equal(2);
+
+      // Should have output JSON with the prompt config
+      expect(capturedOutput.length).to.be.greaterThan(0);
+      const jsonOutput = JSON.parse(capturedOutput[capturedOutput.length - 1]);
+      expect(jsonOutput.prompt).to.exist;
+      expect(jsonOutput.prompt.type).to.equal('list');
+      expect(jsonOutput.prompt.name).to.equal('choice');
+      expect(jsonOutput.prompt.message).to.equal('Pick one:');
+      expect(jsonOutput.prompt.choices).to.have.length(2);
+      expect(jsonOutput.metadata).to.exist;
+      expect(jsonOutput.metadata.command).to.equal('prompt:noconfig');
+    });
+  });
 });
 
 // Helper functions


### PR DESCRIPTION
## Summary
- Auto-detect non-TTY environments in all prompt methods (`prompt()` in `prompt-command.ts`, plus `selectFromList()`, `promptForInput()`, `requireProject()` in `base-command.ts`)
- When `process.stdin.isTTY` is false and no `jsonModeConfig` is explicitly provided, automatically switch to JSON mode
- This prevents all commands from hanging on interactive prompts in CI, Docker, and agent environments

## Changes
- `apps/cli/src/lib/prompt-command.ts`: Added non-TTY auto-detection to `prompt()` method (the single base class fix)
- `apps/cli/src/lib/pmo/base-command.ts`: Added non-TTY auto-detection to `selectFromList()`, `promptForInput()`, and `requireProject()` helper methods
- `apps/cli/test/unit/pmo-base-command.test.ts`: Added test verifying JSON output when stdin is not a TTY and no jsonModeConfig is provided

## Test plan
- [x] Unit test verifies `prompt()` outputs JSON (exit code 2) in non-TTY without explicit jsonModeConfig
- [x] All 126 e2e JSON mode tests pass (json-mode-commands, phase-json-mode, workflow-json-mode)
- [x] All existing prompt-json and base-command unit tests pass
- [x] Build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)