### PR TITLE
chore(TKT-926): bump CLI version to 0.3.26

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump @proletariat/cli version from 0.3.25 to 0.3.26

## Test plan
- [ ] Verify `package.json` version is `0.3.26`
- [ ] Build passes