### PR TITLE
TKT-919: Fix interactive-mode unit tests - auto-prompt assertions failing

### DIFF
--- a/apps/cli/test/unit/interactive-mode.test.ts
+++ b/apps/cli/test/unit/interactive-mode.test.ts
@@ -49,10 +49,15 @@ describe('Interactive Mode Support Audit', () => {
       issues: [],
     };
 
-    // Check for imports
+    // Check for imports - detect direct inquirer usage AND wrapper patterns
+    // Commands may use inquirer directly, or via FlagResolver/this.prompt()/this.selectFromList()
     info.usesInquirer = content.includes("import inquirer from 'inquirer'") ||
                         content.includes('from "inquirer"') ||
-                        content.includes("require('inquirer')");
+                        content.includes("require('inquirer')") ||
+                        content.includes('FlagResolver') ||
+                        content.includes('this.prompt(') ||
+                        content.includes('this.prompt<') ||
+                        content.includes('this.selectFromList(');
 
     // Check for static flags
     const flagsMatch = content.match(/static flags\s*=\s*\{[\s\S]*?\n\s*\}/);


### PR DESCRIPTION
## Summary

Resolves TKT-919: Fix interactive-mode unit tests - auto-prompt assertions failing

## Description

## Problem
9 interactive mode tests fail because commands are not auto-prompting as expected.

## Failing tests (test/unit/interactive-mode.test.ts)
- ticket/move should auto-prompt for ticket and column
- epic/create should auto-prompt for title
- epic/move should auto-prompt for epic and status
- spec/create should auto-prompt for title
- status/create should auto-prompt for name and category
- status/update should auto-prompt for changes
- phase/create should auto-prompt for name and category
- phase/update should auto-prompt for changes
- action/create should auto-prompt for name and prompt

## Error pattern
AssertionError: expected false to be true

## Root cause
Commands were migrated to this.prompt() pattern but the test assertions may need updating to match the new prompt behavior.

## Changes

- 0b6cd15 fix(TKT-919): fix interactive-mode test to detect this.prompt() and FlagResolver as interactive patterns
- fc81f6a fix(TKT-913): fix oclif plugin warnings polluting JSON output in tests (#350)
- 997b6f9 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts (#340)
- 0b41213 TKT-912: Migrate branch/*, config/*, and remaining commands to this.prompt() (#345)
- f95aaf2 fix(TKT-909): fix macOS /private/var path symlink mismatch in workspace tests by adding realpathSync normalization and update deprecated field names (#344)
- 92e54af refactor(TKT-911): migrate ticket/* and template/* commands to this.prompt() (#343)
- 60a6f94 refactor(TKT-910): migrate work/* commands from raw inquirer.prompt() to this.prompt() for JSON mode safety (#342)
- a64664b fix(TKT-908): add missing this.parse() call to whoami command (#341)
- da9b701 TKT-914: Clean up test data artifacts (test projects, ghost repos) (#346)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
