### PR TITLE
fix(TKT-790): default column to Backlog in JSON mode when not provided

### DIFF
--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -135,6 +135,14 @@ export default class TicketCreate extends PMOCommand {
     // Use FlagResolver to handle both JSON mode and interactive prompts
     // This unifies the two code paths into one pattern
     if (!flags.interactive) {
+      // In JSON mode, default column to first backlog status if not provided
+      // This prevents prompting for column in non-interactive mode
+      if (jsonMode && !flags.column) {
+        // Prefer "Backlog" column, fall back to first column
+        const backlogColumn = columns.find(c => c.toLowerCase() === 'backlog') || columns[0];
+        flags.column = backlogColumn;
+      }
+
       const resolver = new FlagResolver<typeof flags>({
         commandName: 'ticket create',
         baseCommand: 'prlt ticket create',

--- a/apps/cli/test/e2e/pmo-ticket-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-commands.test.ts
@@ -53,6 +53,32 @@ describe('PMO Ticket Commands E2E Tests', () => {
       expect(tickets[0].priority).to.equal('HIGH');
     });
 
+    it('should default column to Backlog in JSON mode when not provided', () => {
+      // This is TKT-790: JSON mode should default column to Backlog instead of prompting
+      const output = exec(
+        'ticket create --json --title "JSON mode ticket" --priority HIGH --category bug'
+      );
+
+      // Should create ticket successfully, not output a prompt for column selection
+      expect(output).to.contain('Created ticket');
+      expect(output).to.contain('JSON mode ticket');
+
+      // Verify ticket was created
+      const ticket = db.prepare('SELECT id, priority FROM pmo_tickets WHERE title = ?').get('JSON mode ticket') as { id: string; priority: string } | undefined;
+      expect(ticket).to.not.be.undefined;
+      expect(ticket!.priority).to.equal('HIGH');
+
+      // Verify it's in the first column (SHIP BL in test setup - the default backlog)
+      const boardTicket = db.prepare(`
+        SELECT c.name
+        FROM pmo_board_tickets bt
+        JOIN pmo_columns c ON c.id = bt.column_id
+        WHERE bt.ticket_id = ?
+      `).get(ticket!.id) as { name: string } | undefined;
+
+      expect(boardTicket?.name).to.equal('SHIP BL');
+    });
+
     it('should auto-generate ticket ID', () => {
       exec('ticket create --title "Test ticket" --column "SHIP BL"');
 


### PR DESCRIPTION
## Summary

- Fix bug where `prlt ticket create --json -t title -d desc -p P1 --category feature` exits with code 2 and dumps a column selection prompt as JSON instead of defaulting to Backlog
- In JSON mode, column now defaults to Backlog (or first column) if not explicitly provided, matching non-JSON behavior

## Changes

- Modified `ticket create` command to default column to first backlog status when in JSON mode and column is not provided
- Added E2E test to verify the fix

## Test plan

- [x] Manual test: `prlt ticket create --json --title "Test" --priority P1 --category bug -P PROJ-005` creates ticket in Backlog
- [x] Unit tests pass
- [ ] E2E test added (may take time to run in CI)

🤖 Generated with [Claude Code](https://claude.ai/code)