### PR TITLE
fix(TKT-832): Fix epic link hanging with unsettled top-level await

### DIFF
--- a/apps/cli/src/commands/epic/link/index.ts
+++ b/apps/cli/src/commands/epic/link/index.ts
@@ -121,6 +121,28 @@ export default class EpicLink extends PMOCommand {
     }
 
     // Interactive mode: show menu in a loop
+    // In JSON mode, output the interactive menu config instead of prompting
+    if (jsonMode) {
+      const menuChoices = [
+        { name: 'View dependencies', value: 'view' },
+        { name: 'Add blocking dependency (blocked by...)', value: 'blocks' },
+        { name: 'Add relates_to dependency', value: 'relates_to' },
+        { name: 'Add duplicates dependency', value: 'duplicates' },
+        { name: 'Remove dependency', value: 'remove' },
+        { name: 'Done', value: 'done' },
+      ]
+      outputPromptAsJson(
+        buildPromptConfig('list', 'action', `Dependencies for ${epicId}:`, menuChoices),
+        createMetadata('epic link', flags)
+      )
+      return
+    }
+
+    // Check for TTY before showing interactive menu
+    if (!process.stdin.isTTY) {
+      this.error('Interactive mode requires a TTY. Use --json for scripted usage or provide flags like --blocks, --relates, or --duplicates.')
+    }
+
     let continueLoop = true
     while (continueLoop) {
       // eslint-disable-next-line no-await-in-loop -- Interactive user loop


### PR DESCRIPTION
## Summary
- Add TTY check before showing interactive menu in `epic link` command
- In non-TTY context without `--json`, show clear error with usage guidance
- In JSON mode, output the interactive menu config as JSON for scripted usage

## Problem
`epic link` without subcommand hangs with 'unsettled top-level await' warning in non-TTY context. The inquirer prompt waits for input that never comes.

## Solution
Added checks before the interactive loop:
1. If in JSON mode, output menu choices as JSON and return
2. If not TTY (and not JSON mode), error with helpful message suggesting `--json` flag or direct flags like `--blocks`

## Test plan
- [ ] Run `epic link EPIC-001` in TTY - should show interactive menu
- [ ] Run `echo "" | epic link EPIC-001` - should show error about TTY requirement
- [ ] Run `epic link EPIC-001 --json` - should output JSON prompt config
- [ ] Run `epic link EPIC-001 --blocks EPIC-002` - should work directly without interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)