### PR TITLE
TKT-907: Fix claude.ts missing return after outputPromptAsJson

### DIFF
--- a/apps/cli/src/commands/claude.ts
+++ b/apps/cli/src/commands/claude.ts
@@ -214,6 +214,7 @@ export default class Claude extends Command {
           validate: (input: unknown) => (input as string).trim() ? true : 'Session name required',
         },
       ], jsonModeConfig)
+      if (jsonMode) return
       slug = inputSlug.trim()
     }
 
@@ -373,6 +374,7 @@ export default class Claude extends Command {
           default: 'terminal',
         },
       ], jsonModeConfig)
+      if (jsonMode) return
       displayMode = selectedDisplay as DisplayMode
     }
 
@@ -393,6 +395,7 @@ export default class Claude extends Command {
           default: 'danger',
         },
       ], jsonModeConfig)
+      if (jsonMode) return
       sandboxed = permissionMode === 'safe'
     }
 
@@ -631,6 +634,7 @@ export default class Claude extends Command {
               })),
             },
           ], jsonModeConfig)
+          if (jsonMode) { db.close(); return }
           projectId = selectedProject
         }
       }
@@ -647,6 +651,7 @@ export default class Claude extends Command {
             validate: (input: unknown) => (input as string).trim() ? true : 'Title required',
           },
         ], jsonModeConfig)
+        if (jsonMode) { db.close(); return }
         ticketTitle = inputTitle.trim()
       }
 
@@ -822,6 +827,7 @@ export default class Claude extends Command {
             default: 'terminal',
           },
         ], jsonModeConfig)
+        if (jsonMode) { db.close(); return }
         displayMode = selectedDisplay as DisplayMode
       }
 
@@ -843,6 +849,7 @@ export default class Claude extends Command {
             default: 'danger',
           },
         ], jsonModeConfig)
+        if (jsonMode) { db.close(); return }
         sandboxed = permissionMode === 'safe'
       }
 


### PR DESCRIPTION
## Summary

Resolves TKT-907: Fix claude.ts missing return after outputPromptAsJson

## Description

## Problem
In claude.ts, multiple locations call outputPromptAsJson() without a return statement, causing code to fall through to inquirer.prompt() after JSON output. This means in JSON/agent mode, the CLI outputs JSON AND then tries to display an interactive prompt.

## Example (line 168-178)
if (jsonMode) {
  outputPromptAsJson(...)
  // BUG: no return here - falls through to inquirer.prompt below
}
const { inputSlug } = await inquirer.prompt([...])

## Files
- src/commands/claude.ts (~10 spots)

## Requirements
- R1: Add return statement after every outputPromptAsJson() call
- R2: Verify --json flag works correctly for all claude command prompts
- R3: No interactive prompts should appear in JSON mode

## Changes

- 6a4e5c3 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
