### PR TITLE
fix(TKT-794): fix template phase create crashing in non-TTY

### DIFF
--- a/apps/cli/src/commands/phase/template/create.ts
+++ b/apps/cli/src/commands/phase/template/create.ts
@@ -1,7 +1,8 @@
 import { Flags, Args } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
 import { styles } from '../../../lib/styles.js';
+import { shouldOutputJson, outputSuccessAsJson, createMetadata } from '../../../lib/prompt-json.js';
+import { FlagResolver } from '../../../lib/flags/index.js';
 
 export default class PhaseTemplateCreate extends PMOCommand {
   static description = 'Create a new phase template from current workspace phases';
@@ -9,6 +10,7 @@ export default class PhaseTemplateCreate extends PMOCommand {
   static examples = [
     '<%= config.bin %> <%= command.id %> "My Custom Phases"',
     '<%= config.bin %> <%= command.id %> "Enterprise" --description "Enterprise project lifecycle"',
+    '<%= config.bin %> <%= command.id %> "My Phases" --description "Custom phases" --json',
   ];
 
   static args = {
@@ -33,30 +35,91 @@ export default class PhaseTemplateCreate extends PMOCommand {
   async execute(): Promise<void> {
     const { args, flags } = await this.parse(PhaseTemplateCreate);
 
-    // Get template name - prompt if not provided
-    let templateName = args.name;
-    if (!templateName) {
-      const { name } = await inquirer.prompt([{
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags);
+
+    // Build base command with positional arg if name provided
+    const baseCmd = args.name
+      ? `prlt phase template create "${args.name}"`
+      : 'prlt phase template create';
+
+    // Use FlagResolver for unified JSON mode and interactive handling
+    const resolver = new FlagResolver<{
+      name?: string;
+      description?: string;
+      machine?: boolean;
+      json?: boolean;
+    }>({
+      commandName: 'phase template create',
+      baseCommand: baseCmd,
+      jsonMode,
+      flags: {
+        description: flags.description,
+        machine: flags.machine,
+        json: flags.json,
+      },
+      args: { name: args.name },
+    });
+
+    // Name prompt - required (only if not provided as positional arg)
+    if (!args.name) {
+      resolver.addPrompt({
+        flagName: 'name',
         type: 'input',
-        name: 'name',
         message: 'Template name:',
-        validate: (input: string) => input.length > 0 || 'Name is required',
-      }]);
-      templateName = name;
+        validate: (value) => (value as string).length > 0 || 'Name is required',
+        context: {
+          hint: 'Provide name with: prlt phase template create "Template Name"',
+          example: 'prlt phase template create "My Phases" --description "Custom phases"',
+        },
+        // For input prompts, the agent will re-run with the positional arg
+        getCommand: (value) => `prlt phase template create "${value}" --json`,
+      });
     }
 
-    // Get description if not provided
-    let description = flags.description;
-    if (description === undefined) {
-      const { desc } = await inquirer.prompt([{
+    // Description prompt - optional (only in interactive mode without --json)
+    if (!jsonMode && args.name && flags.description === undefined) {
+      resolver.addPrompt({
+        flagName: 'description',
         type: 'input',
-        name: 'desc',
         message: 'Description (optional):',
-      }]);
-      description = desc || undefined;
+      });
     }
 
-    const template = await this.storage.savePhaseTemplate(templateName!, description);
+    // Resolve missing flags
+    const resolved = await resolver.resolve();
+
+    // Get name from args or resolved (for interactive mode)
+    const templateName = args.name || (resolved as { name?: string }).name;
+
+    // Validate required fields
+    if (!templateName) {
+      this.error('Name is required. Provide as positional argument: prlt phase template create "Template Name"');
+    }
+
+    // Get description from flags or resolved
+    const description = flags.description ?? resolved.description ?? undefined;
+
+    const template = await this.storage.savePhaseTemplate(templateName, description);
+
+    // Output as JSON in machine mode
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          id: template.id,
+          name: template.name,
+          description: template.description,
+          phasesCount: template.phases.length,
+          phases: template.phases.map(p => ({
+            name: p.name,
+            category: p.category,
+            isDefault: p.isDefault,
+          })),
+        },
+        createMetadata('phase template create', flags as Record<string, unknown>)
+      );
+      return;
+    }
 
     this.log(styles.success(`\nCreated phase template "${styles.emphasis(template.name)}" (${template.id})`));
     this.log(styles.muted(`Saved ${template.phases.length} phases:`));

--- a/apps/cli/src/commands/template/phase/create.ts
+++ b/apps/cli/src/commands/template/phase/create.ts
@@ -6,6 +6,7 @@ export default class TemplatePhaseCreate extends Command {
   static examples = [
     '<%= config.bin %> <%= command.id %> "My Phases"',
     '<%= config.bin %> <%= command.id %> "Sprint Phases" --description "Agile sprint phases"',
+    '<%= config.bin %> <%= command.id %> "My Phases" --description "Custom phases" --json',
   ];
 
   static args = {
@@ -20,9 +21,15 @@ export default class TemplatePhaseCreate extends Command {
       char: 'd',
       description: 'Template description',
     }),
-    json: Flags.boolean({
-      description: 'Output prompt configuration as JSON (for AI agents/scripts)',
+    machine: Flags.boolean({
+      char: 'm',
+      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
       default: false,
+    }),
+    json: Flags.boolean({
+      description: 'Output as JSON (deprecated, use --machine)',
+      default: false,
+      hidden: true,
     }),
   };
 
@@ -32,6 +39,7 @@ export default class TemplatePhaseCreate extends Command {
     const cmdArgs: string[] = [];
     if (args.name) cmdArgs.push(args.name);
     if (flags.description) cmdArgs.push('--description', flags.description);
+    if (flags.machine) cmdArgs.push('--machine');
     if (flags.json) cmdArgs.push('--json');
 
     await this.config.runCommand('phase:template:create', cmdArgs);

--- a/apps/cli/test/e2e/pmo-phase-template-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-phase-template-commands.test.ts
@@ -149,8 +149,17 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     it('should create template from workspace phases', () => {
       const output = exec('phase template create "My Custom Phases"');
 
-      expect(output).to.contain('Created phase template');
-      expect(output).to.contain('My Custom Phases');
+      // In non-TTY mode, output is JSON; in TTY mode, output is text
+      // Check for either format
+      const isJson = output.trim().startsWith('{');
+      if (isJson) {
+        const json = JSON.parse(output);
+        expect(json.success).to.equal(true);
+        expect(json.result.name).to.equal('My Custom Phases');
+      } else {
+        expect(output).to.contain('Created phase template');
+        expect(output).to.contain('My Custom Phases');
+      }
 
       // Verify template was created
       const template = db.prepare('SELECT * FROM pmo_phase_templates WHERE name = ?').get('My Custom Phases');

--- a/apps/cli/test/e2e/template-json-mode.test.ts
+++ b/apps/cli/test/e2e/template-json-mode.test.ts
@@ -772,10 +772,13 @@ describe('Template Commands - JSON Mode E2E Tests', () => {
         const createChoice = findChoice(step1!.prompt.choices!, 'Create');
         expect(createChoice).to.exist;
 
-        // Step 2: Execute create with all flags (no JSON mode on create command)
+        // Step 2: Execute create with all flags
+        // In non-TTY mode (like tests), output is JSON
         const result = execProduction('phase template create "Agent Created" --description "Created by agent"');
-        expect(result).to.include('Created phase template');
-        expect(result).to.include('Agent Created');
+        const json = extractJson<{ success: boolean; result: { name: string } }>(result);
+        expect(json).to.not.be.null;
+        expect(json!.success).to.equal(true);
+        expect(json!.result.name).to.equal('Agent Created');
 
         // Verify in database
         const template = getPhaseTemplate('agent-created');
@@ -784,8 +787,13 @@ describe('Template Commands - JSON Mode E2E Tests', () => {
       });
 
       it('should create phase template with direct command and verify DB', () => {
+        // In non-TTY mode (like tests), output is JSON
         const result = execProduction('phase template create "Direct Create" --description "Direct test"');
-        expect(result).to.include('Created phase template');
+        const json = extractJson<{ success: boolean; result: { name: string; description: string } }>(result);
+        expect(json).to.not.be.null;
+        expect(json!.success).to.equal(true);
+        expect(json!.result.name).to.equal('Direct Create');
+        expect(json!.result.description).to.equal('Direct test');
 
         const template = db.prepare(
           'SELECT * FROM pmo_phase_templates WHERE name = ?'
@@ -793,6 +801,109 @@ describe('Template Commands - JSON Mode E2E Tests', () => {
         expect(template).to.exist;
         expect(template!.description).to.equal('Direct test');
         expect(template!.is_builtin).to.equal(0);
+      });
+    });
+
+    describe('phase template create - JSON mode support (TKT-794)', () => {
+      it('should output prompt as JSON when name not provided with --json flag', () => {
+        const result = agentExec('phase template create --json');
+        expect(result).to.not.be.null;
+        expect(result!.prompt.type).to.equal('input');
+        expect(result!.prompt.name).to.equal('name');
+        expect(result!.prompt.message).to.include('Template name');
+      });
+
+      it('should output prompt as JSON when name not provided with --machine flag', () => {
+        const result = agentExec('phase template create --machine');
+        expect(result).to.not.be.null;
+        expect(result!.prompt.type).to.equal('input');
+        expect(result!.prompt.name).to.equal('name');
+        expect(result!.prompt.message).to.include('Template name');
+      });
+
+      it('should output success JSON when all required fields provided via flags', () => {
+        const output = execProduction('phase template create "JSON Success Test" --description "Created via JSON" --json');
+        const json = extractJson<{
+          prompt: null;
+          success: boolean;
+          result: { id: string; name: string; description: string; phasesCount: number };
+        }>(output);
+
+        expect(json).to.not.be.null;
+        expect(json!.success).to.equal(true);
+        expect(json!.prompt).to.be.null;
+        expect(json!.result.name).to.equal('JSON Success Test');
+        expect(json!.result.description).to.equal('Created via JSON');
+        expect(json!.result.phasesCount).to.be.greaterThan(0);
+
+        // Verify in database
+        const template = getPhaseTemplate('json-success-test');
+        expect(template).to.exist;
+        expect(template!.name).to.equal('JSON Success Test');
+      });
+
+      it('should work via template phase create wrapper with --json', () => {
+        const output = execProduction('template phase create "Wrapper JSON Test" --description "Via wrapper" --json');
+        const json = extractJson<{
+          prompt: null;
+          success: boolean;
+          result: { id: string; name: string };
+        }>(output);
+
+        expect(json).to.not.be.null;
+        expect(json!.success).to.equal(true);
+        expect(json!.result.name).to.equal('Wrapper JSON Test');
+
+        // Verify in database
+        const template = getPhaseTemplate('wrapper-json-test');
+        expect(template).to.exist;
+      });
+
+      it('should work via template phase create wrapper with --machine', () => {
+        const output = execProduction('template phase create "Machine Flag Test" --machine');
+        const json = extractJson<{
+          prompt: null;
+          success: boolean;
+          result: { id: string; name: string };
+        }>(output);
+
+        expect(json).to.not.be.null;
+        expect(json!.success).to.equal(true);
+        expect(json!.result.name).to.equal('Machine Flag Test');
+
+        // Verify in database
+        const template = getPhaseTemplate('machine-flag-test');
+        expect(template).to.exist;
+      });
+
+      it('should include context hints in prompt JSON', () => {
+        const result = agentExec('phase template create --json');
+        expect(result).to.not.be.null;
+        expect(result!.prompt.type).to.equal('input');
+
+        // The prompt should include context with hints for the agent
+        const promptWithContext = result!.prompt as unknown as { context?: { hint?: string; example?: string } };
+        expect(promptWithContext.context).to.exist;
+        expect(promptWithContext.context!.hint).to.include('prlt phase template create');
+      });
+
+      it('should return phases array in success JSON', () => {
+        const output = execProduction('phase template create "Phases Array Test" --json');
+        const json = extractJson<{
+          success: boolean;
+          result: { phases: Array<{ name: string; category: string; isDefault: boolean }> };
+        }>(output);
+
+        expect(json).to.not.be.null;
+        expect(json!.success).to.equal(true);
+        expect(json!.result.phases).to.be.an('array');
+        expect(json!.result.phases.length).to.be.greaterThan(0);
+
+        // Each phase should have expected properties
+        const firstPhase = json!.result.phases[0];
+        expect(firstPhase).to.have.property('name');
+        expect(firstPhase).to.have.property('category');
+        expect(firstPhase).to.have.property('isDefault');
       });
     });
 


### PR DESCRIPTION
## Summary
- Add --json flag support to `template phase create` command
- Add --machine flag support (standard pattern)
- Use FlagResolver for unified JSON and interactive mode handling
- Skip Inquirer prompts in --json mode, output prompt configuration as JSON instead
- Output success JSON with template details when all required fields provided via flags

## Test plan
- [x] Added 7 new unit tests for JSON mode support
- [x] All 28 existing phase template tests pass
- [x] Verified prompt JSON output when name not provided
- [x] Verified success JSON output when all fields provided
- [x] Tested both `--json` and `--machine` flags

Fixes TKT-794

🤖 Generated with [Claude Code](https://claude.com/claude-code)