### PR TITLE
TKT-947: Support -v flag for version checking

### DIFF
--- a/apps/cli/bin/dev.js
+++ b/apps/cli/bin/dev.js
@@ -2,4 +2,11 @@
 
 import {execute} from '@oclif/core'
 
+// Support -v as shorthand for --version (only when it's the sole argument,
+// to avoid conflicts with command-specific -v flags like repo create --visibility)
+const args = process.argv.slice(2)
+if (args.length === 1 && args[0] === '-v') {
+  process.argv[2] = '--version'
+}
+
 await execute({development: true, dir: import.meta.url})

--- a/apps/cli/bin/run.js
+++ b/apps/cli/bin/run.js
@@ -2,6 +2,13 @@
 
 import {execute} from '@oclif/core'
 
+// Support -v as shorthand for --version (only when it's the sole argument,
+// to avoid conflicts with command-specific -v flags like repo create --visibility)
+const args = process.argv.slice(2)
+if (args.length === 1 && args[0] === '-v') {
+  process.argv[2] = '--version'
+}
+
 // Handle process termination gracefully
 process.on('SIGINT', () => {
   console.log('\n'); // Add newline for clean exit


### PR DESCRIPTION
## Summary

Resolves TKT-947: Support -v flag for version checking

## Description

Add -v as a shorthand alias for --version so users can quickly check the installed prlt version. Currently only prlt --version works (via oclif). Implementation may require a custom hook or flag override in the root command.

## Changes

- 782c0709 feat(TKT-947): add -v shorthand flag for version checking
- ddc98d1b chore: remove apps/deprecated, apps/directive, and apps/cli-old (#386)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
