### PR TITLE
feat(TKT-778): implement spec delete command

### DIFF
--- a/apps/cli/src/commands/spec/delete.ts
+++ b/apps/cli/src/commands/spec/delete.ts
@@ -1,0 +1,139 @@
+import { Args, Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { FlagResolver } from '../../lib/flags/index.js';
+
+export default class SpecDelete extends PMOCommand {
+  static description = 'Delete a spec';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-spec',
+    '<%= config.bin %> <%= command.id %> my-spec --force',
+    '<%= config.bin %> <%= command.id %>  # Interactive selection',
+  ];
+
+  static args = {
+    id: Args.string({
+      description: 'Spec ID to delete',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt',
+      default: false,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SpecDelete);
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('spec delete', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    let specId = args.id;
+
+    // Interactive selection if no ID provided
+    if (!specId) {
+      const specs = await this.storage.listSpecs();
+      if (specs.length === 0) {
+        return handleError('NO_SPECS', 'No specs found');
+      }
+
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec delete',
+        baseCommand: 'prlt spec delete',
+        jsonMode,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'spec',
+        type: 'list',
+        message: 'Select spec to delete:',
+        choices: () => specs.map(s => ({
+          name: `${s.title} [${s.status}]${s.type ? ` (${s.type})` : ''}`,
+          value: s.id,
+        })),
+        getCommand: (value) => `prlt spec delete ${value} --json`,
+      });
+
+      const resolved = await resolver.resolve();
+      specId = resolved.spec;
+    }
+
+    // Get spec details
+    const spec = await this.storage.getSpec(specId!);
+    if (!spec) {
+      return handleError('SPEC_NOT_FOUND', `Spec not found: ${specId}`);
+    }
+
+    // Confirmation prompt
+    if (!flags.force) {
+      const resolver = new FlagResolver<{ confirmed?: boolean }>({
+        commandName: 'spec delete',
+        baseCommand: `prlt spec delete ${specId}`,
+        jsonMode,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'confirmed',
+        type: 'list',
+        message: `Delete spec "${spec.title}"?`,
+        choices: () => [
+          { name: 'No', value: false },
+          { name: 'Yes', value: true },
+        ],
+        getCommand: (value) => value
+          ? `prlt spec delete ${specId} --force --json`
+          : '',
+      });
+
+      const resolved = await resolver.resolve();
+
+      if (!resolved.confirmed) {
+        this.log(styles.muted('Cancelled'));
+        return;
+      }
+    }
+
+    // Delete the spec
+    await this.storage.deleteSpec(specId!);
+
+    // JSON response for agents
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          specId: spec.id,
+          title: spec.title,
+          deleted: true,
+        },
+        createMetadata('spec delete', flags)
+      );
+      return;
+    }
+
+    // Human-readable response
+    this.log(styles.success(`\nDeleted spec "${styles.emphasis(spec.title)}"`));
+  }
+}

--- a/apps/cli/src/commands/spec/index.ts
+++ b/apps/cli/src/commands/spec/index.ts
@@ -29,6 +29,7 @@ export default class Spec extends PMOCommand {
       { name: 'Create new spec', value: 'create' },
       { name: 'List all specs', value: 'list' },
       { name: 'View spec', value: 'view' },
+      { name: 'Delete spec', value: 'delete' },
       { name: 'Generate tickets from spec', value: 'generate' },
       { name: 'Assign ticket to spec', value: 'ticket' },
       { name: 'Manage dependencies', value: 'link' },
@@ -54,6 +55,7 @@ export default class Spec extends PMOCommand {
           create: 'prlt spec create --json',
           list: 'prlt spec list --json',
           view: 'prlt spec view --json',
+          delete: 'prlt spec delete --json',
           generate: 'prlt spec plan --json',
           ticket: 'prlt spec ticket --json',
           link: 'prlt spec link --json',
@@ -80,6 +82,9 @@ export default class Spec extends PMOCommand {
         break;
       case 'view':
         await this.config.runCommand('spec:view', []);
+        break;
+      case 'delete':
+        await this.config.runCommand('spec:delete', []);
         break;
       case 'generate':
         await this.config.runCommand('spec:generate-tickets', []);

--- a/apps/cli/test/unit/spec-json-mode.test.ts
+++ b/apps/cli/test/unit/spec-json-mode.test.ts
@@ -407,6 +407,113 @@ describe('Spec Commands JSON Mode with FlagResolver', () => {
     });
   });
 
+  describe('spec delete JSON mode', () => {
+    it('should create FlagResolver for spec selection in delete', () => {
+      const specs = [
+        { id: 'spec-1', title: 'Spec 1', status: 'active', type: 'product' },
+        { id: 'spec-2', title: 'Spec 2', status: 'draft', type: 'platform' },
+      ];
+
+      const resolver = new FlagResolver<{ spec?: string }>({
+        commandName: 'spec delete',
+        baseCommand: 'prlt spec delete',
+        jsonMode: true,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'spec',
+        type: 'list',
+        message: 'Select spec to delete:',
+        choices: () => specs.map(s => ({
+          name: `${s.title} [${s.status}]${s.type ? ` (${s.type})` : ''}`,
+          value: s.id,
+        })),
+        getCommand: (value) => `prlt spec delete ${value} --json`,
+      });
+
+      expect(resolver).to.be.instanceOf(FlagResolver);
+    });
+
+    it('should create FlagResolver for confirmation prompt in delete', () => {
+      const specId = 'test-spec';
+      const specTitle = 'Test Spec';
+
+      const resolver = new FlagResolver<{ confirmed?: boolean }>({
+        commandName: 'spec delete',
+        baseCommand: `prlt spec delete ${specId}`,
+        jsonMode: true,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'confirmed',
+        type: 'list',
+        message: `Delete spec "${specTitle}"?`,
+        choices: () => [
+          { name: 'No', value: false },
+          { name: 'Yes', value: true },
+        ],
+        getCommand: (value) => value
+          ? `prlt spec delete ${specId} --force --json`
+          : '',
+      });
+
+      expect(resolver).to.be.instanceOf(FlagResolver);
+    });
+
+    it('should build delete success response structure', () => {
+      const spec = {
+        id: 'test-spec',
+        title: 'Test Spec',
+      };
+
+      const result = {
+        specId: spec.id,
+        title: spec.title,
+        deleted: true,
+      };
+
+      expect(result.specId).to.equal('test-spec');
+      expect(result.title).to.equal('Test Spec');
+      expect(result.deleted).to.be.true;
+    });
+
+    it('should include metadata for spec delete', () => {
+      const flags = { json: true, force: true };
+      const metadata = createMetadata('spec delete', flags);
+
+      expect(metadata.command).to.equal('spec delete');
+      expect(metadata.flags.json).to.be.true;
+      expect(metadata.flags.force).to.be.true;
+      expect(metadata.timestamp).to.be.a('string');
+    });
+
+    it('should build confirmation choices for delete', () => {
+      const choices: ResolverChoice<boolean>[] = [
+        { name: 'No', value: false },
+        { name: 'Yes', value: true },
+      ];
+
+      expect(choices).to.have.lengthOf(2);
+      expect(choices[0].value).to.be.false;
+      expect(choices[1].value).to.be.true;
+    });
+
+    it('should skip confirmation when force flag is set', async () => {
+      const resolver = new FlagResolver<{ confirmed?: boolean }>({
+        commandName: 'spec delete',
+        baseCommand: 'prlt spec delete test-spec',
+        jsonMode: false,
+        flags: {},
+      });
+
+      // When --force is used, no prompt is added, so resolve returns empty
+      const resolved = await resolver.resolve();
+      expect(resolved.confirmed).to.be.undefined;
+    });
+  });
+
   describe('shouldOutputJson', () => {
     it('should return true when --json flag is set', () => {
       expect(shouldOutputJson({ json: true })).to.be.true;


### PR DESCRIPTION
## Summary
- Added `prlt spec delete` command to delete specs
- Supports interactive spec selection when no ID provided
- Includes confirmation prompt before deletion
- Added `--force` flag to skip confirmation
- Full JSON mode support for AI agent integration
- Updated spec menu to include delete option

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Unit tests pass (29 tests passing)
- [x] `prlt spec delete --help` shows correct usage
- [x] `prlt spec delete --json` shows spec selection prompt
- [x] `prlt spec delete <id> --json` shows confirmation prompt
- [x] `prlt spec delete <id> --force --json` deletes spec successfully
- [x] Deleting non-existent spec returns SPEC_NOT_FOUND error

🤖 Generated with [Claude Code](https://claude.com/claude-code)