### PR TITLE
TKT-692: Add --to-project flag to ticket move command for cross-project moves

### DIFF
--- a/apps/cli/src/commands/ticket/move.ts
+++ b/apps/cli/src/commands/ticket/move.ts
@@ -172,7 +172,7 @@ export default class TicketMove extends PMOCommand {
 
         // If user chose different project, handle cross-project move
         if (moveType === 'project') {
-          const targetProject = await this.selectFromList({
+          const targetProjectId = await this.selectFromList({
             message: 'Select target project:',
             items: otherProjects,
             getName: (p) => `${p.name} (${p.id})`,
@@ -181,11 +181,30 @@ export default class TicketMove extends PMOCommand {
             jsonMode: jsonMode ? { flags, commandName: 'ticket move' } : null,
           });
 
-          if (!targetProject) {
+          if (!targetProjectId) {
             return; // Cancelled or JSON mode
           }
 
-          await this.executeCrossProjectMove(ticket, targetProject, undefined, jsonMode, flags);
+          // Get columns from target project and ask which column to move to
+          const targetProjectBoard = await this.storage.getProjectBoard(targetProjectId);
+          if (!targetProjectBoard) {
+            this.error('Target project not found.');
+          }
+
+          const targetColumnName = await this.selectFromList({
+            message: 'Move to column:',
+            items: targetProjectBoard.columns as { name: string }[],
+            getName: (col) => col.name,
+            getValue: (col) => col.name,
+            getCommand: (col) => `prlt ticket move ${ticketId} "${col.name}" --to-project ${targetProjectId} --json`,
+            jsonMode: jsonMode ? { flags, commandName: 'ticket move' } : null,
+          });
+
+          if (!targetColumnName) {
+            return; // Cancelled or JSON mode
+          }
+
+          await this.executeCrossProjectMove(ticket, targetProjectId, targetColumnName, jsonMode, flags);
           return;
         }
       }


### PR DESCRIPTION
## Summary

Resolves TKT-692: Add --to-project flag to ticket move command for cross-project moves

## Description

Currently `prlt ticket move` only moves tickets between columns within the same project. The `--project` flag is just for specifying which project to look in, not for moving to a different project.

**Expected:** `prlt ticket move TKT-123 --to-project PROJ-002` should move the ticket to a different project.

**Workaround:** Delete and recreate the ticket in the target project.

**Implementation:**
- Add `--to-project` flag to ticket move command
- Update the ticket's project_id in the database
- Handle column mapping (use Backlog as default if target project has different columns)

## Changes

- 2a77e3a feat(TKT-692): add --to-project flag to ticket move command

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
