### PR TITLE
feat(TKT-844): truncate agent list in error messages

### DIFF
--- a/apps/cli/src/commands/agent/login.ts
+++ b/apps/cli/src/commands/agent/login.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, formatAgentList } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
   isDockerRunning,
@@ -105,7 +105,7 @@ export default class Login extends PMOCommand {
     // Validate agent exists
     const agent = workspaceInfo.agents.find(a => a.name === agentName);
     if (!agent) {
-      this.error(`Agent "${agentName}" not found. Available agents: ${workspaceInfo.agents.map(a => a.name).join(', ')}`);
+      this.error(`Agent "${agentName}" not found. Available: ${formatAgentList(workspaceInfo.agents)}`);
     }
 
     const agentDir = path.join(workspaceInfo.agentsPath, agentName!);

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -3,7 +3,8 @@ import inquirer from 'inquirer';
 import { colors, format } from '../../lib/colors.js';
 import {
   getWorkspaceInfo,
-  removeAgentsFromWorkspace
+  removeAgentsFromWorkspace,
+  formatAgentList
 } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
@@ -124,7 +125,7 @@ export default class Remove extends PMOCommand {
     // Validate agent exists
     const agent = workspaceInfo.agents.find((a) => a.name === agentName);
     if (!agent) {
-      return handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available agents: ${workspaceInfo.agents.map((a) => a.name).join(', ')}`);
+      return handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available: ${formatAgentList(workspaceInfo.agents)}`);
     }
 
     const agentsToRemove = [agentName!];

--- a/apps/cli/src/commands/agent/shell.ts
+++ b/apps/cli/src/commands/agent/shell.ts
@@ -5,7 +5,7 @@ import { execSync, spawn } from 'node:child_process';
 import inquirer from 'inquirer';
 import Database from 'better-sqlite3';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo, getAgentTmuxSessions } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, getAgentTmuxSessions, formatAgentList } from '../../lib/agents/commands.js';
 import { hasDevcontainerConfig } from '../../lib/execution/devcontainer.js';
 import { getTerminalApp } from '../../lib/execution/config.js';
 import { TerminalApp } from '../../lib/execution/types.js';
@@ -104,7 +104,7 @@ export default class Shell extends PMOCommand {
     // Validate agent exists
     const agent = workspaceInfo.agents.find(a => a.name === agentName);
     if (!agent) {
-      this.handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available agents: ${workspaceInfo.agents.map(a => a.name).join(', ')}`, errorConfig);
+      this.handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available: ${formatAgentList(workspaceInfo.agents)}`, errorConfig);
     }
 
     // Check for existing tmux sessions (skip in JSON mode - can't handle interactive tmux)

--- a/apps/cli/src/commands/agent/staff/remove.ts
+++ b/apps/cli/src/commands/agent/staff/remove.ts
@@ -3,7 +3,8 @@ import inquirer from 'inquirer';
 import { colors, format } from '../../../lib/colors.js';
 import {
   getWorkspaceInfo,
-  removeAgentsFromWorkspace
+  removeAgentsFromWorkspace,
+  formatAgentList
 } from '../../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
 import {
@@ -120,7 +121,7 @@ export default class Remove extends PMOCommand {
     // Validate agent exists and is a staff agent
     const agent = staffAgents.find((a) => a.name === agentName);
     if (!agent) {
-      return handleError('AGENT_NOT_FOUND', `Staff agent "${agentName}" not found. Available staff agents: ${staffAgents.map((a) => a.name).join(', ')}`);
+      return handleError('AGENT_NOT_FOUND', `Staff agent "${agentName}" not found. Available: ${formatAgentList(staffAgents)}`);
     }
 
     const agentsToRemove = [agentName!];

--- a/apps/cli/src/commands/agent/status.ts
+++ b/apps/cli/src/commands/agent/status.ts
@@ -3,7 +3,8 @@ import { colors, format } from '../../lib/colors.js';
 import {
   getWorkspaceInfo,
   getAgentStatus,
-  WorkspaceInfo
+  WorkspaceInfo,
+  formatAgentList
 } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
@@ -96,7 +97,7 @@ export default class Status extends PMOCommand {
     // Validate agent exists
     const agent = workspaceInfo.agents.find((a) => a.name === agentName);
     if (!agent) {
-      this.error(`Agent "${agentName}" not found. Available agents: ${workspaceInfo.agents.map((a) => a.name).join(', ')}`);
+      this.error(`Agent "${agentName}" not found. Available: ${formatAgentList(workspaceInfo.agents)}`);
     }
 
     const agentStatus = getAgentStatus(workspaceInfo, agentName);

--- a/apps/cli/src/commands/agent/visit.ts
+++ b/apps/cli/src/commands/agent/visit.ts
@@ -1,7 +1,7 @@
 import { Args, Flags } from '@oclif/core';
 import * as path from 'node:path';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, formatAgentList } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
   shouldOutputJson,
@@ -98,7 +98,7 @@ export default class Visit extends PMOCommand {
     // Validate agent exists
     const agent = workspaceInfo.agents.find(a => a.name === agentName);
     if (!agent) {
-      return handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available agents: ${workspaceInfo.agents.map(a => a.name).join(', ')}`);
+      return handleError('AGENT_NOT_FOUND', `Agent "${agentName}" not found. Available: ${formatAgentList(workspaceInfo.agents)}`);
     }
 
     // Calculate path to agent directory

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -34,6 +34,18 @@ import {
 import { createDevcontainerConfig } from '../execution/devcontainer.js';
 import { getPMOContext } from '../pmo/index.js';
 
+/**
+ * Format a list of agents for display in error messages.
+ * Truncates long lists to avoid overwhelming output.
+ */
+export function formatAgentList(agents: { name: string }[], maxShow = 10): string {
+  const names = agents.map(a => a.name);
+  if (names.length <= maxShow) {
+    return names.join(', ');
+  }
+  return `${names.slice(0, maxShow).join(', ')} ...and ${names.length - maxShow} more. Run 'prlt agent list' to see all.`;
+}
+
 export interface AgentStatus {
   name: string;
   exists: boolean;


### PR DESCRIPTION
## Summary
- Added `formatAgentList` helper function in `src/lib/agents/commands.ts` that truncates long agent lists to max 10 items
- Shows count of remaining agents and suggests `prlt agent list` to see all
- Updated all 6 affected files to use the helper:
  - `src/commands/agent/remove.ts`
  - `src/commands/agent/shell.ts`
  - `src/commands/agent/login.ts`
  - `src/commands/agent/status.ts`
  - `src/commands/agent/visit.ts`
  - `src/commands/agent/staff/remove.ts`

## Test plan
- [ ] Test error message with <10 agents shows all agents
- [ ] Test error message with >10 agents shows truncated list with count
- [ ] Verify all 6 commands show consistent formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)