### PR TITLE
TKT-950: Bump Docker base image from node:20 to node:22

### DIFF
--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -178,7 +178,7 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
 export function generateDockerfile(options: DevcontainerOptions): string {
   const timezone = options.timezone || 'America/Los_Angeles'
 
-  return `FROM node:20
+  return `FROM node:22
 
 # Ensure we run as root for apt-get and system setup
 USER root

--- a/apps/cli/test/unit/devcontainer.test.ts
+++ b/apps/cli/test/unit/devcontainer.test.ts
@@ -149,11 +149,11 @@ describe('Devcontainer', () => {
       ...overrides,
     })
 
-    it('should use node:20 base image', () => {
+    it('should use node:22 base image', () => {
       const options = makeOptions()
       const result = generateDockerfile(options)
 
-      expect(result).to.include('FROM node:20')
+      expect(result).to.include('FROM node:22')
     })
 
     it('should set DEVCONTAINER env var', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-950: Bump Docker base image from node:20 to node:22

## Description

## Problem

The Dockerfile template used for agent devcontainers uses `FROM node:20`, which is the older Maintenance LTS. The current Active LTS is Node 22.

## Changes

Update the Dockerfile template in the prlt CLI source to use `FROM node:22` as the base image. This affects all newly created agent devcontainers.

## Files

Likely in the CLI source where the Dockerfile template is defined (used by `agent add` / devcontainer generation).

## Acceptance Criteria

- [ ] Dockerfile template uses `node:22` as base image
- [ ] Existing agent Dockerfiles are not affected (only new agents)
- [ ] Build passes (`cd apps/cli && pnpm build`)

## Changes

- 285ce945 fix(TKT-950): bump Docker base image from node:20 to node:22
- ddc98d1b chore: remove apps/deprecated, apps/directive, and apps/cli-old (#386)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
