### PR TITLE
fix(TKT-825): update help examples to use valid priority values

### DIFF
--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -17,7 +17,7 @@ export default class TicketCreate extends PMOCommand {
   static examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --title "Fix login bug" --column Backlog',
-    '<%= config.bin %> <%= command.id %> -t "Add feature" -c "In Progress" -p HIGH',
+    '<%= config.bin %> <%= command.id %> -t "Add feature" -c "In Progress" -p P1',
     '<%= config.bin %> <%= command.id %> --project mobile-app -t "New feature"',
     '<%= config.bin %> <%= command.id %> --epic EPIC-001 -t "Implement auth flow"',
     '<%= config.bin %> <%= command.id %> --json  # Output column choices as JSON',

--- a/apps/cli/src/commands/ticket/edit.ts
+++ b/apps/cli/src/commands/ticket/edit.ts
@@ -15,7 +15,7 @@ export default class TicketEdit extends PMOCommand {
   static examples = [
     '<%= config.bin %> <%= command.id %> TICK-001',
     '<%= config.bin %> <%= command.id %> TICK-001 --title "New title"',
-    '<%= config.bin %> <%= command.id %> TICK-001 --priority HIGH --category bug',
+    '<%= config.bin %> <%= command.id %> TICK-001 --priority P1 --category bug',
     '<%= config.bin %> <%= command.id %> TICK-001 --add-subtask "Implement feature" --add-subtask "Write tests"',
     '<%= config.bin %> <%= command.id %> TICK-001 --owner "john" --assignee "agent-1"',
     '<%= config.bin %> <%= command.id %>  # Interactive mode',

--- a/apps/cli/src/commands/ticket/list.ts
+++ b/apps/cli/src/commands/ticket/list.ts
@@ -21,7 +21,7 @@ export default class TicketList extends Command {
   static examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --column Backlog',
-    '<%= config.bin %> <%= command.id %> --priority URGENT',
+    '<%= config.bin %> <%= command.id %> --priority P0',
     '<%= config.bin %> <%= command.id %> --category bug',
     '<%= config.bin %> <%= command.id %> --search "login"',
     '<%= config.bin %> <%= command.id %> --project mobile-app',

--- a/apps/cli/src/commands/ticket/update.ts
+++ b/apps/cli/src/commands/ticket/update.ts
@@ -13,10 +13,10 @@ export default class TicketUpdate extends PMOCommand {
   static description = 'Update priority/category for ticket(s)';
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> TKT-001 --priority HIGH',
+    '<%= config.bin %> <%= command.id %> TKT-001 --priority P1',
     '<%= config.bin %> <%= command.id %> TKT-001 --category bug',
     '<%= config.bin %> <%= command.id %> --bulk',
-    '<%= config.bin %> <%= command.id %> --bulk --priority HIGH',
+    '<%= config.bin %> <%= command.id %> --bulk --priority P1',
     '<%= config.bin %> <%= command.id %> --json  # Output choices as JSON',
   ];
 


### PR DESCRIPTION
## Summary
- Update help examples in ticket commands to use valid priority values (P0-P3) instead of legacy values (HIGH, URGENT)
- Fixed examples in: create.ts, edit.ts, update.ts, list.ts

## Changes
- `ticket create`: Changed `-p HIGH` to `-p P1`
- `ticket edit`: Changed `--priority HIGH` to `--priority P1`
- `ticket update`: Changed `--priority HIGH` to `--priority P1` (2 occurrences)
- `ticket list`: Changed `--priority URGENT` to `--priority P0`

## Test plan
- [ ] Run `prlt ticket create --help` and verify example shows `-p P1`
- [ ] Run `prlt ticket edit --help` and verify example shows `--priority P1`
- [ ] Run `prlt ticket update --help` and verify examples show `--priority P1`
- [ ] Run `prlt ticket list --help` and verify example shows `--priority P0`

Fixes TKT-825

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>