### PR TITLE
TKT-916: Fix agent-json-mode unit tests (TKT-741) - missing JSON flags

### DIFF
--- a/apps/cli/src/commands/agent/auth.ts
+++ b/apps/cli/src/commands/agent/auth.ts
@@ -32,7 +32,7 @@ export default class Auth extends Command {
     json: Flags.boolean({
       char: 'm',
       aliases: ['machine'],
-      description: 'Output as JSON for AI agents/scripts',
+      description: 'Output status as JSON',
       default: false,
     }),
   };

--- a/apps/cli/src/commands/agent/discover.ts
+++ b/apps/cli/src/commands/agent/discover.ts
@@ -25,7 +25,7 @@ export default class Discover extends Command {
     json: Flags.boolean({
       char: 'm',
       aliases: ['machine'],
-      description: 'Output as JSON for AI agents/scripts',
+      description: 'Output discovery results as JSON',
       default: false,
     }),
   };


### PR DESCRIPTION
## Summary

Resolves TKT-916: Fix agent-json-mode unit tests (TKT-741) - missing JSON flags

## Description

## Problem
Agent Command JSON Mode tests (TKT-741) fail because commands are missing expected --json/--machine flags in help output.

## Failing tests (test/unit/agent-json-mode.test.ts)
- agent auth: should have --json flag in help
- agent discover: should have --json flag in help  
- agent auth: should output JSON with command field for each choice
- agent auth: should include navigation commands in choices
- agent discover: should have --machine flag in help
- agent discover: should output JSON with command field for each choice
- Plus similar for other agent subcommands

## Error pattern
AssertionError: expected false to be true (flag not found in help output)
AssertionError: expected 'Set up Claude Code authentication for...' to include 'Output status as JSON'
AssertionError: expected 'Discover agents on disk that are not ...' to include 'Output discovery results as JSON'

## Root cause
Agent commands were refactored but tests still expect old flag names/descriptions.

## Changes

- 32a3a34 fix(TKT-916): fix --json flag descriptions in agent auth and discover commands to match test expectations
- fc81f6a fix(TKT-913): fix oclif plugin warnings polluting JSON output in tests (#350)
- 997b6f9 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts (#340)
- 0b41213 TKT-912: Migrate branch/*, config/*, and remaining commands to this.prompt() (#345)
- f95aaf2 fix(TKT-909): fix macOS /private/var path symlink mismatch in workspace tests by adding realpathSync normalization and update deprecated field names (#344)
- 92e54af refactor(TKT-911): migrate ticket/* and template/* commands to this.prompt() (#343)
- 60a6f94 refactor(TKT-910): migrate work/* commands from raw inquirer.prompt() to this.prompt() for JSON mode safety (#342)
- a64664b fix(TKT-908): add missing this.parse() call to whoami command (#341)
- da9b701 TKT-914: Clean up test data artifacts (test projects, ghost repos) (#346)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
