### PR TITLE
fix(TKT-824): validate column and project flags before filtering tickets

### DIFF
--- a/apps/cli/src/commands/ticket/list.ts
+++ b/apps/cli/src/commands/ticket/list.ts
@@ -102,6 +102,30 @@ export default class TicketList extends Command {
 
       // Determine projectId for the query
       const projectId = flags.all ? undefined : (filter.projectId || undefined);
+
+      // Validate project if specified (not in --all mode)
+      if (flags.project && !flags.all) {
+        const project = await pmoContext.storage.getProject(flags.project);
+        if (!project) {
+          const allProjects = await pmoContext.storage.listProjectSummaries();
+          const validProjectIds = allProjects.map(p => p.id);
+          this.error(`Project "${flags.project}" not found. Valid projects: ${validProjectIds.join(', ')}`);
+        }
+      }
+
+      // Validate column if specified (requires knowing the project)
+      if (flags.column && !flags.all) {
+        // Get the project board to validate the column
+        const targetProjectId = projectId || (await pmoContext.storage.listProjectSummaries())[0]?.id;
+        if (targetProjectId) {
+          const board = await pmoContext.storage.getBoard(targetProjectId);
+          const validColumns = board.columns.map(c => c.name);
+          if (!validColumns.includes(flags.column)) {
+            this.error(`Column "${flags.column}" not found. Valid columns: ${validColumns.join(', ')}`);
+          }
+        }
+      }
+
       const tickets = await pmoContext.storage.listTickets(projectId, filter);
 
       if (tickets.length === 0) {


### PR DESCRIPTION
## Summary
- Added validation for `--column` flag to show error with valid column names when an invalid column is specified
- Added validation for `--project` flag to show error with valid project IDs when an invalid project is specified
- Prevents confusing "No tickets found" message when the issue is an invalid column/project name

## Test plan
- [ ] Run `prlt ticket list --column InvalidColumn` - should show error with valid columns
- [ ] Run `prlt ticket list --project InvalidProject` - should show error with valid projects
- [ ] Run `prlt ticket list --column Backlog` (valid column) - should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)