### PR TITLE
chore: bump CLI version to 0.3.30

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.3.29 to 0.3.30 for npm publish

Includes: TKT-976 (ARG_MAX fix), TKT-965 (position column), TKT-968 (homepage URL), TKT-971 (worktree reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)