### PR TITLE
fix(TKT-798): Fix branch validate misleading error message for ticket ID position

### DIFF
--- a/apps/cli/src/lib/branch/index.ts
+++ b/apps/cli/src/lib/branch/index.ts
@@ -169,6 +169,16 @@ export function validateBranchName(name: string): ValidationResult {
   if (parts.length === 2) {
     // {type}/{description}
     const description = parts[1]
+
+    // Check if description looks like a ticket ID (user put ticket in wrong position)
+    if (isTicketId(description)) {
+      return {
+        valid: false,
+        error: `Segment "${description}" looks like a ticket ID, but ticket IDs must be the first segment. ` +
+               `Expected format: {ticketId}/{type}/{description}`,
+      }
+    }
+
     if (!isKebabCase(description)) {
       return {
         valid: false,
@@ -185,10 +195,28 @@ export function validateBranchName(name: string): ValidationResult {
   const owner = parts[1]
   const description = parts[2]
 
+  // Check if owner looks like a ticket ID (user put ticket in wrong position)
+  if (isTicketId(owner)) {
+    return {
+      valid: false,
+      error: `Segment "${owner}" looks like a ticket ID, but it's in the owner position (segment 2). ` +
+             `Ticket IDs must be the first segment. Expected format: {ticketId}/{type}/{owner}/{description}`,
+    }
+  }
+
   if (!isKebabCase(owner)) {
     return {
       valid: false,
       error: `Owner name must be kebab-case: "${owner}"`,
+    }
+  }
+
+  // Check if description looks like a ticket ID (user put ticket in wrong position)
+  if (isTicketId(description)) {
+    return {
+      valid: false,
+      error: `Segment "${description}" looks like a ticket ID, but it's in the description position (segment 3). ` +
+             `Ticket IDs must be the first segment.`,
     }
   }
 

--- a/apps/cli/test/unit/branch-naming.test.ts
+++ b/apps/cli/test/unit/branch-naming.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { generateBranchName, getBranchType, CATEGORY_TO_BRANCH_TYPE } from '../../src/lib/execution/types.js';
+import { validateBranchName } from '../../src/lib/branch/index.js';
 
 describe('Branch Naming', () => {
   describe('generateBranchName', () => {
@@ -115,6 +116,73 @@ describe('Branch Naming', () => {
         const hasMapping = Object.values(CATEGORY_TO_BRANCH_TYPE).includes(type);
         expect(hasMapping, `Missing mapping for ${type}`).to.be.true;
       }
+    });
+  });
+
+  describe('validateBranchName - ticket ID position error messages', () => {
+    it('should detect ticket ID in owner position and give helpful error', () => {
+      // feat/TKT-001/test - TKT-001 looks like ticket ID but is in owner position
+      const result = validateBranchName('feat/TKT-001/test');
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('looks like a ticket ID');
+      expect(result.error).to.include('owner position');
+      expect(result.error).to.include('first segment');
+    });
+
+    it('should detect ticket ID in description position (2-part branch)', () => {
+      // feat/PROJ-123 - PROJ-123 looks like ticket ID but is in description position
+      const result = validateBranchName('feat/PROJ-123');
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('looks like a ticket ID');
+      expect(result.error).to.include('first segment');
+    });
+
+    it('should detect ticket ID in description position (3-part branch)', () => {
+      // feat/chris/TKT-456 - TKT-456 looks like ticket ID but is in description position
+      const result = validateBranchName('feat/chris/TKT-456');
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('looks like a ticket ID');
+      expect(result.error).to.include('description position');
+      expect(result.error).to.include('first segment');
+    });
+
+    it('should still show kebab-case error for non-ticket-ID values', () => {
+      // feat/chris/AddLogin - AddLogin is not kebab-case but not a ticket ID
+      const result = validateBranchName('feat/chris/AddLogin');
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('kebab-case');
+      expect(result.error).not.to.include('ticket ID');
+    });
+
+    it('should still show kebab-case error for owner when not ticket ID', () => {
+      // feat/ChrisDoe/test - ChrisDoe is not kebab-case but not a ticket ID
+      const result = validateBranchName('feat/ChrisDoe/test');
+      expect(result.valid).to.be.false;
+      expect(result.error).to.include('Owner name must be kebab-case');
+      expect(result.error).not.to.include('ticket ID');
+    });
+
+    it('should validate correct ticket-first format', () => {
+      const result = validateBranchName('TKT-001/feat/test');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.ticketId).to.equal('TKT-001');
+      expect(result.parts?.type).to.equal('feat');
+      expect(result.parts?.description).to.equal('test');
+    });
+
+    it('should validate correct ticket-first format with owner', () => {
+      const result = validateBranchName('TKT-001/feat/chris/add-feature');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.ticketId).to.equal('TKT-001');
+      expect(result.parts?.owner).to.equal('chris');
+    });
+
+    it('should validate correct legacy format', () => {
+      const result = validateBranchName('feat/chris/add-feature');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.type).to.equal('feat');
+      expect(result.parts?.owner).to.equal('chris');
+      expect(result.parts?.description).to.equal('add-feature');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fix validation error messages to correctly label branch name segments
- Detect when a ticket ID pattern (e.g., TKT-001) appears in wrong position and provide helpful error
- Add unit tests for the new error message scenarios

## Problem
When validating `feat/TKT-001/test`, the old error was:
> Owner name must be kebab-case: TKT-001

This was confusing because `TKT-001` is clearly a ticket ID, not an owner name.

## Solution
Now the error correctly identifies the issue:
> Segment "TKT-001" looks like a ticket ID, but it's in the owner position (segment 2). Ticket IDs must be the first segment. Expected format: {ticketId}/{type}/{owner}/{description}

## Test plan
- [x] Unit tests added for ticket ID position detection
- [x] All 27 branch naming unit tests pass
- [x] Manual testing with `prlt branch validate` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)