### PR TITLE
fix(TKT-823): add numeric flag validation (positive integers only)

### DIFF
--- a/apps/cli/src/commands/execution/list.ts
+++ b/apps/cli/src/commands/execution/list.ts
@@ -32,6 +32,7 @@ export default class ExecutionList extends PMOCommand {
       char: 'l',
       description: 'Number of results',
       default: 20,
+      min: 1,
     }),
   }
 

--- a/apps/cli/src/commands/execution/logs.ts
+++ b/apps/cli/src/commands/execution/logs.ts
@@ -40,6 +40,7 @@ export default class ExecutionLogs extends PMOCommand {
     tail: Flags.integer({
       char: 'n',
       description: 'Show last n lines',
+      min: 1,
     }),
     json: Flags.boolean({
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -56,11 +56,13 @@ export default class WorkWatch extends PMOCommand {
     limit: Flags.integer({
       char: 'l',
       description: 'Maximum concurrent executions',
+      min: 1,
     }),
     interval: Flags.integer({
       char: 'i',
       description: 'Polling interval in seconds',
       default: 5,
+      min: 1,
     }),
     once: Flags.boolean({
       description: 'Check once and exit (no continuous watching)',


### PR DESCRIPTION
## Summary
- Added `min: 1` validation to numeric flags to reject negative values and zero
- Updated `--limit` flag in `execution/list.ts`
- Updated `--tail` flag in `execution/logs.ts`
- Updated `--limit` and `--interval` flags in `work/watch.ts`

## Test plan
- [ ] Run `prlt execution list --limit 0` - should error
- [ ] Run `prlt execution list --limit -1` - should error
- [ ] Run `prlt execution logs --tail 0` - should error
- [ ] Run `prlt work watch --interval 0` - should error
- [ ] Run `prlt work watch --limit -1` - should error
- [ ] Run commands with valid positive values - should work normally

🤖 Generated with [Claude Code](https://claude.ai/code)