### PR TITLE
TKT-987: Bump CLI version to 0.3.32

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Resolves TKT-987: Bump CLI version to 0.3.32

## Description

Bump version for npm publish. Includes: TKT-984 (spawn count/filter system), TKT-966 (diet weights), TKT-889 (custom priorities), TKT-978 (sticky header), position migration fix.

## Changes

- 39330d9b chore(TKT-987): bump CLI version to 0.3.32

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
