### PR TITLE
fix(TKT-846): make --current-terminal and --new-tab mutually exclusive

### DIFF
--- a/apps/cli/src/commands/session/attach.ts
+++ b/apps/cli/src/commands/session/attach.ts
@@ -69,6 +69,15 @@ export default class SessionAttach extends PMOCommand {
   async execute(): Promise<void> {
     const { args, flags } = await this.parse(SessionAttach)
 
+    // Check for mutually exclusive flags
+    const rawArgs = process.argv
+    const hasCurrentTerminal = rawArgs.includes('--current-terminal') || rawArgs.includes('-c')
+    const hasNewTab = rawArgs.includes('--new-tab') || rawArgs.includes('-n')
+
+    if (hasCurrentTerminal && hasNewTab) {
+      this.error('--current-terminal and --new-tab are mutually exclusive')
+    }
+
     // Check if JSON output mode is active
     const jsonMode = shouldOutputJson(flags)
 


### PR DESCRIPTION
## Summary
- Added validation to detect when both `--current-terminal` and `--new-tab` flags are passed together
- Shows explicit error: "Error: --current-terminal and --new-tab are mutually exclusive"
- Checks both long (`--current-terminal`, `--new-tab`) and short (`-c`, `-n`) flag variants

## Test plan
- [x] Verified `prlt session attach --current-terminal --new-tab` shows error
- [x] Verified `prlt session attach -c -n` shows error
- [x] Verified `prlt session attach --current-terminal -n` shows error
- [x] Verified `prlt session attach --current-terminal` alone works normally
- [x] Build passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)