### PR TITLE
TKT-915: Bump CLI version to 0.3.25

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump `@proletariat/cli` version from 0.3.24 to 0.3.25

## Test plan
- [x] Build passes
- [ ] Verify `prlt --version` shows 0.3.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)