### PR TITLE
fix(TKT-841): Fix spec ticket command project scope confusion

### DIFF
--- a/apps/cli/src/commands/spec/ticket.ts
+++ b/apps/cli/src/commands/spec/ticket.ts
@@ -1,6 +1,4 @@
 import { Flags, Args } from '@oclif/core';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import {
@@ -110,7 +108,8 @@ export default class SpecTicket extends PMOCommand {
     // Get spec ID
     let specId = args.specId || flags.spec;
     if (!specId) {
-      const specs = await this.listAvailableSpecs(this.pmoPath, projectId);
+      // List all specs globally (specs are not project-scoped)
+      const specs = await this.storage.listSpecs();
       if (specs.length === 0) {
         return handleError('NO_SPECS', 'No specs found. Create one first with: prlt spec create');
       }
@@ -129,7 +128,7 @@ export default class SpecTicket extends PMOCommand {
         type: 'list',
         message: 'Select spec to link:',
         choices: () => specs.map(s => ({
-          name: `${s.name} (${s.status})`,
+          name: `${s.title} (${s.status})`,
           value: s.id,
         })),
       });
@@ -142,11 +141,10 @@ export default class SpecTicket extends PMOCommand {
       this.error('No spec selected');
     }
 
-    // Verify spec exists
-    const specPath = this.findSpecFile(this.pmoPath, projectId, specId);
-    if (!specPath) {
-      const projectName = await this.getProjectName(projectId);
-      this.error(`Spec "${specId}" not found in project "${projectName}"`);
+    // Verify spec exists globally (specs are not project-scoped)
+    const spec = await this.storage.getSpec(specId);
+    if (!spec) {
+      return handleError('SPEC_NOT_FOUND', `Spec "${specId}" not found`);
     }
 
     // Check if already linked
@@ -170,42 +168,5 @@ export default class SpecTicket extends PMOCommand {
     this.log(styles.success(`\n✅ Linked ticket "${styles.emphasis(ticketId)}" to spec "${styles.emphasis(specId)}"`));
     this.log(styles.muted(`\nView ticket:`));
     this.log(styles.muted(`  prlt ticket view ${ticketId}`));
-  }
-
-  private async listAvailableSpecs(pmoPath: string, projectId: string): Promise<Array<{ id: string; name: string; status: string }>> {
-    const specsBasePath = path.join(pmoPath, 'projects', projectId, 'specs');
-    const specs: Array<{ id: string; name: string; status: string }> = [];
-
-    if (!fs.existsSync(specsBasePath)) {
-      return specs;
-    }
-
-    for (const status of ['active', 'draft', 'archived']) {
-      const statusPath = path.join(specsBasePath, status);
-      if (!fs.existsSync(statusPath)) {
-        continue;
-      }
-
-      const files = fs.readdirSync(statusPath).filter(f => f.endsWith('.md'));
-      for (const file of files) {
-        const id = path.basename(file, '.md');
-        specs.push({ id, name: id, status });
-      }
-    }
-
-    return specs;
-  }
-
-  private findSpecFile(pmoPath: string, projectId: string, specId: string): string | null {
-    const specsBasePath = path.join(pmoPath, 'projects', projectId, 'specs');
-
-    for (const status of ['active', 'draft', 'archived']) {
-      const specPath = path.join(specsBasePath, status, `${specId}.md`);
-      if (fs.existsSync(specPath)) {
-        return specPath;
-      }
-    }
-
-    return null;
   }
 }


### PR DESCRIPTION
## Summary
- Remove project scope validation from spec lookup in `spec ticket` command
- Specs are global, not per-project scoped, so any spec can be linked to any ticket regardless of project
- Replace file-system based spec lookup with database storage methods (`this.storage.listSpecs()` and `this.storage.getSpec()`)

## Changes
- Removed unused `fs` and `path` imports
- Replaced `listAvailableSpecs` method (project-scoped file system lookup) with global `this.storage.listSpecs()`
- Replaced `findSpecFile` method (project-scoped file lookup) with global `this.storage.getSpec()`
- Updated error message to remove project reference when spec is not found

## Test plan
- [ ] Verify `prlt spec ticket TKT-001 myspec` works without project check
- [ ] Verify any spec can be linked to any ticket regardless of project

🤖 Generated with [Claude Code](https://claude.com/claude-code)