### PR TITLE
fix(TKT-797): fix config command exiting with code 2 in non-TTY

### DIFF
--- a/apps/cli/src/commands/config/index.ts
+++ b/apps/cli/src/commands/config/index.ts
@@ -16,6 +16,7 @@ import { TerminalApp, Shell } from '../../lib/execution/types.js'
 import {
   shouldOutputJson,
   isAgentMode,
+  isNonTTY,
   outputPromptAsJson,
   outputSuccessAsJson,
   outputErrorAsJson,
@@ -150,8 +151,12 @@ export default class Config extends Command {
       }
 
       // Handle --list or --json flag without --setting (just show config)
-      if ((flags.list || flags.json) && !flags.setting) {
-        if (jsonMode) {
+      // Also handle non-TTY mode without explicit flags - output config as readable list
+      const isExplicitJsonMode = flags.json === true
+      const shouldShowConfigList = flags.list || (isExplicitJsonMode && !flags.setting) || (isNonTTY() && !flags.setting && !flags.set?.length)
+
+      if (shouldShowConfigList) {
+        if (isExplicitJsonMode) {
           outputSuccessAsJson({
             terminal: {
               app: config.terminal.app,

--- a/apps/cli/test/commands/config.test.ts
+++ b/apps/cli/test/commands/config.test.ts
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -21,6 +23,25 @@ function runCli(args: string[]): string {
   } catch (error: unknown) {
     // Return stdout even on error (for --help commands that may exit with code 0)
     return (error as { stdout?: string })?.stdout || '';
+  }
+}
+
+// Helper to run CLI commands and get both stdout and exit code
+function runCliWithExitCode(args: string[], cwd?: string): { stdout: string; exitCode: number } {
+  const binPath = path.join(root, 'bin', 'run.js');
+  try {
+    const stdout = execSync(`node ${binPath} ${args.join(' ')}`, {
+      cwd: cwd || root,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; status?: number };
+    return {
+      stdout: err.stdout || '',
+      exitCode: err.status ?? 1
+    };
   }
 }
 
@@ -66,6 +87,89 @@ describe('Config Command', () => {
 
     it('help shows terminal.openInBackground example', () => {
       expect(helpOutput).to.contain('openInBackground');
+    });
+  });
+
+  /**
+   * Tests for non-TTY behavior
+   * TKT-797: Fix config command exiting with code 2 in non-TTY
+   */
+  describe('Non-TTY Behavior', () => {
+    let testWorkspacePath: string;
+
+    before(() => {
+      // Create a temporary workspace for testing
+      testWorkspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-config-test-'));
+      // Initialize workspace
+      const binPath = path.join(root, 'bin', 'run.js');
+      execSync(`node ${binPath} init --json --name test-config --no-pmo`, {
+        cwd: testWorkspacePath,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    });
+
+    after(() => {
+      // Cleanup temporary workspace
+      if (testWorkspacePath && fs.existsSync(testWorkspacePath)) {
+        fs.rmSync(testWorkspacePath, { recursive: true, force: true });
+      }
+    });
+
+    it('outputs readable config list in non-TTY without --json flag and exits with code 0', () => {
+      const workspaceDir = path.join(testWorkspacePath, 'test-config-hq');
+      const result = runCliWithExitCode(['config'], workspaceDir);
+
+      // Should output readable format, not JSON prompt
+      expect(result.stdout).to.contain('Workspace Configuration');
+      expect(result.stdout).to.contain('Terminal');
+      expect(result.stdout).to.contain('app:');
+      expect(result.stdout).to.not.contain('"prompt"');
+
+      // Should exit with code 0, not code 2
+      expect(result.exitCode).to.equal(0);
+    });
+
+    it('outputs JSON when --json flag is explicitly set', () => {
+      const workspaceDir = path.join(testWorkspacePath, 'test-config-hq');
+      const result = runCliWithExitCode(['config', '--json'], workspaceDir);
+
+      // Should output JSON format
+      const output = JSON.parse(result.stdout);
+      expect(output).to.have.property('success', true);
+      expect(output).to.have.property('result');
+      expect(output.result).to.have.property('terminal');
+      expect(output.result).to.have.property('shell');
+
+      // Should exit with code 0
+      expect(result.exitCode).to.equal(0);
+    });
+
+    it('outputs prompt JSON with --setting --json and exits with code 2', () => {
+      const workspaceDir = path.join(testWorkspacePath, 'test-config-hq');
+      const result = runCliWithExitCode(['config', '--setting', 'terminal.app', '--json'], workspaceDir);
+
+      // Should output prompt JSON
+      const output = JSON.parse(result.stdout);
+      expect(output).to.have.property('prompt');
+      expect(output.prompt).to.have.property('type', 'list');
+      expect(output.prompt).to.have.property('choices');
+
+      // Should exit with code 2 (needs input)
+      expect(result.exitCode).to.equal(2);
+    });
+
+    it('--list flag outputs readable format in non-TTY', () => {
+      const workspaceDir = path.join(testWorkspacePath, 'test-config-hq');
+      const result = runCliWithExitCode(['config', '--list'], workspaceDir);
+
+      // Should output readable format
+      expect(result.stdout).to.contain('Workspace Configuration');
+      expect(result.stdout).to.contain('Terminal');
+      expect(result.stdout).to.not.contain('"prompt"');
+
+      // Should exit with code 0
+      expect(result.exitCode).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed config command to detect non-TTY environments and output config as a readable list instead of dumping interactive menu JSON to stderr and exiting with code 2
- Added `isNonTTY` import and check to distinguish between explicit `--json` flag and non-TTY environment
- When in non-TTY without explicit `--json` flag, the command now behaves like `--list` - outputs readable config and exits with code 0

## Test plan
- [x] Added unit tests for non-TTY behavior in `test/commands/config.test.ts`
- [x] Tested manually by piping output: `prlt config | cat` outputs readable list and exits 0
- [x] Verified `--json` flag still outputs JSON format
- [x] Verified `--setting --json` still outputs prompt JSON with exit code 2
- [x] All 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)