### PR TITLE
TKT-909: Fix macOS /private/var path symlink mismatch in workspace tests

### DIFF
--- a/apps/cli/test/e2e/workspace-commands.test.ts
+++ b/apps/cli/test/e2e/workspace-commands.test.ts
@@ -21,7 +21,7 @@ describe('Workspace Commands E2E Tests', () => {
     originalHome = process.env.HOME;
 
     // Create a temp directory for testing
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-e2e-'));
+    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-e2e-')));
     process.env.HOME = testDir;
 
     // Create two test workspaces
@@ -100,8 +100,8 @@ describe('Workspace Commands E2E Tests', () => {
       expect(fs.existsSync(configPath)).to.be.true;
 
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(config.workspaces).to.have.length(1);
-      expect(config.workspaces[0].path).to.equal(testWorkspace1);
+      expect(config.headquarters).to.have.length(1);
+      expect(config.headquarters[0].path).to.equal(testWorkspace1);
     });
 
     it('should register with custom name', () => {
@@ -112,7 +112,7 @@ describe('Workspace Commands E2E Tests', () => {
 
       const configPath = path.join(testDir, '.proletariat', 'config.json');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(config.workspaces[0].name).to.equal('My Custom Name');
+      expect(config.headquarters[0].name).to.equal('My Custom Name');
     });
 
     it('should reject non-workspace directories', () => {
@@ -193,7 +193,7 @@ describe('Workspace Commands E2E Tests', () => {
 
       const configPath = path.join(testDir, '.proletariat', 'config.json');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(config.activeWorkspace).to.equal(testWorkspace2);
+      expect(config.activeHeadquarters).to.equal(testWorkspace2);
     });
 
     it('should switch active workspace by path', () => {
@@ -236,8 +236,8 @@ describe('Workspace Commands E2E Tests', () => {
       // Verify removed from config
       const configPath = path.join(testDir, '.proletariat', 'config.json');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(config.workspaces).to.have.length(1);
-      expect(config.workspaces[0].name).to.equal('workspace-two');
+      expect(config.headquarters).to.have.length(1);
+      expect(config.headquarters[0].name).to.equal('workspace-two');
     });
 
     it('should unregister workspace by path', () => {
@@ -252,7 +252,7 @@ describe('Workspace Commands E2E Tests', () => {
 
       const configPath = path.join(testDir, '.proletariat', 'config.json');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-      expect(config.activeWorkspace).to.be.null;
+      expect(config.activeHeadquarters).to.be.null;
     });
 
     it('should reject non-existent workspace', () => {
@@ -273,7 +273,7 @@ describe('Workspace Commands E2E Tests', () => {
 
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       expect(config.version).to.equal('1.0.0');
-      expect(config.workspaces).to.be.an('array');
+      expect(config.headquarters).to.be.an('array');
     });
   });
 

--- a/apps/cli/test/unit/machine-config.test.ts
+++ b/apps/cli/test/unit/machine-config.test.ts
@@ -28,7 +28,7 @@ describe('Machine Config', () => {
 
   beforeEach(() => {
     // Create a temp directory for testing
-    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'machine-config-test-'));
+    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'machine-config-test-')));
 
     // Save original HOME and override it
     originalHome = process.env.HOME;
@@ -99,7 +99,7 @@ describe('Machine Config', () => {
       const config = readMachineConfig();
       expect(config.version).to.equal('1.0.0');
       expect(config.headquarters).to.deep.equal([]);
-      expect(config.activeWorkspace).to.be.null;
+      expect(config.activeHeadquarters).to.be.null;
     });
 
     it('reads existing config file', () => {
@@ -187,7 +187,7 @@ describe('Machine Config', () => {
       registerWorkspace(testWorkspaceDir);
 
       const config = readMachineConfig();
-      expect(config.activeWorkspace).to.equal(testWorkspaceDir);
+      expect(config.activeHeadquarters).to.equal(testWorkspaceDir);
     });
 
     it('updates existing entry instead of creating duplicate', () => {
@@ -227,7 +227,7 @@ describe('Machine Config', () => {
       unregisterWorkspace(testWorkspaceDir);
 
       const config = readMachineConfig();
-      expect(config.activeWorkspace).to.be.null;
+      expect(config.activeHeadquarters).to.be.null;
     });
 
     it('returns false if workspace not found', () => {
@@ -289,7 +289,7 @@ describe('Machine Config', () => {
     });
 
     it('throws error if workspace not found', () => {
-      expect(() => setActiveWorkspace('/nonexistent')).to.throw('Workspace not found');
+      expect(() => setActiveWorkspace('/nonexistent')).to.throw('Headquarters not found');
     });
 
     it('throws error if path no longer exists', () => {
@@ -310,7 +310,7 @@ describe('Machine Config', () => {
       registerWorkspace(testWorkspaceDir, 'duplicate', false);
       registerWorkspace(ws2Dir, 'duplicate', false);
 
-      expect(() => setActiveWorkspace('duplicate')).to.throw('Multiple workspaces found');
+      expect(() => setActiveWorkspace('duplicate')).to.throw('Multiple headquarters found');
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves TKT-909: Fix macOS /private/var path symlink mismatch in workspace tests

## Description

## Problem
5 workspace tests fail because mkdtemp returns /private/var/folders/... but the code compares against /var/folders/... These are the same path (macOS symlink) but string comparison fails.

Example assertion error:
  expected '/private/var/folders/b1/b2s4rkm5687g0...' to equal '/var/folders/b1/b2s4rkm5687g04bbfssx9...'

## Files
- Test files using workspace path comparison (likely test/e2e/ or test/unit/ workspace tests)

## Requirements
- R1: Use fs.realpathSync() or equivalent to normalize paths before comparison
- R2: All 5 path-related test failures should pass on macOS

## Changes

- 0951f95 fix(TKT-909): fix macOS /private/var path symlink mismatch in workspace tests by adding realpathSync normalization and update deprecated field names

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
