### PR TITLE
TKT-921: Fix template-json-flags unit tests - missing flags and JSON output

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -16,6 +16,11 @@ const hook: Hook<'init'> = async function ({ id, config }) {
     return
   }
 
+  // Skip when --help flag is present - help should always be available
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    return
+  }
+
   // Skip for help-related commands/flags
   // When user runs just `prlt` with no args, id is undefined
   if (!id || id === 'help') {

--- a/apps/cli/test/unit/template-json-flags.test.ts
+++ b/apps/cli/test/unit/template-json-flags.test.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { initializePMOTables } from '../../src/lib/pmo/storage/base.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,6 +14,15 @@ const CLI_PATH = path.resolve(__dirname, '../../bin/run.js');
 /**
  * Unit tests for template/* command machine-readable output mode support
  * Verifies that all template commands properly use machineOutputFlags for JSON mode
+ *
+ * Template commands use a flat structure:
+ *   template          - index (menu)
+ *   template create   - create ticket or phase template
+ *   template list     - list templates
+ *   template apply    - apply a template
+ *   template save     - save ticket as template
+ *   template update   - update phase template
+ *   template delete   - delete templates
  */
 describe('Template Commands Machine Output Mode Support', () => {
   // Isolated env to prevent test commands from polluting production database
@@ -25,12 +38,13 @@ describe('Template Commands Machine Output Mode Support', () => {
   }
 
   // Helper to run CLI and get output
-  function runCli(args: string): string {
+  function runCli(args: string, options?: { cwd?: string }): string {
     try {
       return execSync(`node ${CLI_PATH} ${args} 2>&1`, {
         encoding: 'utf-8',
         timeout: 10000,
         env: getIsolatedEnv(),
+        cwd: options?.cwd,
       });
     } catch (error) {
       // Return stderr/stdout even on error (JSON mode exits with code 2)
@@ -57,234 +71,168 @@ describe('Template Commands Machine Output Mode Support', () => {
     }
   }
 
+  // Minimal workspace for tests that run commands (not just --help)
+  let tempHQ: string;
+  let db: Database.Database;
+
+  before(() => {
+    tempHQ = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'template-test-')));
+    const proletariatDir = path.join(tempHQ, '.proletariat');
+    fs.mkdirSync(proletariatDir, { recursive: true });
+    fs.writeFileSync(path.join(proletariatDir, 'config.json'), JSON.stringify({
+      type: 'hq',
+      name: 'test-hq',
+      hasPmo: true,
+    }));
+
+    // Create database with PMO tables for commands that need storage
+    const dbPath = path.join(proletariatDir, 'workspace.db');
+    db = new Database(dbPath);
+    db.pragma('foreign_keys = ON');
+    initializePMOTables(db);
+
+    // Create PMO directory and set path in settings
+    const pmoPath = path.join(tempHQ, 'pmo');
+    fs.mkdirSync(path.join(pmoPath, 'projects', 'test-project'), { recursive: true });
+    db.prepare("INSERT OR REPLACE INTO pmo_settings (key, value) VALUES ('pmo_path', ?)").run(pmoPath);
+
+    // Create a test project
+    db.prepare("INSERT INTO pmo_projects (id, name, description, workflow_id) VALUES (?, ?, ?, ?)").run(
+      'test-project', 'Test Project', 'Test project for template tests', 'default'
+    );
+  });
+
+  after(() => {
+    if (db) db.close();
+    if (tempHQ && fs.existsSync(tempHQ)) {
+      fs.rmSync(tempHQ, { recursive: true, force: true });
+    }
+  });
+
   describe('template index (machineOutputFlags)', () => {
-    it('should have --machine flag in help', () => {
+    it('should have --json flag with -m shorthand in help', () => {
       const output = runCli('template --help');
-      expect(output).to.include('--machine');
+      expect(output).to.include('--json');
       expect(output).to.include('-m');
     });
 
     it('should output JSON with command field for each choice', () => {
-      const output = runCli('template --machine');
+      const output = runCli('template --json', { cwd: tempHQ });
       const json = parseJson(output) as { prompt: { type: string; choices: Array<{ command?: string }> } };
       expect(json).to.not.be.null;
       expect(json.prompt.type).to.equal('list');
       expect(json.prompt.choices).to.be.an('array');
-      expect(json.prompt.choices.every((c) => c.command)).to.be.true;
+      expect(json.prompt.choices.every((c) => c.command !== undefined)).to.be.true;
     });
 
     it('should include navigation commands in choices', () => {
-      const output = runCli('template --machine');
+      const output = runCli('template --json', { cwd: tempHQ });
       const json = parseJson(output) as { prompt: { choices: Array<{ command: string }> } };
       expect(json).to.not.be.null;
       const commands = json.prompt.choices.map((c) => c.command);
       expect(commands).to.include('prlt template list --json');
-      expect(commands).to.include('prlt template ticket --json');
-      expect(commands).to.include('prlt template phase --json');
-    });
-  });
-
-  describe('template phase index (machineOutputFlags)', () => {
-    it('should have --machine flag in help', () => {
-      const output = runCli('template phase --help');
-      expect(output).to.include('--machine');
-      expect(output).to.include('-m');
-    });
-
-    it('should output JSON with command field for each choice', () => {
-      const output = runCli('template phase --machine');
-      const json = parseJson(output) as { prompt: { type: string; choices: Array<{ command?: string }> } };
-      expect(json).to.not.be.null;
-      expect(json.prompt.type).to.equal('list');
-      expect(json.prompt.choices).to.be.an('array');
-      expect(json.prompt.choices.every((c) => c.command)).to.be.true;
-    });
-  });
-
-  describe('template ticket index (machineOutputFlags)', () => {
-    it('should have --machine flag in help', () => {
-      const output = runCli('template ticket --help');
-      expect(output).to.include('--machine');
-      expect(output).to.include('-m');
-    });
-
-    it('should output JSON with command field for each choice', () => {
-      const output = runCli('template ticket --machine');
-      const json = parseJson(output) as { prompt: { type: string; choices: Array<{ command?: string }> } };
-      expect(json).to.not.be.null;
-      expect(json.prompt.type).to.equal('list');
-      expect(json.prompt.choices).to.be.an('array');
-      expect(json.prompt.choices.every((c) => c.command)).to.be.true;
+      expect(commands).to.include('prlt template create --json');
+      expect(commands).to.include('prlt template apply --json');
     });
   });
 
   describe('template delete (machineOutputFlags via pmoBaseFlags)', () => {
-    it('should have --machine flag in help', () => {
+    it('should have --json flag with -m shorthand in help', () => {
       const output = runCli('template delete --help');
-      expect(output).to.include('--machine');
+      expect(output).to.include('--json');
       expect(output).to.include('-m');
     });
   });
 
-  // Passthrough commands - verify they have --json flag for backward compatibility
-  describe('template phase create', () => {
+  describe('template create', () => {
     it('should have --json flag in help', () => {
-      const output = runCli('template phase create --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template phase update', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template phase update --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template ticket save', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template ticket save --help');
-      expect(output).to.include('--json');
-    });
-
-    it('should have --template-name flag in help', () => {
-      const output = runCli('template ticket save --help');
-      expect(output).to.include('--template-name');
-      expect(output).to.include('-n');
-    });
-
-    it('should have --machine flag in help', () => {
-      const output = runCli('template ticket save --help');
-      expect(output).to.include('--machine');
-      expect(output).to.include('-m');
-    });
-  });
-
-  describe('template phase apply', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template phase apply --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template phase list', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template phase list --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template phase delete', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template phase delete --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template ticket apply', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template ticket apply --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template ticket list', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template ticket list --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template ticket delete', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template ticket delete --help');
-      expect(output).to.include('--json');
-    });
-  });
-
-  describe('template ticket create', () => {
-    it('should have --json flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--json');
     });
 
     it('should have --subtask flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--subtask');
     });
 
     it('should have --ac flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--ac');
     });
 
     it('should have --label flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--label');
     });
 
     it('should have --title-pattern flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--title-pattern');
     });
 
     it('should have --description-template flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--description-template');
     });
 
     it('should have --priority flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--priority');
     });
 
     it('should have --category flag in help', () => {
-      const output = runCli('template ticket create --help');
+      const output = runCli('template create --help');
       expect(output).to.include('--category');
     });
 
-    it('should output JSON form prompt when --json flag is used without name', () => {
-      const output = runCli('template ticket create --json');
-      const json = parseJson(output) as { prompt: { type: string; fields: Array<{ name: string }> } };
+    it('should output JSON type prompt when --json is used without --type', () => {
+      const output = runCli('template create --json', { cwd: tempHQ });
+      const json = parseJson(output) as { prompt: { type: string; name: string; choices: Array<{ value: string }> } };
       expect(json).to.not.be.null;
-      expect(json.prompt.type).to.equal('form');
-      expect(json.prompt.fields).to.be.an('array');
-      // Should have name field in the form
-      const fieldNames = json.prompt.fields.map(f => f.name);
-      expect(fieldNames).to.include('name');
+      expect(json.prompt.type).to.equal('list');
+      expect(json.prompt.name).to.equal('type');
+      const values = json.prompt.choices.map(c => c.value);
+      expect(values).to.include('ticket');
+      expect(values).to.include('phase');
     });
   });
 
-  describe('ticket template create (underlying implementation)', () => {
+  describe('template list', () => {
     it('should have --json flag in help', () => {
-      const output = runCli('ticket template create --help');
+      const output = runCli('template list --help');
+      expect(output).to.include('--json');
+    });
+  });
+
+  describe('template apply', () => {
+    it('should have --json flag in help', () => {
+      const output = runCli('template apply --help');
+      expect(output).to.include('--json');
+    });
+  });
+
+  describe('template save', () => {
+    it('should have --json flag in help', () => {
+      const output = runCli('template save --help');
       expect(output).to.include('--json');
     });
 
-    it('should have --subtask flag in help', () => {
-      const output = runCli('ticket template create --help');
-      expect(output).to.include('--subtask');
+    it('should have --template-name flag in help', () => {
+      const output = runCli('template save --help');
+      expect(output).to.include('--template-name');
+      expect(output).to.include('-n');
     });
 
-    it('should have --ac flag in help', () => {
-      const output = runCli('ticket template create --help');
-      expect(output).to.include('--ac');
+    it('should have -m shorthand for --json in help', () => {
+      const output = runCli('template save --help');
+      expect(output).to.include('-m');
     });
+  });
 
-    it('should have --label flag in help', () => {
-      const output = runCli('ticket template create --help');
-      expect(output).to.include('--label');
-    });
-
-    it('should output JSON form prompt when --json flag is used without name', () => {
-      const output = runCli('ticket template create --json');
-      const json = parseJson(output) as { prompt: { type: string; fields: Array<{ name: string }> } };
-      expect(json).to.not.be.null;
-      expect(json.prompt.type).to.equal('form');
-      expect(json.prompt.fields).to.be.an('array');
-      // Should have name field in the form
-      const fieldNames = json.prompt.fields.map(f => f.name);
-      expect(fieldNames).to.include('name');
+  describe('template update', () => {
+    it('should have --json flag in help', () => {
+      const output = runCli('template update --help');
+      expect(output).to.include('--json');
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves TKT-921: Fix template-json-flags unit tests - missing flags and JSON output

## Description

## Problem
25 template command tests fail because template commands are missing expected flags or producing incorrect JSON output.

## Failing tests (test/unit/template-json-flags.test.ts)
- template index: should have --machine flag
- template delete: should have --machine flag
- template phase/ticket apply/create/delete/index/list/update: should have --machine/--json flags
- template ticket create: should have --subtask/--ac/--label/--title-pattern/--description-template/--priority/--category flags
- template ticket create: should output JSON form prompt when --json used without name (2 failures)

## Error patterns
- expected '...' to include '--machine' (flag not in help output)
- expected '...' to include '--json' (flag not in help output)
- expected '...' to include '--subtask' etc. (flags missing)
- expected null not to be null (JSON output not produced)
- expected [...] to include 'prlt template ticket --json' (wrong command format)

## Root cause
Template commands were refactored and flags renamed/removed but tests not updated.

## Changes

- 9c1461d fix(TKT-921): fix template-json-flags tests: update for flat command structure and fix init hook --help bypass
- fc81f6a fix(TKT-913): fix oclif plugin warnings polluting JSON output in tests (#350)
- 997b6f9 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts (#340)
- 0b41213 TKT-912: Migrate branch/*, config/*, and remaining commands to this.prompt() (#345)
- f95aaf2 fix(TKT-909): fix macOS /private/var path symlink mismatch in workspace tests by adding realpathSync normalization and update deprecated field names (#344)
- 92e54af refactor(TKT-911): migrate ticket/* and template/* commands to this.prompt() (#343)
- 60a6f94 refactor(TKT-910): migrate work/* commands from raw inquirer.prompt() to this.prompt() for JSON mode safety (#342)
- a64664b fix(TKT-908): add missing this.parse() call to whoami command (#341)
- da9b701 TKT-914: Clean up test data artifacts (test projects, ghost repos) (#346)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
