### PR TITLE
fix(TKT-829): Fix template delete interpreting ID as subcommand

### DIFF
--- a/apps/cli/src/commands/template/ticket/delete.ts
+++ b/apps/cli/src/commands/template/ticket/delete.ts
@@ -11,7 +11,7 @@ export default class TemplateTicketDelete extends Command {
   static args = {
     id: Args.string({
       description: 'Template ID to delete',
-      required: true,
+      required: false,
     }),
   };
 
@@ -30,7 +30,8 @@ export default class TemplateTicketDelete extends Command {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(TemplateTicketDelete);
 
-    const cmdArgs: string[] = [args.id];
+    const cmdArgs: string[] = [];
+    if (args.id) cmdArgs.push(args.id);
     if (flags.force) cmdArgs.push('--force');
     if (flags.json) cmdArgs.push('--json');
 


### PR DESCRIPTION
## Summary
- Changed `required: true` to `required: false` for the `id` arg in the template ticket delete wrapper command
- Fixed the wrapper to only pass the ID argument when provided, preventing `undefined` from being passed

## Fix
The wrapper command (`template/ticket/delete.ts`) had `required: true` for the ID arg, but oclif was interpreting the argument as a subcommand path. The underlying implementation (`ticket/template/delete.ts`) already had `required: false` and handles prompting for template selection when no ID is provided.

## Test plan
- [x] Build passes
- [x] `prlt template ticket delete --help` shows `[ID]` (optional) instead of `ID` (required)
- [x] `prlt template ticket delete` without ID works (prompts for selection or shows "no templates")
- [x] `prlt template ticket delete mytemplate` passes the ID correctly to the implementation

Closes TKT-829

🤖 Generated with [Claude Code](https://claude.com/claude-code)