### PR TITLE
TKT-906: Fix agent.test.ts - update agent remove refs to agent staff remove

### DIFF
--- a/apps/cli/test/commands/agent-commands.test.ts
+++ b/apps/cli/test/commands/agent-commands.test.ts
@@ -32,14 +32,14 @@ describe('CLI Commands', () => {
     it('shows agent subcommands', async () => {
       const { stdout } = await runCommand(['agent', '--help'], { root });
       // Test actual existing commands
-      expect(stdout).to.contain('agent remove');
+      expect(stdout).to.contain('agent staff');
       expect(stdout).to.contain('agent visit');
       expect(stdout).to.contain('agent status');
       expect(stdout).to.contain('agent shell');
     });
 
-    it('agent remove shows proper help', async () => {
-      const { stdout } = await runCommand(['agent', 'remove', '--help'], { root });
+    it('agent staff remove shows proper help', async () => {
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
       expect(stdout).to.contain('Remove');
       expect(stdout).to.contain('USAGE');
     });
@@ -73,7 +73,7 @@ describe('CLI Commands', () => {
 describe('Agent Command Contract', () => {
   // Test actual existing agent commands
   const expectedAgentCommands = [
-    'agent remove',
+    'agent staff remove',
     'agent visit',
     'agent status',
     'agent shell',
@@ -93,7 +93,7 @@ describe('Agent Command Contract', () => {
   it('agent command shows all subcommands', async () => {
     const { stdout } = await runCommand(['agent', '--help'], { root });
     // Test that key subcommands appear in help
-    expect(stdout).to.contain('remove');
+    expect(stdout).to.contain('staff');
     expect(stdout).to.contain('visit');
     expect(stdout).to.contain('status');
   });
@@ -103,7 +103,7 @@ describe('Command Contract', () => {
   // Test commands that actually exist
   const expectedCommands = [
     'init',
-    'agent remove',
+    'agent staff remove',
     'agent visit',
     'agent status',
     'ticket create',

--- a/apps/cli/test/commands/agent.test.ts
+++ b/apps/cli/test/commands/agent.test.ts
@@ -29,7 +29,7 @@ describe('Agent Management System', () => {
   describe('Agent Help Commands', () => {
     it('agent help shows subcommands', async () => {
       const { stdout } = await runCommand(['agent', '--help'], { root });
-      expect(stdout).to.contain('agent remove');
+      expect(stdout).to.contain('agent staff');
       expect(stdout).to.contain('agent visit');
       expect(stdout).to.contain('agent status');
       expect(stdout).to.contain('agent shell');
@@ -41,7 +41,7 @@ describe('Agent Management System', () => {
     });
 
     // Test actual existing agent commands
-    const agentCommands = ['remove', 'visit', 'status', 'shell', 'login', 'rebuild', 'restart'];
+    const agentCommands = ['visit', 'status', 'shell', 'login', 'rebuild', 'restart'];
     agentCommands.forEach(cmd => {
       it(`agent ${cmd} shows help`, async () => {
         const { stdout } = await runCommand(['agent', cmd, '--help'], { root });
@@ -49,11 +49,17 @@ describe('Agent Management System', () => {
         expect(stdout).to.not.contain('not found');
       });
     });
+
+    it('agent staff remove shows help', async () => {
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
+      expect(stdout).to.contain('USAGE');
+      expect(stdout).to.not.contain('not found');
+    });
   });
 
   describe('Agent Command Contracts', () => {
-    it('agent remove help contains proper description', async () => {
-      const { stdout } = await runCommand(['agent', 'remove', '--help'], { root });
+    it('agent staff remove help contains proper description', async () => {
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
       expect(stdout).to.contain('Remove');
     });
 
@@ -83,7 +89,7 @@ describe('Agent Management System', () => {
     // Verify actual existing commands
     const specifiedCommands = [
       { cmd: 'agent', desc: 'Show agent command help' },
-      { cmd: 'agent remove', desc: 'Remove agents' },
+      { cmd: 'agent staff remove', desc: 'Remove agents' },
       { cmd: 'agent visit', desc: 'Navigate to agent directory' },
       { cmd: 'agent status', desc: 'Show detailed agent status' },
       { cmd: 'agent shell', desc: 'Open shell in agent' }
@@ -108,7 +114,7 @@ describe('Agent Management System', () => {
   describe('Database Integration', () => {
     it('commands reference SQLite integration in help', async () => {
       // Verify that help text works for existing commands
-      const { stdout } = await runCommand(['agent', 'remove', '--help'], { root });
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
       expect(stdout).to.contain('Remove');
 
       const { stdout: statusHelp } = await runCommand(['agent', 'status', '--help'], { root });
@@ -120,14 +126,14 @@ describe('Agent Management System', () => {
 describe('Agent Command Architecture', () => {
   describe('DRY Principles', () => {
     it('all agent commands use consistent help format', async () => {
-      const commands = ['remove', 'visit', 'status', 'shell'];
+      const commands = [['agent', 'staff', 'remove'], ['agent', 'visit'], ['agent', 'status'], ['agent', 'shell']];
 
-      await Promise.all(commands.map(async (cmd) => {
-        const { stdout } = await runCommand(['agent', cmd, '--help'], { root });
+      for (const cmd of commands) {
+        const { stdout } = await runCommand([...cmd, '--help'], { root });
         expect(stdout).to.contain('USAGE');
         // Consistent format across all commands
         expect(stdout).to.match(/\$ prlt agent/);
-      }));
+      }
     });
   });
 
@@ -137,19 +143,19 @@ describe('Agent Command Architecture', () => {
 
       try {
         const commands = [
-          ['agent', 'remove', 'test'],
+          ['agent', 'staff', 'remove', 'test'],
           ['agent', 'visit', 'test'],
           ['agent', 'status']
         ];
 
-        await Promise.all(commands.map(async (cmd) => {
+        for (const cmd of commands) {
           try {
             await runCommand(cmd, { root: testDir });
           } catch (error: unknown) {
             // Expect an error when not in workspace
             expect(error).to.exist;
           }
-        }));
+        }
       } finally {
         fs.rmSync(testDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary
- Update all `agent remove` references to `agent staff remove` in test files
- Fix `Promise.all` concurrent `runCommand` calls that caused test runner crashes (changed to sequential `for...of`)
- Affected files: `agent.test.ts` and `agent-commands.test.ts`

## Test plan
- [x] All 45 tests in both files pass (0 failures)
- [x] Test runner no longer crashes mid-run
- [x] Build passes

> Note: This fix depends on the TKT-750 agent restructuring (agent remove → agent staff remove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)