### PR TITLE
feat(TKT-777): implement spec edit command

### DIFF
--- a/apps/cli/src/commands/spec/edit.ts
+++ b/apps/cli/src/commands/spec/edit.ts
@@ -1,0 +1,293 @@
+import { Flags, Args } from '@oclif/core';
+import inquirer from 'inquirer';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import { SpecType, SpecStatus } from '../../lib/pmo/types.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { FlagResolver } from '../../lib/flags/index.js';
+
+export default class SpecEdit extends PMOCommand {
+  static description = 'Edit an existing spec';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> user-authentication',
+    '<%= config.bin %> <%= command.id %> --spec api-design --title "New API Design"',
+    '<%= config.bin %> <%= command.id %> user-auth --status active',
+    '<%= config.bin %> <%= command.id %> user-auth --type product --problem "Need better auth"',
+    '<%= config.bin %> <%= command.id %> -i  # Interactive mode',
+  ];
+
+  static args = {
+    spec: Args.string({
+      description: 'Spec ID to edit',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    spec: Flags.string({
+      char: 's',
+      description: 'Spec ID to edit',
+    }),
+    title: Flags.string({
+      char: 't',
+      description: 'New spec title',
+    }),
+    status: Flags.string({
+      description: 'Spec status',
+      options: ['draft', 'active', 'implemented'],
+    }),
+    type: Flags.string({
+      description: 'Spec type',
+      options: ['product', 'platform', 'infra', 'integration', 'none'],
+    }),
+    problem: Flags.string({
+      description: 'Problem statement',
+    }),
+    solution: Flags.string({
+      description: 'Solution description',
+    }),
+    decisions: Flags.string({
+      description: 'Design decisions',
+    }),
+    interactive: Flags.boolean({
+      char: 'i',
+      description: 'Interactive mode - prompts for all fields',
+      default: false,
+    }),
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SpecEdit);
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags);
+
+    // Helper to handle errors in JSON mode
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('spec edit', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Get spec ID from args or flags
+    let specId = args.spec || flags.spec;
+
+    if (!specId) {
+      // List specs for selection
+      const specs = await this.storage.listSpecs();
+
+      if (specs.length === 0) {
+        return handleError('NO_SPECS', 'No specs found. Create one first with: prlt spec create');
+      }
+
+      // Use FlagResolver for spec selection
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec edit',
+        baseCommand: 'prlt spec edit',
+        jsonMode,
+        flags: { spec: flags.spec },
+      });
+
+      resolver.addPrompt({
+        flagName: 'spec',
+        type: 'list',
+        message: 'Select spec to edit:',
+        choices: () => specs.map(s => ({
+          name: `${s.title} [${s.status}]${s.type ? ` (${s.type})` : ''}`,
+          value: s.id,
+        })),
+      });
+
+      const resolved = await resolver.resolve();
+      specId = resolved.spec;
+    }
+
+    // Get current spec
+    const spec = await this.storage.getSpec(specId!);
+    if (!spec) {
+      return handleError('NOT_FOUND', `Spec "${specId}" not found.`);
+    }
+
+    // Build choices for prompts
+    const typeChoices = [
+      { name: 'Product (user-facing feature)', value: 'product' },
+      { name: 'Platform (internal tooling)', value: 'platform' },
+      { name: 'Infra (technical infrastructure)', value: 'infra' },
+      { name: 'Integration (external service)', value: 'integration' },
+      { name: 'None', value: '' },
+    ];
+    const statusChoices = [
+      { name: 'Draft (planning)', value: 'draft' },
+      { name: 'Active (in progress)', value: 'active' },
+      { name: 'Implemented (complete)', value: 'implemented' },
+    ];
+
+    // Determine what to update
+    let updates: Partial<{
+      title: string;
+      status: SpecStatus;
+      type: SpecType | undefined;
+      problem: string;
+      solution: string;
+      decisions: string;
+    }> = {};
+
+    const hasFlags = flags.title || flags.status || flags.type || flags.problem ||
+      flags.solution || flags.decisions;
+
+    if (flags.interactive || !hasFlags) {
+      // Interactive mode - prompt for editable fields
+      updates = await this.promptForEdits(spec, typeChoices, statusChoices);
+    } else {
+      // Use flag values
+      if (flags.title) updates.title = flags.title;
+      if (flags.status) updates.status = flags.status as SpecStatus;
+      if (flags.type) {
+        updates.type = flags.type === 'none' ? undefined : flags.type as SpecType;
+      }
+      if (flags.problem) updates.problem = flags.problem;
+      if (flags.solution) updates.solution = flags.solution;
+      if (flags.decisions) updates.decisions = flags.decisions;
+    }
+
+    // Check if anything changed
+    if (Object.keys(updates).length === 0) {
+      this.log(styles.muted('\nNo changes made.'));
+      return;
+    }
+
+    // Update the spec
+    const updatedSpec = await this.storage.updateSpec(specId!, updates);
+
+    // Display updated spec
+    this.log(styles.success(`\n✅ Updated spec "${styles.emphasis(updatedSpec.title)}"`));
+
+    const changedFields: string[] = [];
+    if (updates.title) changedFields.push(`Title: ${updatedSpec.title}`);
+    if (updates.status) changedFields.push(`Status: ${updatedSpec.status}`);
+    if (updates.type !== undefined) changedFields.push(`Type: ${updatedSpec.type || 'none'}`);
+    if (updates.problem !== undefined) changedFields.push(`Problem: ${updates.problem ? 'updated' : '(cleared)'}`);
+    if (updates.solution !== undefined) changedFields.push(`Solution: ${updates.solution ? 'updated' : '(cleared)'}`);
+    if (updates.decisions !== undefined) changedFields.push(`Decisions: ${updates.decisions ? 'updated' : '(cleared)'}`);
+
+    for (const field of changedFields) {
+      this.log(styles.muted(`   ${field}`));
+    }
+
+    this.log('');
+    this.log(styles.muted(`View spec: prlt spec view ${updatedSpec.id}`));
+  }
+
+  private async promptForEdits(
+    spec: {
+      title: string;
+      status: SpecStatus;
+      type?: SpecType;
+      problem?: string;
+      solution?: string;
+      decisions?: string;
+    },
+    typeChoices: { name: string; value: string }[],
+    statusChoices: { name: string; value: string }[]
+  ): Promise<{
+    title?: string;
+    status?: SpecStatus;
+    type?: SpecType | undefined;
+    problem?: string;
+    solution?: string;
+    decisions?: string;
+  }> {
+    const answers = await inquirer.prompt<{
+      title: string;
+      status: string;
+      type: string;
+      problem: string;
+      solution: string;
+      decisions: string;
+    }>([
+      {
+        type: 'input',
+        name: 'title',
+        message: 'Title:',
+        default: spec.title,
+        validate: (input: string) => input.length > 0 || 'Title is required',
+      },
+      {
+        type: 'list',
+        name: 'status',
+        message: 'Status:',
+        choices: statusChoices,
+        default: spec.status,
+      },
+      {
+        type: 'list',
+        name: 'type',
+        message: 'Type:',
+        choices: typeChoices,
+        default: spec.type || '',
+      },
+      {
+        type: 'editor',
+        name: 'problem',
+        message: 'Problem statement (opens $EDITOR):',
+        default: spec.problem || '',
+        waitForUseInput: false,
+      },
+      {
+        type: 'editor',
+        name: 'solution',
+        message: 'Solution (opens $EDITOR):',
+        default: spec.solution || '',
+        waitForUseInput: false,
+      },
+      {
+        type: 'editor',
+        name: 'decisions',
+        message: 'Design decisions (opens $EDITOR):',
+        default: spec.decisions || '',
+        waitForUseInput: false,
+      },
+    ]);
+
+    // Build updates object with only changed fields
+    const updates: {
+      title?: string;
+      status?: SpecStatus;
+      type?: SpecType | undefined;
+      problem?: string;
+      solution?: string;
+      decisions?: string;
+    } = {};
+
+    if (answers.title !== spec.title) {
+      updates.title = answers.title;
+    }
+    if (answers.status !== spec.status) {
+      updates.status = answers.status as SpecStatus;
+    }
+
+    const newType = answers.type === '' ? undefined : answers.type as SpecType;
+    if (newType !== spec.type) {
+      updates.type = newType;
+    }
+    if (answers.problem !== (spec.problem || '')) {
+      updates.problem = answers.problem || undefined;
+    }
+    if (answers.solution !== (spec.solution || '')) {
+      updates.solution = answers.solution || undefined;
+    }
+    if (answers.decisions !== (spec.decisions || '')) {
+      updates.decisions = answers.decisions || undefined;
+    }
+
+    return updates;
+  }
+}

--- a/apps/cli/test/unit/spec-edit.test.ts
+++ b/apps/cli/test/unit/spec-edit.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for spec edit command JSON mode support.
+ *
+ * These tests verify that the FlagResolver pattern is correctly implemented
+ * in the spec edit command for JSON mode support.
+ */
+
+import { expect } from 'chai';
+import {
+  shouldOutputJson,
+  createMetadata,
+} from '../../src/lib/prompt-json.js';
+import { FlagResolver, ResolverChoice } from '../../src/lib/flags/resolver.js';
+
+describe('Spec Edit Command', () => {
+  describe('FlagResolver configuration for spec edit', () => {
+    it('should create FlagResolver with correct configuration', () => {
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec edit',
+        baseCommand: 'prlt spec edit',
+        jsonMode: false,
+        flags: {},
+      });
+
+      expect(resolver).to.be.instanceOf(FlagResolver);
+    });
+
+    it('should create FlagResolver with initial spec from args', () => {
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec edit',
+        baseCommand: 'prlt spec edit',
+        jsonMode: false,
+        flags: { spec: 'user-authentication' },
+      });
+
+      expect(resolver.getFlag('spec')).to.equal('user-authentication');
+    });
+
+    it('should include metadata with command name for JSON output', () => {
+      const flags = { json: true, spec: 'auth-spec' };
+      const metadata = createMetadata('spec edit', flags);
+
+      expect(metadata.command).to.equal('spec edit');
+      expect(metadata.flags.json).to.be.true;
+      expect(metadata.flags.spec).to.equal('auth-spec');
+      expect(metadata.timestamp).to.be.a('string');
+    });
+  });
+
+  describe('Spec selection prompt', () => {
+    it('should build choice list for spec selection', () => {
+      const specs = [
+        { id: 'spec-1', title: 'Auth System', status: 'active', type: 'product' },
+        { id: 'spec-2', title: 'API Design', status: 'draft', type: 'platform' },
+        { id: 'spec-3', title: 'DB Schema', status: 'implemented', type: 'infra' },
+      ];
+
+      const choices: ResolverChoice<string>[] = specs.map(s => ({
+        name: `${s.title} [${s.status}]${s.type ? ` (${s.type})` : ''}`,
+        value: s.id,
+      }));
+
+      expect(choices).to.have.lengthOf(3);
+      expect(choices[0].name).to.equal('Auth System [active] (product)');
+      expect(choices[0].value).to.equal('spec-1');
+      expect(choices[1].name).to.equal('API Design [draft] (platform)');
+      expect(choices[2].name).to.equal('DB Schema [implemented] (infra)');
+    });
+
+    it('should add spec selection prompt to resolver', () => {
+      const specs = [
+        { id: 'spec-1', title: 'Auth System', status: 'active', type: 'product' },
+      ];
+
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec edit',
+        baseCommand: 'prlt spec edit',
+        jsonMode: false,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'spec',
+        type: 'list',
+        message: 'Select spec to edit:',
+        choices: () => specs.map(s => ({
+          name: `${s.title} [${s.status}]${s.type ? ` (${s.type})` : ''}`,
+          value: s.id,
+        })),
+      });
+
+      expect(resolver).to.be.instanceOf(FlagResolver);
+    });
+  });
+
+  describe('Type choices for spec edit', () => {
+    it('should build type choices including None option', () => {
+      const typeChoices: ResolverChoice<string>[] = [
+        { name: 'Product (user-facing feature)', value: 'product' },
+        { name: 'Platform (internal tooling)', value: 'platform' },
+        { name: 'Infra (technical infrastructure)', value: 'infra' },
+        { name: 'Integration (external service)', value: 'integration' },
+        { name: 'None', value: '' },
+      ];
+
+      expect(typeChoices).to.have.lengthOf(5);
+      expect(typeChoices[0].value).to.equal('product');
+      expect(typeChoices[1].value).to.equal('platform');
+      expect(typeChoices[2].value).to.equal('infra');
+      expect(typeChoices[3].value).to.equal('integration');
+      expect(typeChoices[4].value).to.equal('');
+      expect(typeChoices[4].name).to.equal('None');
+    });
+  });
+
+  describe('Status choices for spec edit', () => {
+    it('should build status choices', () => {
+      const statusChoices: ResolverChoice<string>[] = [
+        { name: 'Draft (planning)', value: 'draft' },
+        { name: 'Active (in progress)', value: 'active' },
+        { name: 'Implemented (complete)', value: 'implemented' },
+      ];
+
+      expect(statusChoices).to.have.lengthOf(3);
+      expect(statusChoices[0].value).to.equal('draft');
+      expect(statusChoices[1].value).to.equal('active');
+      expect(statusChoices[2].value).to.equal('implemented');
+    });
+  });
+
+  describe('Update detection', () => {
+    it('should detect title change', () => {
+      const spec = { title: 'Old Title', status: 'draft' as const };
+      const answers = { title: 'New Title', status: 'draft' };
+
+      const updates: { title?: string } = {};
+      if (answers.title !== spec.title) {
+        updates.title = answers.title;
+      }
+
+      expect(updates.title).to.equal('New Title');
+    });
+
+    it('should not include unchanged fields', () => {
+      const spec = { title: 'Same Title', status: 'draft' as const };
+      const answers = { title: 'Same Title', status: 'draft' };
+
+      const updates: { title?: string; status?: string } = {};
+      if (answers.title !== spec.title) {
+        updates.title = answers.title;
+      }
+      if (answers.status !== spec.status) {
+        updates.status = answers.status;
+      }
+
+      expect(updates).to.deep.equal({});
+    });
+
+    it('should detect type change from undefined to value', () => {
+      const spec = { title: 'Test', status: 'draft' as const, type: undefined };
+      const answers = { title: 'Test', status: 'draft', type: 'product' };
+
+      const updates: { type?: string } = {};
+      const newType = answers.type === '' ? undefined : answers.type;
+      if (newType !== spec.type) {
+        updates.type = newType;
+      }
+
+      expect(updates.type).to.equal('product');
+    });
+
+    it('should detect type change from value to undefined (none)', () => {
+      const spec = { title: 'Test', status: 'draft' as const, type: 'product' as const };
+      const answers = { title: 'Test', status: 'draft', type: '' };
+
+      const updates: { type?: string | undefined } = {};
+      const newType = answers.type === '' ? undefined : answers.type;
+      if (newType !== spec.type) {
+        updates.type = newType;
+      }
+
+      expect(updates.type).to.equal(undefined);
+      expect('type' in updates).to.be.true;
+    });
+
+    it('should detect status change', () => {
+      const spec = { title: 'Test', status: 'draft' as const };
+      const answers = { title: 'Test', status: 'active' };
+
+      const updates: { status?: string } = {};
+      if (answers.status !== spec.status) {
+        updates.status = answers.status;
+      }
+
+      expect(updates.status).to.equal('active');
+    });
+
+    it('should detect problem change', () => {
+      const spec = { title: 'Test', status: 'draft' as const, problem: 'Old problem' };
+      const answers = { problem: 'New problem' };
+
+      const updates: { problem?: string } = {};
+      if (answers.problem !== (spec.problem || '')) {
+        updates.problem = answers.problem || undefined;
+      }
+
+      expect(updates.problem).to.equal('New problem');
+    });
+
+    it('should detect clearing of problem field', () => {
+      const spec = { title: 'Test', status: 'draft' as const, problem: 'Old problem' };
+      const answers = { problem: '' };
+
+      const updates: { problem?: string | undefined } = {};
+      if (answers.problem !== (spec.problem || '')) {
+        updates.problem = answers.problem || undefined;
+      }
+
+      expect(updates.problem).to.equal(undefined);
+      expect('problem' in updates).to.be.true;
+    });
+  });
+
+  describe('Flag parsing', () => {
+    it('should convert type "none" to undefined', () => {
+      const flagType = 'none';
+      const specType = flagType === 'none' ? undefined : flagType;
+
+      expect(specType).to.be.undefined;
+    });
+
+    it('should keep valid type values', () => {
+      const types = ['product', 'platform', 'infra', 'integration'];
+
+      for (const t of types) {
+        const specType = t === 'none' ? undefined : t;
+        expect(specType).to.equal(t);
+      }
+    });
+
+    it('should handle all valid status values', () => {
+      const statuses = ['draft', 'active', 'implemented'];
+
+      for (const s of statuses) {
+        expect(statuses).to.include(s);
+      }
+    });
+  });
+
+  describe('JSON mode detection', () => {
+    it('should return true when --json flag is set', () => {
+      expect(shouldOutputJson({ json: true })).to.be.true;
+    });
+
+    it('should return true when --machine flag is set', () => {
+      expect(shouldOutputJson({ machine: true })).to.be.true;
+    });
+
+    it('should return false when no flags are set in TTY', () => {
+      const originalIsTTY = process.stdout.isTTY;
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+      expect(shouldOutputJson({ json: false })).to.be.false;
+      expect(shouldOutputJson({})).to.be.false;
+
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+    });
+  });
+
+  describe('FlagResolver resolve behavior', () => {
+    it('should skip spec prompt when spec flag is already set', async () => {
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec edit',
+        baseCommand: 'prlt spec edit',
+        jsonMode: false,
+        flags: { spec: 'existing-spec' },
+      });
+
+      resolver.addPrompt({
+        flagName: 'spec',
+        type: 'list',
+        message: 'Select spec to edit:',
+        choices: () => [{ name: 'Test', value: 'test' }],
+      });
+
+      const resolved = await resolver.resolve();
+      expect(resolved.spec).to.equal('existing-spec');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `prlt spec edit` command for editing specs after creation
- Support flags for `--title`, `--problem`, `--type`, `--status`, `--solution`, `--decisions`
- Add JSON mode support with FlagResolver pattern for AI agents
- Add interactive mode with editor prompts for multi-line fields

## Test plan
- [x] Unit tests pass (21 tests)
- [x] Build succeeds
- [x] Command appears in CLI help
- [ ] Manual testing with `prlt spec edit` command

Closes TKT-777

🤖 Generated with [Claude Code](https://claude.com/claude-code)