### PR TITLE
TKT-891: BUG: Background display mode not working for work spawn

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -1706,9 +1706,11 @@ exec bash
       }
     }
 
-    // Step 2: Create tmux session with bash explicitly (not default shell which may be zsh)
-    // Using bash avoids zsh-newuser-install prompt that blocks the session
-    const createSessionCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" bash${mouseOption} \\; set-option -g set-titles on \\; set-option -g set-titles-string "#{window_name}"`
+    // Step 2: Create tmux session running the script directly
+    // Pass the script as the session command (like host runner does) instead of using send-keys.
+    // The send-keys approach had a race condition where keys could be lost if bash hadn't
+    // fully initialized, causing background mode to create empty sessions without running claude.
+    const createSessionCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "bash ${scriptPath}"${mouseOption} \\; set-option -g set-titles on \\; set-option -g set-titles-string "#{window_name}"`
     try {
       execSync(`docker exec ${actualContainerId} bash -c '${createSessionCmd}'`, { stdio: 'pipe' })
     } catch (error) {
@@ -1718,21 +1720,23 @@ exec bash
       }
     }
 
-    // Step 3: Send keys to run the script (this runs in the interactive bash)
-    const sendKeysCmd = `tmux send-keys -t "${sessionName}" "source ${scriptPath}" Enter`
-    try {
-      execSync(`docker exec ${actualContainerId} bash -c '${sendKeysCmd}'`, { stdio: 'pipe' })
-    } catch (error) {
-      return {
-        success: false,
-        error: `Failed to start script in tmux session: ${error instanceof Error ? error.message : error}`,
-      }
-    }
-
-    // Step 2: Open iTerm tab that attaches directly to container's tmux
-    // Skip this step for background mode - just return success after tmux session is created
+    // Step 3: Handle display mode
+    // For background mode, return success after tmux session is created
     // User can reattach later with `prlt session attach`
     if (displayMode === 'background') {
+      // Verify the tmux session was actually created (brief delay to let tmux start)
+      await new Promise(resolve => setTimeout(resolve, 500))
+      try {
+        execSync(
+          `docker exec ${actualContainerId} tmux has-session -t "${sessionName}" 2>&1`,
+          { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        )
+      } catch (err) {
+        return {
+          success: false,
+          error: `Failed to verify tmux session "${sessionName}" inside container. The session may not have started correctly.`,
+        }
+      }
       return {
         success: true,
         containerId: actualContainerId,
@@ -1740,7 +1744,7 @@ exec bash
       }
     }
 
-    // Foreground mode: attach to container's tmux session in current terminal (blocking)
+    // For foreground mode: attach to container's tmux session in current terminal (blocking)
     if (displayMode === 'foreground') {
       try {
         // Clear screen and attach - this blocks until user detaches or claude exits


### PR DESCRIPTION
## Summary

Resolves TKT-891: BUG: Background display mode not working for work spawn

## Description

## Problem
`prlt work spawn --display background` does not work. Agents are not spawned in background tmux sessions as expected. Only `--display terminal` (new tab) works currently.

## Expected Behavior
`--display background` should spawn agents in detached tmux sessions that run in the background. Users can then attach to them later with `prlt session attach` or `tmux attach`.

## Reproduction
```bash
prlt work spawn TKT-XXX --display background --skip-permissions --action implement --yes
# Expected: agent running in background tmux session
# Actual: ???
```

## Investigation Needed
- Check `apps/cli/src/commands/work/spawn.ts` — how display mode is passed to work start
- Check `apps/cli/src/commands/work/start.ts` — how display mode affects execution
- Check `apps/cli/src/lib/execution/runners.ts` — how background vs terminal tmux sessions are created
- Check `apps/cli/src/lib/execution/spawner.ts` — how display mode flows through to runner

## Done when
- [ ] `prlt work spawn TKT-XXX --display background` creates detached tmux sessions
- [ ] Agents run and complete work in background
- [ ] `prlt session list` shows background sessions
- [ ] `prlt session attach` can connect to background sessions
- [ ] Both host and Docker environments work with background mode

## Changes

- b60bee8 fix(TKT-891): fix background display mode for work spawn by running script directly in tmux

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a race condition that could cause input loss during session initialization.
* Added verification in background mode to ensure tmux sessions are properly created.
* Improved error messaging for session creation and verification failures.
* Enhanced attachment handling for foreground mode execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->