### PR TITLE
fix(TKT-793): Fix template ticket save crashing in non-TTY

### DIFF
--- a/apps/cli/src/commands/template/ticket/save.ts
+++ b/apps/cli/src/commands/template/ticket/save.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
+import { machineOutputFlags } from '../../../lib/pmo/base-command.js';
 
 export default class TemplateTicketSave extends Command {
   static description = 'Create a template from an existing ticket';
@@ -6,6 +7,7 @@ export default class TemplateTicketSave extends Command {
   static examples = [
     '<%= config.bin %> <%= command.id %> TKT-001 "Bug Report Template"',
     '<%= config.bin %> <%= command.id %> TKT-042 "Feature Request" --description "Standard feature request template"',
+    '<%= config.bin %> <%= command.id %> TKT-001 --template-name "My Template" --json',
   ];
 
   static args = {
@@ -20,6 +22,11 @@ export default class TemplateTicketSave extends Command {
   };
 
   static flags = {
+    ...machineOutputFlags,
+    'template-name': Flags.string({
+      char: 'n',
+      description: 'Template name (alternative to positional arg, required in non-TTY/JSON mode)',
+    }),
     description: Flags.string({
       char: 'd',
       description: 'Template description',
@@ -36,8 +43,10 @@ export default class TemplateTicketSave extends Command {
     const cmdArgs: string[] = [];
     if (args.ticket) cmdArgs.push(args.ticket);
     if (args.name) cmdArgs.push(args.name);
+    if (flags['template-name']) cmdArgs.push('--template-name', flags['template-name']);
     if (flags.description) cmdArgs.push('--description', flags.description);
     if (flags.json) cmdArgs.push('--json');
+    if (flags.machine) cmdArgs.push('--machine');
 
     await this.config.runCommand('ticket:template:save', cmdArgs);
   }

--- a/apps/cli/src/commands/ticket/template/save.ts
+++ b/apps/cli/src/commands/ticket/template/save.ts
@@ -2,6 +2,16 @@ import { Flags, Args } from '@oclif/core';
 import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
 import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+  buildPromptConfig,
+  buildFormPromptConfig,
+  FormField,
+} from '../../../lib/prompt-json.js';
 
 export default class TicketTemplateSave extends PMOCommand {
   static description = 'Create a template from an existing ticket';
@@ -24,14 +34,33 @@ export default class TicketTemplateSave extends PMOCommand {
 
   static flags = {
     ...pmoBaseFlags,
+    'template-name': Flags.string({
+      char: 'n',
+      description: 'Template name (alternative to positional arg, required in non-TTY/JSON mode)',
+    }),
     description: Flags.string({
       char: 'd',
       description: 'Template description',
+    }),
+    json: Flags.boolean({
+      description: 'Output prompt configuration as JSON (for AI agents/scripts)',
+      default: false,
     }),
   };
 
   async execute(): Promise<void> {
     const { args, flags } = await this.parse(TicketTemplateSave);
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags);
+
+    // Helper to handle errors in JSON mode
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('ticket template save', flags));
+      }
+      this.error(message);
+    };
 
     // Get ticket ID - prompt with picker if not provided
     let ticketId = args.ticket;
@@ -39,7 +68,19 @@ export default class TicketTemplateSave extends PMOCommand {
       const projectId = await this.requireProject();
       const tickets = await this.storage.listTickets(projectId);
       if (tickets.length === 0) {
-        this.error('No tickets found in this project.\nCreate a ticket first: prlt ticket create');
+        return handleError('NO_TICKETS', 'No tickets found in this project.\nCreate a ticket first: prlt ticket create');
+      }
+
+      // In JSON mode, output prompt config for ticket selection
+      if (jsonMode) {
+        const choices = tickets.slice(0, 20).map(t => ({
+          name: `${t.id} - ${t.title}`,
+          value: t.id,
+        }));
+        outputPromptAsJson(
+          buildPromptConfig('list', 'ticket', 'Select a ticket to save as template:', choices),
+          createMetadata('ticket template save', flags)
+        );
       }
 
       const { selectedTicket } = await inquirer.prompt([{
@@ -57,25 +98,35 @@ export default class TicketTemplateSave extends PMOCommand {
     // Verify ticket exists
     const ticket = await this.storage.getTicket(ticketId!);
     if (!ticket) {
-      this.error(`Ticket not found: ${ticketId}\nRun 'prlt ticket list' to see available tickets.`);
+      return handleError('TICKET_NOT_FOUND', `Ticket not found: ${ticketId}\nRun 'prlt ticket list' to see available tickets.`);
     }
 
-    // Get template name - prompt if not provided
-    let templateName = args.name;
+    // Get template name - prefer flag over positional arg
+    let templateName = flags['template-name'] || args.name;
     if (!templateName) {
+      const defaultName = ticket.category || ticket.title.split(' ')[0];
+
+      // In JSON mode, output prompt config for template name
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('input', 'name', 'Template name:', undefined, defaultName),
+          createMetadata('ticket template save', flags)
+        );
+      }
+
       const { name } = await inquirer.prompt([{
         type: 'input',
         name: 'name',
         message: 'Template name:',
-        default: ticket.category || ticket.title.split(' ')[0],
+        default: defaultName,
         validate: (input: string) => input.length > 0 || 'Name is required',
       }]);
       templateName = name;
     }
 
-    // Get description if not provided
+    // Get description if not provided - only prompt interactively (not in JSON mode)
     let description = flags.description;
-    if (description === undefined) {
+    if (description === undefined && !jsonMode) {
       const { desc } = await inquirer.prompt([{
         type: 'input',
         name: 'desc',
@@ -90,6 +141,30 @@ export default class TicketTemplateSave extends PMOCommand {
       templateName!,
       description
     );
+
+    // In JSON mode, output success as JSON
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          template: {
+            id: template.id,
+            name: template.name,
+            description: template.description,
+            titlePattern: template.titlePattern,
+            defaultPriority: template.defaultPriority,
+            defaultCategory: template.defaultCategory,
+            defaultStatusId: template.defaultStatusId,
+            defaultAssignee: template.defaultAssignee,
+            defaultOwner: template.defaultOwner,
+            defaultLabels: template.defaultLabels,
+            suggestedSubtasks: template.suggestedSubtasks,
+          },
+          sourceTicketId: ticketId,
+        },
+        createMetadata('ticket template save', flags)
+      );
+      return;
+    }
 
     this.log(styles.success(`\nCreated template "${styles.emphasis(template.name)}" from ticket ${ticketId}`));
     this.log(styles.muted(`  ID: ${template.id}`));

--- a/apps/cli/test/e2e/pmo-ticket-template-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-template-commands.test.ts
@@ -186,6 +186,50 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
 
       expect(output.toLowerCase()).to.contain('already exists');
     });
+
+    it('should accept --template-name flag instead of positional argument', () => {
+      const output = exec('ticket template save TKT-001 --template-name "Flag Template"');
+
+      expect(output).to.contain('Created template');
+      expect(output).to.contain('Flag Template');
+
+      const template = db.prepare('SELECT * FROM pmo_ticket_templates WHERE name = ?').get('Flag Template') as { id: string } | undefined;
+      expect(template).to.not.be.undefined;
+    });
+
+    it('should output JSON with --json flag', () => {
+      const output = exec('ticket template save TKT-001 "JSON Template" --json');
+
+      const json = JSON.parse(output);
+      expect(json.success).to.be.true;
+      expect(json.result).to.be.an('object');
+      expect(json.result.template).to.be.an('object');
+      expect(json.result.template.name).to.equal('JSON Template');
+      expect(json.result.sourceTicketId).to.equal('TKT-001');
+      expect(json.metadata.command).to.equal('ticket template save');
+    });
+
+    it('should output prompt as JSON when missing name in --json mode', () => {
+      // Run without name to trigger prompt for template name
+      const output = exec('ticket template save TKT-001 --json');
+
+      // Should output a prompt configuration for the template name input
+      const json = JSON.parse(output);
+      expect(json.prompt).to.be.an('object');
+      expect(json.prompt.type).to.equal('input');
+      expect(json.prompt.name).to.equal('name');
+      expect(json.prompt.message).to.include('Template name');
+      expect(json.metadata.command).to.equal('ticket template save');
+    });
+
+    it('should work non-interactively with all required args', () => {
+      const output = exec('ticket template save TKT-001 -n "Non-Interactive Template" -d "Created non-interactively" --json');
+
+      const json = JSON.parse(output);
+      expect(json.success).to.be.true;
+      expect(json.result.template.name).to.equal('Non-Interactive Template');
+      expect(json.result.template.description).to.equal('Created non-interactively');
+    });
   });
 
   describe('prlt ticket template delete', () => {

--- a/apps/cli/test/unit/template-json-flags.test.ts
+++ b/apps/cli/test/unit/template-json-flags.test.ts
@@ -133,6 +133,18 @@ describe('Template Commands Machine Output Mode Support', () => {
       const output = runCli('template ticket save --help');
       expect(output).to.include('--json');
     });
+
+    it('should have --template-name flag in help', () => {
+      const output = runCli('template ticket save --help');
+      expect(output).to.include('--template-name');
+      expect(output).to.include('-n');
+    });
+
+    it('should have --machine flag in help', () => {
+      const output = runCli('template ticket save --help');
+      expect(output).to.include('--machine');
+      expect(output).to.include('-m');
+    });
   });
 
   describe('template phase apply', () => {


### PR DESCRIPTION
## Summary
- Fixed `prlt template ticket save TKT-001` crashing with exit code 13 in non-TTY environments
- Added `--json` flag support for JSON output mode
- Added `--template-name` / `-n` flag to accept template name non-interactively
- Added `--machine` / `-m` flag support (via machineOutputFlags)
- Skip Inquirer prompts in JSON mode and output prompt configuration as JSON instead

## Test plan
- [x] Unit tests pass for flag presence in help output
- [ ] E2E tests (have pre-existing schema issues unrelated to this change)
- [ ] Manual testing with `prlt template ticket save TKT-XXX "Template Name" --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)