### PR TITLE
TKT-906: Fix agent.test.ts crashing test runner - update agent remove refs

### DIFF
--- a/apps/cli/test/commands/agent-commands.test.ts
+++ b/apps/cli/test/commands/agent-commands.test.ts
@@ -32,14 +32,14 @@ describe('CLI Commands', () => {
     it('shows agent subcommands', async () => {
       const { stdout } = await runCommand(['agent', '--help'], { root });
       // Test actual existing commands
-      expect(stdout).to.contain('agent remove');
+      expect(stdout).to.contain('agent staff');
       expect(stdout).to.contain('agent visit');
       expect(stdout).to.contain('agent status');
       expect(stdout).to.contain('agent shell');
     });
 
-    it('agent remove shows proper help', async () => {
-      const { stdout } = await runCommand(['agent', 'remove', '--help'], { root });
+    it('agent staff remove shows proper help', async () => {
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
       expect(stdout).to.contain('Remove');
       expect(stdout).to.contain('USAGE');
     });
@@ -73,7 +73,7 @@ describe('CLI Commands', () => {
 describe('Agent Command Contract', () => {
   // Test actual existing agent commands
   const expectedAgentCommands = [
-    'agent remove',
+    'agent staff remove',
     'agent visit',
     'agent status',
     'agent shell',
@@ -93,7 +93,7 @@ describe('Agent Command Contract', () => {
   it('agent command shows all subcommands', async () => {
     const { stdout } = await runCommand(['agent', '--help'], { root });
     // Test that key subcommands appear in help
-    expect(stdout).to.contain('remove');
+    expect(stdout).to.contain('staff');
     expect(stdout).to.contain('visit');
     expect(stdout).to.contain('status');
   });
@@ -103,7 +103,7 @@ describe('Command Contract', () => {
   // Test commands that actually exist
   const expectedCommands = [
     'init',
-    'agent remove',
+    'agent staff remove',
     'agent visit',
     'agent status',
     'ticket create',

--- a/apps/cli/test/commands/agent.test.ts
+++ b/apps/cli/test/commands/agent.test.ts
@@ -29,7 +29,7 @@ describe('Agent Management System', () => {
   describe('Agent Help Commands', () => {
     it('agent help shows subcommands', async () => {
       const { stdout } = await runCommand(['agent', '--help'], { root });
-      expect(stdout).to.contain('agent remove');
+      expect(stdout).to.contain('agent staff');
       expect(stdout).to.contain('agent visit');
       expect(stdout).to.contain('agent status');
       expect(stdout).to.contain('agent shell');
@@ -41,7 +41,7 @@ describe('Agent Management System', () => {
     });
 
     // Test actual existing agent commands
-    const agentCommands = ['remove', 'visit', 'status', 'shell', 'login', 'rebuild', 'restart'];
+    const agentCommands = ['visit', 'status', 'shell', 'login', 'rebuild', 'restart'];
     agentCommands.forEach(cmd => {
       it(`agent ${cmd} shows help`, async () => {
         const { stdout } = await runCommand(['agent', cmd, '--help'], { root });
@@ -49,11 +49,17 @@ describe('Agent Management System', () => {
         expect(stdout).to.not.contain('not found');
       });
     });
+
+    it('agent staff remove shows help', async () => {
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
+      expect(stdout).to.contain('USAGE');
+      expect(stdout).to.not.contain('not found');
+    });
   });
 
   describe('Agent Command Contracts', () => {
-    it('agent remove help contains proper description', async () => {
-      const { stdout } = await runCommand(['agent', 'remove', '--help'], { root });
+    it('agent staff remove help contains proper description', async () => {
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
       expect(stdout).to.contain('Remove');
     });
 
@@ -83,7 +89,7 @@ describe('Agent Management System', () => {
     // Verify actual existing commands
     const specifiedCommands = [
       { cmd: 'agent', desc: 'Show agent command help' },
-      { cmd: 'agent remove', desc: 'Remove agents' },
+      { cmd: 'agent staff remove', desc: 'Remove agents' },
       { cmd: 'agent visit', desc: 'Navigate to agent directory' },
       { cmd: 'agent status', desc: 'Show detailed agent status' },
       { cmd: 'agent shell', desc: 'Open shell in agent' }
@@ -108,7 +114,7 @@ describe('Agent Management System', () => {
   describe('Database Integration', () => {
     it('commands reference SQLite integration in help', async () => {
       // Verify that help text works for existing commands
-      const { stdout } = await runCommand(['agent', 'remove', '--help'], { root });
+      const { stdout } = await runCommand(['agent', 'staff', 'remove', '--help'], { root });
       expect(stdout).to.contain('Remove');
 
       const { stdout: statusHelp } = await runCommand(['agent', 'status', '--help'], { root });
@@ -120,10 +126,10 @@ describe('Agent Management System', () => {
 describe('Agent Command Architecture', () => {
   describe('DRY Principles', () => {
     it('all agent commands use consistent help format', async () => {
-      const commands = ['remove', 'visit', 'status', 'shell'];
+      const commands = [['agent', 'staff', 'remove'], ['agent', 'visit'], ['agent', 'status'], ['agent', 'shell']];
 
       for (const cmd of commands) {
-        const { stdout } = await runCommand(['agent', cmd, '--help'], { root });
+        const { stdout } = await runCommand([...cmd, '--help'], { root });
         expect(stdout).to.contain('USAGE');
         // Consistent format across all commands
         expect(stdout).to.match(/\$ prlt agent/);
@@ -137,7 +143,7 @@ describe('Agent Command Architecture', () => {
 
       try {
         const commands = [
-          ['agent', 'remove', 'test'],
+          ['agent', 'staff', 'remove', 'test'],
           ['agent', 'visit', 'test'],
           ['agent', 'status']
         ];


### PR DESCRIPTION
## Summary

Resolves TKT-906: Fix agent.test.ts crashing test runner - update agent remove refs

## Description

## Problem
The test file agent.test.ts references the old agent remove command path which no longer exists (moved to agent staff remove). Test #8 runs runCommand agent remove --help which calls process.exit(), killing mocha and preventing ~1000 remaining tests from running.

## Files
- test/commands/agent.test.ts
- test/commands/agent-commands.test.ts

## Requirements
- R1: Update all agent remove references to agent staff remove
- R2: Verify the test suite no longer crashes mid-run
- R3: All 1062 tests should execute (not just 44)

## Changes

- f9440e7 fix(TKT-906): update agent remove refs to agent staff remove in tests
- fc81f6a fix(TKT-913): fix oclif plugin warnings polluting JSON output in tests (#350)
- 997b6f9 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts (#340)
- 0b41213 TKT-912: Migrate branch/*, config/*, and remaining commands to this.prompt() (#345)
- f95aaf2 fix(TKT-909): fix macOS /private/var path symlink mismatch in workspace tests by adding realpathSync normalization and update deprecated field names (#344)
- 92e54af refactor(TKT-911): migrate ticket/* and template/* commands to this.prompt() (#343)
- 60a6f94 refactor(TKT-910): migrate work/* commands from raw inquirer.prompt() to this.prompt() for JSON mode safety (#342)
- a64664b fix(TKT-908): add missing this.parse() call to whoami command (#341)
- da9b701 TKT-914: Clean up test data artifacts (test projects, ghost repos) (#346)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
