### PR TITLE
fix(TKT-994): Register missing command paths for template, link, theme, and agent temp commands

### DIFF
--- a/apps/cli/src/commands/agent/index.ts
+++ b/apps/cli/src/commands/agent/index.ts
@@ -55,6 +55,7 @@ export default class Agent extends PMOCommand {
         { name: '🗑️  Remove agent', value: 'remove', command: 'prlt agent remove --machine' },
         // Management group
         { name: '👔 Manage staff agents', value: 'staff', command: 'prlt agent staff --machine' },
+        { name: '⏱️  Manage temp agents', value: 'temp', command: 'prlt agent temp --machine' },
         { name: '🧹 Cleanup agents', value: 'cleanup', command: 'prlt agent cleanup --machine' },
         { name: '🎨 Manage themes', value: 'themes', command: 'prlt agent themes --machine' },
         // Operations group
@@ -102,8 +103,14 @@ export default class Agent extends PMOCommand {
           break;
         }
         case 'staff': {
-          const { default: StaffCommand } = await import('../staff/index.js');
+          const { default: StaffCommand } = await import('./staff/index.js');
           const cmd = new StaffCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'temp': {
+          const { default: TempCommand } = await import('./temp/index.js');
+          const cmd = new TempCommand([], this.config);
           await cmd.run();
           break;
         }
@@ -114,7 +121,7 @@ export default class Agent extends PMOCommand {
           break;
         }
         case 'themes': {
-          const { default: ThemeCommand } = await import('../theme/index.js');
+          const { default: ThemeCommand } = await import('./themes/index.js');
           const cmd = new ThemeCommand([], this.config);
           await cmd.run();
           break;

--- a/apps/cli/src/commands/agent/staff/add.ts
+++ b/apps/cli/src/commands/agent/staff/add.ts
@@ -1,0 +1,1 @@
+export { default } from '../../staff/add.js';

--- a/apps/cli/src/commands/agent/staff/index.ts
+++ b/apps/cli/src/commands/agent/staff/index.ts
@@ -1,0 +1,102 @@
+import { Flags } from '@oclif/core';
+import inquirer from 'inquirer';
+import { colors } from '../../../lib/colors.js';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class AgentStaff extends PMOCommand {
+  static description = 'Manage staff (persistent) agents';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> list',
+    '<%= config.bin %> <%= command.id %> add',
+    '<%= config.bin %> <%= command.id %> remove camry',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+    'no-interactive': Flags.boolean({
+      description: 'Alias for --json flag',
+      default: false,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(AgentStaff);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const menuChoices = [
+      { name: 'List staff agents', value: 'list', command: 'prlt agent staff list --machine' },
+      { name: 'Add staff agent', value: 'add', command: 'prlt agent staff add --machine' },
+      { name: 'Remove staff agent', value: 'remove', command: 'prlt agent staff remove --machine' },
+      { name: 'Cancel', value: 'cancel', command: '' },
+    ];
+    const message = 'What would you like to do?';
+
+    if (jsonMode) {
+      outputPromptAsJson(
+        buildPromptConfig('list', 'action', message, menuChoices),
+        createMetadata('agent staff', flags)
+      );
+      return;
+    }
+
+    this.log(colors.primary('Staff Agents'));
+    this.log(colors.textMuted('Persistent agents with dedicated worktrees.\n'));
+
+    const { action } = await this.prompt<{ action: string }>([{
+      type: 'list',
+      name: 'action',
+      message,
+      choices: [
+        { name: '📋 ' + menuChoices[0].name, value: menuChoices[0].value },
+        { name: '➕ ' + menuChoices[1].name, value: menuChoices[1].value },
+        { name: '🗑️  ' + menuChoices[2].name, value: menuChoices[2].value },
+        new inquirer.Separator(),
+        { name: '❌ ' + menuChoices[3].name, value: menuChoices[3].value },
+      ]
+    }], null);
+
+    if (action === 'cancel') {
+      this.log(colors.textMuted('Operation cancelled.'));
+      return;
+    }
+
+    try {
+      switch (action) {
+        case 'list': {
+          const { default: ListCommand } = await import('./list.js');
+          const cmd = new ListCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'add': {
+          const { default: AddCommand } = await import('./add.js');
+          const cmd = new AddCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'remove': {
+          const { default: RemoveCommand } = await import('./remove.js');
+          const cmd = new RemoveCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        default:
+          this.error(`Unknown action: ${action}`);
+      }
+    } catch (error) {
+      this.error(`Failed to execute staff ${action}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}

--- a/apps/cli/src/commands/agent/staff/list.ts
+++ b/apps/cli/src/commands/agent/staff/list.ts
@@ -1,0 +1,1 @@
+export { default } from '../../staff/list.js';

--- a/apps/cli/src/commands/agent/staff/remove.ts
+++ b/apps/cli/src/commands/agent/staff/remove.ts
@@ -1,0 +1,1 @@
+export { default } from '../../staff/remove.js';

--- a/apps/cli/src/commands/agent/themes/add-names.ts
+++ b/apps/cli/src/commands/agent/themes/add-names.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/add-names.js';

--- a/apps/cli/src/commands/agent/themes/create.ts
+++ b/apps/cli/src/commands/agent/themes/create.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/create.js';

--- a/apps/cli/src/commands/agent/themes/index.ts
+++ b/apps/cli/src/commands/agent/themes/index.ts
@@ -1,0 +1,167 @@
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import { PromptCommand } from '../../../lib/prompt-command.js';
+import { machineOutputFlags } from '../../../lib/pmo/index.js';
+import { getWorkspaceInfo } from '../../../lib/agents/commands.js';
+import { ensureBuiltinThemes } from '../../../lib/themes.js';
+import { getThemes, getAvailableThemeNames } from '../../../lib/database/index.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class AgentThemes extends PromptCommand {
+  static description = 'Manage agent naming themes';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> list',
+    '<%= config.bin %> <%= command.id %> create greek-gods',
+    '<%= config.bin %> <%= command.id %> add-names greek-gods zeus athena',
+  ];
+
+  static flags = {
+    ...machineOutputFlags,
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(AgentThemes);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const menuChoices = [
+      { id: 'list', name: 'List themes', command: 'prlt agent themes list --format json' },
+      { id: 'create', name: 'Create a new theme', command: 'prlt agent themes create --machine' },
+      { id: 'add-names', name: 'Add names to a theme', command: 'prlt agent themes add-names --machine' },
+      { id: 'cancel', name: 'Cancel', command: '' },
+    ];
+    const message = 'What would you like to do?';
+
+    if (jsonMode) {
+      outputPromptAsJson(
+        buildPromptConfig('list', 'action', message, menuChoices.map(c => ({
+          name: c.name,
+          value: c.id,
+          command: c.command,
+        }))),
+        createMetadata('agent themes', flags)
+      );
+      return;
+    }
+
+    this.log(chalk.bold('\nAgent Themes'));
+    this.log(chalk.dim('Optional themed name pools for your agents.\n'));
+
+    const { action } = await this.prompt<{ action: string }>([{
+      type: 'list',
+      name: 'action',
+      message,
+      choices: [
+        ...menuChoices.slice(0, 3).map(c => ({ name: c.name, value: c.id })),
+        new inquirer.Separator(),
+        { name: menuChoices[3].name, value: menuChoices[3].id }
+      ]
+    }], null);
+
+    if (action === 'cancel') {
+      this.log(chalk.dim('Cancelled.'));
+      return;
+    }
+
+    try {
+      switch (action) {
+        case 'list': {
+          const { default: ListCommand } = await import('./list.js');
+          const cmd = new ListCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'create': {
+          const { themeName } = await this.prompt<{ themeName: string }>([{
+            type: 'input',
+            name: 'themeName',
+            message: 'Theme name:',
+            validate: (input: unknown) => {
+              if (!(input as string).trim()) return 'Theme name is required';
+              return true;
+            }
+          }], null);
+          const normalized = themeName.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+          if (themeName.trim() !== normalized) {
+            this.log(chalk.blue(`Normalized: ${themeName.trim()} → ${normalized}`));
+          }
+          const { default: CreateCommand } = await import('./create.js');
+          const cmd = new CreateCommand([normalized], this.config);
+          await cmd.run();
+
+          const { addNamesNow } = await this.prompt<{ addNamesNow: boolean }>([{
+            type: 'list',
+            name: 'addNamesNow',
+            message: 'Add names to this theme now?',
+            choices: [
+              { name: 'Yes', value: true },
+              { name: 'No', value: false },
+            ],
+          }], null);
+
+          if (addNamesNow) {
+            const { names } = await this.prompt<{ names: string }>([{
+              type: 'input',
+              name: 'names',
+              message: 'Enter names (space-separated):',
+              validate: (input: unknown) => (input as string).trim() ? true : 'At least one name is required'
+            }], null);
+            const addArgs = [normalized, ...names.trim().split(/\s+/)];
+            const { default: AddNamesCommand } = await import('./add-names.js');
+            const addCmd = new AddNamesCommand(addArgs, this.config);
+            await addCmd.run();
+          }
+          break;
+        }
+        case 'add-names': {
+          const workspaceInfo = getWorkspaceInfo();
+          ensureBuiltinThemes(workspaceInfo.path);
+          const themes = getThemes(workspaceInfo.path);
+
+          if (themes.length === 0) {
+            this.log(chalk.yellow('No themes found. Create one first.'));
+            return;
+          }
+
+          const themeChoices = themes.map(t => {
+            const availableNames = getAvailableThemeNames(workspaceInfo.path, t.id);
+            const builtinTag = t.builtin ? chalk.dim(' [built-in]') : '';
+            return {
+              name: `${t.display_name}${builtinTag} ${chalk.dim(`(${availableNames.length} names available)`)}`,
+              value: t.id
+            };
+          });
+
+          const { selectedTheme } = await this.prompt<{ selectedTheme: string }>([{
+            type: 'list',
+            name: 'selectedTheme',
+            message: 'Select theme to add names to:',
+            choices: themeChoices
+          }], null);
+
+          const { names } = await this.prompt<{ names: string }>([{
+            type: 'input',
+            name: 'names',
+            message: 'Names to add (space-separated):',
+            validate: (input: unknown) => (input as string).trim() ? true : 'At least one name is required'
+          }], null);
+          const addArgs = [selectedTheme, ...names.trim().split(/\s+/)];
+          const { default: AddNamesCommand } = await import('./add-names.js');
+          const cmd = new AddNamesCommand(addArgs, this.config);
+          await cmd.run();
+          break;
+        }
+        default:
+          this.error(`Unknown action: ${action}`);
+      }
+    } catch (error) {
+      this.error(error instanceof Error ? error.message : String(error));
+    }
+  }
+}

--- a/apps/cli/src/commands/agent/themes/list.ts
+++ b/apps/cli/src/commands/agent/themes/list.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/list.js';

--- a/apps/cli/src/commands/agent/themes/set.ts
+++ b/apps/cli/src/commands/agent/themes/set.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/set.js';

--- a/apps/cli/src/commands/agents/themes/add-names.ts
+++ b/apps/cli/src/commands/agents/themes/add-names.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/add-names.js';

--- a/apps/cli/src/commands/agents/themes/create.ts
+++ b/apps/cli/src/commands/agents/themes/create.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/create.js';

--- a/apps/cli/src/commands/agents/themes/list.ts
+++ b/apps/cli/src/commands/agents/themes/list.ts
@@ -1,0 +1,1 @@
+export { default } from '../../theme/list.js';

--- a/apps/cli/src/commands/phase/template/apply.ts
+++ b/apps/cli/src/commands/phase/template/apply.ts
@@ -1,0 +1,16 @@
+import TemplateApply from '../../template/apply.js';
+
+export default class PhaseTemplateApply extends TemplateApply {
+  static description = 'Apply a phase template to the workspace';
+  static args = TemplateApply.args;
+  static flags = TemplateApply.flags;
+  static examples = TemplateApply.examples;
+
+  async run(): Promise<void> {
+    const argv = this.argv as string[];
+    if (!argv.includes('--type') && !argv.includes('-t')) {
+      argv.push('--type', 'phase');
+    }
+    return super.run();
+  }
+}

--- a/apps/cli/src/commands/phase/template/create.ts
+++ b/apps/cli/src/commands/phase/template/create.ts
@@ -1,0 +1,16 @@
+import TemplateCreate from '../../template/create.js';
+
+export default class PhaseTemplateCreate extends TemplateCreate {
+  static description = 'Create a phase template from current workspace phases';
+  static args = TemplateCreate.args;
+  static flags = TemplateCreate.flags;
+  static examples = TemplateCreate.examples;
+
+  async run(): Promise<void> {
+    const argv = this.argv as string[];
+    if (!argv.includes('--type') && !argv.includes('-t')) {
+      argv.push('--type', 'phase');
+    }
+    return super.run();
+  }
+}

--- a/apps/cli/src/commands/phase/template/delete.ts
+++ b/apps/cli/src/commands/phase/template/delete.ts
@@ -1,0 +1,77 @@
+import { Args, Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../../lib/prompt-json.js';
+
+export default class PhaseTemplateDelete extends PMOCommand {
+  static description = 'Delete a phase template';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-template --force',
+  ];
+
+  static args = {
+    id: Args.string({
+      description: 'Template ID to delete',
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation',
+      default: false,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(PhaseTemplateDelete);
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('phase template delete', flags));
+      }
+      this.error(message);
+    };
+
+    const template = await this.storage.getPhaseTemplate(args.id);
+    if (!template) {
+      return handleError('NOT_FOUND', `Phase template not found: ${args.id}`);
+    }
+
+    if (template.isBuiltin) {
+      return handleError('BUILTIN', `Cannot delete built-in template "${template.name}".`);
+    }
+
+    if (!flags.force) {
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
+        type: 'list',
+        name: 'confirm',
+        message: `Delete phase template "${template.name}"?`,
+        choices: [
+          { name: 'No', value: false },
+          { name: 'Yes', value: true },
+        ],
+      }], jsonMode ? { flags, commandName: 'phase template delete' } : null);
+
+      if (!confirm) {
+        this.log(styles.muted('Cancelled.'));
+        return;
+      }
+    }
+
+    await this.storage.deletePhaseTemplate(args.id);
+    this.log(styles.success(`\nDeleted phase template "${template.name}"`));
+  }
+}

--- a/apps/cli/src/commands/phase/template/list.ts
+++ b/apps/cli/src/commands/phase/template/list.ts
@@ -1,0 +1,103 @@
+import { Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import { StateCategory, PhaseTemplate } from '../../../lib/pmo/types.js';
+
+export default class PhaseTemplateList extends PMOCommand {
+  static description = 'List phase templates';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --builtin',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+    builtin: Flags.boolean({
+      description: 'Show only built-in templates',
+      exclusive: ['custom'],
+    }),
+    custom: Flags.boolean({
+      description: 'Show only custom templates',
+      exclusive: ['builtin'],
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(PhaseTemplateList);
+
+    let builtinFilter: { isBuiltin?: boolean } | undefined;
+    if (flags.builtin) builtinFilter = { isBuiltin: true };
+    if (flags.custom) builtinFilter = { isBuiltin: false };
+
+    const templates = await this.storage.listPhaseTemplates(builtinFilter);
+
+    if (flags.json) {
+      this.log(JSON.stringify(templates, null, 2));
+      return;
+    }
+
+    if (templates.length === 0) {
+      this.log(styles.muted('\nNo phase templates found.'));
+      return;
+    }
+
+    this.log(`\n${styles.emphasis('Phase Templates')}`);
+    this.log('═'.repeat(60));
+
+    const builtinTemplates = templates.filter(t => t.isBuiltin);
+    const customTemplates = templates.filter(t => !t.isBuiltin);
+
+    if (builtinTemplates.length > 0 && !flags.custom) {
+      this.log(`\n${styles.emphasis('Built-in Templates')}`);
+      this.log('─'.repeat(40));
+      for (const template of builtinTemplates) {
+        this.printTemplate(template);
+      }
+    }
+
+    if (customTemplates.length > 0 && !flags.builtin) {
+      this.log(`\n${styles.emphasis('Custom Templates')}`);
+      this.log('─'.repeat(40));
+      for (const template of customTemplates) {
+        this.printTemplate(template);
+      }
+    }
+
+    this.log('');
+  }
+
+  private printTemplate(template: PhaseTemplate): void {
+    const categoryEmoji: Record<StateCategory, string> = {
+      triage: '📬',
+      backlog: '📥',
+      unstarted: '📋',
+      started: '🚀',
+      completed: '✅',
+      canceled: '🚫',
+    };
+
+    this.log(`  ${styles.emphasis(template.name)} ${styles.muted(`(${template.id})`)}`);
+    if (template.description) {
+      this.log(`    ${styles.muted(template.description)}`);
+    }
+    if (template.phases && template.phases.length > 0) {
+      const phasesByCategory = new Map<StateCategory, string[]>();
+      for (const phase of template.phases) {
+        const existing = phasesByCategory.get(phase.category) || [];
+        existing.push(phase.name);
+        phasesByCategory.set(phase.category, existing);
+      }
+      const phaseParts: string[] = [];
+      for (const [category, names] of phasesByCategory) {
+        phaseParts.push(`${categoryEmoji[category]} ${names.join(', ')}`);
+      }
+      this.log(`    ${styles.muted(phaseParts.join(' → '))}`);
+    }
+  }
+}

--- a/apps/cli/src/commands/phase/template/update.ts
+++ b/apps/cli/src/commands/phase/template/update.ts
@@ -1,0 +1,1 @@
+export { default } from '../../template/update.js';

--- a/apps/cli/src/commands/spec/link/depends.ts
+++ b/apps/cli/src/commands/spec/link/depends.ts
@@ -1,0 +1,111 @@
+import { Args } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputErrorAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class SpecLinkDepends extends PMOCommand {
+  static description = 'Add a dependency between specs';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> SPEC-001 SPEC-002',
+    '<%= config.bin %> <%= command.id %> SPEC-001 --machine',
+  ];
+
+  static args = {
+    spec: Args.string({
+      description: 'Source spec ID (the one that depends on another)',
+      required: true,
+    }),
+    target: Args.string({
+      description: 'Target spec ID (the one depended upon)',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SpecLinkDepends);
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('spec link depends', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Verify source spec exists
+    const sourceSpec = await this.storage.getSpec(args.spec);
+    if (!sourceSpec) {
+      return handleError('SPEC_NOT_FOUND', `Spec not found: ${args.spec}`);
+    }
+
+    // If target not provided, prompt for selection
+    if (!args.target) {
+      const specs = await this.storage.listSpecs();
+      const otherSpecs = specs.filter(s => s.id !== args.spec);
+
+      if (otherSpecs.length === 0) {
+        return handleError('NO_SPECS', 'No other specs to select as dependency.');
+      }
+
+      const choices = otherSpecs.map(s => ({
+        name: `${s.id} - ${s.title}`,
+        value: s.id,
+        command: `prlt spec link depends ${args.spec} ${s.id} --json`,
+      }));
+      const message = `Select spec that ${args.spec} depends on:`;
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'target', message, choices),
+          createMetadata('spec link depends', flags)
+        );
+        return;
+      }
+
+      const { selected } = await this.prompt<{ selected: string }>([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }], null);
+
+      args.target = selected;
+    }
+
+    // Verify target spec exists
+    const targetSpec = await this.storage.getSpec(args.target!);
+    if (!targetSpec) {
+      return handleError('TARGET_NOT_FOUND', `Spec not found: ${args.target}`);
+    }
+
+    // Create the dependency
+    try {
+      await this.storage.createSpecDependency(args.spec, args.target!, 'depends_on');
+
+      this.log(styles.success(`\n${args.spec} now depends on ${args.target}`));
+      this.log(styles.muted(`  ${sourceSpec.title}`));
+      this.log(styles.muted(`  depends on: ${targetSpec.title}`));
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('already exists')) {
+        return handleError('ALREADY_EXISTS', 'Dependency already exists.');
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/cli/src/commands/spec/link/index.ts
+++ b/apps/cli/src/commands/spec/link/index.ts
@@ -1,0 +1,120 @@
+import { Args } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class SpecLink extends PMOCommand {
+  static description = 'Manage links (dependencies) for a spec';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> SPEC-001',
+    '<%= config.bin %> <%= command.id %> --machine',
+  ];
+
+  static args = {
+    spec: Args.string({
+      description: 'Spec ID',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SpecLink);
+    const jsonMode = shouldOutputJson(flags);
+
+    // If no spec ID provided, prompt for selection
+    if (!args.spec) {
+      const specs = await this.storage.listSpecs();
+      if (specs.length === 0) {
+        this.log(styles.muted('No specs found.'));
+        return;
+      }
+
+      const choices = specs.map(s => ({
+        name: `${s.id} - ${s.title}`,
+        value: s.id,
+        command: `prlt spec link ${s.id} --machine`,
+      }));
+      const message = 'Select a spec to manage links:';
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'id', message, choices),
+          createMetadata('spec link', flags)
+        );
+        return;
+      }
+
+      const { selected } = await this.prompt<{ selected: string }>([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }], null);
+
+      args.spec = selected;
+    }
+
+    const spec = await this.storage.getSpec(args.spec!);
+    if (!spec) {
+      this.error(`Spec not found: ${args.spec}`);
+    }
+
+    // Show link actions submenu
+    const menuChoices = [
+      { name: 'Add dependency', value: 'depends', command: `prlt spec link depends ${args.spec} --machine` },
+      { name: 'Remove dependency', value: 'remove', command: `prlt spec link remove ${args.spec} --machine` },
+      { name: 'Cancel', value: 'cancel', command: '' },
+    ];
+    const message = `Manage links for ${args.spec}: ${spec.title}`;
+
+    if (jsonMode) {
+      outputPromptAsJson(
+        buildPromptConfig('list', 'action', message, menuChoices),
+        createMetadata('spec link', flags)
+      );
+      return;
+    }
+
+    const { action } = await this.prompt<{ action: string }>([{
+      type: 'list',
+      name: 'action',
+      message,
+      choices: menuChoices,
+    }], null);
+
+    if (action === 'cancel') {
+      this.log(styles.muted('Cancelled.'));
+      return;
+    }
+
+    switch (action) {
+      case 'depends': {
+        const { default: DependsCommand } = await import('./depends.js');
+        const cmd = new DependsCommand([args.spec!], this.config);
+        await cmd.run();
+        break;
+      }
+      case 'remove': {
+        const { default: RemoveCommand } = await import('./remove.js');
+        const cmd = new RemoveCommand([args.spec!], this.config);
+        await cmd.run();
+        break;
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/spec/link/remove.ts
+++ b/apps/cli/src/commands/spec/link/remove.ts
@@ -1,0 +1,113 @@
+import { Args } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputErrorAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class SpecLinkRemove extends PMOCommand {
+  static description = 'Remove a dependency between specs';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> SPEC-001 SPEC-002',
+    '<%= config.bin %> <%= command.id %> SPEC-001 --machine',
+  ];
+
+  static args = {
+    spec: Args.string({
+      description: 'Source spec ID',
+      required: true,
+    }),
+    target: Args.string({
+      description: 'Target spec ID to remove dependency from',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SpecLinkRemove);
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('spec link remove', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Verify source spec exists
+    const sourceSpec = await this.storage.getSpec(args.spec);
+    if (!sourceSpec) {
+      return handleError('SPEC_NOT_FOUND', `Spec not found: ${args.spec}`);
+    }
+
+    // If target not provided, show existing dependencies for selection
+    if (!args.target) {
+      const dependencies = await this.storage.listSpecDependencies(args.spec);
+      if (dependencies.length === 0) {
+        if (jsonMode) {
+          outputErrorAsJson('NO_DEPENDENCIES', `No dependencies found for ${args.spec}.`, createMetadata('spec link remove', flags));
+          return;
+        }
+        this.log(styles.muted(`No dependencies found for ${args.spec}.`));
+        return;
+      }
+
+      // Get spec details for dependency targets
+      const choices: Array<{ name: string; value: string; command: string }> = [];
+      for (const dep of dependencies) {
+        const targetSpec = await this.storage.getSpec(dep.dependsOnSpecId);
+        const name = targetSpec ? `${dep.dependsOnSpecId} - ${targetSpec.title} (${dep.dependencyType})` : `${dep.dependsOnSpecId} (${dep.dependencyType})`;
+        choices.push({
+          name,
+          value: dep.dependsOnSpecId,
+          command: `prlt spec link remove ${args.spec} ${dep.dependsOnSpecId} --json`,
+        });
+      }
+
+      const message = `Select dependency to remove from ${args.spec}:`;
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'target', message, choices),
+          createMetadata('spec link remove', flags)
+        );
+        return;
+      }
+
+      const { selected } = await this.prompt<{ selected: string }>([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }], null);
+
+      args.target = selected;
+    }
+
+    // Remove the dependency
+    try {
+      await this.storage.deleteSpecDependency(args.spec, args.target!);
+
+      this.log(styles.success(`\nRemoved dependency: ${args.spec} no longer depends on ${args.target}`));
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return handleError('NOT_FOUND', `Dependency not found between ${args.spec} and ${args.target}`);
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/cli/src/commands/ticket/link/block.ts
+++ b/apps/cli/src/commands/ticket/link/block.ts
@@ -1,0 +1,122 @@
+import { Args } from '@oclif/core';
+import { autoExportToBoard, PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class TicketLinkBlock extends PMOCommand {
+  static description = 'Add a blocking dependency to a ticket';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> TKT-001',
+    '<%= config.bin %> <%= command.id %> TKT-001 TKT-002',
+    '<%= config.bin %> <%= command.id %> TKT-001 --json',
+  ];
+
+  static args = {
+    ticket: Args.string({
+      description: 'Ticket that will be blocked',
+      required: true,
+    }),
+    blocker: Args.string({
+      description: 'Ticket that blocks (the blocker)',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(TicketLinkBlock);
+    const jsonMode = shouldOutputJson(flags);
+
+    const projectId = await this.requireProject();
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('ticket link block', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Verify the target ticket exists
+    const ticket = await this.storage.getTicket(args.ticket);
+    if (!ticket) {
+      return handleError('TICKET_NOT_FOUND', `Ticket not found: ${args.ticket}`);
+    }
+
+    // If blocker not provided, prompt for selection
+    if (!args.blocker) {
+      const tickets = await this.storage.listTickets(projectId);
+      const otherTickets = tickets.filter(t => t.id !== args.ticket);
+
+      if (otherTickets.length === 0) {
+        return handleError('NO_TICKETS', 'No other tickets to select as blocker.');
+      }
+
+      const projectFlag = flags.project ? ` -P ${flags.project}` : '';
+      const choices = otherTickets.map(t => ({
+        name: `${t.id} - ${t.title}`,
+        value: t.id,
+        command: `prlt ticket link block ${args.ticket} ${t.id}${projectFlag} --json`,
+      }));
+      const message = `Select ticket that blocks ${args.ticket}:`;
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'blocker', message, choices),
+          createMetadata('ticket link block', flags)
+        );
+        return;
+      }
+
+      const { selected } = await this.prompt<{ selected: string }>([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }], null);
+
+      args.blocker = selected;
+    }
+
+    // Verify blocker exists
+    const blockerTicket = await this.storage.getTicket(args.blocker!);
+    if (!blockerTicket) {
+      return handleError('BLOCKER_NOT_FOUND', `Blocker ticket not found: ${args.blocker}`);
+    }
+
+    // Create the blocking dependency
+    try {
+      await this.storage.createTicketDependency(args.ticket, args.blocker!, 'blocks');
+      await autoExportToBoard(this.pmoPath, this.storage, (msg) => this.log(styles.muted(msg)));
+
+      if (jsonMode) {
+        outputSuccessAsJson({
+          ticketId: args.ticket,
+          blockerId: args.blocker,
+          type: 'blocks',
+        }, createMetadata('ticket link block', flags));
+        return;
+      }
+
+      this.log(styles.success(`\n${args.ticket} is now blocked by ${args.blocker}`));
+      this.log(styles.muted(`  ${ticket.title}`));
+      this.log(styles.muted(`  blocked by: ${blockerTicket.title}`));
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('already exists')) {
+        return handleError('ALREADY_EXISTS', 'Blocking dependency already exists.');
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/cli/src/commands/ticket/link/index.ts
+++ b/apps/cli/src/commands/ticket/link/index.ts
@@ -1,0 +1,124 @@
+import { Args } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class TicketLink extends PMOCommand {
+  static description = 'Manage links (dependencies) for a ticket';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> TKT-001',
+    '<%= config.bin %> <%= command.id %> TKT-001 --json',
+  ];
+
+  static args = {
+    ticket: Args.string({
+      description: 'Ticket ID',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(TicketLink);
+    const jsonMode = shouldOutputJson(flags);
+
+    const projectId = await this.requireProject();
+
+    // If no ticket ID provided, prompt for selection
+    if (!args.ticket) {
+      const tickets = await this.storage.listTickets(projectId);
+      if (tickets.length === 0) {
+        this.log(styles.muted('No tickets found.'));
+        return;
+      }
+
+      const choices = tickets.map(t => ({
+        name: `${t.id} - ${t.title}`,
+        value: t.id,
+        command: `prlt ticket link ${t.id}${flags.project ? ` -P ${flags.project}` : ''} --json`,
+      }));
+      const message = 'Select a ticket to manage links:';
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'ticket', message, choices),
+          createMetadata('ticket link', flags)
+        );
+        return;
+      }
+
+      const { selected } = await this.prompt<{ selected: string }>([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }], null);
+
+      args.ticket = selected;
+    }
+
+    const ticket = await this.storage.getTicket(args.ticket!);
+    if (!ticket) {
+      this.error(`Ticket not found: ${args.ticket}`);
+    }
+
+    // Show link actions submenu
+    const projectFlag = flags.project ? ` -P ${flags.project}` : '';
+    const menuChoices = [
+      { name: 'Add blocker', value: 'block', command: `prlt ticket link block ${args.ticket}${projectFlag} --json` },
+      { name: 'View links', value: 'view', command: `prlt link list ${args.ticket}${projectFlag} --json` },
+      { name: 'Remove link', value: 'remove', command: `prlt link remove ${args.ticket}${projectFlag} --json` },
+      { name: 'Cancel', value: 'cancel', command: '' },
+    ];
+    const message = `Manage links for ${args.ticket}: ${ticket.title}`;
+
+    if (jsonMode) {
+      outputPromptAsJson(
+        buildPromptConfig('list', 'action', message, menuChoices),
+        createMetadata('ticket link', flags)
+      );
+      return;
+    }
+
+    const { action } = await this.prompt<{ action: string }>([{
+      type: 'list',
+      name: 'action',
+      message,
+      choices: menuChoices,
+    }], null);
+
+    if (action === 'cancel') {
+      this.log(styles.muted('Cancelled.'));
+      return;
+    }
+
+    switch (action) {
+      case 'block': {
+        const { default: BlockCommand } = await import('./block.js');
+        const cmd = new BlockCommand([args.ticket!, ...(flags.project ? ['-P', flags.project] : [])], this.config);
+        await cmd.run();
+        break;
+      }
+      case 'view': {
+        const { default: LinkListCommand } = await import('../../link/list.js');
+        const cmd = new LinkListCommand([args.ticket!, ...(flags.project ? ['-P', flags.project] : [])], this.config);
+        await cmd.run();
+        break;
+      }
+      case 'remove': {
+        this.log(styles.muted('Use: prlt link remove <from> <to>'));
+        break;
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/ticket/template/apply.ts
+++ b/apps/cli/src/commands/ticket/template/apply.ts
@@ -1,0 +1,16 @@
+import TemplateApply from '../../template/apply.js';
+
+export default class TicketTemplateApply extends TemplateApply {
+  static description = 'Apply a ticket template to create a new ticket';
+  static args = TemplateApply.args;
+  static flags = TemplateApply.flags;
+  static examples = TemplateApply.examples;
+
+  async run(): Promise<void> {
+    const argv = this.argv as string[];
+    if (!argv.includes('--type') && !argv.includes('-t')) {
+      argv.push('--type', 'ticket');
+    }
+    return super.run();
+  }
+}

--- a/apps/cli/src/commands/ticket/template/delete.ts
+++ b/apps/cli/src/commands/ticket/template/delete.ts
@@ -1,0 +1,77 @@
+import { Args, Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../../lib/prompt-json.js';
+
+export default class TicketTemplateDelete extends PMOCommand {
+  static description = 'Delete a ticket template';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-template --force',
+  ];
+
+  static args = {
+    id: Args.string({
+      description: 'Template ID to delete',
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation',
+      default: false,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(TicketTemplateDelete);
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('ticket template delete', flags));
+      }
+      this.error(message);
+    };
+
+    const template = await this.storage.getTicketTemplate(args.id);
+    if (!template) {
+      return handleError('NOT_FOUND', `Ticket template not found: ${args.id}`);
+    }
+
+    if (template.isBuiltin) {
+      return handleError('BUILTIN', `Cannot delete built-in template "${template.name}".`);
+    }
+
+    if (!flags.force) {
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
+        type: 'list',
+        name: 'confirm',
+        message: `Delete ticket template "${template.name}"?`,
+        choices: [
+          { name: 'No', value: false },
+          { name: 'Yes', value: true },
+        ],
+      }], jsonMode ? { flags, commandName: 'ticket template delete' } : null);
+
+      if (!confirm) {
+        this.log(styles.muted('Cancelled.'));
+        return;
+      }
+    }
+
+    await this.storage.deleteTicketTemplate(args.id);
+    this.log(styles.success(`\nDeleted template "${template.name}"`));
+  }
+}

--- a/apps/cli/src/commands/ticket/template/list.ts
+++ b/apps/cli/src/commands/ticket/template/list.ts
@@ -1,0 +1,88 @@
+import { Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import { TicketTemplate } from '../../../lib/pmo/types.js';
+
+export default class TicketTemplateList extends PMOCommand {
+  static description = 'List ticket templates';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --builtin',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+    builtin: Flags.boolean({
+      description: 'Show only built-in templates',
+      exclusive: ['custom'],
+    }),
+    custom: Flags.boolean({
+      description: 'Show only custom templates',
+      exclusive: ['builtin'],
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(TicketTemplateList);
+
+    let builtinFilter: { isBuiltin?: boolean } | undefined;
+    if (flags.builtin) builtinFilter = { isBuiltin: true };
+    if (flags.custom) builtinFilter = { isBuiltin: false };
+
+    const templates = await this.storage.listTicketTemplates(builtinFilter);
+
+    if (flags.json) {
+      this.log(JSON.stringify(templates, null, 2));
+      return;
+    }
+
+    if (templates.length === 0) {
+      this.log(styles.muted('\nNo ticket templates found.'));
+      return;
+    }
+
+    this.log(`\n${styles.emphasis('Ticket Templates')}`);
+    this.log('═'.repeat(60));
+
+    const builtinTemplates = templates.filter(t => t.isBuiltin);
+    const customTemplates = templates.filter(t => !t.isBuiltin);
+
+    if (builtinTemplates.length > 0 && !flags.custom) {
+      this.log(`\n${styles.emphasis('Built-in Templates')}`);
+      this.log('─'.repeat(40));
+      for (const template of builtinTemplates) {
+        this.printTemplate(template);
+      }
+    }
+
+    if (customTemplates.length > 0 && !flags.builtin) {
+      this.log(`\n${styles.emphasis('Custom Templates')}`);
+      this.log('─'.repeat(40));
+      for (const template of customTemplates) {
+        this.printTemplate(template);
+      }
+    }
+
+    this.log('');
+  }
+
+  private printTemplate(template: TicketTemplate): void {
+    this.log(`  ${styles.emphasis(template.name)} ${styles.muted(`(${template.id})`)}`);
+    if (template.description) {
+      this.log(`    ${styles.muted(template.description)}`);
+    }
+    const details: string[] = [];
+    if (template.defaultPriority) details.push(`Priority: ${template.defaultPriority}`);
+    if (template.defaultCategory) details.push(`Category: ${template.defaultCategory}`);
+    if (template.suggestedSubtasks.length > 0) details.push(`Subtasks: ${template.suggestedSubtasks.length}`);
+    if (details.length > 0) {
+      this.log(`    ${styles.muted(details.join(' | '))}`);
+    }
+  }
+}

--- a/apps/cli/src/commands/ticket/template/save.ts
+++ b/apps/cli/src/commands/ticket/template/save.ts
@@ -1,0 +1,120 @@
+import { Flags, Args } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../../lib/pmo/index.js';
+import { styles } from '../../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+  buildPromptConfig,
+} from '../../../lib/prompt-json.js';
+
+export default class TicketTemplateSave extends PMOCommand {
+  static description = 'Create a ticket template from an existing ticket';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> TKT-001 "Bug Report Template"',
+    '<%= config.bin %> <%= command.id %> TKT-042 "Feature Request" -d "Standard feature request"',
+  ];
+
+  static args = {
+    ticket: Args.string({
+      description: 'Ticket ID to create template from',
+      required: false,
+    }),
+    name: Args.string({
+      description: 'Template name',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    'template-name': Flags.string({
+      char: 'n',
+      description: 'Template name (alternative to positional arg)',
+    }),
+    description: Flags.string({
+      char: 'd',
+      description: 'Template description',
+    }),
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(TicketTemplateSave);
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('ticket template save', flags));
+      }
+      this.error(message);
+    };
+
+    // Get ticket ID
+    let ticketId = args.ticket;
+    if (!ticketId) {
+      const projectId = await this.requireProject();
+      const tickets = await this.storage.listTickets(projectId);
+      if (tickets.length === 0) {
+        return handleError('NO_TICKETS', 'No tickets found. Create a ticket first.');
+      }
+
+      if (jsonMode) {
+        const choices = tickets.slice(0, 20).map(t => ({ name: `${t.id} - ${t.title}`, value: t.id }));
+        outputPromptAsJson(buildPromptConfig('list', 'ticket', 'Select ticket:', choices), createMetadata('ticket template save', flags));
+        return;
+      }
+
+      const { selected } = await this.prompt<{ selected: string }>([{
+        type: 'list',
+        name: 'selected',
+        message: 'Select ticket:',
+        choices: tickets.slice(0, 20).map(t => ({ name: `${t.id} - ${t.title}`, value: t.id })),
+      }], null);
+      ticketId = selected;
+    }
+
+    const ticket = await this.storage.getTicket(ticketId!);
+    if (!ticket) {
+      return handleError('TICKET_NOT_FOUND', `Ticket not found: ${ticketId}`);
+    }
+
+    // Get template name
+    let templateName = flags['template-name'] || args.name;
+    if (!templateName) {
+      if (jsonMode) {
+        outputPromptAsJson(buildPromptConfig('input', 'name', 'Template name:', undefined, ticket.category || ticket.title.split(' ')[0]), createMetadata('ticket template save', flags));
+        return;
+      }
+
+      const { name } = await this.prompt<{ name: string }>([{
+        type: 'input',
+        name: 'name',
+        message: 'Template name:',
+        default: ticket.category || ticket.title.split(' ')[0],
+        validate: (i: unknown) => (i as string).length > 0 || 'Required',
+      }], null);
+      templateName = name;
+    }
+
+    // Get description
+    let description = flags.description;
+    if (description === undefined && !jsonMode) {
+      const { desc } = await this.prompt<{ desc: string }>([{ type: 'input', name: 'desc', message: 'Description (optional):' }], null);
+      description = desc || undefined;
+    }
+
+    const template = await this.storage.createTicketTemplateFromTicket(ticketId!, templateName!, description);
+
+    if (flags.json === true) {
+      outputSuccessAsJson({ template, sourceTicketId: ticketId }, createMetadata('ticket template save', flags));
+      return;
+    }
+
+    this.log(styles.success(`\nCreated template "${styles.emphasis(template.name)}" from ${ticketId}`));
+    this.log(styles.muted(`  ID: ${template.id}`));
+    this.log(styles.muted(`\nApply with: prlt ticket template apply ${template.id}`));
+  }
+}

--- a/apps/cli/test/e2e/pmo-ticket-template-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-template-commands.test.ts
@@ -303,8 +303,12 @@ function setupTestDatabase(db: Database.Database) {
       name TEXT NOT NULL,
       template TEXT DEFAULT 'kanban',
       description TEXT,
+      status TEXT NOT NULL DEFAULT 'active',
       phase_id TEXT,
+      workflow_id TEXT,
       is_archived INTEGER NOT NULL DEFAULT 0,
+      target_date TIMESTAMP,
+      initiative_id TEXT,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
@@ -346,6 +350,7 @@ function setupTestDatabase(db: Database.Database) {
       spec_id TEXT,
       epic_id TEXT,
       labels TEXT NOT NULL DEFAULT '[]',
+      position INTEGER NOT NULL DEFAULT 0,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       last_synced_from_spec TIMESTAMP,

--- a/apps/cli/test/e2e/theme-commands.test.ts
+++ b/apps/cli/test/e2e/theme-commands.test.ts
@@ -251,8 +251,14 @@ function setupTestDatabase(db: Database.Database) {
     -- Agents table
     CREATE TABLE IF NOT EXISTS agents (
       name TEXT PRIMARY KEY,
+      type TEXT DEFAULT 'persistent',
+      status TEXT DEFAULT 'active',
+      base_name TEXT,
       theme_id TEXT,
+      worktree_path TEXT,
+      mount_mode TEXT DEFAULT 'worktree',
       created_at TEXT NOT NULL,
+      cleaned_at TEXT,
       FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
     );
 


### PR DESCRIPTION
## Summary

- Create ~27 new command files to register CLI commands at paths expected by tests, fixing ~60 of the ~70 test failures
- Uses three patterns: **re-exports** (simple path aliases), **wrappers** (inject --type flag), and **custom standalone** commands
- Fix test schemas to match production DB (missing columns in agents, pmo_projects, pmo_tickets tables)
- Add temp agent management menu option to agent/index.ts

### New command registrations:
- phase template (apply, create, delete, list, update)
- ticket template (apply, delete, list, save)
- ticket link (index, block)
- spec link (index, depends, remove)
- agent staff (index, add, list, remove)
- agent themes (index, create, list, set, add-names)
- agents themes (create, list, add-names)

## Test plan
- [x] Phase Template tests: 28/28 passing
- [x] Ticket Template tests: 22/23 passing (1 pre-existing priority normalization issue)
- [x] Theme tests: 14/14 passing
- [x] JSON Mode tests: 53/53 passing
- [x] Spec JSON Mode tests: 48/49 passing (1 pre-existing)
- [x] Agent JSON Mode tests: 108/117 passing (9 pre-existing in agent/list.ts)
- [x] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)