### PR TITLE
feat(TKT-779): implement execution view command

### DIFF
--- a/apps/cli/src/commands/execution/index.ts
+++ b/apps/cli/src/commands/execution/index.ts
@@ -3,10 +3,11 @@ import inquirer from 'inquirer'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 
 export default class Execution extends PMOCommand {
-  static description = 'Single execution operations (logs, stop)'
+  static description = 'Single execution operations (view, logs, stop)'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> view WORK-001',
     '<%= config.bin %> <%= command.id %> logs WORK-001',
     '<%= config.bin %> <%= command.id %> stop WORK-001',
   ]
@@ -35,6 +36,7 @@ export default class Execution extends PMOCommand {
         message: 'What would you like to do?',
         choices: [
           { name: '📋 List all executions', value: 'list', command: 'prlt execution list --json' },
+          { name: '🔍 View execution details', value: 'view', command: 'prlt execution view --json' },
           { name: '📜 View logs for an execution', value: 'logs', command: 'prlt execution logs --json' },
           { name: '🛑 Stop an execution', value: 'stop', command: 'prlt execution stop --json' },
           { name: '🛑 Stop all running', value: 'stop-all', command: 'prlt execution stop --all --json' },
@@ -51,6 +53,7 @@ export default class Execution extends PMOCommand {
     // Run the selected subcommand
     const commands: Record<string, { cmd: string; args: string[] }> = {
       list: { cmd: 'execution:list', args: [] },
+      view: { cmd: 'execution:view', args: [] },
       logs: { cmd: 'execution:logs', args: [] },
       stop: { cmd: 'execution:stop', args: [] },
       'stop-all': { cmd: 'execution:stop', args: ['--all'] },

--- a/apps/cli/src/commands/execution/view.ts
+++ b/apps/cli/src/commands/execution/view.ts
@@ -1,0 +1,317 @@
+import { Args, Flags } from '@oclif/core'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import Database from 'better-sqlite3'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import { ExecutionStorage } from '../../lib/execution/storage.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import {
+  outputErrorAsJson,
+  createMetadata,
+  shouldOutputJson,
+} from '../../lib/prompt-json.js'
+
+export default class ExecutionView extends PMOCommand {
+  static description = 'View details of a specific execution'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> WORK-001',
+    '<%= config.bin %> <%= command.id %>  # Interactive mode',
+  ]
+
+  static args = {
+    id: Args.string({
+      description: 'Execution ID - prompts if not provided',
+      required: false,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+    json: Flags.boolean({
+      description: 'Output execution details as JSON',
+      default: false,
+    }),
+  }
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false }
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ExecutionView)
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags)
+
+    // Helper to handle errors in JSON mode
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('execution view', flags))
+        this.exit(1)
+      }
+      this.error(message)
+    }
+
+    // Get workspace info
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      return handleError('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt init" first.')
+    }
+
+    // Open database
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new Database(dbPath)
+    const executionStorage = new ExecutionStorage(db)
+
+    try {
+      // Get execution ID - prompt if not provided
+      let execId = args.id
+
+      if (!execId) {
+        const executions = executionStorage.listExecutions({ limit: 20 })
+
+        if (executions.length === 0) {
+          if (jsonMode) {
+            outputErrorAsJson('NO_EXECUTIONS', 'No executions found.', createMetadata('execution view', flags))
+            db.close()
+            this.exit(1)
+          }
+          this.log(styles.muted('\nNo executions found.\n'))
+          return
+        }
+
+        const jsonModeConfig = (flags.json || flags.machine) ? { flags, commandName: 'execution view' } : null
+
+        const { selectedId } = await this.prompt<{ selectedId: string }>([
+          {
+            type: 'list',
+            name: 'selectedId',
+            message: 'Select execution to view:',
+            choices: executions.map((e) => ({
+              name: `${e.id} - ${e.ticketId} (${e.agentName}, ${e.status})`,
+              value: e.id,
+              command: `prlt execution view ${e.id} --json`,
+            })),
+          },
+        ], jsonModeConfig)
+        execId = selectedId
+      }
+
+      // Get execution
+      const execution = executionStorage.getExecution(execId!)
+      if (!execution) {
+        return handleError('NOT_FOUND', `Execution "${execId}" not found.`)
+      }
+
+      // If JSON mode with ID provided, output the execution data as JSON
+      if (jsonMode && args.id) {
+        console.log(JSON.stringify({
+          success: true,
+          data: {
+            id: execution.id,
+            ticketId: execution.ticketId,
+            agentName: execution.agentName,
+            executor: execution.executor,
+            environment: execution.environment,
+            displayMode: execution.displayMode,
+            sandboxed: execution.sandboxed,
+            status: execution.status,
+            branch: execution.branch || null,
+            pid: execution.pid || null,
+            containerId: execution.containerId || null,
+            sessionId: execution.sessionId || null,
+            host: execution.host || null,
+            logPath: execution.logPath || null,
+            startedAt: execution.startedAt.toISOString(),
+            completedAt: execution.completedAt?.toISOString() || null,
+            exitCode: execution.exitCode ?? null,
+          },
+          metadata: createMetadata('execution view', flags),
+        }, null, 2))
+        return
+      }
+
+      // Display execution details
+      this.log('')
+      this.log(`${styles.header('🚀 Execution')} ${styles.emphasis(execution.id)}`)
+      this.log('═'.repeat(60))
+      this.log('')
+
+      // Basic info
+      this.log(`${styles.header('Ticket:')}       ${execution.ticketId}`)
+      this.log(`${styles.header('Agent:')}        ${execution.agentName}`)
+      this.log(`${styles.header('Executor:')}     ${execution.executor}`)
+      this.log(`${styles.header('Status:')}       ${getStatusDisplay(execution.status)}`)
+      this.log('')
+
+      // Environment info
+      this.log(styles.header('Environment'))
+      this.log('─'.repeat(40))
+      const envIcon = getEnvironmentIcon(execution.environment)
+      this.log(`${styles.muted('Type:')}         ${envIcon} ${execution.environment}`)
+      this.log(`${styles.muted('Display:')}      ${execution.displayMode}`)
+      this.log(`${styles.muted('Permissions:')}  ${execution.sandboxed ? styles.success('sandboxed (safe)') : styles.warning('unrestricted (danger)')}`)
+      if (execution.branch) {
+        this.log(`${styles.muted('Branch:')}       ${execution.branch}`)
+      }
+      this.log('')
+
+      // Process info
+      if (execution.pid || execution.containerId || execution.sessionId || execution.host) {
+        this.log(styles.header('Process Info'))
+        this.log('─'.repeat(40))
+        if (execution.pid) {
+          this.log(`${styles.muted('PID:')}          ${execution.pid}`)
+        }
+        if (execution.containerId) {
+          this.log(`${styles.muted('Container:')}    ${execution.containerId}`)
+        }
+        if (execution.sessionId) {
+          this.log(`${styles.muted('Session:')}      ${execution.sessionId}`)
+        }
+        if (execution.host) {
+          this.log(`${styles.muted('Host:')}         ${execution.host}`)
+        }
+        this.log('')
+      }
+
+      // Timing info
+      this.log(styles.header('Timing'))
+      this.log('─'.repeat(40))
+      this.log(`${styles.muted('Started:')}      ${execution.startedAt.toLocaleString()} (${formatTimeAgo(execution.startedAt)})`)
+      if (execution.completedAt) {
+        this.log(`${styles.muted('Completed:')}    ${execution.completedAt.toLocaleString()} (${formatTimeAgo(execution.completedAt)})`)
+        const duration = execution.completedAt.getTime() - execution.startedAt.getTime()
+        this.log(`${styles.muted('Duration:')}     ${formatDuration(duration)}`)
+      }
+      if (execution.exitCode !== undefined) {
+        const exitStyle = execution.exitCode === 0 ? styles.success : styles.error
+        this.log(`${styles.muted('Exit Code:')}    ${exitStyle(execution.exitCode.toString())}`)
+      }
+      this.log('')
+
+      // Logs summary
+      if (execution.logPath) {
+        this.log(styles.header('Logs'))
+        this.log('─'.repeat(40))
+        this.log(`${styles.muted('Path:')}         ${execution.logPath}`)
+
+        if (fs.existsSync(execution.logPath)) {
+          const stats = fs.statSync(execution.logPath)
+          this.log(`${styles.muted('Size:')}         ${formatFileSize(stats.size)}`)
+
+          // Show last few lines of the log
+          const content = fs.readFileSync(execution.logPath, 'utf-8')
+          const lines = content.trim().split('\n')
+          if (lines.length > 0) {
+            this.log(`${styles.muted('Lines:')}        ${lines.length}`)
+            this.log('')
+            this.log(styles.muted('Last 5 lines:'))
+            const lastLines = lines.slice(-5)
+            for (const line of lastLines) {
+              // Truncate long lines
+              const truncated = line.length > 80 ? line.substring(0, 77) + '...' : line
+              this.log(styles.muted(`  ${truncated}`))
+            }
+          }
+        } else {
+          this.log(styles.warning('  Log file not found'))
+        }
+        this.log('')
+      }
+
+      // Commands
+      this.log('═'.repeat(60))
+      this.log(styles.muted('Commands:'))
+      if (execution.logPath) {
+        this.log(styles.muted(`  prlt execution logs ${execution.id}         View full logs`))
+      }
+      if (['starting', 'running'].includes(execution.status)) {
+        this.log(styles.muted(`  prlt execution stop ${execution.id}         Stop execution`))
+        if (execution.sessionId) {
+          if (execution.environment === 'devcontainer' && execution.containerId) {
+            this.log(styles.muted(`  docker exec -it ${execution.containerId} tmux attach -t ${execution.sessionId}`))
+          } else {
+            this.log(styles.muted(`  tmux attach -t ${execution.sessionId}     Attach to session`))
+          }
+        }
+      }
+      this.log('')
+    } finally {
+      db.close()
+    }
+  }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+function getStatusDisplay(status: string): string {
+  switch (status) {
+    case 'running':
+      return styles.success('● running')
+    case 'starting':
+      return styles.warning('◐ starting')
+    case 'completed':
+      return styles.muted('✓ completed')
+    case 'failed':
+      return styles.error('✗ failed')
+    case 'stopped':
+      return styles.muted('■ stopped')
+    default:
+      return status
+  }
+}
+
+function getEnvironmentIcon(environment: string): string {
+  switch (environment) {
+    case 'devcontainer':
+      return '🐳'
+    case 'host':
+      return '💻'
+    case 'docker':
+      return '📦'
+    case 'vm':
+      return '☁️'
+    default:
+      return '❓'
+  }
+}
+
+function formatTimeAgo(date: Date): string {
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / (1000 * 60))
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffMins < 1) return 'just now'
+  if (diffMins < 60) return `${diffMins} min ago`
+  if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`
+  return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m ${seconds % 60}s`
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`
+  }
+  return `${seconds}s`
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/apps/cli/test/unit/execution-view.test.ts
+++ b/apps/cli/test/unit/execution-view.test.ts
@@ -1,0 +1,284 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { ExecutionStorage } from '../../src/lib/execution/storage.js'
+import { PMO_TABLES } from '../../src/lib/pmo/schema.js'
+
+/**
+ * Unit tests for ExecutionView command
+ * Tests the getExecution() method used by the view command
+ */
+describe('ExecutionView', () => {
+  let testDir: string
+  let db: Database.Database
+  let storage: ExecutionStorage
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'execution-view-test-'))
+    const dbPath = path.join(testDir, 'test.db')
+    db = new Database(dbPath)
+
+    // Create the agent_work table
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${PMO_TABLES.agent_work} (
+        id TEXT PRIMARY KEY,
+        ticket_id TEXT NOT NULL,
+        agent_name TEXT NOT NULL,
+        executor TEXT NOT NULL,
+        environment TEXT DEFAULT 'host',
+        display_mode TEXT DEFAULT 'terminal',
+        sandboxed INTEGER DEFAULT 1,
+        status TEXT NOT NULL,
+        branch TEXT,
+        pid TEXT,
+        container_id TEXT,
+        session_id TEXT,
+        host TEXT,
+        log_path TEXT,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        exit_code INTEGER
+      )
+    `)
+
+    storage = new ExecutionStorage(db)
+  })
+
+  afterEach(() => {
+    db.close()
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('getExecution', () => {
+    it('returns null for non-existent execution', () => {
+      const exec = storage.getExecution('WORK-999')
+      expect(exec).to.be.null
+    })
+
+    it('returns execution with all basic fields', () => {
+      storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'agent-1',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        sandboxed: true,
+      })
+
+      const executions = storage.listExecutions({ limit: 1 })
+      const execId = executions[0].id
+
+      const exec = storage.getExecution(execId)
+      expect(exec).to.not.be.null
+      expect(exec!.ticketId).to.equal('TKT-001')
+      expect(exec!.agentName).to.equal('agent-1')
+      expect(exec!.executor).to.equal('claude-code')
+      expect(exec!.environment).to.equal('host')
+      expect(exec!.displayMode).to.equal('terminal')
+      expect(exec!.sandboxed).to.equal(true)
+      expect(exec!.status).to.equal('starting')
+      expect(exec!.startedAt).to.be.instanceOf(Date)
+    })
+
+    it('returns execution with optional fields', () => {
+      storage.createExecution({
+        ticketId: 'TKT-002',
+        agentName: 'agent-2',
+        executor: 'claude-code',
+        environment: 'devcontainer',
+        displayMode: 'background',
+        sandboxed: false,
+        branch: 'TKT-002/feat/user/agent-2/test-branch',
+        pid: '12345',
+        containerId: 'abc123def',
+        sessionId: 'prlt-TKT-002-implement',
+        host: 'localhost',
+        logPath: '/tmp/execution.log',
+      })
+
+      const executions = storage.listExecutions({ limit: 1 })
+      const execId = executions[0].id
+
+      const exec = storage.getExecution(execId)
+      expect(exec).to.not.be.null
+      expect(exec!.environment).to.equal('devcontainer')
+      expect(exec!.displayMode).to.equal('background')
+      expect(exec!.sandboxed).to.equal(false)
+      expect(exec!.branch).to.equal('TKT-002/feat/user/agent-2/test-branch')
+      expect(exec!.pid).to.equal('12345')
+      expect(exec!.containerId).to.equal('abc123def')
+      expect(exec!.sessionId).to.equal('prlt-TKT-002-implement')
+      expect(exec!.host).to.equal('localhost')
+      expect(exec!.logPath).to.equal('/tmp/execution.log')
+    })
+
+    it('returns execution with completion info', () => {
+      storage.createExecution({
+        ticketId: 'TKT-003',
+        agentName: 'agent-3',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        sandboxed: true,
+      })
+
+      const executions = storage.listExecutions({ limit: 1 })
+      const execId = executions[0].id
+
+      storage.updateStatus(execId, 'completed', 0)
+
+      const exec = storage.getExecution(execId)
+      expect(exec).to.not.be.null
+      expect(exec!.status).to.equal('completed')
+      expect(exec!.exitCode).to.equal(0)
+      expect(exec!.completedAt).to.be.instanceOf(Date)
+    })
+
+    it('returns execution with failed status and exit code', () => {
+      storage.createExecution({
+        ticketId: 'TKT-004',
+        agentName: 'agent-4',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        sandboxed: true,
+      })
+
+      const executions = storage.listExecutions({ limit: 1 })
+      const execId = executions[0].id
+
+      storage.updateStatus(execId, 'failed', 1)
+
+      const exec = storage.getExecution(execId)
+      expect(exec).to.not.be.null
+      expect(exec!.status).to.equal('failed')
+      expect(exec!.exitCode).to.equal(1)
+    })
+
+    it('returns different executor types', () => {
+      const executorTypes = ['claude-code', 'codex', 'aider', 'custom'] as const
+
+      for (const executor of executorTypes) {
+        storage.createExecution({
+          ticketId: `TKT-${executor}`,
+          agentName: 'agent-executor',
+          executor,
+          environment: 'host',
+          displayMode: 'terminal',
+          sandboxed: true,
+        })
+      }
+
+      const executions = storage.listExecutions({ limit: 10 })
+      expect(executions).to.have.length(4)
+
+      for (const exec of executions) {
+        expect(executorTypes).to.include(exec.executor)
+      }
+    })
+
+    it('returns different environment types', () => {
+      const environments = ['host', 'devcontainer', 'docker', 'vm'] as const
+
+      for (const environment of environments) {
+        storage.createExecution({
+          ticketId: `TKT-${environment}`,
+          agentName: 'agent-env',
+          executor: 'claude-code',
+          environment,
+          displayMode: 'terminal',
+          sandboxed: true,
+        })
+      }
+
+      const executions = storage.listExecutions({ limit: 10 })
+      expect(executions).to.have.length(4)
+
+      for (const exec of executions) {
+        expect(environments).to.include(exec.environment)
+      }
+    })
+
+    it('returns different display modes', () => {
+      const displayModes = ['terminal', 'background', 'foreground'] as const
+
+      for (const displayMode of displayModes) {
+        storage.createExecution({
+          ticketId: `TKT-${displayMode}`,
+          agentName: 'agent-display',
+          executor: 'claude-code',
+          environment: 'host',
+          displayMode,
+          sandboxed: true,
+        })
+      }
+
+      const executions = storage.listExecutions({ limit: 10 })
+      expect(executions).to.have.length(3)
+
+      for (const exec of executions) {
+        expect(displayModes).to.include(exec.displayMode)
+      }
+    })
+  })
+
+  describe('listExecutions for view selection', () => {
+    it('returns executions ordered by start time descending', () => {
+      // Create executions with different start times
+      const now = Date.now()
+
+      db.prepare(`
+        INSERT INTO ${PMO_TABLES.agent_work} (
+          id, ticket_id, agent_name, executor, environment, display_mode,
+          sandboxed, status, started_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run('WORK-OLD', 'TKT-001', 'agent-1', 'claude-code', 'host', 'terminal', 1, 'completed', now - 10000)
+
+      db.prepare(`
+        INSERT INTO ${PMO_TABLES.agent_work} (
+          id, ticket_id, agent_name, executor, environment, display_mode,
+          sandboxed, status, started_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run('WORK-NEW', 'TKT-002', 'agent-2', 'claude-code', 'host', 'terminal', 1, 'running', now)
+
+      const executions = storage.listExecutions({ limit: 10 })
+      expect(executions[0].id).to.equal('WORK-NEW')
+      expect(executions[1].id).to.equal('WORK-OLD')
+    })
+
+    it('returns executions with all statuses for view command', () => {
+      const statuses = ['starting', 'running', 'completed', 'failed', 'stopped']
+
+      for (const status of statuses) {
+        storage.createExecution({
+          ticketId: `TKT-${status}`,
+          agentName: 'agent-status',
+          executor: 'claude-code',
+          environment: 'host',
+          displayMode: 'terminal',
+          sandboxed: true,
+        })
+
+        const executions = storage.listExecutions({ limit: 1 })
+        const execId = executions[0].id
+
+        if (status !== 'starting') {
+          storage.updateStatus(execId, status as 'running' | 'completed' | 'failed' | 'stopped')
+        }
+      }
+
+      // View command should show all statuses (unlike logs/stop which filter)
+      const executions = storage.listExecutions({ limit: 20 })
+      expect(executions).to.have.length(5)
+
+      const returnedStatuses = executions.map(e => e.status)
+      for (const status of statuses) {
+        expect(returnedStatuses).to.include(status)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Added `prlt execution view` command to display detailed information about a specific execution
- Updated the execution menu to include the view option
- Added comprehensive unit tests

## Changes

- Created `src/commands/execution/view.ts` - new command that shows execution details including:
  - Basic info (ticket, agent, executor, status)
  - Environment details (type, display mode, permissions, branch)
  - Process info (PID, container ID, session ID, host)
  - Timing info (started, completed, duration, exit code)
  - Logs summary (path, size, last 5 lines)
  - Helpful commands for interacting with the execution

- Updated `src/commands/execution/index.ts` to add view option in the interactive menu

- Added `test/unit/execution-view.test.ts` with tests for:
  - Getting execution by ID
  - Handling all execution fields (basic and optional)
  - Various statuses, environments, display modes, and executors
  - List ordering for view selection

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [x] `prlt execution view --help` shows correct usage
- [x] `prlt help execution` lists the view command

🤖 Generated with [Claude Code](https://claude.com/claude-code)