### PR TITLE
TKT-908: Fix whoami command missing this.parse() call

### DIFF
--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -13,6 +13,7 @@ export default class Whoami extends Command {
   ];
 
   async run(): Promise<void> {
+    await this.parse(Whoami);
     const isDevcontainer = process.env.DEVCONTAINER === 'true';
     const agentName = this.detectAgentName();
     const repoName = this.detectRepoName();


### PR DESCRIPTION
## Summary

Resolves TKT-908: Fix whoami command missing this.parse() call

## Description

## Problem
The whoami command does not call this.parse(), causing oclif to emit 7 UnparsedCommand warnings every time the CLI runs (since whoami is referenced in tests and internal flows).

Warning: Command whoami did not parse its arguments. Did you forget to call this.parse?

## Files
- src/commands/whoami.ts

## Requirements
- R1: Add this.parse() call to the whoami command
- R2: Verify no more UnparsedCommand warnings in test output

## Changes

- 54dbe8f fix(TKT-908): add missing this.parse() call to whoami command

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
