### PR TITLE
feat(TKT-784): Implement project update command

### DIFF
--- a/apps/cli/src/commands/project/update.ts
+++ b/apps/cli/src/commands/project/update.ts
@@ -1,0 +1,214 @@
+import { Args, Flags } from '@oclif/core';
+import inquirer from 'inquirer';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+  buildFormPromptConfig,
+  FormField,
+} from '../../lib/prompt-json.js';
+
+export default class ProjectUpdate extends PMOCommand {
+  static description = 'Update project metadata (name, description)';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-project --name "New Project Name"',
+    '<%= config.bin %> <%= command.id %> my-project --description "Updated description"',
+    '<%= config.bin %> <%= command.id %> my-project --name "New Name" --description "New description"',
+    '<%= config.bin %> <%= command.id %> my-project  # Interactive mode',
+  ];
+
+  static args = {
+    id: Args.string({
+      description: 'Project ID or name',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    name: Flags.string({
+      char: 'n',
+      description: 'New project name',
+    }),
+    description: Flags.string({
+      char: 'd',
+      description: 'New project description',
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ProjectUpdate);
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags);
+
+    // Helper to handle errors in JSON mode
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('project update', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Agent mode config for prompts
+    const agentConfig = jsonMode ? { flags, commandName: 'project update' } : null;
+
+    // Get project ID - from args or prompt
+    let projectId = args.id;
+
+    if (!projectId) {
+      // List available projects for selection
+      const projects = await this.storage.listProjects({ isArchived: false });
+
+      if (projects.length === 0) {
+        return handleError('NO_PROJECTS', 'No projects found. Create one with: prlt project create');
+      }
+
+      const projectChoices = projects.map(p => ({
+        name: `${p.id} - ${p.name}`,
+        value: p.id,
+        command: `prlt project update ${p.id} --json`,
+      }));
+
+      // Handle JSON mode for project selection
+      if (jsonMode) {
+        outputPromptAsJson(
+          {
+            type: 'list',
+            name: 'projectId',
+            message: 'Select project to update:',
+            choices: projectChoices,
+          },
+          createMetadata('project update', flags)
+        );
+        return;
+      }
+
+      const { selectedProjectId } = await inquirer.prompt<{ selectedProjectId: string }>([{
+        type: 'list',
+        name: 'selectedProjectId',
+        message: 'Select project to update:',
+        choices: projectChoices,
+      }]);
+
+      projectId = selectedProjectId;
+    }
+
+    // Get the project
+    const project = await this.storage.getProject(projectId);
+    if (!project) {
+      return handleError('PROJECT_NOT_FOUND', `Project "${projectId}" not found.`);
+    }
+
+    // Determine what to update
+    let newName: string | undefined = flags.name;
+    let newDescription: string | undefined = flags.description;
+
+    // If no flags provided, enter interactive mode
+    if (newName === undefined && newDescription === undefined) {
+      const fields: FormField[] = [
+        {
+          type: 'input',
+          name: 'name',
+          message: 'Project name:',
+          default: project.name,
+        },
+        {
+          type: 'input',
+          name: 'description',
+          message: 'Project description:',
+          default: project.description || '',
+        },
+      ];
+
+      // Handle JSON mode for field input
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildFormPromptConfig(fields),
+          createMetadata('project update', flags)
+        );
+        return;
+      }
+
+      const answers = await inquirer.prompt<{ name: string; description: string }>(
+        fields.map(field => ({
+          ...field,
+          validate: field.name === 'name'
+            ? ((input: string) => input.length > 0 || 'Name is required')
+            : undefined,
+        }))
+      );
+
+      newName = answers.name;
+      newDescription = answers.description;
+    }
+
+    // Build changes object - only include fields that are different
+    const changes: { name?: string; description?: string } = {};
+
+    if (newName !== undefined && newName !== project.name) {
+      changes.name = newName;
+    }
+
+    if (newDescription !== undefined && newDescription !== (project.description || '')) {
+      // Allow clearing description with empty string (storage layer converts '' to null)
+      changes.description = newDescription;
+    }
+
+    // Check if anything changed
+    if (Object.keys(changes).length === 0) {
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            projectId: project.id,
+            projectName: project.name,
+            description: project.description,
+            noChanges: true,
+          },
+          createMetadata('project update', flags)
+        );
+        return;
+      }
+      this.log(styles.muted('No changes made.'));
+      return;
+    }
+
+    // Update the project
+    const updated = await this.storage.updateProject(project.id, changes);
+
+    // Output success
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          projectId: updated.id,
+          projectName: updated.name,
+          description: updated.description,
+          changes: Object.keys(changes),
+        },
+        createMetadata('project update', flags)
+      );
+      return;
+    }
+
+    this.log(styles.success(`\nUpdated project "${styles.emphasis(updated.name)}"`));
+    this.log(styles.muted(`  ID: ${updated.id}`));
+    if (changes.name) {
+      this.log(styles.muted(`  Name: ${project.name} → ${updated.name}`));
+    }
+    if ('description' in changes) {
+      const oldDesc = project.description || '(none)';
+      const newDesc = updated.description || '(none)';
+      this.log(styles.muted(`  Description: ${oldDesc} → ${newDesc}`));
+    }
+  }
+}

--- a/apps/cli/test/e2e/pmo-project-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-project-commands.test.ts
@@ -443,6 +443,93 @@ describe('PMO Project Commands E2E Tests', () => {
     });
   });
 
+  describe('prlt project update', () => {
+    beforeEach(() => {
+      createLocalTestProject(db, 'update-project', 'Update Test Project', 'Original description');
+      createLocalTestColumns(db, 'update-project');
+    });
+
+    it('should update project name with --name flag', () => {
+      exec('project update update-project --name "New Project Name"');
+
+      const project = db.prepare('SELECT name FROM pmo_projects WHERE id = ?').get('update-project') as { name: string };
+      expect(project.name).to.equal('New Project Name');
+    });
+
+    it('should update project description with --description flag', () => {
+      exec('project update update-project --description "New description"');
+
+      const project = db.prepare('SELECT description FROM pmo_projects WHERE id = ?').get('update-project') as { description: string };
+      expect(project.description).to.equal('New description');
+    });
+
+    it('should update both name and description', () => {
+      exec('project update update-project --name "Updated Name" --description "Updated description"');
+
+      const project = db.prepare('SELECT name, description FROM pmo_projects WHERE id = ?').get('update-project') as { name: string; description: string };
+      expect(project.name).to.equal('Updated Name');
+      expect(project.description).to.equal('Updated description');
+    });
+
+    it('should clear description with empty string', () => {
+      exec('project update update-project --description ""');
+
+      const project = db.prepare('SELECT description FROM pmo_projects WHERE id = ?').get('update-project') as { description: string | null };
+      expect(project.description).to.be.null;
+    });
+
+    it('should show success message', () => {
+      const output = exec('project update update-project --name "Success Test"');
+
+      // Non-TTY outputs JSON with success: true
+      expect(output).to.satisfy((o: string) =>
+        o.includes('Updated project') || o.includes('"success"')
+      );
+    });
+
+    it('should error for non-existent project', () => {
+      const output = exec('project update non-existent --name "Test"');
+
+      expect(output.toLowerCase()).to.contain('not found');
+    });
+
+    it('should report no changes when same values provided', () => {
+      const output = exec('project update update-project --name "Update Test Project"');
+
+      // Non-TTY outputs JSON; check for no-change indicator in either format
+      expect(output.toLowerCase()).to.satisfy((o: string) =>
+        o.includes('no changes') || o.includes('"noChanges"') || o.includes('"nochanges"')
+      );
+    });
+
+    it('should update updated_at timestamp', () => {
+      const before = db.prepare('SELECT updated_at FROM pmo_projects WHERE id = ?').get('update-project') as { updated_at: string };
+
+      // Wait a bit to ensure timestamp differs
+      exec('project update update-project --name "Timestamp Test"');
+
+      const after = db.prepare('SELECT updated_at FROM pmo_projects WHERE id = ?').get('update-project') as { updated_at: string };
+      expect(after.updated_at).to.not.equal(before.updated_at);
+    });
+
+    it('should support JSON mode output', () => {
+      const output = exec('project update update-project --name "JSON Test" --machine');
+
+      const json = JSON.parse(output);
+      expect(json.success).to.be.true;
+      expect(json.result.projectName).to.equal('JSON Test');
+      expect(json.result.changes).to.include('name');
+    });
+
+    it('should preserve project ID when updating name', () => {
+      exec('project update update-project --name "Completely Different Name"');
+
+      const project = db.prepare('SELECT id, name FROM pmo_projects WHERE id = ?').get('update-project') as { id: string; name: string };
+      expect(project.id).to.equal('update-project');
+      expect(project.name).to.equal('Completely Different Name');
+    });
+  });
+
   describe('prlt project list --archived', () => {
     beforeEach(() => {
       createLocalTestProject(db, 'active-proj', 'Active Project');


### PR DESCRIPTION
## Summary
- Created `src/commands/project/update.ts` implementing the project update command
- Added `--name` and `--description` flags for updating project metadata
- Full JSON mode support for AI agent integration
- 10 comprehensive unit tests covering all functionality

## Test plan
- [x] Run `prlt project update <project-id> --name "New Name"` to update project name
- [x] Run `prlt project update <project-id> --description "New desc"` to update description
- [x] Run `prlt project update <project-id> --machine` to verify JSON mode output
- [x] Run `pnpm test --grep "prlt project update"` to run unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)