### PR TITLE
fix(TKT-828): fix --category filter in status list command

### DIFF
--- a/apps/cli/src/commands/status/list.ts
+++ b/apps/cli/src/commands/status/list.ts
@@ -43,7 +43,12 @@ export default class StatusList extends PMOCommand {
       this.error(`Project "${projectId}" has no workflow assigned.`);
     }
 
-    const statuses = await this.storage.listStatuses(project.workflowId);
+    const allStatuses = await this.storage.listStatuses(project.workflowId);
+
+    // Apply category filter if specified
+    const statuses = flags.category
+      ? allStatuses.filter(s => s.category === flags.category)
+      : allStatuses;
 
     if (jsonMode) {
       this.log(JSON.stringify(statuses, null, 2));
@@ -73,8 +78,6 @@ export default class StatusList extends PMOCommand {
     };
 
     for (const category of STATE_CATEGORY_ORDER) {
-      if (flags.category && flags.category !== category) continue;
-
       const categoryStatuses = grouped.get(category);
       if (!categoryStatuses || categoryStatuses.length === 0) continue;
 


### PR DESCRIPTION
## Summary
- Fixed `status list --category` filter that was returning all statuses instead of filtering
- The category filter was only applied in the display loop, but the JSON mode output bypassed it entirely
- Moved the category filter to be applied early (before JSON output), ensuring consistent filtering across all output modes

## Changes
- Apply category filter to statuses array before JSON output
- Simplified display loop by removing redundant filter check

## Test plan
- [ ] Verify `prlt status list --category started` returns only started statuses
- [ ] Verify `prlt status list --category completed` returns only completed statuses
- [ ] Verify `prlt status list --category started --json` returns only started statuses in JSON format
- [ ] Verify `prlt status list` (without filter) still returns all statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)