### PR TITLE
fix(TKT-818): Standardize --json as primary flag with -m/--machine aliases

### DIFF
--- a/apps/cli/src/commands/action/list.ts
+++ b/apps/cli/src/commands/action/list.ts
@@ -29,6 +29,8 @@ export default class ActionList extends PMOCommand {
       options: ['backlog', 'unstarted', 'started', 'completed', 'canceled'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/auth.ts
+++ b/apps/cli/src/commands/agent/auth.ts
@@ -29,15 +29,11 @@ export default class Auth extends Command {
       description: 'Force re-authentication even if credentials exist',
       default: false,
     }),
-    machine: Flags.boolean({
-      char: 'm',
-      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-      default: false,
-    }),
     json: Flags.boolean({
-      description: 'Output as JSON (deprecated, use --machine)',
+      char: 'm',
+      aliases: ['machine'],
+      description: 'Output as JSON for AI agents/scripts',
       default: false,
-      hidden: true,
     }),
   };
 

--- a/apps/cli/src/commands/agent/discover.ts
+++ b/apps/cli/src/commands/agent/discover.ts
@@ -22,15 +22,11 @@ export default class Discover extends Command {
       description: 'Show what would be discovered without making changes',
       default: false,
     }),
-    machine: Flags.boolean({
-      char: 'm',
-      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-      default: false,
-    }),
     json: Flags.boolean({
-      description: 'Output as JSON (deprecated, use --machine)',
+      char: 'm',
+      aliases: ['machine'],
+      description: 'Output as JSON for AI agents/scripts',
       default: false,
-      hidden: true,
     }),
   };
 

--- a/apps/cli/src/commands/agent/index.ts
+++ b/apps/cli/src/commands/agent/index.ts
@@ -22,6 +22,8 @@ export default class Agent extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/login.ts
+++ b/apps/cli/src/commands/agent/login.ts
@@ -35,6 +35,8 @@ export default class Login extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/rebuild.ts
+++ b/apps/cli/src/commands/agent/rebuild.ts
@@ -35,6 +35,8 @@ export default class AgentRebuild extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -33,6 +33,8 @@ export default class Remove extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/restart.ts
+++ b/apps/cli/src/commands/agent/restart.ts
@@ -34,6 +34,8 @@ export default class AgentRestart extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/shell.ts
+++ b/apps/cli/src/commands/agent/shell.ts
@@ -40,6 +40,8 @@ export default class Shell extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/staff/add.ts
+++ b/apps/cli/src/commands/agent/staff/add.ts
@@ -47,15 +47,11 @@ export default class Add extends Command {
       char: 't',
       description: 'Pick agent name(s) from a theme (billionaires, toyotas, companies, or custom)',
     }),
-    machine: Flags.boolean({
-      char: 'm',
-      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-      default: false,
-    }),
     json: Flags.boolean({
-      description: 'Output as JSON (deprecated, use --machine)',
+      char: 'm',
+      aliases: ['machine'],
+      description: 'Output as JSON for AI agents/scripts',
       default: false,
-      hidden: true,
     }),
     clone: Flags.boolean({
       description: 'Use independent git clone instead of worktree (more isolation, no real-time sync)',

--- a/apps/cli/src/commands/agent/staff/index.ts
+++ b/apps/cli/src/commands/agent/staff/index.ts
@@ -21,6 +21,8 @@ export default class Staff extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/staff/remove.ts
+++ b/apps/cli/src/commands/agent/staff/remove.ts
@@ -33,6 +33,8 @@ export default class Remove extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/status.ts
+++ b/apps/cli/src/commands/agent/status.ts
@@ -31,6 +31,8 @@ export default class Status extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/temp/cleanup.ts
+++ b/apps/cli/src/commands/agent/temp/cleanup.ts
@@ -65,6 +65,8 @@ export default class Cleanup extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/temp/index.ts
+++ b/apps/cli/src/commands/agent/temp/index.ts
@@ -21,6 +21,8 @@ export default class Temp extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/agent/themes/index.ts
+++ b/apps/cli/src/commands/agent/themes/index.ts
@@ -21,15 +21,11 @@ export default class Themes extends Command {
   ];
 
   static flags = {
-    machine: Flags.boolean({
-      char: 'm',
-      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-      default: false,
-    }),
     json: Flags.boolean({
-      description: 'Output as JSON (deprecated, use --machine)',
+      char: 'm',
+      aliases: ['machine'],
+      description: 'Output as JSON for AI agents/scripts',
       default: false,
-      hidden: true,
     }),
   };
 

--- a/apps/cli/src/commands/agent/themes/set.ts
+++ b/apps/cli/src/commands/agent/themes/set.ts
@@ -27,15 +27,11 @@ export default class ThemesSet extends Command {
   };
 
   static flags = {
-    machine: Flags.boolean({
-      char: 'm',
-      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-      default: false,
-    }),
     json: Flags.boolean({
-      description: 'Output as JSON (deprecated, use --machine)',
+      char: 'm',
+      aliases: ['machine'],
+      description: 'Output as JSON for AI agents/scripts',
       default: false,
-      hidden: true,
     }),
   };
 

--- a/apps/cli/src/commands/agent/visit.ts
+++ b/apps/cli/src/commands/agent/visit.ts
@@ -27,6 +27,8 @@ export default class Visit extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/branch/create.ts
+++ b/apps/cli/src/commands/branch/create.ts
@@ -106,6 +106,8 @@ export default class BranchCreate extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/branch/index.ts
+++ b/apps/cli/src/commands/branch/index.ts
@@ -10,6 +10,8 @@ export default class Branch extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/branch/where.ts
+++ b/apps/cli/src/commands/branch/where.ts
@@ -26,6 +26,8 @@ export default class BranchWhere extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output in JSON format',
       default: false,
     }),

--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -79,6 +79,8 @@ export default class Claude extends Command {
 
   static flags = {
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/commit.ts
+++ b/apps/cli/src/commands/commit.ts
@@ -228,6 +228,8 @@ export default class Commit extends Command {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/config/index.ts
+++ b/apps/cli/src/commands/config/index.ts
@@ -38,6 +38,8 @@ export default class Config extends Command {
 
   static flags = {
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/activate.ts
+++ b/apps/cli/src/commands/epic/activate.ts
@@ -30,6 +30,8 @@ export default class EpicActivate extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/archive.ts
+++ b/apps/cli/src/commands/epic/archive.ts
@@ -30,6 +30,8 @@ export default class EpicArchive extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/create.ts
+++ b/apps/cli/src/commands/epic/create.ts
@@ -42,6 +42,8 @@ export default class EpicCreate extends PMOCommand {
       description: 'Link to spec ID (the design spec that describes this epic)',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/index.ts
+++ b/apps/cli/src/commands/epic/index.ts
@@ -12,6 +12,8 @@ export default class Epic extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/link/block.ts
+++ b/apps/cli/src/commands/epic/link/block.ts
@@ -26,6 +26,8 @@ export default class EpicLinkBlock extends PMOCommand {
     ...pmoBaseFlags,
     project: Flags.string({ char: 'P', description: 'Project ID' }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/link/duplicates.ts
+++ b/apps/cli/src/commands/epic/link/duplicates.ts
@@ -22,6 +22,8 @@ export default class EpicLinkDuplicates extends PMOCommand {
     ...pmoBaseFlags,
     project: Flags.string({ char: 'P', description: 'Project ID' }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/link/index.ts
+++ b/apps/cli/src/commands/epic/link/index.ts
@@ -53,6 +53,8 @@ export default class EpicLink extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/link/relates.ts
+++ b/apps/cli/src/commands/epic/link/relates.ts
@@ -22,6 +22,8 @@ export default class EpicLinkRelates extends PMOCommand {
     ...pmoBaseFlags,
     project: Flags.string({ char: 'P', description: 'Project ID' }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/link/remove.ts
+++ b/apps/cli/src/commands/epic/link/remove.ts
@@ -28,6 +28,8 @@ export default class EpicLinkRemove extends PMOCommand {
     type: Flags.string({ char: 't', description: 'Dependency type', options: ['blocks', 'relates_to', 'duplicates'] }),
     all: Flags.boolean({ char: 'a', description: 'Remove all dependencies', default: false }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/move.ts
+++ b/apps/cli/src/commands/epic/move.ts
@@ -43,6 +43,8 @@ export default class EpicMove extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/progress.ts
+++ b/apps/cli/src/commands/epic/progress.ts
@@ -37,6 +37,8 @@ export default class EpicProgress extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/project.ts
+++ b/apps/cli/src/commands/epic/project.ts
@@ -34,6 +34,8 @@ export default class EpicProject extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/reorder.ts
+++ b/apps/cli/src/commands/epic/reorder.ts
@@ -49,6 +49,8 @@ export default class EpicReorder extends PMOCommand {
       exclusive: ['first', 'last', 'after'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/spec.ts
+++ b/apps/cli/src/commands/epic/spec.ts
@@ -34,6 +34,8 @@ export default class EpicSpec extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/ticket.ts
+++ b/apps/cli/src/commands/epic/ticket.ts
@@ -39,6 +39,8 @@ export default class EpicTicket extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/epic/view.ts
+++ b/apps/cli/src/commands/epic/view.ts
@@ -33,6 +33,8 @@ export default class EpicView extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/execution/config.ts
+++ b/apps/cli/src/commands/execution/config.ts
@@ -47,6 +47,8 @@ export default class ExecutionConfig extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/execution/index.ts
+++ b/apps/cli/src/commands/execution/index.ts
@@ -15,6 +15,8 @@ export default class Execution extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),
@@ -27,7 +29,7 @@ export default class Execution extends PMOCommand {
   async execute(): Promise<void> {
     const { flags } = await this.parse(Execution)
 
-    const jsonModeConfig = (flags.json || flags.machine) ? { flags, commandName: 'execution' } : null
+    const jsonModeConfig = flags.json ? { flags, commandName: 'execution' } : null
 
     const { action } = await this.prompt<{ action: string }>([
       {

--- a/apps/cli/src/commands/execution/logs.ts
+++ b/apps/cli/src/commands/execution/logs.ts
@@ -43,6 +43,8 @@ export default class ExecutionLogs extends PMOCommand {
       min: 1,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),
@@ -85,7 +87,7 @@ export default class ExecutionLogs extends PMOCommand {
           this.error('No executions found.')
         }
 
-        const jsonModeConfig = (flags.json || flags.machine) ? { flags, commandName: 'execution logs' } : null
+        const jsonModeConfig = flags.json ? { flags, commandName: 'execution logs' } : null
 
         const { selectedId } = await this.prompt<{ selectedId: string }>([
           {

--- a/apps/cli/src/commands/execution/stop.ts
+++ b/apps/cli/src/commands/execution/stop.ts
@@ -44,6 +44,8 @@ export default class ExecutionStop extends PMOCommand {
       description: 'Stop all executions for a specific agent',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),
@@ -141,7 +143,7 @@ export default class ExecutionStop extends PMOCommand {
   private async singleStop(
     executionStorage: ExecutionStorage,
     execId: string | undefined,
-    flags: { force?: boolean; json?: boolean; machine?: boolean }
+    flags: { force?: boolean; json?: boolean }
   ): Promise<void> {
     // Get execution ID - prompt if not provided
     let id = execId
@@ -165,7 +167,7 @@ export default class ExecutionStop extends PMOCommand {
         return
       }
 
-      const jsonModeConfig = (flags.json || flags.machine) ? { flags: flags as Record<string, unknown>, commandName: 'execution stop' } : null
+      const jsonModeConfig = flags.json ? { flags: flags as Record<string, unknown>, commandName: 'execution stop' } : null
 
       const { selectedId } = await this.prompt<{ selectedId: string }>([
         {

--- a/apps/cli/src/commands/execution/view.ts
+++ b/apps/cli/src/commands/execution/view.ts
@@ -30,6 +30,8 @@ export default class ExecutionView extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output execution details as JSON',
       default: false,
     }),
@@ -84,7 +86,7 @@ export default class ExecutionView extends PMOCommand {
           return
         }
 
-        const jsonModeConfig = (flags.json || flags.machine) ? { flags, commandName: 'execution view' } : null
+        const jsonModeConfig = flags.json ? { flags, commandName: 'execution view' } : null
 
         const { selectedId } = await this.prompt<{ selectedId: string }>([
           {

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -26,6 +26,8 @@ export default class Init extends Command {
 
   static flags = {
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Agent mode: use flags instead of prompts, output JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/phase/create.ts
+++ b/apps/cli/src/commands/phase/create.ts
@@ -77,7 +77,6 @@ export default class PhaseCreate extends PMOCommand {
       color?: string;
       description?: string;
       default?: boolean;
-      machine?: boolean;
       json?: boolean;
     }>({
       commandName: 'phase create',
@@ -88,7 +87,6 @@ export default class PhaseCreate extends PMOCommand {
         color: flags.color,
         description: flags.description,
         default: flags.default,
-        machine: flags.machine,
         json: flags.json,
       },
     });

--- a/apps/cli/src/commands/phase/delete.ts
+++ b/apps/cli/src/commands/phase/delete.ts
@@ -58,11 +58,11 @@ export default class PhaseDelete extends PMOCommand {
 
     if (!flags.force) {
       // Use FlagResolver for confirmation
-      const resolver = new FlagResolver<{ confirmed?: boolean; machine?: boolean; json?: boolean }>({
+      const resolver = new FlagResolver<{ confirmed?: boolean; json?: boolean }>({
         commandName: 'phase delete',
         baseCommand: `prlt phase delete ${args.id}`,
         jsonMode,
-        flags: { machine: flags.machine, json: flags.json },
+        flags: { json: flags.json },
       });
 
       resolver.addPrompt({

--- a/apps/cli/src/commands/phase/move.ts
+++ b/apps/cli/src/commands/phase/move.ts
@@ -61,11 +61,11 @@ export default class PhaseMove extends PMOCommand {
         return handleError('NO_PHASES', 'No phases found. Create a phase first with "prlt phase create".');
       }
 
-      const idResolver = new FlagResolver<{ phaseId?: string; machine?: boolean; json?: boolean }>({
+      const idResolver = new FlagResolver<{ phaseId?: string; json?: boolean }>({
         commandName: 'phase move',
         baseCommand: 'prlt phase move',
         jsonMode,
-        flags: { machine: flags.machine, json: flags.json },
+        flags: { json: flags.json },
       });
 
       idResolver.addPrompt({
@@ -100,11 +100,11 @@ export default class PhaseMove extends PMOCommand {
       const phases = await this.storage.listPhases();
       const categoryPhases = phases.filter(p => p.category === phase.category);
 
-      const posResolver = new FlagResolver<{ position?: string; machine?: boolean; json?: boolean }>({
+      const posResolver = new FlagResolver<{ position?: string; json?: boolean }>({
         commandName: 'phase move',
         baseCommand: `prlt phase move ${phaseId}`,
         jsonMode,
-        flags: { machine: flags.machine, json: flags.json },
+        flags: { json: flags.json },
       });
 
       posResolver.addPrompt({

--- a/apps/cli/src/commands/phase/template/apply.ts
+++ b/apps/cli/src/commands/phase/template/apply.ts
@@ -34,6 +34,8 @@ export default class PhaseTemplateApply extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/phase/template/create.ts
+++ b/apps/cli/src/commands/phase/template/create.ts
@@ -47,7 +47,6 @@ export default class PhaseTemplateCreate extends PMOCommand {
     const resolver = new FlagResolver<{
       name?: string;
       description?: string;
-      machine?: boolean;
       json?: boolean;
     }>({
       commandName: 'phase template create',
@@ -55,7 +54,6 @@ export default class PhaseTemplateCreate extends PMOCommand {
       jsonMode,
       flags: {
         description: flags.description,
-        machine: flags.machine,
         json: flags.json,
       },
       args: { name: args.name },

--- a/apps/cli/src/commands/phase/template/delete.ts
+++ b/apps/cli/src/commands/phase/template/delete.ts
@@ -33,6 +33,8 @@ export default class PhaseTemplateDelete extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/phase/template/index.ts
+++ b/apps/cli/src/commands/phase/template/index.ts
@@ -21,6 +21,8 @@ export default class PhaseTemplateMenu extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/phase/template/list.ts
+++ b/apps/cli/src/commands/phase/template/list.ts
@@ -23,6 +23,8 @@ export default class PhaseTemplateList extends PMOCommand {
       exclusive: ['builtin'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/phase/update.ts
+++ b/apps/cli/src/commands/phase/update.ts
@@ -86,7 +86,7 @@ export default class PhaseUpdate extends PMOCommand {
         commandName: 'phase update',
         baseCommand: 'prlt phase update',
         jsonMode,
-        flags: { machine: flags.machine, json: flags.json },
+        flags: { json: flags.json },
       });
 
       idResolver.addPrompt({
@@ -150,7 +150,7 @@ export default class PhaseUpdate extends PMOCommand {
         commandName: 'phase update',
         baseCommand: `prlt phase update ${phaseId}`,
         jsonMode,
-        flags: { machine: flags.machine, json: flags.json },
+        flags: { json: flags.json },
       });
 
       resolver.addPrompt({

--- a/apps/cli/src/commands/pmo/init.ts
+++ b/apps/cli/src/commands/pmo/init.ts
@@ -53,6 +53,8 @@ export default class PMOInit extends Command {
       description: 'Board name',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/repo/add.ts
+++ b/apps/cli/src/commands/repo/add.ts
@@ -45,6 +45,8 @@ export default class Add extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/add-project.ts
+++ b/apps/cli/src/commands/roadmap/add-project.ts
@@ -37,6 +37,8 @@ export default class RoadmapAddProject extends PMOCommand {
       description: 'Position in the roadmap (0-indexed)',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/create.ts
+++ b/apps/cli/src/commands/roadmap/create.ts
@@ -50,6 +50,8 @@ export default class RoadmapCreate extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/delete.ts
+++ b/apps/cli/src/commands/roadmap/delete.ts
@@ -34,6 +34,8 @@ export default class RoadmapDelete extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/generate.ts
+++ b/apps/cli/src/commands/roadmap/generate.ts
@@ -41,6 +41,8 @@ export default class RoadmapGenerate extends PMOCommand {
       description: 'Output directory (default: {pmoPath}/roadmaps)',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/index.ts
+++ b/apps/cli/src/commands/roadmap/index.ts
@@ -12,6 +12,8 @@ export default class Roadmap extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/remove-project.ts
+++ b/apps/cli/src/commands/roadmap/remove-project.ts
@@ -38,6 +38,8 @@ export default class RoadmapRemoveProject extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/reorder.ts
+++ b/apps/cli/src/commands/roadmap/reorder.ts
@@ -36,6 +36,8 @@ export default class RoadmapReorder extends PMOCommand {
       description: 'New position (0-indexed)',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/update.ts
+++ b/apps/cli/src/commands/roadmap/update.ts
@@ -43,6 +43,8 @@ export default class RoadmapUpdate extends PMOCommand {
       allowNo: true,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/roadmap/view.ts
+++ b/apps/cli/src/commands/roadmap/view.ts
@@ -28,6 +28,8 @@ export default class RoadmapView extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/session/attach.ts
+++ b/apps/cli/src/commands/session/attach.ts
@@ -42,6 +42,8 @@ export default class SessionAttach extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/session/index.ts
+++ b/apps/cli/src/commands/session/index.ts
@@ -14,6 +14,8 @@ export default class Session extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/delete.ts
+++ b/apps/cli/src/commands/template/delete.ts
@@ -29,6 +29,8 @@ export default class TemplateDelete extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/list.ts
+++ b/apps/cli/src/commands/template/list.ts
@@ -32,6 +32,8 @@ export default class TemplateList extends PMOCommand {
       exclusive: ['builtin'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/template/phase/apply.ts
+++ b/apps/cli/src/commands/template/phase/apply.ts
@@ -27,6 +27,8 @@ export default class TemplatePhaseApply extends Command {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/phase/create.ts
+++ b/apps/cli/src/commands/template/phase/create.ts
@@ -21,15 +21,11 @@ export default class TemplatePhaseCreate extends Command {
       char: 'd',
       description: 'Template description',
     }),
-    machine: Flags.boolean({
-      char: 'm',
-      description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-      default: false,
-    }),
     json: Flags.boolean({
-      description: 'Output as JSON (deprecated, use --machine)',
+      char: 'm',
+      aliases: ['machine'],
+      description: 'Output as JSON for AI agents/scripts',
       default: false,
-      hidden: true,
     }),
   };
 
@@ -39,7 +35,6 @@ export default class TemplatePhaseCreate extends Command {
     const cmdArgs: string[] = [];
     if (args.name) cmdArgs.push(args.name);
     if (flags.description) cmdArgs.push('--description', flags.description);
-    if (flags.machine) cmdArgs.push('--machine');
     if (flags.json) cmdArgs.push('--json');
 
     await this.config.runCommand('phase:template:create', cmdArgs);

--- a/apps/cli/src/commands/template/phase/delete.ts
+++ b/apps/cli/src/commands/template/phase/delete.ts
@@ -22,6 +22,8 @@ export default class TemplatePhaseDelete extends Command {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/phase/list.ts
+++ b/apps/cli/src/commands/template/phase/list.ts
@@ -19,6 +19,8 @@ export default class TemplatePhaseList extends Command {
       exclusive: ['builtin'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/template/phase/update.ts
+++ b/apps/cli/src/commands/template/phase/update.ts
@@ -25,6 +25,8 @@ export default class TemplatePhaseUpdate extends Command {
       description: 'New template description',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/ticket/apply.ts
+++ b/apps/cli/src/commands/template/ticket/apply.ts
@@ -38,6 +38,8 @@ export default class TemplateTicketApply extends Command {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/ticket/create.ts
+++ b/apps/cli/src/commands/template/ticket/create.ts
@@ -50,6 +50,8 @@ export default class TemplateTicketCreate extends Command {
       multiple: true,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/ticket/delete.ts
+++ b/apps/cli/src/commands/template/ticket/delete.ts
@@ -22,6 +22,8 @@ export default class TemplateTicketDelete extends Command {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/template/ticket/list.ts
+++ b/apps/cli/src/commands/template/ticket/list.ts
@@ -19,6 +19,8 @@ export default class TemplateTicketList extends Command {
       exclusive: ['builtin'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/template/ticket/save.ts
+++ b/apps/cli/src/commands/template/ticket/save.ts
@@ -31,10 +31,6 @@ export default class TemplateTicketSave extends Command {
       char: 'd',
       description: 'Template description',
     }),
-    json: Flags.boolean({
-      description: 'Output prompt configuration as JSON (for AI agents/scripts)',
-      default: false,
-    }),
   };
 
   async run(): Promise<void> {
@@ -46,7 +42,6 @@ export default class TemplateTicketSave extends Command {
     if (flags['template-name']) cmdArgs.push('--template-name', flags['template-name']);
     if (flags.description) cmdArgs.push('--description', flags.description);
     if (flags.json) cmdArgs.push('--json');
-    if (flags.machine) cmdArgs.push('--machine');
 
     await this.config.runCommand('ticket:template:save', cmdArgs);
   }

--- a/apps/cli/src/commands/ticket/bulk.ts
+++ b/apps/cli/src/commands/ticket/bulk.ts
@@ -19,6 +19,8 @@ export default class TicketBulk extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/complete.ts
+++ b/apps/cli/src/commands/ticket/complete.ts
@@ -30,6 +30,8 @@ export default class TicketComplete extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -26,6 +26,8 @@ export default class TicketCreate extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/delete.ts
+++ b/apps/cli/src/commands/ticket/delete.ts
@@ -33,6 +33,8 @@ export default class TicketDelete extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/edit.ts
+++ b/apps/cli/src/commands/ticket/edit.ts
@@ -84,6 +84,8 @@ export default class TicketEdit extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/epic.ts
+++ b/apps/cli/src/commands/ticket/epic.ts
@@ -33,6 +33,8 @@ export default class TicketEpic extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/index.ts
+++ b/apps/cli/src/commands/ticket/index.ts
@@ -18,6 +18,8 @@ export default class Ticket extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/link/block.ts
+++ b/apps/cli/src/commands/ticket/link/block.ts
@@ -29,6 +29,8 @@ export default class TicketLinkBlock extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/link/duplicates.ts
+++ b/apps/cli/src/commands/ticket/link/duplicates.ts
@@ -29,6 +29,8 @@ export default class TicketLinkDuplicates extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/link/index.ts
+++ b/apps/cli/src/commands/ticket/link/index.ts
@@ -29,6 +29,8 @@ export default class TicketLink extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/link/relates.ts
+++ b/apps/cli/src/commands/ticket/link/relates.ts
@@ -29,6 +29,8 @@ export default class TicketLinkRelates extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/link/remove.ts
+++ b/apps/cli/src/commands/ticket/link/remove.ts
@@ -32,6 +32,8 @@ export default class TicketLinkRemove extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/move.ts
+++ b/apps/cli/src/commands/ticket/move.ts
@@ -35,6 +35,8 @@ export default class TicketMove extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/project.ts
+++ b/apps/cli/src/commands/ticket/project.ts
@@ -32,6 +32,8 @@ export default class TicketProject extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/reassign.ts
+++ b/apps/cli/src/commands/ticket/reassign.ts
@@ -33,6 +33,8 @@ export default class TicketReassign extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/spec.ts
+++ b/apps/cli/src/commands/ticket/spec.ts
@@ -33,6 +33,8 @@ export default class TicketSpec extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/status.ts
+++ b/apps/cli/src/commands/ticket/status.ts
@@ -25,6 +25,8 @@ export default class TicketStatus extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/template/apply.ts
+++ b/apps/cli/src/commands/ticket/template/apply.ts
@@ -73,6 +73,8 @@ export default class TicketTemplateApply extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/template/create.ts
+++ b/apps/cli/src/commands/ticket/template/create.ts
@@ -66,6 +66,8 @@ export default class TicketTemplateCreate extends PMOCommand {
       multiple: true,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/template/delete.ts
+++ b/apps/cli/src/commands/ticket/template/delete.ts
@@ -26,6 +26,8 @@ export default class TicketTemplateDelete extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/template/index.ts
+++ b/apps/cli/src/commands/ticket/template/index.ts
@@ -16,6 +16,8 @@ export default class TicketTemplateIndex extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/template/list.ts
+++ b/apps/cli/src/commands/ticket/template/list.ts
@@ -24,6 +24,8 @@ export default class TicketTemplateList extends PMOCommand {
       exclusive: ['builtin'],
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/template/save.ts
+++ b/apps/cli/src/commands/ticket/template/save.ts
@@ -43,6 +43,8 @@ export default class TicketTemplateSave extends PMOCommand {
       description: 'Template description',
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/update.ts
+++ b/apps/cli/src/commands/ticket/update.ts
@@ -30,6 +30,8 @@ export default class TicketUpdate extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/ticket/view.ts
+++ b/apps/cli/src/commands/ticket/view.ts
@@ -18,6 +18,8 @@ export default class TicketView extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/complete.ts
+++ b/apps/cli/src/commands/work/complete.ts
@@ -30,6 +30,8 @@ export default class WorkComplete extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/index.ts
+++ b/apps/cli/src/commands/work/index.ts
@@ -12,6 +12,8 @@ export default class Work extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -49,6 +49,8 @@ export default class WorkReady extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/revise.ts
+++ b/apps/cli/src/commands/work/revise.ts
@@ -56,6 +56,8 @@ export default class WorkRevise extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/spawn-all.ts
+++ b/apps/cli/src/commands/work/spawn-all.ts
@@ -14,6 +14,8 @@ export default class WorkSpawnAll extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -37,6 +37,8 @@ export default class WorkSpawn extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -121,6 +121,8 @@ export default class WorkStart extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -36,6 +36,8 @@ export default class WorkWatch extends PMOCommand {
   static flags = {
     ...pmoBaseFlags,
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/workflow/index.ts
+++ b/apps/cli/src/commands/workflow/index.ts
@@ -22,6 +22,8 @@ export default class Workflow extends PMOCommand {
       default: false,
     }),
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON',
       default: false,
     }),

--- a/apps/cli/src/commands/workspace/list.ts
+++ b/apps/cli/src/commands/workspace/list.ts
@@ -28,6 +28,8 @@ export default class WorkspaceList extends Command {
 
   static flags = {
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output as JSON for machine-readable format',
       default: false,
     }),

--- a/apps/cli/src/commands/workspace/remove.ts
+++ b/apps/cli/src/commands/workspace/remove.ts
@@ -31,6 +31,8 @@ export default class WorkspaceRemove extends PromptCommand {
 
   static flags = {
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/commands/workspace/use.ts
+++ b/apps/cli/src/commands/workspace/use.ts
@@ -28,6 +28,8 @@ export default class WorkspaceUse extends PromptCommand {
 
   static flags = {
     json: Flags.boolean({
+      char: 'm',
+      aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
       default: false,
     }),

--- a/apps/cli/src/lib/pmo/base-command.ts
+++ b/apps/cli/src/lib/pmo/base-command.ts
@@ -12,13 +12,15 @@ import {
 } from '../prompt-json.js';
 
 /**
- * Base flags for JSON/agent mode support (legacy)
+ * Base flags for JSON/agent mode support
  * Include these in your command's flags by spreading: ...jsonModeFlags
  * @deprecated Use machineOutputFlags instead
  */
 export const jsonModeFlags = {
   json: Flags.boolean({
-    description: 'Output prompts as JSON for AI agents/scripts',
+    char: 'm',
+    aliases: ['machine'],
+    description: 'Output as JSON for AI agents/scripts',
     default: false,
   }),
 };
@@ -26,18 +28,14 @@ export const jsonModeFlags = {
 /**
  * Base flags for machine-readable output mode
  * Include these in your command's flags by spreading: ...machineOutputFlags
- * Supports both --machine (new) and --json (legacy, deprecated)
+ * --json is the primary flag, -m/--machine are aliases
  */
 export const machineOutputFlags = {
-  machine: Flags.boolean({
-    char: 'm',
-    description: 'Output as JSON for AI agents/scripts (machine-readable mode)',
-    default: false,
-  }),
   json: Flags.boolean({
-    description: 'Output as JSON (deprecated, use --machine)',
+    char: 'm',
+    aliases: ['machine'],
+    description: 'Output as JSON for AI agents/scripts',
     default: false,
-    hidden: true,  // Hide from help since it's deprecated
   }),
 };
 

--- a/apps/cli/src/lib/prompt-json.ts
+++ b/apps/cli/src/lib/prompt-json.ts
@@ -140,8 +140,7 @@ export interface ErrorJsonOutput {
 export type JsonOutput = PromptJsonOutput | SuccessJsonOutput | ErrorJsonOutput
 
 /**
- * Flags interface for JSON mode detection (legacy)
- * @deprecated Use MachineOutputFlags instead
+ * Flags interface for JSON mode detection
  */
 export interface JsonFlags {
   json?: boolean
@@ -149,12 +148,10 @@ export interface JsonFlags {
 
 /**
  * Flags interface for machine-readable output mode detection
- * Supports both new --machine format and legacy --json boolean
+ * --json is the primary flag, -m/--machine are aliases that set json=true
  */
 export interface MachineOutputFlags {
-  /** New format: --machine (enables machine-readable JSON output for AI agents) */
-  machine?: boolean
-  /** Legacy format: --json (deprecated, use --machine instead) */
+  /** Primary JSON output flag. -m and --machine are aliases to this flag */
   json?: boolean
 }
 
@@ -171,20 +168,14 @@ export function isNonTTY(): boolean {
  * Determine if JSON output mode is active (for AI agents)
  *
  * Returns true if:
- * - The --machine flag is explicitly set
- * - The --json flag is explicitly set
+ * - The --json flag is set (or -m/--machine aliases)
  * - The environment is non-TTY (piped output)
  *
  * @param flags - Command flags object
  * @returns true if JSON mode should be used
  */
-export function shouldOutputJson(flags: JsonFlags & { machine?: boolean }): boolean {
-  // New --machine flag
-  if ((flags as { machine?: boolean }).machine === true) {
-    return true
-  }
-
-  // Legacy --json flag
+export function shouldOutputJson(flags: JsonFlags): boolean {
+  // --json flag (includes -m and --machine aliases)
   if (flags.json === true) {
     return true
   }
@@ -202,20 +193,14 @@ export const isAgentMode = shouldOutputJson
  * Determine if machine-readable output mode is active (for AI agents/scripts)
  *
  * Returns true if:
- * - The --machine flag is set
- * - The --json flag is explicitly set (legacy support)
+ * - The --json flag is set (or -m/--machine aliases)
  * - The environment is non-TTY (piped output)
  *
  * @param flags - Command flags object
  * @returns true if machine-readable output mode should be used
  */
 export function isMachineOutput(flags: MachineOutputFlags): boolean {
-  // New --machine flag takes precedence
-  if (flags.machine === true) {
-    return true
-  }
-
-  // Legacy --json flag support
+  // --json flag (includes -m and --machine aliases)
   if (flags.json === true) {
     return true
   }


### PR DESCRIPTION
## Summary
- Standardized `--json` as the primary flag name across all CLI commands
- Added `-m` as short form and `--machine` as alias to `--json`
- Updated 119 files for consistent flag behavior
- All list/view commands now output valid JSON when flag is passed

## Changes
- Updated `machineOutputFlags` in base-command.ts to use `--json` as primary
- Updated all command files to use the standardized flag pattern:
  ```typescript
  json: Flags.boolean({
    char: 'm',
    aliases: ['machine'],
    description: 'Output as JSON for AI agents/scripts',
    default: false,
  }),
  ```
- Removed references to `flags.machine` since it's now an alias
- Updated `shouldOutputJson` and `isMachineOutput` functions

## Test plan
- [x] Verify `--json` flag outputs valid JSON
- [x] Verify `-m` shortcut outputs valid JSON
- [x] Verify `--machine` alias outputs valid JSON
- [x] Build passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)