### PR TITLE
fix(TKT-789): Add --force flag to agent staff remove for non-interactive use

### DIFF
--- a/apps/cli/src/commands/agent/staff/remove.ts
+++ b/apps/cli/src/commands/agent/staff/remove.ts
@@ -35,6 +35,11 @@ export default class Remove extends PMOCommand {
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt (for non-interactive use)',
+      default: false,
+    }),
   };
 
   protected getPMOOptions() {
@@ -120,39 +125,42 @@ export default class Remove extends PMOCommand {
 
     const agentsToRemove = [agentName!];
 
-    // Build choices once, use for both JSON and interactive modes
-    const confirmChoices = [
-      { name: 'No, cancel', value: 'false' },
-      { name: 'Yes, remove agent', value: 'true' },
-    ];
-    const confirmMessage = `Are you sure you want to remove agent "${agentName!}"? This will delete its worktree.`;
+    // Skip confirmation if --force flag is passed
+    if (!flags.force) {
+      // Build choices once, use for both JSON and interactive modes
+      const confirmChoices = [
+        { name: 'No, cancel', value: 'false' },
+        { name: 'Yes, remove agent', value: 'true' },
+      ];
+      const confirmMessage = `Are you sure you want to remove agent "${agentName!}"? This will delete its worktree.`;
 
-    // Confirm removal
-    // In JSON mode, output confirmation prompt
-    if (jsonMode) {
-      outputPromptAsJson(
-        buildPromptConfig('list', 'confirmed', confirmMessage, confirmChoices),
-        createMetadata('agent remove', flags)
-      );
-      return;
-    }
-
-    const { confirm } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'confirm',
-        message: confirmMessage,
-        choices: [
-          { name: '❌ ' + confirmChoices[0].name, value: false },
-          { name: '⚠️  ' + confirmChoices[1].name, value: true }
-        ],
-        default: 0 // Default to "No, cancel"
+      // Confirm removal
+      // In JSON mode, output confirmation prompt
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'confirmed', confirmMessage, confirmChoices),
+          createMetadata('agent remove', flags)
+        );
+        return;
       }
-    ]);
 
-    if (!confirm) {
-      this.log(colors.textMuted('Removal cancelled.'));
-      return;
+      const { confirm } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'confirm',
+          message: confirmMessage,
+          choices: [
+            { name: '❌ ' + confirmChoices[0].name, value: false },
+            { name: '⚠️  ' + confirmChoices[1].name, value: true }
+          ],
+          default: 0 // Default to "No, cancel"
+        }
+      ]);
+
+      if (!confirm) {
+        this.log(colors.textMuted('Removal cancelled.'));
+        return;
+      }
     }
 
     // Remove agents


### PR DESCRIPTION
## Summary
- Added `--force` / `-f` flag to `agent staff remove` command
- When `--force` is passed, the confirmation prompt is skipped
- Allows AI agents and scripts to use the command non-interactively

## Test plan
- [ ] Run `prlt agent staff remove <name> --force` - should skip confirmation
- [ ] Run `prlt agent staff remove <name> -f` - should work with shorthand
- [ ] Run `prlt agent staff remove nonexistent --force` - should error with "not found"
- [ ] Run without `--force` - should still prompt for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)