### PR TITLE
TKT-859: Add --dry-run flag to validate command inputs without executing

### DIFF
--- a/apps/cli/src/commands/epic/create.ts
+++ b/apps/cli/src/commands/epic/create.ts
@@ -7,6 +7,8 @@ import { createEpicFile, getRelativeEpicPath } from '../../lib/pmo/epic-files.js
 import {
   shouldOutputJson,
   outputPromptAsJson,
+  outputDryRunSuccessAsJson,
+  outputDryRunErrorsAsJson,
   createMetadata,
   buildFormPromptConfig,
   FormField,
@@ -20,6 +22,7 @@ export default class EpicCreate extends PMOCommand {
     '<%= config.bin %> <%= command.id %> --title "User Authentication System"',
     '<%= config.bin %> <%= command.id %> -t "API Design" --status draft',
     '<%= config.bin %> <%= command.id %> -t "Implement Auth" --spec SPEC-001',
+    '<%= config.bin %> <%= command.id %> --title "Test" -P PROJ-001 --dry-run --json  # Validate without creating',
   ];
 
   static flags = {
@@ -45,6 +48,10 @@ export default class EpicCreate extends PMOCommand {
       char: 'm',
       aliases: ['machine'],
       description: 'Output prompt configuration as JSON (for AI agents/scripts)',
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Validate inputs without creating epic (use with --json for structured output)',
       default: false,
     }),
   };
@@ -117,8 +124,46 @@ export default class EpicCreate extends PMOCommand {
     if (epicData.specId) {
       const spec = await this.storage.getSpec(epicData.specId);
       if (!spec) {
+        if (flags['dry-run']) {
+          if (jsonMode) {
+            outputDryRunErrorsAsJson(
+              [{ field: 'spec', error: `Spec not found: ${epicData.specId}` }],
+              createMetadata('epic create', flags)
+            );
+          }
+        }
         this.error(`Spec not found: ${epicData.specId}`);
       }
+    }
+
+    // Handle dry-run: show what would be created without actually creating
+    if (flags['dry-run']) {
+      const projectName = await this.getProjectName(projectId);
+      const wouldCreate = {
+        title: epicData.title,
+        project: projectId,
+        status: epicData.status,
+        ...(epicData.description && { description: epicData.description }),
+        ...(epicData.specId && { spec: epicData.specId }),
+      };
+
+      if (jsonMode) {
+        outputDryRunSuccessAsJson('epic', wouldCreate, createMetadata('epic create', flags));
+      }
+
+      // Human-readable dry-run output
+      this.log(styles.warning('\n[DRY RUN] Would create epic:'));
+      this.log(styles.muted(`   Title: ${epicData.title}`));
+      this.log(styles.muted(`   Project: ${projectName}`));
+      this.log(styles.muted(`   Status: ${epicData.status}`));
+      if (epicData.description) {
+        this.log(styles.muted(`   Description: ${epicData.description}`));
+      }
+      if (epicData.specId) {
+        this.log(styles.muted(`   Spec: ${epicData.specId}`));
+      }
+      this.log(styles.muted('\n(No epic was created)'));
+      return;
     }
 
     const epic = await this.storage.createEpic(projectId, {

--- a/apps/cli/src/commands/project/create.ts
+++ b/apps/cli/src/commands/project/create.ts
@@ -9,6 +9,8 @@ import {
   shouldOutputJson,
   outputPromptAsJson,
   outputSuccessAsJson,
+  outputDryRunSuccessAsJson,
+  outputDryRunErrorsAsJson,
   createMetadata,
   buildFormPromptConfig,
   FormField,
@@ -24,6 +26,7 @@ export default class ProjectCreate extends PMOCommand {
     '<%= config.bin %> <%= command.id %> "My New Project"',
     '<%= config.bin %> <%= command.id %> --name "Mobile App" --description "iOS and Android app"',
     '<%= config.bin %> <%= command.id %> -i  # Interactive mode',
+    '<%= config.bin %> <%= command.id %> --name "Test" --dry-run --json  # Validate without creating',
   ];
 
   static args = {
@@ -55,6 +58,10 @@ export default class ProjectCreate extends PMOCommand {
     interactive: Flags.boolean({
       char: 'i',
       description: 'Interactive mode',
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Validate inputs without creating project (use with --json for structured output)',
       default: false,
     }),
   };
@@ -115,7 +122,45 @@ export default class ProjectCreate extends PMOCommand {
     // Check if project already exists
     const existing = await this.storage.getProject(projectId);
     if (existing) {
+      if (flags['dry-run']) {
+        if (jsonMode) {
+          outputDryRunErrorsAsJson(
+            [{ field: 'id', error: `Project "${projectId}" already exists` }],
+            createMetadata('project create', flags)
+          );
+        }
+      }
       this.error(`Project "${projectId}" already exists.`);
+    }
+
+    // Get the statuses from the workflow (for dry-run preview)
+    const statuses = await this.storage.listStatuses(projectData.template);
+
+    // Handle dry-run: show what would be created without actually creating
+    if (flags['dry-run']) {
+      const wouldCreate = {
+        id: projectId,
+        name: projectData.name,
+        template: projectData.template,
+        statuses: statuses.map(s => s.name),
+        ...(projectData.description && { description: projectData.description }),
+      };
+
+      if (jsonMode) {
+        outputDryRunSuccessAsJson('project', wouldCreate, createMetadata('project create', flags));
+      }
+
+      // Human-readable dry-run output
+      this.log(styles.warning('\n[DRY RUN] Would create project:'));
+      this.log(styles.muted(`   ID: ${projectId}`));
+      this.log(styles.muted(`   Name: ${projectData.name}`));
+      this.log(styles.muted(`   Template: ${projectData.template}`));
+      this.log(styles.muted(`   Statuses: ${statuses.map(s => s.name).join(' → ')}`));
+      if (projectData.description) {
+        this.log(styles.muted(`   Description: ${projectData.description}`));
+      }
+      this.log(styles.muted('\n(No project was created)'));
+      return;
     }
 
     // Create project in database
@@ -137,9 +182,6 @@ export default class ProjectCreate extends PMOCommand {
 
     // Create spec folders in project directory
     const specsPath = createSpecFolders(this.pmoPath, projectId);
-
-    // Get the statuses from the workflow (template name = workflow ID for built-in templates)
-    const statuses = await this.storage.listStatuses(projectData.template);
 
     // In JSON mode, output success with project details
     if (jsonMode) {

--- a/apps/cli/src/commands/spec/create.ts
+++ b/apps/cli/src/commands/spec/create.ts
@@ -3,7 +3,12 @@ import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import { slugify } from '../../lib/pmo/utils.js';
 import { SpecType, SpecStatus } from '../../lib/pmo/types.js';
-import { shouldOutputJson } from '../../lib/prompt-json.js';
+import {
+  shouldOutputJson,
+  outputDryRunSuccessAsJson,
+  outputDryRunErrorsAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
 import { FlagResolver } from '../../lib/flags/index.js';
 
 export default class SpecCreate extends PMOCommand {
@@ -13,6 +18,7 @@ export default class SpecCreate extends PMOCommand {
     '<%= config.bin %> <%= command.id %> "User Authentication"',
     '<%= config.bin %> <%= command.id %> --title "API Design" --type product',
     '<%= config.bin %> <%= command.id %> -i  # Interactive mode',
+    '<%= config.bin %> <%= command.id %> --title "Test" --dry-run --json  # Validate without creating',
   ];
 
   static args = {
@@ -44,6 +50,10 @@ export default class SpecCreate extends PMOCommand {
     interactive: Flags.boolean({
       char: 'i',
       description: 'Interactive mode',
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Validate inputs without creating spec (use with --json for structured output)',
       default: false,
     }),
   };
@@ -130,6 +140,49 @@ export default class SpecCreate extends PMOCommand {
 
     // Generate ID from title
     const specId = slugify(resolved.title!);
+
+    // Check if spec already exists
+    const existing = await this.storage.getSpec(specId);
+    if (existing) {
+      if (flags['dry-run']) {
+        if (jsonMode) {
+          outputDryRunErrorsAsJson(
+            [{ field: 'id', error: `Spec "${specId}" already exists` }],
+            createMetadata('spec create', flags)
+          );
+        }
+      }
+      this.error(`Spec "${specId}" already exists.`);
+    }
+
+    // Handle dry-run: show what would be created without actually creating
+    if (flags['dry-run']) {
+      const wouldCreate = {
+        id: specId,
+        title: resolved.title!,
+        status: resolved.status || 'draft',
+        ...(specType && { type: specType }),
+        ...(resolved.problem && { problem: resolved.problem }),
+      };
+
+      if (jsonMode) {
+        outputDryRunSuccessAsJson('spec', wouldCreate, createMetadata('spec create', flags));
+      }
+
+      // Human-readable dry-run output
+      this.log(styles.warning('\n[DRY RUN] Would create spec:'));
+      this.log(styles.muted(`   ID: ${specId}`));
+      this.log(styles.muted(`   Title: ${resolved.title}`));
+      this.log(styles.muted(`   Status: ${resolved.status || 'draft'}`));
+      if (specType) {
+        this.log(styles.muted(`   Type: ${specType}`));
+      }
+      if (resolved.problem) {
+        this.log(styles.muted(`   Problem: ${resolved.problem}`));
+      }
+      this.log(styles.muted('\n(No spec was created)'));
+      return;
+    }
 
     // Create spec in database
     const spec = await this.storage.createSpec({

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -7,6 +7,8 @@ import { TicketTemplate, PRIORITIES, PRIORITY_LABELS } from '../../lib/pmo/types
 import {
   shouldOutputJson,
   outputErrorAsJson,
+  outputDryRunSuccessAsJson,
+  outputDryRunErrorsAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js';
 import { FlagResolver } from '../../lib/flags/index.js';
@@ -21,6 +23,7 @@ export default class TicketCreate extends PMOCommand {
     '<%= config.bin %> <%= command.id %> --project mobile-app -t "New feature"',
     '<%= config.bin %> <%= command.id %> --epic EPIC-001 -t "Implement auth flow"',
     '<%= config.bin %> <%= command.id %> --json  # Output column choices as JSON',
+    '<%= config.bin %> <%= command.id %> --title "Test" -P PROJ-001 --dry-run --json  # Validate without creating',
   ];
 
   static flags = {
@@ -70,6 +73,10 @@ export default class TicketCreate extends PMOCommand {
     labels: Flags.string({
       char: 'l',
       description: 'Labels (comma-separated)',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Validate inputs without creating ticket (use with --json for structured output)',
+      default: false,
     }),
   };
 
@@ -202,7 +209,60 @@ export default class TicketCreate extends PMOCommand {
 
     // Validate status/column
     if (!columns.includes(ticketData.statusName)) {
+      if (flags['dry-run']) {
+        if (jsonMode) {
+          outputDryRunErrorsAsJson(
+            [{ field: 'column', error: `Invalid column "${ticketData.statusName}". Available: ${columns.join(', ')}` }],
+            createMetadata('ticket create', flags)
+          );
+        }
+        this.error(`Invalid column "${ticketData.statusName}". Available columns: ${columns.join(', ')}`);
+      }
       this.error(`Invalid column "${ticketData.statusName}". Available columns: ${columns.join(', ')}`);
+    }
+
+    // Handle dry-run: show what would be created without actually creating
+    if (flags['dry-run']) {
+      const wouldCreate = {
+        title: ticketData.title,
+        project: projectId,
+        column: ticketData.statusName,
+        ...(ticketData.priority && { priority: ticketData.priority }),
+        ...(ticketData.category && { category: ticketData.category }),
+        ...(ticketData.description && { description: ticketData.description }),
+        ...(ticketData.epicId && { epic: ticketData.epicId }),
+        ...(ticketData.labels && ticketData.labels.length > 0 && { labels: ticketData.labels }),
+      };
+
+      if (jsonMode) {
+        outputDryRunSuccessAsJson('ticket', wouldCreate, createMetadata('ticket create', flags));
+      }
+
+      // Human-readable dry-run output
+      this.log(styles.warning('\n[DRY RUN] Would create ticket:'));
+      this.log(styles.muted(`   Title: ${ticketData.title}`));
+      this.log(styles.muted(`   Project: ${projectName}`));
+      this.log(styles.muted(`   Column: ${ticketData.statusName}`));
+      if (ticketData.priority) {
+        this.log(styles.muted(`   Priority: ${ticketData.priority}`));
+      }
+      if (ticketData.category) {
+        this.log(styles.muted(`   Category: ${ticketData.category}`));
+      }
+      if (ticketData.epicId) {
+        this.log(styles.muted(`   Epic: ${ticketData.epicId}`));
+      }
+      if (ticketData.labels && ticketData.labels.length > 0) {
+        this.log(styles.muted(`   Labels: ${ticketData.labels.join(', ')}`));
+      }
+      if (template) {
+        this.log(styles.muted(`   Template: ${template.name}`));
+        if (template.suggestedSubtasks.length > 0) {
+          this.log(styles.muted(`   Subtasks: ${template.suggestedSubtasks.length} would be created`));
+        }
+      }
+      this.log(styles.muted('\n(No ticket was created)'));
+      return;
     }
 
     const ticket = await this.storage.createTicket(projectId, {

--- a/apps/cli/src/lib/prompt-json.ts
+++ b/apps/cli/src/lib/prompt-json.ts
@@ -135,9 +135,31 @@ export interface ErrorJsonOutput {
 }
 
 /**
+ * JSON output for dry-run validation (what would happen)
+ */
+export interface DryRunJsonOutput {
+  /** Indicates this is a dry-run result */
+  type: 'dry-run'
+  /** Whether the inputs are valid */
+  valid: boolean
+  /** What would be created if valid */
+  wouldCreate?: {
+    type: string
+    [key: string]: unknown
+  }
+  /** Validation errors if invalid */
+  errors?: Array<{
+    field: string
+    error: string
+  }>
+  /** Command metadata */
+  metadata: OutputMetadata
+}
+
+/**
  * Union type for all JSON output types
  */
-export type JsonOutput = PromptJsonOutput | SuccessJsonOutput | ErrorJsonOutput
+export type JsonOutput = PromptJsonOutput | SuccessJsonOutput | ErrorJsonOutput | DryRunJsonOutput
 
 /**
  * Flags interface for JSON mode detection
@@ -407,4 +429,55 @@ export function buildFormPromptConfig(
     type: 'form',
     fields,
   }
+}
+
+/**
+ * Output a successful dry-run result as JSON and exit
+ *
+ * Use this when --dry-run is set and all validation passes.
+ * Shows what would be created without actually creating it.
+ *
+ * @param entityType - Type of entity that would be created (e.g., "ticket", "project")
+ * @param wouldCreate - Data about what would be created
+ * @param metadata - Command metadata
+ */
+export function outputDryRunSuccessAsJson(
+  entityType: string,
+  wouldCreate: Record<string, unknown>,
+  metadata: OutputMetadata
+): never {
+  const output: DryRunJsonOutput = {
+    type: 'dry-run',
+    valid: true,
+    wouldCreate: {
+      type: entityType,
+      ...wouldCreate,
+    },
+    metadata,
+  }
+  console.log(JSON.stringify(output, null, 2))
+  process.exit(EXIT_SUCCESS)
+}
+
+/**
+ * Output a dry-run validation failure as JSON and exit
+ *
+ * Use this when --dry-run is set and validation fails.
+ * Shows the validation errors without attempting to create.
+ *
+ * @param errors - Array of validation errors
+ * @param metadata - Command metadata
+ */
+export function outputDryRunErrorsAsJson(
+  errors: Array<{ field: string; error: string }>,
+  metadata: OutputMetadata
+): never {
+  const output: DryRunJsonOutput = {
+    type: 'dry-run',
+    valid: false,
+    errors,
+    metadata,
+  }
+  console.log(JSON.stringify(output, null, 2))
+  process.exit(EXIT_ERROR)
 }


### PR DESCRIPTION
## Summary

Resolves TKT-859: Add --dry-run flag to validate command inputs without executing

## Description

## Summary
Add --dry-run flag to validate command inputs without executing, returning what would happen.

## Implementation
1. Add `--dry-run` flag to commands that create/modify data (ticket create, project create, etc.)
2. When --dry-run is set, validate all inputs and return a preview without executing
3. Works with --json to output structured validation result

## Example Usage
```bash
prlt ticket create --title "Test" -P PROJ-001 --dry-run --json
```

## Example Output
```json
{
  "type": "dry-run",
  "valid": true,
  "wouldCreate": {
    "type": "ticket",
    "title": "Test",
    "project": "PROJ-001",
    "column": "Backlog"
  }
}
```

Or if invalid:
```json
{
  "type": "dry-run",
  "valid": false,
  "errors": [
    { "field": "project", "error": "Project not found" }
  ]
}
```

## Commands to add --dry-run
- ticket create
- project create  
- spec create
- epic create

## Files to modify
- `src/commands/ticket/create.ts`
- `src/commands/project/create.ts`
- `src/commands/spec/create.ts`
- `src/commands/epic/create.ts`

## Acceptance Criteria
- [ ] --dry-run flag validates inputs without executing
- [ ] Returns structured JSON showing what would be created
- [ ] Returns validation errors if inputs are invalid

## Changes

- 5a2e380 feat(TKT-859): add --dry-run flag to ticket, project, spec, and epic create commands
- a737b43 Update LICENSE to Apache 2.0 (#315)
- db78a7c Update LICENSE to Apache 2.0 (#314)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
