### PR TITLE
chore(TKT-969): bump CLI version to 0.3.29

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bumps `@proletariat/cli` version from 0.3.28 to 0.3.29

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)