### PR TITLE
fix(TKT-815): suppress verbose Docker error logging in production

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -711,8 +711,7 @@ export function isDockerRunning(): boolean {
     try {
       execSync('docker info', { stdio: 'pipe', timeout })
       return true
-    } catch (err) {
-      console.debug(`[runners:docker] Docker check attempt ${attempt}/${maxRetries} failed:`, err)
+    } catch {
       if (attempt === maxRetries) {
         return false
       }


### PR DESCRIPTION
## Summary
- Removed verbose `console.debug()` call in `isDockerRunning()` that logged full stack traces with raw Buffer objects 3 times per check
- When Docker isn't running, the function now silently returns `false` and lets the caller display a clean error message

## Test plan
- [ ] Verify no stack traces appear when Docker is not running
- [ ] Verify no Buffer objects in output
- [ ] Verify single clean error message is displayed to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)