### PR TITLE
feat(TKT-971): reuse existing worktree for dead agent recovery

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -20,6 +20,7 @@ import {
   createEphemeralAgent,
   getTicketTmuxSession,
   killTmuxSession,
+  findWorktreeForBranch,
   WorkspaceInfo,
 } from '../../lib/agents/commands.js'
 import { Agent } from '../../lib/database/index.js'
@@ -457,12 +458,35 @@ export default class WorkStart extends PMOCommand {
         // For 'spawn', we continue with creating a new agent
       }
 
+      // Check for existing worktree with ticket's branch (dead agent recovery)
+      let reusingWorktree = false
+
+      if (ticket.branch && !flags.agent) {
+        const existingWorktree = findWorktreeForBranch(workspaceInfo, ticket.branch)
+        if (existingWorktree) {
+          reusingWorktree = true
+          if (!jsonMode) {
+            this.log(styles.muted(`Found existing worktree for branch in dead agent "${existingWorktree.agentName}"`))
+            this.log(styles.muted(`Reusing worktree at: ${existingWorktree.agentDir}`))
+          }
+        }
+      }
+
       // Agent selection: ephemeral flag, agent flag, ticket assignee, or prompt
       let agentName: string | undefined
       let agentWorktreePath: string | undefined
       let isEphemeralAgent = flags.ephemeral
 
-      if (flags.ephemeral) {
+      if (reusingWorktree) {
+        // Reuse dead agent's worktree — skip creating a new agent
+        const existingWorktree = findWorktreeForBranch(workspaceInfo, ticket.branch!)!
+        agentName = existingWorktree.agentName
+        agentWorktreePath = existingWorktree.agentDir
+        isEphemeralAgent = true
+        if (!jsonMode) {
+          this.log(styles.success(`Reusing agent: ${agentName} (worktree recovery)`))
+        }
+      } else if (flags.ephemeral) {
         // Create ephemeral agent on-demand
         if (!jsonMode) {
           this.log(styles.muted('Creating ephemeral agent...'))
@@ -1452,8 +1476,11 @@ export default class WorkStart extends PMOCommand {
           // Note: fetch already happened above (unconditionally for all action types)
 
           try {
-            // Check if branch exists and checkout
-            if (tryGitCommand(`git rev-parse --verify ${finalBranch}`, repoPath)) {
+            if (reusingWorktree) {
+              // Branch already checked out in this worktree — just fetch latest
+              this.log(styles.muted(`   ${repoName}: reusing existing branch (worktree recovery)`))
+            } else if (tryGitCommand(`git rev-parse --verify ${finalBranch}`, repoPath)) {
+              // Check if branch exists and checkout
               execSync(`git checkout ${finalBranch}`, { cwd: repoPath, stdio: 'pipe' })
               this.log(styles.muted(`   ${repoName}: checked out branch`))
             } else {

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -802,6 +802,80 @@ export function getAgentTmuxSessions(agentName: string): string[] {
     .map(s => s.name);
 }
 
+export interface ExistingWorktreeInfo {
+  agentName: string;
+  agentDir: string;
+  worktreePath: string;
+  branch: string;
+}
+
+/**
+ * Find an existing worktree that has a specific branch checked out.
+ * Used to detect dead agents whose worktrees still hold a branch,
+ * allowing worktree reuse instead of creating a fresh agent.
+ *
+ * Returns null if no worktree has the branch, or if the agent is still alive.
+ */
+export function findWorktreeForBranch(
+  workspaceInfo: WorkspaceInfo,
+  branch: string
+): ExistingWorktreeInfo | null {
+  for (const repo of workspaceInfo.repositories) {
+    const sourceRepoPath = path.join(workspaceInfo.path, 'repos', repo.name);
+    if (!fs.existsSync(sourceRepoPath)) continue;
+
+    try {
+      const output = execSync('git worktree list --porcelain', {
+        cwd: sourceRepoPath,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const blocks = output.split('\n\n').filter(Boolean);
+
+      for (const block of blocks) {
+        const lines = block.split('\n');
+        const worktreeLine = lines.find(l => l.startsWith('worktree '));
+        const branchLine = lines.find(l => l.startsWith('branch '));
+        const isPrunable = lines.some(l => l.startsWith('prunable'));
+
+        if (!worktreeLine || !branchLine || isPrunable) continue;
+
+        const worktreeFullPath = worktreeLine.replace('worktree ', '');
+        const branchRef = branchLine.replace('branch refs/heads/', '');
+
+        if (branchRef !== branch) continue;
+
+        // Found a worktree with this branch — confirm it's inside agents/
+        const relativePath = path.relative(workspaceInfo.path, worktreeFullPath);
+        if (!relativePath.startsWith('agents/')) continue;
+
+        // Extract agent name: agents/{subdir}/{agentName}/{repoName}
+        const parts = relativePath.split(path.sep);
+        if (parts.length < 4) continue;
+
+        const agentName = parts[parts.length - 2];
+        const agentDir = path.dirname(worktreeFullPath);
+
+        // Confirm agent has no active tmux sessions (it's dead)
+        const agentSessions = getAgentTmuxSessions(agentName);
+        if (agentSessions.length > 0) continue;
+
+        return {
+          agentName,
+          agentDir,
+          worktreePath: worktreeFullPath,
+          branch: branchRef,
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Get docker containers associated with an agent directory
  */


### PR DESCRIPTION
## Summary
- When respawning work on a ticket whose branch is still checked out in a dead agent's worktree, reuse that worktree instead of creating a fresh one (which would fail on `git checkout`)
- Adds `findWorktreeForBranch()` utility using `git worktree list --porcelain` to detect stale worktrees
- Pre-flight check in `work start` skips agent creation and branch checkout when reusing

## Test plan
- [ ] Spawn work on a ticket with an existing stale worktree (e.g. TKT-472) — should detect and reuse
- [ ] Spawn work on a ticket with no existing worktree — should create fresh agent as before
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)