### PR TITLE
chore(TKT-981): add root-level publish:npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pack:cli": "pnpm --filter @proletariat/cli pack",
     "prlt": "node apps/cli/bin/run.js",
     "prlt:isolated": "PRLT_HQ_PATH=/tmp/prlt-test-$RANDOM node apps/cli/bin/run.js",
+    "publish:npm": "pnpm --filter @proletariat/cli publish:npm",
     "test": "pnpm -r test",
     "test:cli": "pnpm --filter @proletariat/cli test"
   }


### PR DESCRIPTION
## Summary
- Adds a `publish:npm` script to the root `package.json` that forwards to the CLI's `publish:npm` script via `pnpm --filter @proletariat/cli publish:npm`
- Allows running `pnpm publish:npm` from the repo root instead of having to `cd apps/cli` first
- Follows the same `--filter` pattern already used by `build:cli`, `pack:cli`, and `test:cli`

## Test plan
- [ ] Verify `pnpm publish:npm` from root invokes the CLI's publish:npm script
- [ ] Verify the build passes (`cd apps/cli && pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)