### PR TITLE
TKT-882: Add custom/ad-hoc action option to spawn action picker

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -686,10 +686,14 @@ export default class WorkSpawn extends PMOCommand {
         } else if (flags.action === 'custom') {
           // Custom action specified via flag - require --message
           if (!flags.message) {
+            db.close()
             return handleError('MISSING_MESSAGE', '--action custom requires --message flag with the custom prompt')
           }
           batchAction = 'custom'
           batchCustomMessage = flags.message
+        } else if (flags.message && flags.action !== 'custom') {
+          // --message provided without --action custom - warn user
+          this.warn('--message flag is only used with --action custom, ignoring')
         }
 
         // Now fetch action details after selection is made
@@ -1072,6 +1076,12 @@ export default class WorkSpawn extends PMOCommand {
             if (batchRunOnHost) startArgs.push('--run-on-host')
             if (flags.force) startArgs.push('--force')
             if (flags.focus) startArgs.push('--focus')
+            // Pass action/prompt - custom action uses --prompt, others use --action
+            if (batchAction === 'custom' && batchCustomMessage) {
+              startArgs.push('--prompt', batchCustomMessage)
+            } else if (batchAction) {
+              startArgs.push('--action', batchAction)
+            }
           } else {
             // Batch mode: pass all settings to skip prompts
             // batchDisplayMode is for devcontainer, batchDisplay is for host

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -677,7 +677,7 @@ export default class WorkStart extends PMOCommand {
         // Handle special "custom" action - requires --prompt flag
         if (flags.action === 'custom') {
           db.close()
-          this.error('--action custom requires --prompt flag.\nUsage: prlt work start TKT-001 --prompt "your custom instructions"')
+          this.error('--action custom requires --prompt flag.\nUsage: prlt work start TKT-001 --action custom --prompt "your custom instructions"')
         }
         // Specific action requested
         selectedAction = await this.storage.getAction(flags.action)


### PR DESCRIPTION
## Summary

Resolves TKT-882: Add custom/ad-hoc action option to spawn action picker

## Description

## Problem
When spawning work, users must pick from predefined actions (groom, implement, review, etc.). There's no way to type a custom prompt or ad-hoc instruction for the agent.

## Requirements
- R1: Add "Custom" or "Ad-hoc" option to the action picker in `prlt work spawn` and `prlt work start`
- R2: When selected, prompt user for a custom instruction/prompt text
- R3: Custom prompt is passed to the agent as the action
- R4: Support via flag too: `prlt work spawn TKT-123 --action custom --message "do X"`
- R5: Works in both interactive and JSON modes

## Done when
- [ ] "Custom" appears as an option in the action picker
- [ ] User can type a custom prompt when selected
- [ ] Agent receives and executes the custom prompt
- [ ] --action custom --message flag works
- [ ] JSON mode supported

## Related
- TKT-680 (--message flag to append custom instructions) - complements but different: that appends to existing actions, this IS the action
- TKT-685 (Refactor action definitions) - architectural foundation

## Changes

- fed94b0 feat(TKT-882): add custom/ad-hoc action option to spawn action picker

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for a "custom" action allowing users to supply ad-hoc prompts to the agent.
  * New --message flag to pass custom prompts non-interactively when using --action custom.
  * Interactive selection now includes a custom action option in batch flows.

* **Bug Fixes**
  * Validates presence of a custom prompt and returns a clear error if missing when required.

* **Documentation**
  * Updated examples and help text to show custom action usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->