### PR TITLE
fix(TKT-837): correct template phase command path references

### DIFF
--- a/apps/cli/src/commands/phase/template/apply.ts
+++ b/apps/cli/src/commands/phase/template/apply.ts
@@ -63,7 +63,7 @@ export default class PhaseTemplateApply extends PMOCommand {
     if (!templateId) {
       const templates = await this.storage.listPhaseTemplates();
       if (templates.length === 0) {
-        return handleError('NO_TEMPLATES', `No phase templates found.\nCreate one with: prlt phase template create "Template Name"`);
+        return handleError('NO_TEMPLATES', `No phase templates found.\nCreate one with: prlt template phase create "Template Name"`);
       }
 
       const { selectedTemplate } = await inquirer.prompt([{
@@ -81,7 +81,7 @@ export default class PhaseTemplateApply extends PMOCommand {
     // Verify template exists
     const template = await this.storage.getPhaseTemplate(templateId!);
     if (!template) {
-      return handleError('TEMPLATE_NOT_FOUND', `Phase template not found: ${templateId}. Run 'prlt phase template list' to see available templates.`);
+      return handleError('TEMPLATE_NOT_FOUND', `Phase template not found: ${templateId}. Run 'prlt template phase list' to see available templates.`);
     }
 
     // Check if workspace has existing phases

--- a/apps/cli/src/commands/phase/template/create.ts
+++ b/apps/cli/src/commands/phase/template/create.ts
@@ -40,8 +40,8 @@ export default class PhaseTemplateCreate extends PMOCommand {
 
     // Build base command with positional arg if name provided
     const baseCmd = args.name
-      ? `prlt phase template create "${args.name}"`
-      : 'prlt phase template create';
+      ? `prlt template phase create "${args.name}"`
+      : 'prlt template phase create';
 
     // Use FlagResolver for unified JSON mode and interactive handling
     const resolver = new FlagResolver<{
@@ -69,11 +69,11 @@ export default class PhaseTemplateCreate extends PMOCommand {
         message: 'Template name:',
         validate: (value) => (value as string).length > 0 || 'Name is required',
         context: {
-          hint: 'Provide name with: prlt phase template create "Template Name"',
-          example: 'prlt phase template create "My Phases" --description "Custom phases"',
+          hint: 'Provide name with: prlt template phase create "Template Name"',
+          example: 'prlt template phase create "My Phases" --description "Custom phases"',
         },
         // For input prompts, the agent will re-run with the positional arg
-        getCommand: (value) => `prlt phase template create "${value}" --json`,
+        getCommand: (value) => `prlt template phase create "${value}" --json`,
       });
     }
 
@@ -94,7 +94,7 @@ export default class PhaseTemplateCreate extends PMOCommand {
 
     // Validate required fields
     if (!templateName) {
-      this.error('Name is required. Provide as positional argument: prlt phase template create "Template Name"');
+      this.error('Name is required. Provide as positional argument: prlt template phase create "Template Name"');
     }
 
     // Get description from flags or resolved

--- a/apps/cli/src/commands/phase/template/list.ts
+++ b/apps/cli/src/commands/phase/template/list.ts
@@ -75,7 +75,7 @@ export default class PhaseTemplateList extends PMOCommand {
     }
 
     this.log('');
-    this.log(styles.muted('Apply a template: prlt phase template apply <template-id>'));
+    this.log(styles.muted('Apply a template: prlt template phase apply <template-id>'));
     this.log('');
   }
 

--- a/apps/cli/src/commands/template/phase/index.ts
+++ b/apps/cli/src/commands/template/phase/index.ts
@@ -38,10 +38,10 @@ export default class TemplatePhase extends Command {
       message: 'What would you like to do?',
       choices: () => [
         { name: 'List phase templates', value: 'list', command: 'prlt template phase list --json' },
-        { name: 'Apply a phase template to project', value: 'apply', command: 'prlt phase template apply --json' },
-        { name: 'Create a new phase template', value: 'create', command: 'prlt phase template create --json' },
-        { name: 'Update a phase template', value: 'update', command: 'prlt phase template update --json' },
-        { name: 'Delete a phase template', value: 'delete', command: 'prlt phase template delete --json' },
+        { name: 'Apply a phase template to project', value: 'apply', command: 'prlt template phase apply --json' },
+        { name: 'Create a new phase template', value: 'create', command: 'prlt template phase create --json' },
+        { name: 'Update a phase template', value: 'update', command: 'prlt template phase update --json' },
+        { name: 'Delete a phase template', value: 'delete', command: 'prlt template phase delete --json' },
       ],
     });
 

--- a/apps/cli/test/e2e/template-json-mode.test.ts
+++ b/apps/cli/test/e2e/template-json-mode.test.ts
@@ -884,7 +884,7 @@ describe('Template Commands - JSON Mode E2E Tests', () => {
         // The prompt should include context with hints for the agent
         const promptWithContext = result!.prompt as unknown as { context?: { hint?: string; example?: string } };
         expect(promptWithContext.context).to.exist;
-        expect(promptWithContext.context!.hint).to.include('prlt phase template create');
+        expect(promptWithContext.context!.hint).to.include('prlt template phase create');
       });
 
       it('should return phases array in success JSON', () => {


### PR DESCRIPTION
## Summary
- Fixed error messages referencing wrong command path in phase template commands
- Changed `prlt phase template list/create/apply` to `prlt template phase list/create/apply` to match actual command structure
- Updated test expectations to match new command paths

## Test plan
- [ ] Run `prlt template phase list` to verify command works
- [ ] Run `prlt template phase apply` on a non-existent template and verify error message shows correct command path
- [ ] Copy-paste the suggested command from error message and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)