### PR TITLE
fix(TKT-826): Fix execution kill command not accepting ID argument

### DIFF
--- a/apps/cli/src/commands/execution/kill.ts
+++ b/apps/cli/src/commands/execution/kill.ts
@@ -7,6 +7,8 @@ import ExecutionStop from './stop.js'
 export default class ExecutionKill extends ExecutionStop {
   static description = 'Stop running execution(s) (alias for "execution stop")'
 
+  static args = ExecutionStop.args
+
   static examples = [
     '<%= config.bin %> <%= command.id %> WORK-001',
     '<%= config.bin %> <%= command.id %> WORK-001 --force',
@@ -16,5 +18,5 @@ export default class ExecutionKill extends ExecutionStop {
     '<%= config.bin %> <%= command.id %> --agent altman',
   ]
 
-  // Inherits all args, flags, and execute() from ExecutionStop
+  // Inherits flags and execute() from ExecutionStop
 }


### PR DESCRIPTION
## Summary
- Added explicit `static args = ExecutionStop.args` inheritance to `ExecutionKill` class
- Fixed issue where `prlt execution kill WORK-ID` wouldn't accept the positional ID argument
- Now consistent with `execution stop` behavior

## Test plan
- [x] Verified `prlt execution kill --help` shows the `[ID]` argument
- [x] Confirmed help output matches `prlt execution stop --help`
- [x] Build passes successfully

Fixes TKT-826

🤖 Generated with [Claude Code](https://claude.com/claude-code)