### PR TITLE
TKT-858: Add 'type' field to JSON prompt output to distinguish prompts from errors

### DIFF
--- a/apps/cli/src/lib/prompt-json.ts
+++ b/apps/cli/src/lib/prompt-json.ts
@@ -99,6 +99,8 @@ export interface OutputMetadata {
  * JSON output when a prompt would be shown
  */
 export interface PromptJsonOutput {
+  /** Output type discriminator */
+  type: 'prompt'
   /** Prompt configuration, or null if no prompt needed */
   prompt: PromptConfig | null
   /** Command metadata */
@@ -109,6 +111,8 @@ export interface PromptJsonOutput {
  * JSON output for successful command execution (no prompt needed)
  */
 export interface SuccessJsonOutput {
+  /** Output type discriminator */
+  type: 'success'
   /** Always null when success output */
   prompt: null
   /** Indicates successful execution */
@@ -123,6 +127,8 @@ export interface SuccessJsonOutput {
  * JSON output for error conditions
  */
 export interface ErrorJsonOutput {
+  /** Output type discriminator */
+  type: 'error'
   /** Error details */
   error: {
     /** Machine-readable error code (e.g., "NO_TICKETS_AVAILABLE") */
@@ -251,6 +257,7 @@ export function outputPromptAsJson(
   metadata: OutputMetadata
 ): never {
   const output: PromptJsonOutput = {
+    type: 'prompt',
     prompt: config,
     metadata,
   }
@@ -273,6 +280,7 @@ export function outputSuccessAsJson(
   metadata: OutputMetadata
 ): never {
   const output: SuccessJsonOutput = {
+    type: 'success',
     prompt: null,
     success: true,
     result,
@@ -299,6 +307,7 @@ export function outputErrorAsJson(
   metadata: OutputMetadata
 ): never {
   const output: ErrorJsonOutput = {
+    type: 'error',
     error: {
       code,
       message,


### PR DESCRIPTION
## Summary

Resolves TKT-858: Add 'type' field to JSON prompt output to distinguish prompts from errors

## Description

## Summary
Add a 'type' field to JSON prompt output so AI agents can distinguish prompts from errors.

## Implementation
1. Edit `src/lib/prompt-json.ts`
2. In `outputPromptAsJson()`, add `"type": "prompt"` to the output object
3. In `outputSuccessAsJson()`, add `"type": "success"`
4. In `outputErrorAsJson()`, add `"type": "error"`

## Example Output
```json
{
  "type": "prompt",
  "promptType": "list",
  "message": "Select project:",
  "choices": [...]
}
```

## Files to modify
- `src/lib/prompt-json.ts`

## Acceptance Criteria
- [ ] JSON prompt output includes `"type": "prompt"`
- [ ] JSON success output includes `"type": "success"`
- [ ] JSON error output includes `"type": "error"`

## Changes

- 12d2850 feat(TKT-858): add type field to JSON prompt output
- a737b43 Update LICENSE to Apache 2.0 (#315)
- db78a7c Update LICENSE to Apache 2.0 (#314)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
