### PR TITLE
fix(TKT-820): validate and trim whitespace-only inputs for required fields

### DIFF
--- a/apps/cli/src/commands/epic/create.ts
+++ b/apps/cli/src/commands/epic/create.ts
@@ -168,7 +168,7 @@ export default class EpicCreate extends PMOCommand {
     }>(fields.map(field => ({
       ...field,
       validate: field.name === 'title'
-        ? ((input: string) => input.length > 0 || 'Title is required')
+        ? ((input: string) => input.trim() ? true : 'Title cannot be empty')
         : undefined,
       when: field.name === 'specId' ? () => hasSpecs : undefined,
     })));

--- a/apps/cli/src/commands/phase/create.ts
+++ b/apps/cli/src/commands/phase/create.ts
@@ -102,7 +102,7 @@ export default class PhaseCreate extends PMOCommand {
         flagName: 'name',
         type: 'input',
         message: 'Phase name:',
-        validate: (value) => (value as string).length > 0 || 'Name is required',
+        validate: (value) => (value as string).trim() ? true : 'Name cannot be empty',
         context: {
           hint: 'Provide name with: prlt phase create "Phase Name" --category <category>',
           example: 'prlt phase create "In Review" --category started',

--- a/apps/cli/src/commands/spec/create.ts
+++ b/apps/cli/src/commands/spec/create.ts
@@ -94,7 +94,7 @@ export default class SpecCreate extends PMOCommand {
         flagName: 'title',
         type: 'input',
         message: 'Spec title:',
-        validate: (value) => (value as string).length > 0 || 'Title is required',
+        validate: (value) => (value as string).trim() ? true : 'Title cannot be empty',
         when: (ctx) => !ctx.flags.title,
       });
 

--- a/apps/cli/src/commands/status/create.ts
+++ b/apps/cli/src/commands/status/create.ts
@@ -95,7 +95,7 @@ export default class StatusCreate extends PMOCommand {
       type: 'input',
       message: 'Status name:',
       default: initialName,
-      validate: (value) => (value as string).length > 0 || 'Name is required',
+      validate: (value) => (value as string).trim() ? true : 'Name cannot be empty',
       when: (ctx) => !ctx.flags.name || flags.interactive,
     });
 

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -166,7 +166,7 @@ export default class TicketCreate extends PMOCommand {
         type: 'input',
         message: 'Enter ticket title:',
         when: (ctx) => !ctx.flags.title && ctx.flags.column !== undefined,
-        validate: (value) => (value as string).length > 0 || 'Title is required',
+        validate: (value) => (value as string).trim() ? true : 'Title cannot be empty',
         context: (ctx) => ({
           hint: `Provide title with: ${ctx.baseCommand}${ctx.projectId ? ` -P ${ctx.projectId}` : ''} --column "${ctx.flags.column}" --title "Your title here"`,
           requiredFields: ['--title'],
@@ -330,7 +330,7 @@ export default class TicketCreate extends PMOCommand {
         name: 'title',
         message: 'Ticket title:',
         default: flags.title || template?.titlePattern,
-        validate: (input: string) => input.length > 0 || 'Title is required',
+        validate: (input: string) => input.trim() ? true : 'Title cannot be empty',
       },
       {
         type: 'list',
@@ -385,7 +385,7 @@ export default class TicketCreate extends PMOCommand {
         name: 'customCategory',
         message: 'Enter custom category:',
         when: (answers: { categoryChoice: string }) => answers.categoryChoice === '__custom__',
-        validate: (input: string) => input.length > 0 || 'Category is required when choosing custom',
+        validate: (input: string) => input.trim() ? true : 'Category cannot be empty',
       },
     ]);
 
@@ -434,7 +434,7 @@ export default class TicketCreate extends PMOCommand {
         type: 'input',
         name: 'what',
         message: 'What is the concrete outcome? (one sentence):',
-        validate: (input: string) => input.length > 0 || 'Outcome is required - what does success look like?',
+        validate: (input: string) => input.trim() ? true : 'Outcome cannot be empty - what does success look like?',
       },
       {
         type: 'input',

--- a/apps/cli/src/commands/ticket/edit.ts
+++ b/apps/cli/src/commands/ticket/edit.ts
@@ -292,7 +292,7 @@ export default class TicketEdit extends PMOCommand {
         name: 'title',
         message: 'Title:',
         default: ticket.title,
-        validate: (input: string) => input.length > 0 || 'Title is required',
+        validate: (input: string) => input.trim() ? true : 'Title cannot be empty',
       },
       {
         type: 'editor',
@@ -347,7 +347,7 @@ export default class TicketEdit extends PMOCommand {
         name: 'customCategory',
         message: 'Enter custom category:',
         when: (answers: { categoryChoice: string }) => answers.categoryChoice === '__custom__',
-        validate: (input: string) => input.length > 0 || 'Category is required when choosing custom',
+        validate: (input: string) => input.trim() ? true : 'Category cannot be empty',
       },
     ]);
 

--- a/apps/cli/src/commands/ticket/template/create.ts
+++ b/apps/cli/src/commands/ticket/template/create.ts
@@ -212,7 +212,7 @@ export default class TicketTemplateCreate extends PMOCommand {
         type: 'input',
         name: 'templateName',
         message: 'Template name:',
-        validate: (input: string) => input.length > 0 || 'Name is required',
+        validate: (input: string) => input.trim() ? true : 'Name cannot be empty',
       }]);
       name = templateName;
     }
@@ -314,7 +314,7 @@ export default class TicketTemplateCreate extends PMOCommand {
             type: 'input',
             name: 'subtaskTitle',
             message: 'Subtask title:',
-            validate: (input: string) => input.length > 0 || 'Title is required',
+            validate: (input: string) => input.trim() ? true : 'Title cannot be empty',
           }]);
           subtasks.push(subtaskTitle);
 


### PR DESCRIPTION
## Summary
- Updated validation for all required text fields to trim whitespace before checking for empty values
- Whitespace-only input is now rejected with a clear error message for required fields
- Updated error messages to say "cannot be empty" instead of "is required"

## Files Changed
- `src/commands/ticket/create.ts` - 4 validation updates
- `src/commands/ticket/edit.ts` - 2 validation updates
- `src/commands/epic/create.ts` - 1 validation update
- `src/commands/spec/create.ts` - 1 validation update
- `src/commands/phase/create.ts` - 1 validation update
- `src/commands/status/create.ts` - 1 validation update
- `src/commands/ticket/template/create.ts` - 2 validation updates

## Test plan
- [x] Build passes
- [x] All CLI tests pass
- [ ] Manually test whitespace-only input is rejected for ticket title
- [ ] Verify clear error messages are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)