### PR TITLE
feat(TKT-840): fix agent list --json to output all agents grouped by type

### DIFF
--- a/apps/cli/src/commands/agent/list.ts
+++ b/apps/cli/src/commands/agent/list.ts
@@ -46,8 +46,41 @@ export default class List extends PMOCommand {
       // Filter to active agents only
       const activeAgents = workspaceInfo.agents.filter(a => a.status === 'active');
 
-      // Determine type filter - prompt if not provided
+      // Determine type filter - prompt if not provided (but not in JSON mode)
       let typeFilter = flags.type as 'staff' | 'temp' | 'all' | undefined;
+
+      // In JSON mode without type filter, output all agents grouped by type
+      if (jsonMode && !typeFilter) {
+        const staffAgents = activeAgents.filter(a => a.type === 'persistent');
+        const tempAgents = activeAgents.filter(a => a.type === 'ephemeral');
+        const agentsStatus = getAllAgentsStatus(workspaceInfo);
+
+        const formatAgentJson = (agents: typeof activeAgents) => {
+          return agents.map(agent => {
+            const status = agentsStatus.find(s => s.name === agent.name);
+            const sessions = getAgentTmuxSessions(agent.name);
+            return {
+              name: agent.name,
+              type: agent.type === 'persistent' ? 'staff' : 'temp',
+              exists: status?.exists ?? false,
+              branch: status?.branch ?? null,
+              repositories: status?.repositories ?? [],
+              assignedTickets: status?.assignedTickets ?? [],
+              completedTickets: status?.completedTickets ?? [],
+              running: sessions.length > 0,
+            };
+          });
+        };
+
+        const output = {
+          staff: formatAgentJson(staffAgents),
+          temp: formatAgentJson(tempAgents),
+          all: formatAgentJson(activeAgents),
+        };
+
+        this.log(JSON.stringify(output, null, 2));
+        return;
+      }
 
       if (!typeFilter) {
         const { selectedType } = await this.prompt<{ selectedType: 'staff' | 'temp' | 'all' }>([{

--- a/apps/cli/test/e2e/agent-commands.test.ts
+++ b/apps/cli/test/e2e/agent-commands.test.ts
@@ -226,31 +226,40 @@ describe('Agent Commands E2E Tests', () => {
       })
     })
 
-    describe('agent list - type selection flow', () => {
-      it('should output type selection with --machine', () => {
-        const result = agentExec('agent list --machine')
+    describe('agent list - JSON output', () => {
+      it('should output all agents grouped by type with --machine (no --type)', () => {
+        const output = exec('agent list --machine')
+
+        if (hasContextError(output)) {
+          return
+        }
+
+        const result = extractJson<{ staff: unknown[]; temp: unknown[]; all: unknown[] }>(output)
 
         if (!result) {
           return
         }
 
-        expect(result.prompt.type).to.equal('list')
-        expect(result.metadata.command).to.equal('agent list')
+        // Should have staff, temp, and all arrays
+        expect(result).to.have.property('staff')
+        expect(result).to.have.property('temp')
+        expect(result).to.have.property('all')
+        expect(Array.isArray(result.staff)).to.equal(true)
+        expect(Array.isArray(result.temp)).to.equal(true)
+        expect(Array.isArray(result.all)).to.equal(true)
       })
 
-      it('should include command in type choices', () => {
-        const result = agentExec('agent list --machine')
+      it('should work with --type flag to filter agents', () => {
+        // When --type is provided, it should filter to that type
+        // This just verifies the command works with --type
+        const output = exec('agent list --machine --type all')
 
-        if (!result) {
+        if (hasContextError(output)) {
           return
         }
 
-        for (const choice of result.prompt.choices) {
-          if (choice.command) {
-            expect(choice.command).to.include('agent list')
-            expect(choice.command).to.include('--type')
-          }
-        }
+        // Should output JSON or agent list, not throw an exception
+        expect(output).to.not.include('command failed')
       })
     })
 


### PR DESCRIPTION
## Summary
- `agent list --json` now outputs all agents grouped by type (`staff`, `temp`, `all`) instead of prompting for type selection
- No interactive prompt shown in JSON mode

## Changes
- Modified `list.ts` to detect JSON mode without type filter and output all agents as grouped JSON
- Updated e2e tests to verify the new behavior

## Test plan
- [x] Run `prlt agent list --json` without `--type` - should output `{"staff": [...], "temp": [...], "all": [...]}`
- [x] Run `prlt agent list --json --type staff` - should still work with type filter
- [x] All agent command e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)