### PR TITLE
TKT-911: Migrate ticket/* commands to this.prompt() for JSON mode safety

### DIFF
--- a/apps/cli/src/commands/template/create.ts
+++ b/apps/cli/src/commands/template/create.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { PRIORITIES, PRIORITY_LABELS, TICKET_CATEGORIES } from '../../lib/pmo/types.js';
 import { styles } from '../../lib/styles.js';
@@ -105,16 +104,16 @@ export default class TemplateCreate extends PMOCommand {
         return;
       }
 
-      const { selectedType } = await inquirer.prompt([{
+      const { selectedType } = await this.prompt<{ selectedType: string }>([{
         type: 'list',
         name: 'selectedType',
         message: 'What type of template?',
         choices: [
-          { name: 'Ticket template', value: 'ticket' },
-          { name: 'Phase template', value: 'phase' },
+          { name: 'Ticket template', value: 'ticket', command: 'prlt template create --type ticket --json' },
+          { name: 'Phase template', value: 'phase', command: 'prlt template create --type phase --json' },
         ],
-      }]);
-      templateType = selectedType;
+      }], jsonMode ? { flags, commandName: 'template create' } : null);
+      templateType = selectedType as TemplateType;
     }
 
     if (templateType === 'ticket') {
@@ -158,12 +157,13 @@ export default class TemplateCreate extends PMOCommand {
         return;
       }
 
-      const { templateName } = await inquirer.prompt([{
+      const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'template create' } : null;
+      const { templateName } = await this.prompt<{ templateName: string }>([{
         type: 'input',
         name: 'templateName',
         message: 'Template name:',
-        validate: (input: string) => input.trim() ? true : 'Name required',
-      }]);
+        validate: (input: unknown) => (input as string).trim() ? true : 'Name required',
+      }], jsonModeConfig);
       name = templateName;
     }
 
@@ -179,14 +179,14 @@ export default class TemplateCreate extends PMOCommand {
 
     // Interactive prompts for missing optional values
     if (!jsonMode && description === undefined) {
-      const { desc } = await inquirer.prompt([{
+      const { desc } = await this.prompt<{ desc: string }>([{
         type: 'input', name: 'desc', message: 'Description (optional):',
-      }]);
+      }], null);
       description = desc || undefined;
     }
 
     if (!jsonMode && priority === undefined) {
-      const { p } = await inquirer.prompt([{
+      const { p } = await this.prompt<{ p: string }>([{
         type: 'list',
         name: 'p',
         message: 'Default priority:',
@@ -194,12 +194,12 @@ export default class TemplateCreate extends PMOCommand {
           { name: 'None', value: '' },
           ...PRIORITIES.map(pr => ({ name: PRIORITY_LABELS[pr], value: pr })),
         ],
-      }]);
+      }], null);
       priority = p || undefined;
     }
 
     if (!jsonMode && category === undefined) {
-      const { c } = await inquirer.prompt([{
+      const { c } = await this.prompt<{ c: string }>([{
         type: 'list',
         name: 'c',
         message: 'Default category:',
@@ -207,7 +207,7 @@ export default class TemplateCreate extends PMOCommand {
           { name: 'None', value: '' },
           ...TICKET_CATEGORIES.map(cat => ({ name: cat, value: cat })),
         ],
-      }]);
+      }], null);
       category = c || undefined;
     }
 
@@ -250,20 +250,21 @@ export default class TemplateCreate extends PMOCommand {
         return;
       }
 
-      const { templateName } = await inquirer.prompt([{
+      const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'template create' } : null;
+      const { templateName } = await this.prompt<{ templateName: string }>([{
         type: 'input',
         name: 'templateName',
         message: 'Template name:',
-        validate: (input: string) => input.trim() ? true : 'Name required',
-      }]);
+        validate: (input: unknown) => (input as string).trim() ? true : 'Name required',
+      }], jsonModeConfig);
       name = templateName;
     }
 
     let description = flags.description as string | undefined;
     if (!jsonMode && description === undefined) {
-      const { desc } = await inquirer.prompt([{
+      const { desc } = await this.prompt<{ desc: string }>([{
         type: 'input', name: 'desc', message: 'Description (optional):',
-      }]);
+      }], null);
       description = desc || undefined;
     }
 

--- a/apps/cli/src/commands/template/index.ts
+++ b/apps/cli/src/commands/template/index.ts
@@ -1,9 +1,9 @@
-import { Command, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
+import { Flags } from '@oclif/core';
 import { styles } from '../../lib/styles.js';
 import { shouldOutputJson, outputPromptAsJson, buildPromptConfig, createMetadata } from '../../lib/prompt-json.js';
+import { PromptCommand } from '../../lib/prompt-command.js';
 
-export default class Template extends Command {
+export default class Template extends PromptCommand {
   static description = 'Manage templates (ticket and phase)';
 
   static aliases = ['templates'];
@@ -49,12 +49,12 @@ export default class Template extends Command {
     this.log(`\n${styles.emphasis('Templates')}`);
     this.log(styles.muted('Manage ticket and phase templates\n'));
 
-    const { action } = await inquirer.prompt([{
+    const { action } = await this.prompt<{ action: string }>([{
       type: 'list',
       name: 'action',
       message: 'What would you like to do?',
-      choices: menuChoices.map(c => ({ name: c.name, value: c.value })),
-    }]);
+      choices: menuChoices.map(c => ({ name: c.name, value: c.value, command: c.command })),
+    }], null);
 
     if (action === 'cancel') return;
 

--- a/apps/cli/src/commands/template/save.ts
+++ b/apps/cli/src/commands/template/save.ts
@@ -1,5 +1,4 @@
 import { Flags, Args } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import {
@@ -74,12 +73,13 @@ export default class TemplateSave extends PMOCommand {
         return;
       }
 
-      const { selected } = await inquirer.prompt([{
+      const jsonModeConfig = jsonMode ? { flags, commandName: 'template save' } : null;
+      const { selected } = await this.prompt<{ selected: string }>([{
         type: 'list',
         name: 'selected',
         message: 'Select ticket:',
-        choices: tickets.slice(0, 20).map(t => ({ name: `${t.id} - ${t.title}`, value: t.id })),
-      }]);
+        choices: tickets.slice(0, 20).map(t => ({ name: `${t.id} - ${t.title}`, value: t.id, command: `prlt template save ${t.id} --json` })),
+      }], jsonModeConfig);
       ticketId = selected;
     }
 
@@ -96,20 +96,21 @@ export default class TemplateSave extends PMOCommand {
         return;
       }
 
-      const { name } = await inquirer.prompt([{
+      const jsonModeConfig2 = jsonMode ? { flags, commandName: 'template save' } : null;
+      const { name } = await this.prompt<{ name: string }>([{
         type: 'input',
         name: 'name',
         message: 'Template name:',
         default: ticket.category || ticket.title.split(' ')[0],
-        validate: (i: string) => i.length > 0 || 'Required',
-      }]);
+        validate: (i: unknown) => (i as string).length > 0 || 'Required',
+      }], jsonModeConfig2);
       templateName = name;
     }
 
     // Get description
     let description = flags.description;
     if (description === undefined && !jsonMode) {
-      const { desc } = await inquirer.prompt([{ type: 'input', name: 'desc', message: 'Description (optional):' }]);
+      const { desc } = await this.prompt<{ desc: string }>([{ type: 'input', name: 'desc', message: 'Description (optional):' }], null);
       description = desc || undefined;
     }
 

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -1,6 +1,7 @@
 import { Flags } from '@oclif/core';
 import inquirer from 'inquirer';
 import { autoExportToBoard, PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+// Note: inquirer import kept for inquirer.Separator usage in interactive mode
 import { styles } from '../../lib/styles.js';
 import { updateEpicTicketsSection } from '../../lib/pmo/epic-files.js';
 import { TicketTemplate, PRIORITIES, PRIORITY_LABELS } from '../../lib/pmo/types.js';
@@ -359,7 +360,7 @@ export default class TicketCreate extends PMOCommand {
     if (!template && !flags.template) {
       const templates = await storage.listTicketTemplates();
       if (templates.length > 0) {
-        const { selectedTemplate } = await inquirer.prompt<{ selectedTemplate: string }>([
+        const { selectedTemplate } = await this.prompt<{ selectedTemplate: string }>([
           {
             type: 'list',
             name: 'selectedTemplate',
@@ -373,7 +374,7 @@ export default class TicketCreate extends PMOCommand {
               })),
             ],
           },
-        ]);
+        ], null);
 
         if (selectedTemplate) {
           template = templates.find(t => t.id === selectedTemplate) || null;
@@ -381,27 +382,30 @@ export default class TicketCreate extends PMOCommand {
       }
     }
 
-    const answers = await inquirer.prompt<{
-      title: string;
-      column: string;
-      priority?: string;
-      categoryChoice: string;
-      customCategory?: string;
-    }>([
+    // Prompt for title
+    const { title: answerTitle } = await this.prompt<{ title: string }>([
       {
         type: 'input',
         name: 'title',
         message: 'Ticket title:',
         default: flags.title || template?.titlePattern,
-        validate: (input: string) => input.trim() ? true : 'Title cannot be empty',
+        validate: (input: unknown) => (input as string).trim() ? true : 'Title cannot be empty',
       },
+    ], null);
+
+    // Prompt for column
+    const { column: answerColumn } = await this.prompt<{ column: string }>([
       {
         type: 'list',
         name: 'column',
         message: 'Column:',
-        choices: columns,
+        choices: columns.map(c => ({ name: c, value: c })),
         default: flags.column || columns[0],
       },
+    ], null);
+
+    // Prompt for priority
+    const { priority: answerPriority } = await this.prompt<{ priority?: string }>([
       {
         type: 'list',
         name: 'priority',
@@ -412,6 +416,10 @@ export default class TicketCreate extends PMOCommand {
         ],
         default: flags.priority || template?.defaultPriority,
       },
+    ], null);
+
+    // Prompt for category
+    const { categoryChoice } = await this.prompt<{ categoryChoice: string }>([
       {
         type: 'list',
         name: 'categoryChoice',
@@ -443,14 +451,21 @@ export default class TicketCreate extends PMOCommand {
         ],
         default: flags.category || template?.defaultCategory || '',
       },
-      {
+    ], null);
+
+    // Custom category prompt if needed
+    let customCategory: string | undefined;
+    if (categoryChoice === '__custom__') {
+      const result = await this.prompt<{ customCategory: string }>([{
         type: 'input',
         name: 'customCategory',
         message: 'Enter custom category:',
-        when: (answers: { categoryChoice: string }) => answers.categoryChoice === '__custom__',
-        validate: (input: string) => input.trim() ? true : 'Category cannot be empty',
-      },
-    ]);
+        validate: (input: unknown) => (input as string).trim() ? true : 'Category cannot be empty',
+      }], null);
+      customCategory = result.customCategory;
+    }
+
+    const answers = { title: answerTitle, column: answerColumn, priority: answerPriority, categoryChoice, customCategory };
 
     // Resolve category from choice or custom input
     const category = answers.categoryChoice === '__custom__'
@@ -488,14 +503,14 @@ export default class TicketCreate extends PMOCommand {
     this.log(styles.muted('\n─── Ticket Description (for agent execution) ───'));
 
     // Prompt for "What" - the main outcome
-    const { what } = await inquirer.prompt<{ what: string }>([
+    const { what } = await this.prompt<{ what: string }>([
       {
         type: 'input',
         name: 'what',
         message: 'What is the concrete outcome? (one sentence):',
-        validate: (input: string) => input.trim() ? true : 'Outcome cannot be empty - what does success look like?',
+        validate: (input: unknown) => (input as string).trim() ? true : 'Outcome cannot be empty - what does success look like?',
       },
-    ]);
+    ], null);
 
     // Prompt for acceptance criteria using multiline input
     const doneWhenResult = await multiLineInput({
@@ -508,23 +523,23 @@ export default class TicketCreate extends PMOCommand {
     }
 
     // Continue with remaining prompts
-    const { context, notInScope } = await inquirer.prompt<{
-      context: string;
-      notInScope: string;
-    }>([
+    const { context } = await this.prompt<{ context: string }>([
       {
         type: 'input',
         name: 'context',
         message: 'Context (files, patterns, hints - optional):',
         default: '',
       },
+    ], null);
+
+    const { notInScope } = await this.prompt<{ notInScope: string }>([
       {
         type: 'input',
         name: 'notInScope',
         message: 'Not in scope (explicit exclusions - optional):',
         default: '',
       },
-    ]);
+    ], null);
 
     // Build structured description
     const parts: string[] = [];

--- a/apps/cli/src/commands/ticket/delete.ts
+++ b/apps/cli/src/commands/ticket/delete.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import {
   autoExportToBoard,
   PMOCommand,
@@ -75,7 +74,7 @@ export default class TicketDelete extends PMOCommand {
 
     // Bulk mode
     if (flags.bulk) {
-      await this.executeBulk(allTickets, flags.force);
+      await this.executeBulk(allTickets, flags.force, flags);
       return;
     }
 
@@ -115,16 +114,17 @@ export default class TicketDelete extends PMOCommand {
       this.log(`  Project: ${board.name}`);
       this.log(`  Status: ${ticket.statusName}`);
 
-      const { confirmed } = await inquirer.prompt([{
+      const jsonModeConfig = jsonMode ? { flags, commandName: 'ticket delete' } : null;
+      const { confirmed } = await this.prompt<{ confirmed: boolean }>([{
         type: 'list',
         name: 'confirmed',
         message: 'Are you sure?',
         choices: [
-          { name: 'No, cancel', value: false },
-          { name: 'Yes, delete', value: true },
+          { name: 'No, cancel', value: false, command: '' },
+          { name: 'Yes, delete', value: true, command: `prlt ticket delete ${ticketId} --force --json` },
         ],
         default: 0,
-      }]);
+      }], jsonModeConfig);
 
       if (!confirmed) {
         this.log(styles.warning('Deletion cancelled.'));
@@ -144,12 +144,15 @@ export default class TicketDelete extends PMOCommand {
 
   private async executeBulk(
     allTickets: Awaited<ReturnType<typeof this.storage.listTickets>>,
-    force: boolean
+    force: boolean,
+    flags?: Record<string, unknown>
   ): Promise<void> {
+    const jsonMode = flags ? shouldOutputJson(flags) : false;
+    const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket delete' } : null;
     this.log(styles.emphasis('🗑️  Delete Multiple Tickets\n'));
 
     // Select tickets to delete
-    const { selectedTickets } = await inquirer.prompt([{
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
       type: 'checkbox',
       name: 'selectedTickets',
       message: 'Select tickets to DELETE:',
@@ -157,7 +160,7 @@ export default class TicketDelete extends PMOCommand {
         name: `${t.id} - ${t.title} (${t.statusName})`,
         value: t.id,
       })),
-    }]);
+    }], jsonModeConfig);
 
     if (selectedTickets.length === 0) {
       this.log(styles.muted('No tickets selected.'));
@@ -173,16 +176,16 @@ export default class TicketDelete extends PMOCommand {
       }
       this.log('');
 
-      const { confirm } = await inquirer.prompt([{
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
         type: 'list',
         name: 'confirm',
         message: 'Are you sure? This cannot be undone.',
         choices: [
-          { name: 'No, cancel', value: false },
-          { name: 'Yes, DELETE tickets', value: true }
+          { name: 'No, cancel', value: false, command: '' },
+          { name: 'Yes, DELETE tickets', value: true, command: 'prlt ticket delete --bulk --force --json' }
         ],
         default: 0
-      }]);
+      }], jsonModeConfig);
 
       if (!confirm) {
         this.log(styles.muted('Deletion cancelled.'));

--- a/apps/cli/src/commands/ticket/edit.ts
+++ b/apps/cli/src/commands/ticket/edit.ts
@@ -308,15 +308,15 @@ export default class TicketEdit extends PMOCommand {
     category?: string;
   }> {
     // First prompt for title
-    const { title } = await inquirer.prompt<{ title: string }>([
+    const { title } = await this.prompt<{ title: string }>([
       {
         type: 'input',
         name: 'title',
         message: 'Title:',
         default: ticket.title,
-        validate: (input: string) => input.trim() ? true : 'Title cannot be empty',
+        validate: (input: unknown) => (input as string).trim() ? true : 'Title cannot be empty',
       },
-    ]);
+    ], null);
 
     // Prompt for description using inline multiline input
     const descResult = await multiLineInput({
@@ -329,12 +329,8 @@ export default class TicketEdit extends PMOCommand {
       throw new Error('Edit cancelled');
     }
 
-    // Continue with remaining prompts
-    const answers = await inquirer.prompt<{
-      priority: string;
-      categoryChoice: string;
-      customCategory?: string;
-    }>([
+    // Continue with remaining prompts - priority first
+    const { priority } = await this.prompt<{ priority: string }>([
       {
         type: 'list',
         name: 'priority',
@@ -345,6 +341,10 @@ export default class TicketEdit extends PMOCommand {
         ],
         default: ticket.priority || '',
       },
+    ], null);
+
+    // Then category
+    const { categoryChoice } = await this.prompt<{ categoryChoice: string }>([
       {
         type: 'list',
         name: 'categoryChoice',
@@ -376,14 +376,21 @@ export default class TicketEdit extends PMOCommand {
         ],
         default: ticket.category || '',
       },
-      {
+    ], null);
+
+    // Custom category prompt if needed
+    let customCategory: string | undefined;
+    if (categoryChoice === '__custom__') {
+      const result = await this.prompt<{ customCategory: string }>([{
         type: 'input',
         name: 'customCategory',
         message: 'Enter custom category:',
-        when: (promptAnswers: { categoryChoice: string }) => promptAnswers.categoryChoice === '__custom__',
-        validate: (input: string) => input.trim() ? true : 'Category cannot be empty',
-      },
-    ]);
+        validate: (input: unknown) => (input as string).trim() ? true : 'Category cannot be empty',
+      }], null);
+      customCategory = result.customCategory;
+    }
+
+    const answers = { priority, categoryChoice, customCategory };
 
     // Build updates object with only changed fields
     const updates: {

--- a/apps/cli/src/commands/ticket/epic.ts
+++ b/apps/cli/src/commands/ticket/epic.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import { Ticket } from '../../lib/pmo/types.js';
@@ -245,7 +244,10 @@ export default class TicketEpic extends PMOCommand {
     'from-epic'?: string;
     force: boolean;
     unlink: boolean;
+    json?: boolean;
   }): Promise<void> {
+    const jsonMode = shouldOutputJson(flags);
+    const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket epic' } : null;
     this.log(styles.emphasis('🔗 Link Tickets to Epic\n'));
 
     // Get project first
@@ -294,7 +296,7 @@ export default class TicketEpic extends PMOCommand {
     }
 
     // Select tickets to link
-    const { selectedTickets } = await inquirer.prompt([{
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
       type: 'checkbox',
       name: 'selectedTickets',
       message: 'Select tickets to link:',
@@ -306,7 +308,7 @@ export default class TicketEpic extends PMOCommand {
           value: t.id,
         };
       }),
-    }]);
+    }], jsonModeConfig);
 
     if (selectedTickets.length === 0) {
       this.log(styles.muted('No tickets selected.'));
@@ -316,18 +318,19 @@ export default class TicketEpic extends PMOCommand {
     // Select target epic
     let targetEpic: string | null | undefined = flags['to-epic'];
     if (targetEpic === undefined) {
-      const { epic } = await inquirer.prompt([{
+      const { epic } = await this.prompt<{ epic: string | null }>([{
         type: 'list',
         name: 'epic',
         message: 'Link to which epic?',
         choices: [
-          { name: 'None (remove epic link)', value: null },
+          { name: 'None (remove epic link)', value: null, command: 'prlt ticket epic --bulk --unlink --json' },
           ...epics.map(e => ({
             name: `${e.title} (${e.status})`,
             value: e.id,
+            command: `prlt ticket epic --bulk --to-epic ${e.id} --json`,
           })),
         ],
-      }]);
+      }], jsonModeConfig);
       targetEpic = epic;
     }
 
@@ -346,16 +349,16 @@ export default class TicketEpic extends PMOCommand {
       }
       this.log('');
 
-      const { confirm } = await inquirer.prompt([{
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
         type: 'list',
         name: 'confirm',
         message: 'Continue?',
         choices: [
-          { name: 'No, cancel', value: false },
-          { name: 'Yes, link tickets', value: true }
+          { name: 'No, cancel', value: false, command: '' },
+          { name: 'Yes, link tickets', value: true, command: `prlt ticket epic --bulk --to-epic ${targetEpic || 'none'} --force --json` }
         ],
         default: 0
-      }]);
+      }], jsonModeConfig);
 
       if (!confirm) {
         this.log(styles.muted('Operation cancelled.'));

--- a/apps/cli/src/commands/ticket/project.ts
+++ b/apps/cli/src/commands/ticket/project.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import {
@@ -198,7 +197,9 @@ export default class TicketProject extends PMOCommand {
     this.log(styles.muted(`\nView ticket: prlt ticket view ${ticketId}`));
   }
 
-  private async executeBulk(flags: { target?: string }): Promise<void> {
+  private async executeBulk(flags: { target?: string; json?: boolean }): Promise<void> {
+    const jsonMode = shouldOutputJson(flags);
+    const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket project' } : null;
     this.log(styles.emphasis('📁 Bulk Move Tickets to Project\n'));
 
     // Get source project ID
@@ -212,7 +213,7 @@ export default class TicketProject extends PMOCommand {
     }
 
     // Select tickets
-    const { selectedTickets } = await inquirer.prompt([{
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
       type: 'checkbox',
       name: 'selectedTickets',
       message: 'Select tickets to move:',
@@ -223,7 +224,7 @@ export default class TicketProject extends PMOCommand {
           value: t.id,
         };
       }),
-    }]);
+    }], jsonModeConfig);
 
     if (selectedTickets.length === 0) {
       this.log(styles.muted('No tickets selected.'));
@@ -242,15 +243,16 @@ export default class TicketProject extends PMOCommand {
     let targetProjectId = flags.target;
 
     if (!targetProjectId) {
-      const { selected } = await inquirer.prompt([{
+      const { selected } = await this.prompt<{ selected: string }>([{
         type: 'list',
         name: 'selected',
         message: 'Select target project:',
         choices: otherProjects.map(p => ({
           name: `${p.id} - ${p.name}`,
           value: p.id,
+          command: `prlt ticket project --bulk --target ${p.id} --json`,
         })),
-      }]);
+      }], jsonModeConfig);
       targetProjectId = selected;
     }
 
@@ -268,15 +270,15 @@ export default class TicketProject extends PMOCommand {
 
     if (ticketsWithEpics.length > 0) {
       this.log(styles.warning(`\n${ticketsWithEpics.length} ticket(s) are assigned to epics.`));
-      const { action } = await inquirer.prompt([{
+      const { action } = await this.prompt<{ action: string }>([{
         type: 'list',
         name: 'action',
         message: 'How to handle epic assignments?',
         choices: [
-          { name: 'Unlink from epics and move', value: 'unlink' },
-          { name: 'Cancel', value: 'cancel' },
+          { name: 'Unlink from epics and move', value: 'unlink', command: `prlt ticket project --bulk --target ${targetProjectId} --json` },
+          { name: 'Cancel', value: 'cancel', command: '' },
         ],
-      }]);
+      }], jsonModeConfig);
 
       if (action === 'cancel') {
         return;

--- a/apps/cli/src/commands/ticket/reassign.ts
+++ b/apps/cli/src/commands/ticket/reassign.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import {
@@ -130,27 +129,29 @@ export default class TicketReassign extends PMOCommand {
     let targetAssignee = args.assignee || flags.to;
 
     if (!targetAssignee) {
-      const { assignee } = await inquirer.prompt([{
+      const jsonModeConfig = jsonMode ? { flags, commandName: 'ticket reassign' } : null;
+      const { assignee } = await this.prompt<{ assignee: string }>([{
         type: 'list',
         name: 'assignee',
         message: `Reassign ${ticketId} to:`,
         choices: [
-          { name: 'None (unassign)', value: '__none__' },
+          { name: 'None (unassign)', value: '__none__', command: `prlt ticket reassign ${ticketId} none${projectId ? ` -P ${projectId}` : ''} --json` },
           ...Array.from(assignees).sort().map(a => ({
             name: a === ticket.assignee ? `${a} (current)` : a,
             value: a,
+            command: `prlt ticket reassign ${ticketId} ${a}${projectId ? ` -P ${projectId}` : ''} --json`,
           })),
-          { name: '── Enter custom name ──', value: '__custom__' },
+          { name: '── Enter custom name ──', value: '__custom__', command: `prlt ticket reassign ${ticketId} <name>${projectId ? ` -P ${projectId}` : ''} --json` },
         ],
-      }]);
+      }], jsonModeConfig);
 
       if (assignee === '__custom__') {
-        const { customAssignee } = await inquirer.prompt([{
+        const { customAssignee } = await this.prompt<{ customAssignee: string }>([{
           type: 'input',
           name: 'customAssignee',
           message: 'Enter agent/assignee name:',
-          validate: (input: string) => input.length > 0 || 'Name is required',
-        }]);
+          validate: (input: unknown) => (input as string).length > 0 || 'Name is required',
+        }], jsonModeConfig);
         targetAssignee = customAssignee;
       } else if (assignee === '__none__') {
         targetAssignee = undefined;
@@ -200,8 +201,9 @@ export default class TicketReassign extends PMOCommand {
   private async executeBulk(
     allTickets: Awaited<ReturnType<typeof this.storage.listTickets>>,
     assigneesList: string[],
-    flags: { to?: string; from?: string; force: boolean }
+    flags: { to?: string; from?: string; force: boolean; json?: boolean }
   ): Promise<void> {
+    const jsonMode = shouldOutputJson(flags);
     this.log(styles.emphasis('👤 Reassign Tickets\n'));
 
     // Filter tickets if --from specified
@@ -220,7 +222,8 @@ export default class TicketReassign extends PMOCommand {
     }
 
     // Select tickets to reassign
-    const { selectedTickets } = await inquirer.prompt([{
+    const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket reassign' } : null;
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
       type: 'checkbox',
       name: 'selectedTickets',
       message: 'Select tickets to reassign:',
@@ -228,7 +231,7 @@ export default class TicketReassign extends PMOCommand {
         name: `${t.id} - ${t.title}  [Assignee: ${t.assignee || '(none)'}]`,
         value: t.id,
       })),
-    }]);
+    }], jsonModeConfig);
 
     if (selectedTickets.length === 0) {
       this.log(styles.muted('No tickets selected.'));
@@ -238,27 +241,28 @@ export default class TicketReassign extends PMOCommand {
     // Select target assignee
     let targetAssignee: string | undefined = flags.to;
     if (targetAssignee === undefined) {
-      const { assignee } = await inquirer.prompt([{
+      const { assignee } = await this.prompt<{ assignee: string }>([{
         type: 'list',
         name: 'assignee',
         message: 'Reassign to which agent?',
         choices: [
-          { name: 'None (unassign)', value: '__none__' },
+          { name: 'None (unassign)', value: '__none__', command: '' },
           ...assigneesList.sort().map(a => ({
             name: a,
             value: a,
+            command: `prlt ticket reassign --bulk --to ${a} --json`,
           })),
-          { name: '── Enter custom name ──', value: '__custom__' },
+          { name: '── Enter custom name ──', value: '__custom__', command: '' },
         ],
-      }]);
+      }], jsonModeConfig);
 
       if (assignee === '__custom__') {
-        const { customAssignee } = await inquirer.prompt([{
+        const { customAssignee } = await this.prompt<{ customAssignee: string }>([{
           type: 'input',
           name: 'customAssignee',
           message: 'Enter agent/assignee name:',
-          validate: (input: string) => input.length > 0 || 'Name is required',
-        }]);
+          validate: (input: unknown) => (input as string).length > 0 || 'Name is required',
+        }], jsonModeConfig);
         targetAssignee = customAssignee;
       } else if (assignee === '__none__') {
         targetAssignee = undefined;
@@ -298,16 +302,16 @@ export default class TicketReassign extends PMOCommand {
       }
       this.log('');
 
-      const { confirm } = await inquirer.prompt([{
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
         type: 'list',
         name: 'confirm',
         message: 'Continue?',
         choices: [
-          { name: 'No, cancel', value: false },
-          { name: 'Yes, reassign tickets', value: true }
+          { name: 'No, cancel', value: false, command: '' },
+          { name: 'Yes, reassign tickets', value: true, command: `prlt ticket reassign --bulk --to ${targetAssignee || 'none'} --force --json` }
         ],
         default: 0
-      }]);
+      }], jsonModeConfig);
 
       if (!confirm) {
         this.log(styles.muted('Operation cancelled.'));

--- a/apps/cli/src/commands/ticket/spec.ts
+++ b/apps/cli/src/commands/ticket/spec.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
 import {
@@ -225,7 +224,9 @@ export default class TicketSpec extends PMOCommand {
     this.log(styles.muted(`\nView ticket: prlt ticket view ${ticketId}`));
   }
 
-  private async executeBulk(flags: { spec?: string; unlink: boolean }, projectId?: string): Promise<void> {
+  private async executeBulk(flags: { spec?: string; unlink: boolean; json?: boolean }, projectId?: string): Promise<void> {
+    const jsonMode = shouldOutputJson(flags);
+    const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket spec' } : null;
     this.log(styles.emphasis('📄 Bulk Assign Spec to Tickets\n'));
 
     // Get all tickets
@@ -236,7 +237,7 @@ export default class TicketSpec extends PMOCommand {
     }
 
     // Select tickets
-    const { selectedTickets } = await inquirer.prompt([{
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
       type: 'checkbox',
       name: 'selectedTickets',
       message: 'Select tickets to update:',
@@ -247,7 +248,7 @@ export default class TicketSpec extends PMOCommand {
           value: t.id,
         };
       }),
-    }]);
+    }], jsonModeConfig);
 
     if (selectedTickets.length === 0) {
       this.log(styles.muted('No tickets selected.'));
@@ -276,15 +277,16 @@ export default class TicketSpec extends PMOCommand {
         return;
       }
 
-      const { selected } = await inquirer.prompt([{
+      const { selected } = await this.prompt<{ selected: string }>([{
         type: 'list',
         name: 'selected',
         message: 'Select spec to assign:',
         choices: specs.map(s => ({
           name: `${s.id} - ${s.title} (${s.status})`,
           value: s.id,
+          command: `prlt ticket spec --bulk --spec ${s.id} --json`,
         })),
-      }]);
+      }], jsonModeConfig);
       specId = selected;
     }
 

--- a/apps/cli/src/commands/ticket/update.ts
+++ b/apps/cli/src/commands/ticket/update.ts
@@ -1,5 +1,4 @@
 import { Args, Flags } from '@oclif/core';
-import inquirer from 'inquirer';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { PRIORITIES, PRIORITY_LABELS } from '../../lib/pmo/types.js';
 import { styles } from '../../lib/styles.js';
@@ -112,58 +111,59 @@ export default class TicketUpdate extends PMOCommand {
 
     if (!updatePriority && !updateCategory) {
       // Ask what to update
-      const { updateType } = await inquirer.prompt([{
+      const jsonModeConfig = jsonMode ? { flags, commandName: 'ticket update' } : null;
+      const { updateType } = await this.prompt<{ updateType: string }>([{
         type: 'list',
         name: 'updateType',
         message: 'What would you like to update?',
         choices: [
-          { name: 'Priority', value: 'priority' },
-          { name: 'Category', value: 'category' },
-          { name: 'Both', value: 'both' },
+          { name: 'Priority', value: 'priority', command: `prlt ticket update ${ticketId} --priority <P0|P1|P2|P3>${projectId ? ` -P ${projectId}` : ''} --json` },
+          { name: 'Category', value: 'category', command: `prlt ticket update ${ticketId} --category <category>${projectId ? ` -P ${projectId}` : ''} --json` },
+          { name: 'Both', value: 'both', command: `prlt ticket update ${ticketId} --priority <P0|P1|P2|P3> --category <category>${projectId ? ` -P ${projectId}` : ''} --json` },
         ],
-      }]);
+      }], jsonModeConfig);
 
       if (updateType === 'priority' || updateType === 'both') {
-        const { priority } = await inquirer.prompt([{
+        const { priority } = await this.prompt<{ priority: string | null }>([{
           type: 'list',
           name: 'priority',
           message: 'Set priority to:',
           choices: [
-            { name: `(Keep existing: ${ticket.priority || 'none'})`, value: null },
-            ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
-            { name: 'None (clear priority)', value: '' },
+            { name: `(Keep existing: ${ticket.priority || 'none'})`, value: null, command: '' },
+            ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p, command: `prlt ticket update ${ticketId} --priority ${p}${projectId ? ` -P ${projectId}` : ''} --json` })),
+            { name: 'None (clear priority)', value: '', command: `prlt ticket update ${ticketId} --priority none${projectId ? ` -P ${projectId}` : ''} --json` },
           ],
-        }]);
+        }], jsonModeConfig);
         if (priority !== null) {
           updatePriority = priority;
         }
       }
 
       if (updateType === 'category' || updateType === 'both') {
-        const { categoryChoice } = await inquirer.prompt([{
+        const { categoryChoice } = await this.prompt<{ categoryChoice: string | null }>([{
           type: 'list',
           name: 'categoryChoice',
           message: 'Set category to:',
           choices: [
-            { name: `(Keep existing: ${ticket.category || 'none'})`, value: null },
-            { name: 'feature', value: 'feature' },
-            { name: 'bug', value: 'bug' },
-            { name: 'refactor', value: 'refactor' },
-            { name: 'docs', value: 'docs' },
-            { name: 'test', value: 'test' },
-            { name: 'chore', value: 'chore' },
-            { name: 'None (clear category)', value: '' },
-            { name: 'Custom...', value: '__custom__' },
+            { name: `(Keep existing: ${ticket.category || 'none'})`, value: null, command: '' },
+            { name: 'feature', value: 'feature', command: `prlt ticket update ${ticketId} --category feature${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'bug', value: 'bug', command: `prlt ticket update ${ticketId} --category bug${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'refactor', value: 'refactor', command: `prlt ticket update ${ticketId} --category refactor${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'docs', value: 'docs', command: `prlt ticket update ${ticketId} --category docs${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'test', value: 'test', command: `prlt ticket update ${ticketId} --category test${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'chore', value: 'chore', command: `prlt ticket update ${ticketId} --category chore${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'None (clear category)', value: '', command: `prlt ticket update ${ticketId} --category none${projectId ? ` -P ${projectId}` : ''} --json` },
+            { name: 'Custom...', value: '__custom__', command: `prlt ticket update ${ticketId} --category <category>${projectId ? ` -P ${projectId}` : ''} --json` },
           ],
-        }]);
+        }], jsonModeConfig);
 
         if (categoryChoice === '__custom__') {
-          const { customCategory } = await inquirer.prompt([{
+          const { customCategory } = await this.prompt<{ customCategory: string }>([{
             type: 'input',
             name: 'customCategory',
             message: 'Enter custom category:',
-            validate: (input: string) => input.length > 0 || 'Category is required',
-          }]);
+            validate: (input: unknown) => (input as string).length > 0 || 'Category is required',
+          }], jsonModeConfig);
           updateCategory = customCategory;
         } else if (categoryChoice !== null) {
           updateCategory = categoryChoice;
@@ -202,12 +202,14 @@ export default class TicketUpdate extends PMOCommand {
 
   private async executeBulk(
     allTickets: Awaited<ReturnType<typeof this.storage.listTickets>>,
-    flags: { priority?: string; category?: string; force: boolean }
+    flags: { priority?: string; category?: string; force: boolean; json?: boolean }
   ): Promise<void> {
+    const jsonMode = shouldOutputJson(flags);
+    const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket update' } : null;
     this.log(styles.emphasis('✏️  Update Multiple Tickets\n'));
 
     // Select tickets to update
-    const { selectedTickets } = await inquirer.prompt([{
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
       type: 'checkbox',
       name: 'selectedTickets',
       message: 'Select tickets to update:',
@@ -215,7 +217,7 @@ export default class TicketUpdate extends PMOCommand {
         name: `${t.id} - ${t.title}  [P:${t.priority || 'none'} C:${t.category || 'none'}]`,
         value: t.id,
       })),
-    }]);
+    }], jsonModeConfig);
 
     if (selectedTickets.length === 0) {
       this.log(styles.muted('No tickets selected.'));
@@ -228,58 +230,58 @@ export default class TicketUpdate extends PMOCommand {
 
     if (!updatePriority && !updateCategory) {
       // Ask what to update
-      const { updateType } = await inquirer.prompt([{
+      const { updateType } = await this.prompt<{ updateType: string }>([{
         type: 'list',
         name: 'updateType',
         message: 'What would you like to update?',
         choices: [
-          { name: 'Priority', value: 'priority' },
-          { name: 'Category', value: 'category' },
-          { name: 'Both', value: 'both' },
+          { name: 'Priority', value: 'priority', command: 'prlt ticket update --bulk --priority <P0|P1|P2|P3> --json' },
+          { name: 'Category', value: 'category', command: 'prlt ticket update --bulk --category <category> --json' },
+          { name: 'Both', value: 'both', command: 'prlt ticket update --bulk --priority <P0|P1|P2|P3> --category <category> --json' },
         ],
-      }]);
+      }], jsonModeConfig);
 
       if (updateType === 'priority' || updateType === 'both') {
-        const { priority } = await inquirer.prompt([{
+        const { priority } = await this.prompt<{ priority: string | null }>([{
           type: 'list',
           name: 'priority',
           message: 'Set priority to:',
           choices: [
-            { name: '(Keep existing)', value: null },
-            ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p })),
-            { name: 'None (clear priority)', value: '' },
+            { name: '(Keep existing)', value: null, command: '' },
+            ...PRIORITIES.map(p => ({ name: PRIORITY_LABELS[p], value: p, command: `prlt ticket update --bulk --priority ${p} --json` })),
+            { name: 'None (clear priority)', value: '', command: 'prlt ticket update --bulk --priority none --json' },
           ],
-        }]);
+        }], jsonModeConfig);
         if (priority !== null) {
           updatePriority = priority;
         }
       }
 
       if (updateType === 'category' || updateType === 'both') {
-        const { categoryChoice } = await inquirer.prompt([{
+        const { categoryChoice } = await this.prompt<{ categoryChoice: string | null }>([{
           type: 'list',
           name: 'categoryChoice',
           message: 'Set category to:',
           choices: [
-            { name: '(Keep existing)', value: null },
-            { name: 'feature', value: 'feature' },
-            { name: 'bug', value: 'bug' },
-            { name: 'refactor', value: 'refactor' },
-            { name: 'docs', value: 'docs' },
-            { name: 'test', value: 'test' },
-            { name: 'chore', value: 'chore' },
-            { name: 'None (clear category)', value: '' },
-            { name: 'Custom...', value: '__custom__' },
+            { name: '(Keep existing)', value: null, command: '' },
+            { name: 'feature', value: 'feature', command: 'prlt ticket update --bulk --category feature --json' },
+            { name: 'bug', value: 'bug', command: 'prlt ticket update --bulk --category bug --json' },
+            { name: 'refactor', value: 'refactor', command: 'prlt ticket update --bulk --category refactor --json' },
+            { name: 'docs', value: 'docs', command: 'prlt ticket update --bulk --category docs --json' },
+            { name: 'test', value: 'test', command: 'prlt ticket update --bulk --category test --json' },
+            { name: 'chore', value: 'chore', command: 'prlt ticket update --bulk --category chore --json' },
+            { name: 'None (clear category)', value: '', command: 'prlt ticket update --bulk --category none --json' },
+            { name: 'Custom...', value: '__custom__', command: 'prlt ticket update --bulk --category <category> --json' },
           ],
-        }]);
+        }], jsonModeConfig);
 
         if (categoryChoice === '__custom__') {
-          const { customCategory } = await inquirer.prompt([{
+          const { customCategory } = await this.prompt<{ customCategory: string }>([{
             type: 'input',
             name: 'customCategory',
             message: 'Enter custom category:',
-            validate: (input: string) => input.length > 0 || 'Category is required',
-          }]);
+            validate: (input: unknown) => (input as string).length > 0 || 'Category is required',
+          }], jsonModeConfig);
           updateCategory = customCategory;
         } else if (categoryChoice !== null) {
           updateCategory = categoryChoice;
@@ -309,16 +311,16 @@ export default class TicketUpdate extends PMOCommand {
       }
       this.log('');
 
-      const { confirm } = await inquirer.prompt([{
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
         type: 'list',
         name: 'confirm',
         message: 'Continue?',
         choices: [
-          { name: 'No, cancel', value: false },
-          { name: 'Yes, update tickets', value: true }
+          { name: 'No, cancel', value: false, command: '' },
+          { name: 'Yes, update tickets', value: true, command: 'prlt ticket update --bulk --force --json' }
         ],
         default: 0
-      }]);
+      }], jsonModeConfig);
 
       if (!confirm) {
         this.log(styles.muted('Operation cancelled.'));


### PR DESCRIPTION
## Summary

Resolves TKT-911: Migrate ticket/* commands to this.prompt() for JSON mode safety

## Description

## Problem
Multiple ticket/* commands use raw inquirer.prompt() calls which break in non-TTY/agent mode.

## Files and counts
- ticket/reassign.ts - 6 unguarded prompts
- ticket/update.ts - 10 unguarded prompts
- ticket/template/create.ts - 11 unguarded prompts
- ticket/project.ts - 3 unguarded prompts
- ticket/edit.ts - 2 unguarded prompts
- ticket/delete.ts - 3 unguarded prompts
- ticket/create.ts - 3 unguarded prompts
- ticket/epic.ts - 3 unguarded prompts
- ticket/spec.ts - 2 unguarded prompts
- ticket/template/save.ts - 3 unguarded prompts
- ticket/template/index.ts - 1 unguarded prompt

Total: ~47 inquirer.prompt() calls to migrate

## Requirements
- R1: Replace all raw inquirer.prompt() calls with this.prompt() and pass jsonModeConfig
- R2: All ticket/* commands should function correctly in both interactive and JSON mode
- R3: Build passes
- R4: Existing tests still pass

## Changes

- 7fbdcf2 refactor(TKT-911): migrate ticket/* and template/* commands to this.prompt()

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
