### PR TITLE
fix(TKT-848): validate phase move position against max and clamp if exceeded

### DIFF
--- a/apps/cli/src/commands/phase/move.ts
+++ b/apps/cli/src/commands/phase/move.ts
@@ -125,8 +125,18 @@ export default class PhaseMove extends PMOCommand {
       newPosition = parseInt(resolved.position, 10);
     }
 
+    // Get phases in same category for validation
+    const allPhases = await this.storage.listPhases();
+    const categoryPhases = allPhases.filter(p => p.category === phase.category);
+    const maxPosition = categoryPhases.length - 1;
+
     if (newPosition! < 0) {
       this.error('Position must be >= 0');
+    }
+
+    if (newPosition! > maxPosition) {
+      this.warn(`Position ${newPosition} exceeds max (${maxPosition}). Clamping to ${maxPosition}.`);
+      newPosition = maxPosition;
     }
 
     const updated = await this.storage.reorderPhase(phaseId!, newPosition!);


### PR DESCRIPTION
## Summary
- Adds upper bound validation to `phase move` command
- Shows warning and clamps position to max when position exceeds the number of phases in the category
- Keeps existing error for negative positions

## Changes
- Fetches phases in the same category before validation
- If position > maxPosition, displays warning and clamps to maxPosition
- Success message already shows actual final position

## Test plan
- [ ] Run `phase move <phase> --position 99` when only 3 phases exist - should warn and clamp to 2
- [ ] Run `phase move <phase> --position -1` - should error
- [ ] Run `phase move <phase> --position 0` - should succeed with correct position

Fixes TKT-848

🤖 Generated with [Claude Code](https://claude.com/claude-code)