### PR TITLE
TKT-1004: Bump CLI version to 0.3.34

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Resolves TKT-1004: Bump CLI version to 0.3.34

## Description

Version bump to 0.3.34 for npm publish. Includes TKT-1000 (--message flag for any action), TKT-986 (talks page mobile/compounding autonomy), and other recent merges.

## Changes

- 8888e312 chore(TKT-1004): bump CLI version to 0.3.34

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
