### PR TITLE
fix(TKT-816): Fix duplicate -m flag conflict in work revise/watch commands

### DIFF
--- a/apps/cli/src/commands/work/revise.ts
+++ b/apps/cli/src/commands/work/revise.ts
@@ -60,7 +60,7 @@ export default class WorkRevise extends PMOCommand {
       default: false,
     }),
     mode: Flags.string({
-      char: 'm',
+      char: 'd',
       description: 'Runtime mode',
       options: ['foreground', 'background', 'tmux', 'terminal', 'devcontainer'],
     }),

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -69,7 +69,7 @@ export default class WorkWatch extends PMOCommand {
       default: false,
     }),
     mode: Flags.string({
-      char: 'm',
+      char: 'd',
       description: 'Display mode for agent output',
       options: ['terminal', 'background'],
     }),


### PR DESCRIPTION
## Summary
- Changed `--mode` short flag from `-m` to `-d` in `work revise` and `work watch` commands
- This resolves the conflict where `-m` was used for both `--mode` and `--machine` flags

## Files Changed
- `apps/cli/src/commands/work/revise.ts`
- `apps/cli/src/commands/work/watch.ts`

## Acceptance Criteria
- [x] `-m` exclusively for `--machine`
- [x] `-d` for `--mode`/`--display`

🤖 Generated with [Claude Code](https://claude.com/claude-code)