### PR TITLE
TKT-917: Fix agent-temp-cleanup unit tests - missing cleanup.ts file

### DIFF
--- a/apps/cli/test/unit/agent-temp-cleanup.test.ts
+++ b/apps/cli/test/unit/agent-temp-cleanup.test.ts
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename);
  * Tests that agent temp cleanup only shows temp agents, not staff agents
  */
 describe('Agent Temp Cleanup (TKT-796)', () => {
-  const cleanupPath = path.resolve(__dirname, '../../src/commands/agent/temp/cleanup.ts');
+  const cleanupPath = path.resolve(__dirname, '../../src/commands/agent/cleanup.ts');
 
   describe('interactive mode filters staff agents', () => {
     it('should NOT include staff agents section in interactive mode', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-917: Fix agent-temp-cleanup unit tests - missing cleanup.ts file

## Description

## Problem
11 agent temp cleanup tests fail because src/commands/agent/temp/cleanup.ts no longer exists.

Error: ENOENT: no such file or directory, open '.../src/commands/agent/temp/cleanup.ts'

## Failing tests (test/unit/agent-temp-cleanup.test.ts)
- should NOT include staff agents section in interactive mode
- should only filter for ephemeral agents in interactive mode
- should show 'No temp agents' message when only staff agents exist
- should have select message that specifies temp agents
- should filter for ephemeral type when using --all flag
- should use getCleanableAgents helper for --temp flag
- should have All temp agents option / Cancel option / Temp Agents separator
- should NOT have Staff Agents separator
- should not have staffAgents variable definition
- does not define staffAgents variable

## Root cause
The agent/temp/cleanup.ts command was removed or renamed but the test file still references it.

## Changes

- b2b3e9a fix(TKT-917): fix test path: cleanup.ts moved from agent/temp/ to agent/
- fc81f6a fix(TKT-913): fix oclif plugin warnings polluting JSON output in tests (#350)
- 997b6f9 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts (#340)
- 0b41213 TKT-912: Migrate branch/*, config/*, and remaining commands to this.prompt() (#345)
- f95aaf2 fix(TKT-909): fix macOS /private/var path symlink mismatch in workspace tests by adding realpathSync normalization and update deprecated field names (#344)
- 92e54af refactor(TKT-911): migrate ticket/* and template/* commands to this.prompt() (#343)
- 60a6f94 refactor(TKT-910): migrate work/* commands from raw inquirer.prompt() to this.prompt() for JSON mode safety (#342)
- a64664b fix(TKT-908): add missing this.parse() call to whoami command (#341)
- da9b701 TKT-914: Clean up test data artifacts (test projects, ghost repos) (#346)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
