### PR TITLE
TKT-954: BUG: Docker containers don't pull the latest prlt CLI version

### DIFF
--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -160,6 +160,9 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
       // Git identity for commit attribution (detected from host's gh/git config)
       ...(options.gitUserName ? { PRLT_GIT_USER_NAME: options.gitUserName } : {}),
       ...(options.gitUserEmail ? { PRLT_GIT_USER_EMAIL: options.gitUserEmail } : {}),
+      // prlt channel info for version updates at container startup (TKT-954)
+      PRLT_REGISTRY: channel.registry,
+      ...(!useMount ? { PRLT_VERSION: channel.version || 'latest' } : {}),
       // /hq/.proletariat/bin contains prlt wrapper with ESM loader for native modules
       PATH: '/hq/.proletariat/bin:/home/node/.npm-global/bin:/usr/local/bin:/usr/bin:/bin',
     },
@@ -571,11 +574,30 @@ configure_git_identity() {
 
 configure_git_identity
 
-# Check if prlt is already installed globally (via npm from GitHub Packages)
+# Check if prlt is already installed globally (via npm)
+# TKT-954: Also check for updates - Docker layer caching may have installed an older version
 if command -v prlt &> /dev/null; then
     PRLT_PATH=$(which prlt)
     if [[ "$PRLT_PATH" == "/home/node/.npm-global/bin/prlt" ]]; then
-        echo "prlt installed via npm, no setup needed"
+        DESIRED_VERSION="\${PRLT_VERSION:-latest}"
+        CURRENT_VERSION=$(prlt --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' || echo "unknown")
+
+        # Determine the target version to compare against
+        if [ "$DESIRED_VERSION" = "latest" ] || [ "$DESIRED_VERSION" = "dev" ] || [ "$DESIRED_VERSION" = "next" ]; then
+            # For tags, check npm registry for the actual version number
+            TARGET_VERSION=$(npm view "@proletariat/cli@\${DESIRED_VERSION}" version 2>/dev/null || echo "unknown")
+        else
+            # For pinned versions (e.g., "1.2.3"), use directly
+            TARGET_VERSION="$DESIRED_VERSION"
+        fi
+
+        if [ "$TARGET_VERSION" != "unknown" ] && [ "$CURRENT_VERSION" != "$TARGET_VERSION" ]; then
+            echo "Updating prlt from v\${CURRENT_VERSION} to v\${TARGET_VERSION} (channel: \${DESIRED_VERSION})..."
+            npm install -g "@proletariat/cli@\${DESIRED_VERSION}" 2>&1
+            echo "prlt updated successfully"
+        else
+            echo "prlt v\${CURRENT_VERSION} is up to date"
+        fi
         exit 0
     fi
 fi

--- a/apps/cli/test/unit/devcontainer.test.ts
+++ b/apps/cli/test/unit/devcontainer.test.ts
@@ -140,6 +140,34 @@ describe('Devcontainer', () => {
       expect(result.capAdd).to.include('NET_ADMIN')
       expect(result.capAdd).to.include('NET_RAW')
     })
+
+    it('should include PRLT_REGISTRY in containerEnv (TKT-954)', () => {
+      const options = makeOptions()
+      const result = generateDevcontainerJson(options)
+
+      expect(result.containerEnv).to.have.property('PRLT_REGISTRY', 'npm')
+    })
+
+    it('should include PRLT_VERSION in containerEnv for npm channel (TKT-954)', () => {
+      const options = makeOptions()
+      const result = generateDevcontainerJson(options)
+
+      expect(result.containerEnv).to.have.property('PRLT_VERSION', 'latest')
+    })
+
+    it('should include specific PRLT_VERSION when channel specifies a version (TKT-954)', () => {
+      const options = makeOptions({ prltChannel: 'npm:1.2.3' })
+      const result = generateDevcontainerJson(options)
+
+      expect(result.containerEnv).to.have.property('PRLT_VERSION', '1.2.3')
+    })
+
+    it('should not include PRLT_VERSION for mount channel (TKT-954)', () => {
+      const options = makeOptions({ prltChannel: 'mount' })
+      const result = generateDevcontainerJson(options)
+
+      expect(result.containerEnv).to.not.have.property('PRLT_VERSION')
+    })
   })
 
   describe('generateDockerfile', () => {
@@ -481,6 +509,37 @@ describe('Devcontainer', () => {
 
         expect(script).to.include('/usr/bin/git -C "$repo_dir" config user.name')
         expect(script).to.include('/usr/bin/git -C "$repo_dir" config user.email')
+      })
+
+      it('should check for prlt version updates at startup (TKT-954)', () => {
+        const script = generatePrltSetupScript()
+
+        expect(script).to.include('PRLT_VERSION')
+        expect(script).to.include('npm view "@proletariat/cli@')
+        expect(script).to.include('npm install -g "@proletariat/cli@')
+      })
+
+      it('should compare installed version with target version (TKT-954)', () => {
+        const script = generatePrltSetupScript()
+
+        expect(script).to.include('CURRENT_VERSION')
+        expect(script).to.include('TARGET_VERSION')
+        expect(script).to.include('Updating prlt from')
+      })
+
+      it('should handle pinned versions in update check (TKT-954)', () => {
+        const script = generatePrltSetupScript()
+
+        // Should handle both tag-based (latest/dev/next) and pinned versions
+        expect(script).to.include('"$DESIRED_VERSION" = "latest"')
+        expect(script).to.include('"$DESIRED_VERSION" = "dev"')
+        expect(script).to.include('TARGET_VERSION="$DESIRED_VERSION"')
+      })
+
+      it('should log up-to-date message when no update needed (TKT-954)', () => {
+        const script = generatePrltSetupScript()
+
+        expect(script).to.include('is up to date')
       })
     })
 


### PR DESCRIPTION
## Summary

Resolves TKT-954: BUG: Docker containers don't pull the latest prlt CLI version

## Description

## Problem

When running prlt inside Docker containers, the installed version is not updated to the latest available release. Containers may have an older version (e.g. v0.3.24) while a newer version (e.g. v0.3.27) is available. Agents end up running stale CLI versions.

## Expected Behavior

Docker containers should pull/install the latest prlt version on startup or rebuild to ensure agents are always running the most up-to-date CLI.

## Options

1. Add a version check + `npm install -g @proletariat/cli@latest` to the container startup script (`setup-prlt.sh`)
2. Always rebuild the image layer that installs prlt (bust the cache)
3. Add a `prlt self-update` command that agents can run

## Source

GitHub issue #389

## Changes

- 74cda30a fix(TKT-954): add version check to setup-prlt.sh so Docker containers update to latest prlt on startup

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
