### PR TITLE
TKT-965: Add position column to tickets for global force ranking

### DIFF
--- a/apps/cli/src/lib/database/drizzle-schema.ts
+++ b/apps/cli/src/lib/database/drizzle-schema.ts
@@ -306,6 +306,7 @@ export const pmoTickets = sqliteTable('pmo_tickets', {
   specId: text('spec_id'),
   epicId: text('epic_id'),
   labels: text('labels').notNull().default('[]'),
+  position: integer('position').notNull().default(0),
   createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
   updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
   lastSyncedFromSpec: text('last_synced_from_spec'),
@@ -320,6 +321,7 @@ export const pmoTickets = sqliteTable('pmo_tickets', {
   idxPriority: index('idx_pmo_tickets_priority').on(table.priority),
   idxCategory: index('idx_pmo_tickets_category').on(table.category),
   idxStatusId: index('idx_pmo_tickets_status_id').on(table.statusId),
+  idxStatusPosition: index('idx_pmo_tickets_status_position').on(table.statusId, table.position),
 }))
 
 /**

--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -269,6 +269,50 @@ export function openWorkspaceDatabase(workspacePath: string): Database.Database 
     // Ignore migration errors - table might not exist yet or column already exists
   }
 
+  // Migration: add position column to pmo_tickets table (TKT-965)
+  try {
+    const ticketsTableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_tickets'").get();
+    if (ticketsTableExists) {
+      const ticketsTableInfo = db.prepare("PRAGMA table_info(pmo_tickets)").all() as { name: string }[];
+      if (!ticketsTableInfo.some(col => col.name === 'position')) {
+        db.exec("ALTER TABLE pmo_tickets ADD COLUMN position INTEGER NOT NULL DEFAULT 0");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_pmo_tickets_status_position ON pmo_tickets(status_id, position)");
+
+        // Backfill existing tickets with gapped positions (1000, 2000, ...) per status,
+        // ordered by priority then created_at
+        const statuses = db.prepare(
+          "SELECT DISTINCT status_id FROM pmo_tickets WHERE status_id IS NOT NULL"
+        ).all() as { status_id: string }[];
+
+        const getTicketsForStatus = db.prepare(`
+          SELECT id FROM pmo_tickets WHERE status_id = ?
+          ORDER BY
+            CASE priority
+              WHEN 'P0' THEN 0
+              WHEN 'P1' THEN 1
+              WHEN 'P2' THEN 2
+              WHEN 'P3' THEN 3
+              ELSE 4
+            END,
+            created_at ASC
+        `);
+        const updatePosition = db.prepare("UPDATE pmo_tickets SET position = ? WHERE id = ?");
+
+        const backfill = db.transaction(() => {
+          for (const { status_id } of statuses) {
+            const tickets = getTicketsForStatus.all(status_id) as { id: string }[];
+            tickets.forEach((ticket, idx) => {
+              updatePosition.run((idx + 1) * 1000, ticket.id);
+            });
+          }
+        });
+        backfill();
+      }
+    }
+  } catch {
+    // Ignore migration errors - table might not exist yet
+  }
+
   return db;
 }
 

--- a/apps/cli/src/lib/mcp/helpers.ts
+++ b/apps/cli/src/lib/mcp/helpers.ts
@@ -48,6 +48,7 @@ export function formatTicket(t: Ticket) {
     owner: t.owner,
     branch: t.branch,
     epicId: t.epicId,
+    position: t.position,
   }
 }
 

--- a/apps/cli/src/lib/mcp/tools/ticket.ts
+++ b/apps/cli/src/lib/mcp/tools/ticket.ts
@@ -57,6 +57,7 @@ export function registerTicketTools(server: McpServer, ctx: McpToolContext): voi
                 owner: t.owner,
                 epicId: t.epicId,
                 branch: t.branch,
+                position: t.position,
                 createdAt: t.createdAt.toISOString(),
                 updatedAt: t.updatedAt.toISOString(),
               })),
@@ -227,6 +228,35 @@ export function registerTicketTools(server: McpServer, ctx: McpToolContext): voi
     async (params) => {
       try {
         const ticket = await ctx.storage.moveTicketToProject(params.id, params.project)
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({ success: true, ticket: formatTicket(ticket) }, null, 2),
+          }],
+        }
+      } catch (error) {
+        return errorResponse(error)
+      }
+    }
+  )
+
+  strictTool(server,
+    'ticket_reorder',
+    'Reorder a ticket within its current status. Provide either a direct position value or place it after another ticket.',
+    {
+      id: z.string().describe('Ticket ID to reorder'),
+      position: z.number().optional().describe('Direct position value (gapped integers, e.g. 1000, 2000)'),
+      after_ticket_id: z.string().optional().describe('Place this ticket after the specified ticket ID'),
+    },
+    async (params) => {
+      try {
+        if (!params.position && !params.after_ticket_id) {
+          throw new Error('Must provide either position or after_ticket_id')
+        }
+        const ticket = await ctx.storage.reorderTicket(params.id, {
+          position: params.position,
+          afterTicketId: params.after_ticket_id,
+        })
         return {
           content: [{
             type: 'text' as const,

--- a/apps/cli/src/lib/pmo/schema.ts
+++ b/apps/cli/src/lib/pmo/schema.ts
@@ -151,6 +151,7 @@ export const PMO_TABLE_SCHEMAS = {
       spec_id TEXT,
       epic_id TEXT,
       labels TEXT NOT NULL DEFAULT '[]',
+      position INTEGER NOT NULL DEFAULT 0,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       last_synced_from_spec TIMESTAMP,
@@ -498,6 +499,7 @@ export const PMO_INDEXES = `
   CREATE INDEX IF NOT EXISTS idx_pmo_tickets_priority ON ${PMO_TABLES.tickets}(priority);
   CREATE INDEX IF NOT EXISTS idx_pmo_tickets_category ON ${PMO_TABLES.tickets}(category);
   CREATE INDEX IF NOT EXISTS idx_pmo_tickets_status_id ON ${PMO_TABLES.tickets}(status_id);
+  CREATE INDEX IF NOT EXISTS idx_pmo_tickets_status_position ON ${PMO_TABLES.tickets}(status_id, position);
   CREATE INDEX IF NOT EXISTS idx_pmo_subtasks_ticket ON ${PMO_TABLES.subtasks}(ticket_id);
   CREATE INDEX IF NOT EXISTS idx_pmo_ticket_specs_spec ON ${PMO_TABLES.ticket_specs}(spec_id);
   CREATE INDEX IF NOT EXISTS idx_pmo_assignments_agent ON ${PMO_TABLES.ticket_assignments}(agent_name);
@@ -607,6 +609,7 @@ export const EXPECTED_TICKET_COLUMNS = [
   'spec_id',
   'epic_id',
   'labels',
+  'position',
   'created_at',
   'updated_at',
   'last_synced_from_spec',

--- a/apps/cli/src/lib/pmo/storage/dependencies.ts
+++ b/apps/cli/src/lib/pmo/storage/dependencies.ts
@@ -119,7 +119,7 @@ export class DependencyStorage {
       SELECT t.*,
              ws.id as column_id,
              ws.name as column_name,
-             ws.position as position
+             t.position as position
       FROM ${T.tickets} t
       JOIN ${T.ticket_dependencies} d ON t.id = d.depends_on_ticket_id
       LEFT JOIN ${T.workflow_statuses} ws ON t.status_id = ws.id
@@ -137,7 +137,7 @@ export class DependencyStorage {
       SELECT t.*,
              ws.id as column_id,
              ws.name as column_name,
-             ws.position as position
+             t.position as position
       FROM ${T.tickets} t
       JOIN ${T.ticket_dependencies} d ON t.id = d.ticket_id
       LEFT JOIN ${T.workflow_statuses} ws ON t.status_id = ws.id

--- a/apps/cli/src/lib/pmo/storage/epics.ts
+++ b/apps/cli/src/lib/pmo/storage/epics.ts
@@ -219,20 +219,12 @@ export class EpicStorage {
     const rows = this.ctx.db.prepare(`
       SELECT t.*,
              ws.id as column_id,
-             ws.position as position,
+             t.position as position,
              ws.name as column_name
       FROM ${T.tickets} t
       LEFT JOIN ${T.workflow_statuses} ws ON t.status_id = ws.id
       WHERE t.project_id = ? AND t.epic_id = ?
-      ORDER BY ws.position,
-        CASE t.priority
-          WHEN 'P0' THEN 0
-          WHEN 'P1' THEN 1
-          WHEN 'P2' THEN 2
-          WHEN 'P3' THEN 3
-          ELSE 4
-        END,
-        t.created_at ASC
+      ORDER BY ws.position, t.position ASC, t.created_at ASC
     `).all(projectId, epicId) as TicketRow[]
 
     return Promise.all(rows.map((row) => rowToTicket(this.ctx.db, row)))

--- a/apps/cli/src/lib/pmo/storage/index.ts
+++ b/apps/cli/src/lib/pmo/storage/index.ts
@@ -287,6 +287,10 @@ export class SQLiteStorage implements PMOStorage {
     return this.ticketStorage.moveTicket(projectId, id, column, position)
   }
 
+  async reorderTicket(id: string, opts: { position?: number; afterTicketId?: string }): Promise<Ticket> {
+    return this.ticketStorage.reorderTicket(id, opts)
+  }
+
   async moveTicketToProject(ticketId: string, newProjectId: string): Promise<Ticket> {
     return this.ticketStorage.moveTicketToProject(ticketId, newProjectId)
   }

--- a/apps/cli/src/lib/pmo/storage/projects.ts
+++ b/apps/cli/src/lib/pmo/storage/projects.ts
@@ -250,7 +250,7 @@ export class ProjectStorage {
 
   /**
    * Get tickets for a status (column).
-   * Tickets are sorted by priority (P0 first) then created_at (oldest first).
+   * Tickets are sorted by position (force-ranked) then created_at as tiebreaker.
    */
   private async getTicketsForStatus(statusId: string, projectId: string) {
     const ticketRows = this.ctx.db.prepare(`
@@ -260,15 +260,7 @@ export class ProjectStorage {
       FROM ${T.tickets} t
       LEFT JOIN ${T.workflow_statuses} ws ON t.status_id = ws.id
       WHERE t.status_id = ? AND t.project_id = ?
-      ORDER BY
-        CASE t.priority
-          WHEN 'P0' THEN 0
-          WHEN 'P1' THEN 1
-          WHEN 'P2' THEN 2
-          WHEN 'P3' THEN 3
-          ELSE 4
-        END,
-        t.created_at ASC
+      ORDER BY t.position ASC, t.created_at ASC
     `).all(statusId, projectId) as TicketRow[]
 
     return Promise.all(ticketRows.map((row) => rowToTicket(this.ctx.db, row)))

--- a/apps/cli/src/lib/pmo/storage/specs.ts
+++ b/apps/cli/src/lib/pmo/storage/specs.ts
@@ -286,20 +286,12 @@ export class SpecStorage {
     const rows = this.ctx.db.prepare(`
       SELECT t.*,
              ws.id as column_id,
-             ws.position as position,
+             t.position as position,
              ws.name as column_name
       FROM ${T.tickets} t
       LEFT JOIN ${T.workflow_statuses} ws ON t.status_id = ws.id
       WHERE t.project_id = ? AND t.spec_id = ?
-      ORDER BY ws.position,
-        CASE t.priority
-          WHEN 'P0' THEN 0
-          WHEN 'P1' THEN 1
-          WHEN 'P2' THEN 2
-          WHEN 'P3' THEN 3
-          ELSE 4
-        END,
-        t.created_at ASC
+      ORDER BY ws.position, t.position ASC, t.created_at ASC
     `).all(projectId, specId) as TicketRow[]
 
     return Promise.all(rows.map((row) => rowToTicket(this.ctx.db, row)))

--- a/apps/cli/src/lib/pmo/storage/tickets.ts
+++ b/apps/cli/src/lib/pmo/storage/tickets.ts
@@ -1,7 +1,8 @@
 /**
  * Ticket operations for PMO.
  * Tickets reference workflow statuses directly via status_id.
- * Board position is derived from priority and created_at (no separate board_tickets table).
+ * Tickets have a position column for force-ranked ordering within a status.
+ * Positions use gapped integers (1000, 2000, 3000...) for stable reordering.
  */
 
 import { PMO_TABLES } from '../schema.js'
@@ -171,6 +172,12 @@ export class TicketStorage {
       }
     }
 
+    // Get next position for the target status (append to end with gapped integer)
+    const maxPos = this.ctx.db.prepare(`
+      SELECT COALESCE(MAX(position), 0) as max_pos FROM ${T.tickets} WHERE status_id = ?
+    `).get(statusId) as { max_pos: number }
+    const position = maxPos.max_pos + 1000
+
     // Insert ticket
     const labels = ticket.labels || []
     try {
@@ -178,9 +185,9 @@ export class TicketStorage {
         INSERT INTO ${T.tickets} (
           id, project_id, title, description, priority, category,
           status_id, owner, assignee, spec_id, epic_id, labels,
-          created_at, updated_at, last_synced_from_spec, last_synced_from_board
+          position, created_at, updated_at, last_synced_from_spec, last_synced_from_board
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         id,
         projectId,
@@ -194,6 +201,7 @@ export class TicketStorage {
         specId,
         ticket.epicId || null,
         JSON.stringify(labels),
+        position,
         now,
         now,
         ticket.lastSyncedFromSpec || null,
@@ -246,7 +254,7 @@ export class TicketStorage {
     const row = this.ctx.db.prepare(`
       SELECT t.*,
              ws.id as column_id,
-             ws.position as position,
+             t.position as position,
              ws.name as column_name
       FROM ${T.tickets} t
       LEFT JOIN ${T.workflow_statuses} ws ON t.status_id = ws.id
@@ -382,9 +390,10 @@ export class TicketStorage {
   /**
    * Move a ticket to a different status (column).
    * In the workflow-based system, columns ARE statuses.
-   * The position parameter is ignored - tickets are sorted by priority then created_at.
+   * If position is provided, the ticket is placed at that position.
+   * Otherwise, the ticket is appended to the end of the target status.
    */
-  async moveTicket(projectId: string, id: string, column: string, _position?: number): Promise<Ticket> {
+  async moveTicket(projectId: string, id: string, column: string, position?: number): Promise<Ticket> {
     const existing = await this.getTicketById(id)
     if (!existing) {
       throw new PMOError('NOT_FOUND', `Ticket not found: ${id}`, id)
@@ -411,16 +420,136 @@ export class TicketStorage {
       throw new PMOError('NOT_FOUND', `Status not found: ${column}`)
     }
 
-    // Update ticket's status_id
+    // Determine position: use provided or append to end
+    let newPosition: number
+    if (position !== undefined) {
+      newPosition = position
+    } else {
+      const maxPos = this.ctx.db.prepare(`
+        SELECT COALESCE(MAX(position), 0) as max_pos FROM ${T.tickets} WHERE status_id = ?
+      `).get(targetStatus.id) as { max_pos: number }
+      newPosition = maxPos.max_pos + 1000
+    }
+
+    // Update ticket's status_id and position
     this.ctx.db.prepare(`
       UPDATE ${T.tickets}
-      SET status_id = ?, updated_at = ?
+      SET status_id = ?, position = ?, updated_at = ?
       WHERE id = ?
-    `).run(targetStatus.id, Date.now(), id)
+    `).run(targetStatus.id, newPosition, Date.now(), id)
 
     this.ctx.updateBoardTimestamp(projectId)
 
     return (await this.getTicketById(id)) as Ticket
+  }
+
+  /**
+   * Reorder a ticket within its current status.
+   * Supports two modes:
+   * 1. Direct position: set ticket to a specific position value
+   * 2. After ticket: place ticket immediately after another ticket
+   */
+  async reorderTicket(id: string, opts: { position?: number; afterTicketId?: string }): Promise<Ticket> {
+    const existing = await this.getTicketById(id)
+    if (!existing) {
+      throw new PMOError('NOT_FOUND', `Ticket not found: ${id}`, id)
+    }
+
+    let newPosition: number
+
+    if (opts.afterTicketId) {
+      // Place after the specified ticket
+      const afterTicket = await this.getTicketById(opts.afterTicketId)
+      if (!afterTicket) {
+        throw new PMOError('NOT_FOUND', `Ticket not found: ${opts.afterTicketId}`, opts.afterTicketId)
+      }
+
+      // The after ticket must be in the same status
+      if (afterTicket.statusId !== existing.statusId) {
+        throw new PMOError('INVALID', `Cannot reorder: ${opts.afterTicketId} is in a different status`)
+      }
+
+      const afterPosition = afterTicket.position ?? 0
+
+      // Find the next ticket after the target
+      const nextTicket = this.ctx.db.prepare(`
+        SELECT position FROM ${T.tickets}
+        WHERE status_id = ? AND position > ? AND id != ?
+        ORDER BY position ASC
+        LIMIT 1
+      `).get(existing.statusId, afterPosition, id) as { position: number } | undefined
+
+      if (nextTicket) {
+        // Place between afterTicket and nextTicket
+        const gap = nextTicket.position - afterPosition
+        if (gap > 1) {
+          newPosition = afterPosition + Math.floor(gap / 2)
+        } else {
+          // No gap - need to re-gap all tickets in this status
+          this.regapPositions(existing.statusId, id)
+          // Re-read the after ticket position after regapping
+          const refreshedAfter = await this.getTicketById(opts.afterTicketId)
+          const refreshedAfterPos = refreshedAfter?.position ?? 0
+          const refreshedNext = this.ctx.db.prepare(`
+            SELECT position FROM ${T.tickets}
+            WHERE status_id = ? AND position > ? AND id != ?
+            ORDER BY position ASC
+            LIMIT 1
+          `).get(existing.statusId, refreshedAfterPos, id) as { position: number } | undefined
+          newPosition = refreshedNext
+            ? refreshedAfterPos + Math.floor((refreshedNext.position - refreshedAfterPos) / 2)
+            : refreshedAfterPos + 1000
+        }
+      } else {
+        // Append after the target (no tickets after it)
+        newPosition = afterPosition + 1000
+      }
+    } else if (opts.position !== undefined) {
+      newPosition = opts.position
+    } else {
+      throw new PMOError('INVALID', 'Must provide either position or after_ticket_id')
+    }
+
+    this.ctx.db.prepare(`
+      UPDATE ${T.tickets}
+      SET position = ?, updated_at = ?
+      WHERE id = ?
+    `).run(newPosition, Date.now(), id)
+
+    if (existing.projectId) {
+      this.ctx.updateBoardTimestamp(existing.projectId)
+    }
+
+    return (await this.getTicketById(id)) as Ticket
+  }
+
+  /**
+   * Re-gap positions for all tickets in a status using 1000-gaps.
+   * Optionally excludes a ticket (e.g., the one being moved).
+   */
+  private regapPositions(statusId: string, excludeTicketId?: string): void {
+    let query = `
+      SELECT id FROM ${T.tickets}
+      WHERE status_id = ?
+    `
+    const params: unknown[] = [statusId]
+
+    if (excludeTicketId) {
+      query += ' AND id != ?'
+      params.push(excludeTicketId)
+    }
+
+    query += ' ORDER BY position ASC, created_at ASC'
+
+    const tickets = this.ctx.db.prepare(query).all(...params) as { id: string }[]
+    const update = this.ctx.db.prepare(`UPDATE ${T.tickets} SET position = ? WHERE id = ?`)
+
+    const regap = this.ctx.db.transaction(() => {
+      tickets.forEach((ticket, idx) => {
+        update.run((idx + 1) * 1000, ticket.id)
+      })
+    })
+    regap()
   }
 
   /**
@@ -480,7 +609,7 @@ export class TicketStorage {
     let query = `
       SELECT t.*,
              ws.id as column_id,
-             ws.position as position,
+             t.position as position,
              ws.name as column_name,
              p.name as project_name
       FROM ${T.tickets} t
@@ -538,27 +667,11 @@ export class TicketStorage {
       params.push(filter.column)
     }
 
-    // Order by project, then status position, then priority, then created_at
+    // Order by status column position, then ticket position within status
     if (projectIdOrName === undefined) {
-      query += ` ORDER BY p.name, ws.position,
-        CASE t.priority
-          WHEN 'P0' THEN 0
-          WHEN 'P1' THEN 1
-          WHEN 'P2' THEN 2
-          WHEN 'P3' THEN 3
-          ELSE 4
-        END,
-        t.created_at ASC`
+      query += ` ORDER BY p.name, ws.position, t.position ASC, t.created_at ASC`
     } else {
-      query += ` ORDER BY ws.position,
-        CASE t.priority
-          WHEN 'P0' THEN 0
-          WHEN 'P1' THEN 1
-          WHEN 'P2' THEN 2
-          WHEN 'P3' THEN 3
-          ELSE 4
-        END,
-        t.created_at ASC`
+      query += ` ORDER BY ws.position, t.position ASC, t.created_at ASC`
     }
 
     const rows = this.ctx.db.prepare(query).all(...params) as TicketRow[]
@@ -623,13 +736,20 @@ export class TicketStorage {
       }
     }
 
-    // Update ticket's project_id and status_id
+    // Get next position for the target status
+    const targetStatusId = newStatusId || existing.statusId
+    const maxPos = this.ctx.db.prepare(`
+      SELECT COALESCE(MAX(position), 0) as max_pos FROM ${T.tickets} WHERE status_id = ?
+    `).get(targetStatusId) as { max_pos: number }
+    const newTicketPosition = maxPos.max_pos + 1000
+
+    // Update ticket's project_id, status_id, and position
     const now = Date.now()
     this.ctx.db.prepare(`
       UPDATE ${T.tickets}
-      SET project_id = ?, status_id = ?, updated_at = ?
+      SET project_id = ?, status_id = ?, position = ?, updated_at = ?
       WHERE id = ?
-    `).run(newProjectId, newStatusId || existing.statusId, now, ticketId)
+    `).run(newProjectId, targetStatusId, newTicketPosition, now, ticketId)
 
     // Update timestamps for both projects
     this.updateProjectTimestamp(oldProjectId)

--- a/apps/cli/src/lib/pmo/storage/views.ts
+++ b/apps/cli/src/lib/pmo/storage/views.ts
@@ -389,16 +389,8 @@ export class ViewStorage {
       params.push(searchTerm, searchTerm)
     }
 
-    // Order by priority then created_at
-    sql += ` ORDER BY
-      CASE t.priority
-        WHEN 'P0' THEN 0
-        WHEN 'P1' THEN 1
-        WHEN 'P2' THEN 2
-        WHEN 'P3' THEN 3
-        ELSE 4
-      END,
-      t.created_at ASC`
+    // Order by ticket position, then created_at as tiebreaker
+    sql += ` ORDER BY t.position ASC, t.created_at ASC`
 
     const rows = this.ctx.db.prepare(sql).all(...params) as Array<{
       id: string

--- a/apps/cli/src/lib/pmo/types.ts
+++ b/apps/cli/src/lib/pmo/types.ts
@@ -884,6 +884,7 @@ export interface PMOStorage {
   getTicket(id: string): Promise<Ticket | null>
   updateTicket(id: string, changes: Partial<Ticket>): Promise<Ticket>
   moveTicket(projectId: string, id: string, column: string, position?: number): Promise<Ticket>
+  reorderTicket(id: string, opts: { position?: number; afterTicketId?: string }): Promise<Ticket>
   moveTicketToProject(ticketId: string, newProjectId: string): Promise<Ticket>
   deleteTicket(id: string): Promise<void>
   listTickets(projectId: string | undefined, filter?: TicketFilter): Promise<Ticket[]>


### PR DESCRIPTION
## Summary

Resolves TKT-965: Add position column to tickets for global force ranking

## Description

## Problem
Tickets have no position/ordering field. Force ranking requires a stable sort order within status. Currently tickets are loosely ordered by priority buckets (P0-P3) which results in 42 P0s with no relative ordering.

## Solution
- Add `position` integer column to pmo_tickets table
- Gapped integers (1000, 2000, 3000...) for stable reordering without cascade updates
- Position is global within status (not per-category — diet enforcement happens at pull time, not ranking time)
- Add MCP tool for reordering: ticket_reorder(ticket_id, position) or ticket_reorder(ticket_id, after_ticket_id)
- Backfill existing tickets with position based on current priority ordering

## Schema
```sql
ALTER TABLE pmo_tickets ADD COLUMN position INTEGER DEFAULT 0;
CREATE INDEX idx_tickets_status_position ON pmo_tickets(status_id, position);
```

## Changes

- 26df3328 feat(TKT-965): add position column to pmo_tickets for force ranking with gapped integers, MCP ticket_reorder tool, and backfill migration

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
