### PR TITLE
TKT-931: Add git tagging to npm publish script

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -126,7 +126,7 @@
     "test:e2e:pmo": "mocha --forbid-only \"test/e2e/pmo-*.test.ts\"",
     "test:commands": "mocha --forbid-only \"test/commands/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
-    "publish:npm": "pnpm build && pnpm publish --access public --no-git-checks && git tag v$(node -p \"require('./package.json').version\") && git push origin --tags",
+    "publish:npm": "pnpm build && pnpm publish --access public --no-git-checks && git tag v$(node -p \"require('./package.json').version\") && git push origin v$(node -p \"require('./package.json').version\")",
     "roadmap:generate": "node ./bin/run.js roadmap generate --all"
   },
   "types": "dist/index.d.ts"


### PR DESCRIPTION
## Summary

Resolves TKT-931: Add git tagging to npm publish script

## Description

The publish:npm script in apps/cli/package.json does not create git tags. Add automatic git tagging after successful npm publish so releases are tracked in git history. Current script: pnpm build && pnpm publish --access public --no-git-checks. Should append: git tag v$(node -p require('./package.json').version) && git push origin --tags. Also consider backfilling tags for versions 0.3.18-0.3.26 that were published without tags.

## Changes

- 8bda048 chore(TKT-931): update publish:npm script to add git tagging after successful publish

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
