### PR TITLE
TKT-498: Add 'prlt ticket show' alias for 'prlt ticket view'

### DIFF
--- a/apps/cli/src/commands/ticket/view.ts
+++ b/apps/cli/src/commands/ticket/view.ts
@@ -8,6 +8,8 @@ import {
 } from '../../lib/prompt-json.js';
 
 export default class TicketView extends PMOCommand {
+  static aliases = ['ticket:show'];
+
   static description = 'View detailed ticket information';
 
   static examples = [

--- a/apps/cli/src/lib/pmo/storage/base.ts
+++ b/apps/cli/src/lib/pmo/storage/base.ts
@@ -617,6 +617,8 @@ Requirements:
 - Use \`--clear-subtasks\` if replacing existing subtasks
 - Use \`--clear-ac\` if replacing existing acceptance criteria
 
+**Tip:** Use \`prlt ticket view <id>\` to see full ticket details at any time.
+
 After updating, output a brief summary of your grooming changes.`,
       suggestedForCategories: ['backlog'],
       defaultMoveToCategory: 'unstarted',


### PR DESCRIPTION
## Summary

Resolves TKT-498: Add 'prlt ticket show' alias for 'prlt ticket view'

## Description

## Problem

Agents (Claude) guess 'prlt ticket show TKT-XXX' because 'show' is a common CLI pattern (git show, kubectl get, etc.), but the actual command is 'prlt ticket view'.

## Solution

Implement both solutions:

### 1. Add 'show' as an alias (preferred approach)
Add `static aliases = ['ticket:show']` to the TicketView class in `apps/cli/src/commands/ticket/view.ts`. This follows the existing oclif alias pattern used elsewhere (e.g., `ticket:templates`, `phase:templates`).

**Why alias over separate file**: Single source of truth, no code duplication, consistent with codebase patterns.

### 2. Update action prompts
Add explicit guidance in groom/implement endPrompts in `apps/cli/src/lib/pmo/storage/base.ts`:
- Groom endPrompt: Already references `prlt ticket edit`, add note that `prlt ticket view <id>` shows full ticket details
- Implement prompt: Consider adding note about viewing ticket details if needed

## Technical Notes
- File to modify: `apps/cli/src/commands/ticket/view.ts` (add aliases property)
- File to modify: `apps/cli/src/lib/pmo/storage/base.ts` (update prompts in seedBuiltinActions)
- Run `pnpm build` after changes to verify
- Alias format should be `ticket:show` (with colon) per oclif conventions

## Related
- TKT-436: Agent CLI discoverability: ticket show vs ticket view

## Changes

- c2a6e54c feat(TKT-498): add ticket:show alias and update groom prompt with ticket view tip

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
