### PR TITLE
TKT-976: Bug: Docker container setup fails with 'argument list too long' for large .claude.json

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -1003,12 +1003,12 @@ function runContainerSetup(containerId: string, sandboxed: boolean = true): bool
     const tips = settings.tipsHistory as Record<string, number>
     tips['new-user-warmup'] = tips['new-user-warmup'] || 1
 
-    // Base64 encode to avoid shell escaping issues
-    const base64Content = Buffer.from(JSON.stringify(settings)).toString('base64')
-    // Write to container at /home/node/.claude.json
+    // Pipe settings via stdin to avoid ARG_MAX limits with large .claude.json files
+    const settingsJson = JSON.stringify(settings)
+    // Write to container at /home/node/.claude.json using stdin piping
     execSync(
-      `docker exec ${containerId} bash -c 'echo "${base64Content}" | base64 -d > /home/node/.claude.json'`,
-      { stdio: 'pipe' }
+      `docker exec -i ${containerId} bash -c 'cat > /home/node/.claude.json'`,
+      { input: settingsJson, stdio: ['pipe', 'pipe', 'pipe'] }
     )
     console.debug(`[runners:docker] Copied .claude.json settings to container (bypassPermissionsModeAccepted=${!sandboxed})`)
   } catch (error) {
@@ -1685,7 +1685,6 @@ echo ""
 echo "✅ Agent work complete. Press Enter to close or run more commands."
 exec bash
 `
-    const base64Script = Buffer.from(tmuxScript).toString('base64')
     const scriptPath = `/tmp/prlt-${sessionName}.sh`
 
     // Write script and start tmux session inside container
@@ -1698,10 +1697,12 @@ exec bash
     // set-titles on + set-titles-string: makes tmux set terminal title to window name
     const mouseOption = buildTmuxMouseOption(useControlMode)
 
-    // Step 1: Write the script to the container
-    const writeScriptCmd = `echo ${base64Script} | base64 -d > ${scriptPath} && chmod +x ${scriptPath}`
+    // Step 1: Write the script to the container via stdin piping to avoid ARG_MAX limits
     try {
-      execSync(`docker exec ${actualContainerId} bash -c '${writeScriptCmd}'`, { stdio: 'pipe' })
+      execSync(`docker exec -i ${actualContainerId} bash -c 'cat > ${scriptPath} && chmod +x ${scriptPath}'`, {
+        input: tmuxScript,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
     } catch (error) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Resolves TKT-976: Bug: Docker container setup fails with 'argument list too long' for large .claude.json

## Description

## Problem
In `runContainerSetup()` (runners.ts:871), the entire `.claude.json` file is base64-encoded and passed as a shell argument to `docker exec`. When the file is large (e.g. many project entries, cached data), it exceeds the OS `ARG_MAX` limit:

```
exec /usr/bin/bash: argument list too long
```

## Stack Trace
```
at checkExecSyncError (node:child_process:882:11)
at execSync (node:child_process:954:15)
at runContainerSetup (runners.js:871:9)
at ensureDockerContainer (runners.js:928:10)
```

## Expected Behavior
Use `docker exec -i` with stdin piping or `docker cp` instead of passing the file content as a command argument. This avoids the OS argument length limit.

## Impact
Agents fail to start in devcontainer mode when the user's `.claude.json` exceeds ~128KB.

## Changes

- 6d68fe4b fix(TKT-976): fix docker exec ARG_MAX error by piping file content via stdin instead of passing as shell argument

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
