### PR TITLE
TKT-1000: Allow --message flag to append instructions to any action, not just custom

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -131,7 +131,7 @@ export default class WorkSpawn extends PMOCommand {
       description: 'Action to perform (e.g., groom, implement, review, custom). Prompts if not provided.',
     }),
     message: Flags.string({
-      description: 'Custom prompt/message for the agent (use with --action custom)',
+      description: 'Additional instructions for the agent (appended to any action prompt)',
     }),
     session: Flags.string({
       description: 'Session manager inside container (tmux runs agent in tmux inside container)',
@@ -1093,9 +1093,6 @@ export default class WorkSpawn extends PMOCommand {
           }
           batchAction = 'custom'
           batchCustomMessage = flags.message
-        } else if (flags.message && flags.action !== 'custom') {
-          // --message provided without --action custom - warn user
-          this.warn('--message flag is only used with --action custom, ignoring')
         }
 
         // Now fetch action details after selection is made
@@ -1491,6 +1488,10 @@ export default class WorkSpawn extends PMOCommand {
             } else if (batchAction) {
               startArgs.push('--action', batchAction)
             }
+            // Pass --message for additional instructions (non-custom actions)
+            if (flags.message && batchAction !== 'custom') {
+              startArgs.push('--message', flags.message)
+            }
           } else {
             // Batch mode: pass all settings to skip prompts
             // batchDisplayMode is for devcontainer, batchDisplay is for host
@@ -1509,6 +1510,10 @@ export default class WorkSpawn extends PMOCommand {
               startArgs.push('--prompt', batchCustomMessage)
             } else {
               startArgs.push('--action', batchAction || 'implement')
+            }
+            // Pass --message for additional instructions (non-custom actions)
+            if (flags.message && batchAction !== 'custom') {
+              startArgs.push('--message', flags.message)
             }
             // Pass session manager (tmux inside container by default)
             if (flags.session) startArgs.push('--session', flags.session)

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -147,6 +147,9 @@ export default class WorkStart extends PMOCommand {
       char: 'p',
       description: 'Custom prompt (overrides action)',
     }),
+    message: Flags.string({
+      description: 'Additional instructions appended to any action prompt',
+    }),
     watch: Flags.boolean({
       char: 'w',
       description: 'Stream output in real-time',
@@ -887,6 +890,8 @@ export default class WorkStart extends PMOCommand {
         actionPrompt: customPrompt || selectedAction?.prompt,
         actionEndPrompt: customPrompt ? undefined : selectedAction?.endPrompt,
         modifiesCode: customPrompt ? true : selectedAction?.modifiesCode ?? true,
+        // Additional instructions from --message flag
+        customMessage: flags.message,
       }
 
       // Check if agent has devcontainer config

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -262,6 +262,11 @@ function buildPrompt(context: ExecutionContext): string {
   // Note: Branch setup (fetch + checkout/create) is now handled programmatically
   // in work/start.ts before the agent spawns, so no prompt instructions needed
 
+  // Additional instructions from --message flag (appended to any action)
+  if (context.customMessage) {
+    prompt += `\n## Additional Instructions\n\n${context.customMessage}\n`
+  }
+
   // END HOOK - Action-specific completion instructions
   prompt += `\n---\n\n## When Complete\n\n`
 

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -165,6 +165,8 @@ export interface ExecutionContext {
   actionPrompt?: string   // The action prompt (start instruction for agent)
   actionEndPrompt?: string // The action end prompt (completion instructions)
   modifiesCode?: boolean  // Whether this action modifies code (needs branch)
+  // Custom message (appended as additional instructions to any action)
+  customMessage?: string
   // PR feedback context (for work revise)
   prFeedback?: string // Formatted PR feedback markdown
   isRevision?: boolean // Whether this is a revision (addressing PR feedback)


### PR DESCRIPTION
## Summary

Resolves TKT-1000: Allow --message flag to append instructions to any action, not just custom

## Description

Currently `--message` on `prlt work spawn` and `prlt work start` is only allowed with `--action custom`. If you pass `--message` with any other action (implement, review, etc.), it warns and ignores it.

**Desired behavior:**
- `--message` appends extra instructions to any action's prompt
- Example: `prlt work spawn TKT-780 --action implement --message "rebase on latest main before continuing"`
- The message gets added after the action prompt and ticket context in `buildPrompt()`
- For `--action custom`, behavior stays the same (message IS the prompt)

**Implementation:**
- Remove the guard in `spawn.ts` (~line 1096) that warns when `--message` is used without `--action custom`
- Same change in `start.ts` if it has the same guard
- In `buildPrompt()` in `runners.ts`, append the custom message as an additional section (e.g., `## Additional Instructions\n\n{message}`)
- Pass `message` through the execution context to `buildPrompt()`

## Changes

- 85632b58 feat(TKT-1000): allow --message flag to append instructions to any action, not just custom

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
