### PR TITLE
TKT-923: BUG: PR description lists phantom commits from stale local main

### DIFF
--- a/apps/cli/src/lib/pr/index.ts
+++ b/apps/cli/src/lib/pr/index.ts
@@ -123,27 +123,32 @@ export function getGitHubRepo(cwd?: string): string | null {
 
 /**
  * Get the default base branch (main or master).
+ * Prefers origin/main over local main to avoid stale local branches
+ * in agent worktrees where local main is never updated.
  */
 export function getDefaultBaseBranch(cwd?: string): string {
-  try {
-    // Check if 'main' exists
-    execSync('git rev-parse --verify main', {
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return 'main';
-  } catch {
-    // Fall back to 'master'
+  // Check origin/main first (most reliable in worktree environments)
+  // then local main, then origin/master, then local master
+  const candidates = [
+    { ref: 'origin/main', name: 'main' },
+    { ref: 'main', name: 'main' },
+    { ref: 'origin/master', name: 'master' },
+    { ref: 'master', name: 'master' },
+  ];
+
+  for (const { ref, name } of candidates) {
     try {
-      execSync('git rev-parse --verify master', {
+      execSync(`git rev-parse --verify ${ref}`, {
         cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
       });
-      return 'master';
+      return name;
     } catch {
-      return 'main'; // Default to main even if not found
+      // Try next candidate
     }
   }
+
+  return 'main'; // Default to main even if not found
 }
 
 /**
@@ -210,10 +215,26 @@ export function hasUnpushedCommits(branch: string, cwd?: string): boolean {
 
 /**
  * Get the commit log between base and head.
+ * Prefers origin/${base} over local ${base} to avoid stale local branches
+ * in agent worktrees where local main/master is never updated.
  */
 export function getCommitLog(base: string, cwd?: string): string[] {
+  // Prefer origin/${base} for accurate comparison (local branch may be stale)
+  let ref = base;
+  if (!base.startsWith('origin/')) {
+    try {
+      execSync(`git rev-parse --verify origin/${base}`, {
+        cwd,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      ref = `origin/${base}`;
+    } catch {
+      // Fall back to local ref
+    }
+  }
+
   try {
-    const output = execSync(`git log ${base}..HEAD --oneline`, {
+    const output = execSync(`git log ${ref}..HEAD --oneline`, {
       cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

Resolves TKT-923: BUG: PR description lists phantom commits from stale local main

## Description

Root cause: getDefaultBaseBranch() in src/lib/pr/index.ts:127 checks for local 'main' branch, but branch creation in work/start.ts uses findBaseBranch() which checks 'origin/main'. In agent worktrees, local 'main' is never updated, so git log main..HEAD returns every commit since the stale local main - including commits already merged to origin/main. This makes PR descriptions look like they contain 9+ unrelated commits when the actual branch only has 1 commit. The GitHub PR diff is correct; only the generated PR body text is wrong. Fix: Change getDefaultBaseBranch() to prefer origin/main over local main, matching what findBaseBranch() already does for branch creation. Affected code: src/lib/pr/index.ts getDefaultBaseBranch(), getCommitLog(), and callers in src/commands/work/ready.ts and src/commands/pr/create.ts.

## Changes

- 2854edf fix(TKT-923): fix getDefaultBaseBranch to prefer origin/main over stale local main, and update getCommitLog to use remote tracking branch for accurate PR descriptions
- 65e65e1 fix(TKT-906): update agent remove refs to agent staff remove in tests (#357)
- 7d1cffc fix(TKT-921): fix template-json-flags tests: update for flat command structure and fix init hook --help bypass (#355)
- ba8a6e9 fix(TKT-919): fix interactive-mode test to detect this.prompt() and FlagResolver as interactive patterns (#354)
- c6ee90c fix(TKT-918): fix execution-storage tests to use UUID-based IDs from createExecution return value instead of hardcoded sequential WORK-001 IDs (#353)
- cccea88 fix(TKT-917): fix test path: cleanup.ts moved from agent/temp/ to agent/ (#351)
- 3dea303 fix(TKT-916): fix --json flag descriptions in agent auth and discover commands to match test expectations (#352)
- fc81f6a fix(TKT-913): fix oclif plugin warnings polluting JSON output in tests (#350)
- 997b6f9 fix(TKT-907): fix missing return after outputPromptAsJson calls in claude.ts (#340)
- 0b41213 TKT-912: Migrate branch/*, config/*, and remaining commands to this.prompt() (#345)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
