### PR TITLE
chore(TKT-381): bump CLI version to 0.3.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.27] - 2026-02-10
+
+### Added
+- TKT-932: Add JSON output and non-TTY auto-detection to remaining commands
+- TKT-933: Add `--description-file` flag to `ticket create`
+- TKT-937: Add `--label` as alias for `--labels` on `ticket create`
+- TKT-931: Add git tagging to npm publish script
+
+### Fixed
+- TKT-936: Add strict parameter validation to all MCP tools
+- TKT-940: Orphaned default project causes ticket command crashes
+- TKT-934: Devcontainer should set git config to user's GitHub identity
+- TKT-938: `workspace prune` needs confirmation or dry-run default
+- TKT-939: Execution list table formatting broken by emoji characters
+- TKT-935: `pmo init --json` still triggers interactive prompt for board template
+
 ## [0.3.24] - 2026-02-06
 
 ### Changed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump `@proletariat/cli` version from 0.3.26 to 0.3.27
- Update CHANGELOG.md with maintenance release entry

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)