### PR TITLE
fix(TKT-839): Fix agent themes add-names misleading help text

### DIFF
--- a/apps/cli/src/commands/agent/themes/add-names.ts
+++ b/apps/cli/src/commands/agent/themes/add-names.ts
@@ -14,8 +14,12 @@ export default class ThemesAddNames extends Command {
 
   static args = {
     theme: Args.string({
-      description: 'Theme ID to add names to',
+      description: 'Theme ID',
       required: true,
+    }),
+    names: Args.string({
+      description: 'Names to add to the theme (space-separated)',
+      required: false,
     }),
   };
 


### PR DESCRIPTION
## Summary
- Added separate `names` arg definition to `add-names` command
- Help text now clearly shows `THEME` followed by `NAMES...` arguments
- Updated theme arg description to be more concise

## Test plan
- [x] Build passes
- [x] Help output verified: `prlt agent themes add-names --help` shows correct format

Fixes TKT-839

🤖 Generated with [Claude Code](https://claude.com/claude-code)