### PR TITLE
TKT-968: Update homepage URL to proletariat.ai in npm package and GitHub repo

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -64,7 +64,7 @@
     "./oclif.manifest.json",
     "README.md"
   ],
-  "homepage": "https://github.com/chrismcdermut/proletariat",
+  "homepage": "https://proletariat.ai/",
   "keywords": [
     "cli",
     "multi-agent",


### PR DESCRIPTION
## Summary

Resolves TKT-968: Update homepage URL to proletariat.ai in npm package and GitHub repo

## Description

## Problem
The npm listing and GitHub repo for @proletariat/cli don't point to proletariat.ai.

## Solution
1. Update `homepage` field in `apps/cli/package.json` to `https://proletariat.ai/`
2. Update GitHub repo "About" section homepage URL to `https://proletariat.ai/`

## Files
- `apps/cli/package.json` — add/update `"homepage": "https://proletariat.ai/"`
- GitHub repo settings — update website URL via `gh repo edit --homepage "https://proletariat.ai/"`

## Changes

- 3a93cf35 chore(TKT-968): update homepage URL to proletariat.ai in package.json

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
