### PR TITLE
chore(TKT-957): bump CLI version to 0.3.28

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump @proletariat/cli version from 0.3.27 to 0.3.28

## Test plan
- [ ] Verify `prlt --version` shows 0.3.28 after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)