### PR TITLE
chore(TKT-810): bump version to 0.3.20

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.21",
+  "version": "0.3.20",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump version to 0.3.20 for next npm release

🤖 Generated with [Claude Code](https://claude.com/claude-code)