### PR TITLE
chore(TKT-1001): bump CLI version to 0.3.33

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.3.32 to 0.3.33

🤖 Generated with [Claude Code](https://claude.com/claude-code)