### PR TITLE
TKT-953: BUG: prlt claude fails with invalid category "adhoc"

### DIFF
--- a/apps/cli/src/lib/pmo/types.ts
+++ b/apps/cli/src/lib/pmo/types.ts
@@ -128,6 +128,7 @@ export const TICKET_CATEGORIES = [
   'security',
   'database',
   'release',
+  'adhoc',
 ] as const
 
 export type TicketCategory = typeof TICKET_CATEGORIES[number]


### PR DESCRIPTION
## Summary

Resolves TKT-953: BUG: prlt claude fails with invalid category "adhoc"

## Description

## Problem

Running `prlt claude` inside an HQ and going through the interactive menu crashes when it tries to create the adhoc ticket:

```
PMOError: Invalid category "adhoc". Valid categories: feature, bug, refactor, docs, test, chore, performance, ci, build, security, database, release
Code: INVALID
```

The `prlt claude` command tries to create a ticket with category `adhoc`, but that category doesn't exist in the valid categories list.

## Steps to Reproduce

1. `cd` into an HQ directory
2. Run `prlt claude`
3. Select a project, enter a title/description
4. Select host, new tab, danger mode
5. Crashes with `PMOError: Invalid category "adhoc"`

## Fix Options

1. Add `adhoc` as a valid ticket category, OR
2. Use an existing category (e.g. `chore`) for adhoc tickets, OR
3. Make category optional and skip it for adhoc sessions

## Related

- TKT-512: Original `prlt claude` command

## Changes

- 17f5a9d7 fix(TKT-953): add adhoc as valid ticket category to fix prlt claude crash
- ddc98d1b chore: remove apps/deprecated, apps/directive, and apps/cli-old (#386)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
