### PR TITLE
TKT-860: Improve --help output to clearly show required vs optional flags

### DIFF
--- a/apps/cli/src/commands/action/create.ts
+++ b/apps/cli/src/commands/action/create.ts
@@ -25,7 +25,7 @@ export default class ActionCreate extends PMOCommand {
     ...pmoBaseFlags,
     prompt: Flags.string({
       char: 'p',
-      description: 'The prompt to send to the agent',
+      description: 'The prompt to send to the agent [required for non-interactive]',
     }),
     description: Flags.string({
       char: 'd',

--- a/apps/cli/src/commands/branch/create.ts
+++ b/apps/cli/src/commands/branch/create.ts
@@ -75,7 +75,7 @@ export default class BranchCreate extends PMOCommand {
     }),
     type: Flags.string({
       char: 't',
-      description: 'Branch type',
+      description: 'Branch type [required for non-interactive with -d]',
       options: Object.keys(BRANCH_TYPES),
     }),
     owner: Flags.string({
@@ -84,7 +84,7 @@ export default class BranchCreate extends PMOCommand {
     }),
     description: Flags.string({
       char: 'd',
-      description: 'Branch description (kebab-case)',
+      description: 'Branch description (kebab-case) [required for non-interactive with -t]',
     }),
     'empty-commit': Flags.boolean({
       char: 'e',

--- a/apps/cli/src/commands/epic/create.ts
+++ b/apps/cli/src/commands/epic/create.ts
@@ -26,7 +26,7 @@ export default class EpicCreate extends PMOCommand {
     ...pmoBaseFlags,
     title: Flags.string({
       char: 't',
-      description: 'Epic title',
+      description: 'Epic title [required for non-interactive]',
     }),
     status: Flags.string({
       char: 's',

--- a/apps/cli/src/commands/phase/create.ts
+++ b/apps/cli/src/commands/phase/create.ts
@@ -25,7 +25,7 @@ export default class PhaseCreate extends PMOCommand {
     ...pmoBaseFlags,
     category: Flags.string({
       char: 'c',
-      description: 'State category',
+      description: 'State category [required for non-interactive]',
       options: ['backlog', 'unstarted', 'started', 'completed', 'canceled'],
     }),
     color: Flags.string({

--- a/apps/cli/src/commands/project/create.ts
+++ b/apps/cli/src/commands/project/create.ts
@@ -37,7 +37,7 @@ export default class ProjectCreate extends PMOCommand {
     ...pmoBaseFlags,
     name: Flags.string({
       char: 'n',
-      description: 'Project name',
+      description: 'Project name [required for non-interactive]',
     }),
     id: Flags.string({
       description: 'Custom project ID (auto-generated from name if not provided)',

--- a/apps/cli/src/commands/spec/create.ts
+++ b/apps/cli/src/commands/spec/create.ts
@@ -26,7 +26,7 @@ export default class SpecCreate extends PMOCommand {
     ...pmoBaseFlags,
     title: Flags.string({
       char: 't',
-      description: 'Spec title',
+      description: 'Spec title [required for non-interactive]',
     }),
     status: Flags.string({
       char: 's',

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -33,7 +33,7 @@ export default class TicketCreate extends PMOCommand {
     }),
     title: Flags.string({
       char: 't',
-      description: 'Ticket title',
+      description: 'Ticket title [required for non-interactive]',
     }),
     column: Flags.string({
       char: 'c',

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -53,7 +53,7 @@ export default class WorkSpawn extends PMOCommand {
     }),
     column: Flags.string({
       char: 'c',
-      description: 'Column name to spawn tickets from (used with --all)',
+      description: 'Column name to spawn tickets from [required for non-interactive with --all]',
     }),
     strategy: Flags.string({
       char: 's',


### PR DESCRIPTION
## Summary

Resolves TKT-860: Improve --help output to clearly show required vs optional flags

## Description

## Summary
Improve --help output to clearly show which flags are required vs optional for non-interactive execution.

## Implementation
1. oclif uses `required: true` on flags but doesn't display it prominently in help
2. Options:
   - Option A: Add custom help class that formats required flags differently
   - Option B: Add [required] suffix to flag descriptions manually
   - Option C: Add a 'Required Flags' section to help output

## Recommended: Option B (simplest)
Update flag descriptions to include [required] where needed:

```typescript
// Before
project: Flags.string({ char: 'P', description: 'Project ID' })

// After  
project: Flags.string({ char: 'P', description: 'Project ID [required for non-interactive]' })
```

## Commands to update
- ticket create
- project create
- work spawn
- Any command with required flags for non-interactive use

## Files to modify
- `src/commands/ticket/create.ts`
- `src/commands/project/create.ts`
- `src/commands/work/spawn.ts`
- Other create/action commands

## Acceptance Criteria
- [ ] Help output shows which flags are required for non-interactive/scripted use
- [ ] AI agents can read --help and know minimum flags needed

## Changes

- d105482 feat(TKT-860): Add [required for non-interactive] labels to flag descriptions in help output
- a737b43 Update LICENSE to Apache 2.0 (#315)
- db78a7c Update LICENSE to Apache 2.0 (#314)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
