### PR TITLE
fix(TKT-1003): resolve correct agent directory for temp agents

### DIFF
--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -197,16 +197,28 @@ export default class WorkReady extends PMOCommand {
               worktreePath = path.join('/workspace', repoDirs[0].name);
             }
           } else {
-            const agentsPath = path.join(workspaceInfo.path, 'agents', 'staff');
-            const agentDir = path.join(agentsPath, agentName);
-            // Look for repo directories inside agent dir
-            const entries = fs.readdirSync(agentDir, { withFileTypes: true });
-            const repoDirs = entries.filter((e) =>
-              e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules'
-            );
-            if (repoDirs.length > 0) {
-              // Use the first repo directory (typically the main worktree)
-              worktreePath = path.join(agentDir, repoDirs[0].name);
+            // Resolve agent directory based on agent type (staff vs temp)
+            const agentRecord = workspaceInfo.agents.find(a => a.name === agentName);
+            let agentDir: string;
+            if (agentRecord?.worktree_path) {
+              // Use the worktree_path from the database if available
+              agentDir = path.join(workspaceInfo.path, agentRecord.worktree_path);
+            } else if (agentRecord?.type === 'ephemeral') {
+              agentDir = path.join(workspaceInfo.path, 'agents', workspaceInfo.ephemeralAgentsDir, agentName);
+            } else {
+              agentDir = path.join(workspaceInfo.path, 'agents', workspaceInfo.persistentAgentsDir, agentName);
+            }
+
+            if (fs.existsSync(agentDir)) {
+              // Look for repo directories inside agent dir
+              const entries = fs.readdirSync(agentDir, { withFileTypes: true });
+              const repoDirs = entries.filter((e) =>
+                e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules'
+              );
+              if (repoDirs.length > 0) {
+                // Use the first repo directory (typically the main worktree)
+                worktreePath = path.join(agentDir, repoDirs[0].name);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- **Bug**: `prlt work ready TKT-xxx --pr` fails with `ENOENT` when run from a temp (ephemeral) agent because the code hardcoded the path `agents/staff/` instead of checking the agent's actual type.
- **Fix**: The agent directory is now resolved by looking up the agent record in the database. If the agent has a `worktree_path`, that is used directly. Otherwise, the correct subdirectory (`ephemeralAgentsDir` for temp agents, `persistentAgentsDir` for staff agents) is used based on the agent's type.
- Added an `fs.existsSync` guard before reading the agent directory to avoid crashes when the directory is missing.

## Test plan
- [ ] Run `prlt work ready TKT-xxx --pr` from a **temp** agent worktree and verify it resolves the path under `agents/temp/` correctly
- [ ] Run `prlt work ready TKT-xxx --pr` from a **staff** agent worktree and verify it continues to work as before
- [ ] Build passes: `cd apps/cli && pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)