### PR TITLE
Bump version to 0.3.23

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bumps @proletariat/cli version from 0.3.22 to 0.3.23 for monorepo open source release

TKT-862

## Test plan
- [ ] Verify package.json version is updated correctly
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)