### PR TITLE
feat(TKT-945): add GitHub Release creation to publish:npm script

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -127,7 +127,7 @@
     "test:e2e:pmo": "mocha --forbid-only \"test/e2e/pmo-*.test.ts\"",
     "test:commands": "mocha --forbid-only \"test/commands/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
-    "publish:npm": "pnpm build && pnpm publish --access public --no-git-checks && git tag v$(node -p \"require('./package.json').version\") && git push origin v$(node -p \"require('./package.json').version\")",
+    "publish:npm": "pnpm build && pnpm publish --access public --no-git-checks && git tag v$(node -p \"require('./package.json').version\") && git push origin v$(node -p \"require('./package.json').version\") && gh release create v$(node -p \"require('./package.json').version\") --generate-notes --title \"v$(node -p \"require('./package.json').version\")\"",
     "roadmap:generate": "node ./bin/run.js roadmap generate --all"
   },
   "types": "dist/index.d.ts"


### PR DESCRIPTION
## Summary
- Adds `gh release create` with `--generate-notes` to the `publish:npm` script
- After publishing to npm and pushing the git tag, a GitHub Release is now automatically created with auto-generated release notes from commits since the last tag

## Test plan
- [ ] Run `pnpm publish:npm` on next release and verify a GitHub Release appears on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)