### PR TITLE
fix(TKT-775): fix deadlocking tests using Promise.all with oclif runCommand

### DIFF
--- a/apps/cli/test/commands/agent.test.ts
+++ b/apps/cli/test/commands/agent.test.ts
@@ -122,12 +122,12 @@ describe('Agent Command Architecture', () => {
     it('all agent commands use consistent help format', async () => {
       const commands = ['remove', 'visit', 'status', 'shell'];
 
-      await Promise.all(commands.map(async (cmd) => {
+      for (const cmd of commands) {
         const { stdout } = await runCommand(['agent', cmd, '--help'], { root });
         expect(stdout).to.contain('USAGE');
         // Consistent format across all commands
         expect(stdout).to.match(/\$ prlt agent/);
-      }));
+      }
     });
   });
 
@@ -142,14 +142,14 @@ describe('Agent Command Architecture', () => {
           ['agent', 'status']
         ];
 
-        await Promise.all(commands.map(async (cmd) => {
+        for (const cmd of commands) {
           try {
             await runCommand(cmd, { root: testDir });
           } catch (error: unknown) {
             // Expect an error when not in workspace
             expect(error).to.exist;
           }
-        }));
+        }
       } finally {
         fs.rmSync(testDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary
- Two tests in `test/commands/agent.test.ts` used `Promise.all` to run multiple oclif `runCommand` calls concurrently in-process, causing a deadlock due to shared internal state
- Replaced `Promise.all` with sequential `for...of` loops in both the "DRY Principles" and "Error Message Consistency" test blocks

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm mocha --timeout 60000 "test/**/*.test.ts"` completes without hanging
- [ ] Verify no regressions in agent command tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)