### PR TITLE
fix(TKT-827): add --force flag to agent remove for consistency

### DIFF
--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -35,6 +35,11 @@ export default class Remove extends PMOCommand {
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt (for non-interactive use)',
+      default: false,
+    }),
   };
 
   protected getPMOOptions() {
@@ -129,39 +134,42 @@ export default class Remove extends PMOCommand {
 
     const agentsToRemove = [agentName!];
 
-    // Build choices once, use for both JSON and interactive modes
-    const confirmChoices = [
-      { name: 'No, cancel', value: 'false' },
-      { name: 'Yes, remove agent', value: 'true' },
-    ];
-    const confirmMessage = `Are you sure you want to remove agent "${agentName!}"? This will delete its worktree.`;
+    // Skip confirmation if --force flag is passed
+    if (!flags.force) {
+      // Build choices once, use for both JSON and interactive modes
+      const confirmChoices = [
+        { name: 'No, cancel', value: 'false' },
+        { name: 'Yes, remove agent', value: 'true' },
+      ];
+      const confirmMessage = `Are you sure you want to remove agent "${agentName!}"? This will delete its worktree.`;
 
-    // Confirm removal
-    // In JSON mode, output confirmation prompt
-    if (jsonMode) {
-      outputPromptAsJson(
-        buildPromptConfig('list', 'confirmed', confirmMessage, confirmChoices),
-        createMetadata('agent remove', flags)
-      );
-      return;
-    }
-
-    const { confirm } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'confirm',
-        message: confirmMessage,
-        choices: [
-          { name: '❌ ' + confirmChoices[0].name, value: false },
-          { name: '⚠️  ' + confirmChoices[1].name, value: true }
-        ],
-        default: 0 // Default to "No, cancel"
+      // Confirm removal
+      // In JSON mode, output confirmation prompt
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'confirmed', confirmMessage, confirmChoices),
+          createMetadata('agent remove', flags)
+        );
+        return;
       }
-    ]);
 
-    if (!confirm) {
-      this.log(colors.textMuted('Removal cancelled.'));
-      return;
+      const { confirm } = await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'confirm',
+          message: confirmMessage,
+          choices: [
+            { name: '❌ ' + confirmChoices[0].name, value: false },
+            { name: '⚠️  ' + confirmChoices[1].name, value: true }
+          ],
+          default: 0 // Default to "No, cancel"
+        }
+      ]);
+
+      if (!confirm) {
+        this.log(colors.textMuted('Removal cancelled.'));
+        return;
+      }
     }
 
     // Remove agents


### PR DESCRIPTION
## Summary
- Added `--force` (`-f`) flag to `agent remove` command
- When used, skips the confirmation prompt for non-interactive use
- Matches the existing behavior of `agent staff remove`

## Changes
- Added `force` flag definition with `-f` shorthand in `src/commands/agent/remove.ts`
- Wrapped confirmation prompt section in `if (!flags.force)` check

## Test plan
- [ ] Run `prlt agent remove <name>` - should show confirmation prompt
- [ ] Run `prlt agent remove <name> --force` - should skip confirmation
- [ ] Run `prlt agent remove <name> -f` - should skip confirmation (short flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)