### PR TITLE
TKT-948: Add 'session create' command for new tmux sessions

### DIFF
--- a/apps/cli/src/commands/session/create.ts
+++ b/apps/cli/src/commands/session/create.ts
@@ -1,0 +1,118 @@
+import { Args, Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
+import { styles } from '../../lib/styles.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+
+export default class SessionCreate extends PMOCommand {
+  static description = 'Create a new tmux session'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-session',
+    '<%= config.bin %> <%= command.id %> my-session --command "npm run dev"',
+    '<%= config.bin %> <%= command.id %> my-session --detach',
+  ]
+
+  static args = {
+    name: Args.string({
+      description: 'Name for the new tmux session',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+    command: Flags.string({
+      char: 'c',
+      description: 'Initial command to run in the session',
+    }),
+    detach: Flags.boolean({
+      char: 'd',
+      description: 'Create session in detached mode (do not attach)',
+      default: false,
+    }),
+  }
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false }
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(SessionCreate)
+    const jsonMode = shouldOutputJson(flags)
+    const sessionName = args.name
+
+    // Check if tmux is available
+    try {
+      execSync('which tmux', { stdio: 'pipe' })
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('TMUX_NOT_FOUND', 'tmux is not installed or not in PATH.', createMetadata('session create', flags))
+      }
+      this.error('tmux is not installed or not in PATH.')
+    }
+
+    // Check if a session with this name already exists
+    try {
+      execSync(`tmux has-session -t "${sessionName}" 2>/dev/null`, { stdio: 'pipe' })
+      // If we get here, session exists
+      if (jsonMode) {
+        outputErrorAsJson('SESSION_EXISTS', `A tmux session named "${sessionName}" already exists.`, createMetadata('session create', flags))
+      }
+      this.error(`A tmux session named "${sessionName}" already exists.`)
+    } catch {
+      // Session doesn't exist, good to proceed
+    }
+
+    // Build the tmux new-session command
+    const tmuxArgs: string[] = ['tmux', 'new-session']
+
+    // Always use detached mode for creation, then attach if needed
+    tmuxArgs.push('-d')
+    tmuxArgs.push('-s', `"${sessionName}"`)
+
+    if (flags.command) {
+      tmuxArgs.push(`"${flags.command}"`)
+    }
+
+    try {
+      execSync(tmuxArgs.join(' '), { stdio: 'pipe' })
+    } catch (error) {
+      const message = `Failed to create tmux session "${sessionName}": ${error instanceof Error ? error.message : error}`
+      if (jsonMode) {
+        outputErrorAsJson('CREATE_FAILED', message, createMetadata('session create', flags))
+      }
+      this.error(message)
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        sessionName,
+        detached: flags.detach,
+        command: flags.command || null,
+      }, createMetadata('session create', flags))
+    }
+
+    this.log('')
+    this.log(styles.success(`Created tmux session: ${sessionName}`))
+
+    if (!flags.detach) {
+      this.log(styles.info(`Attaching to session: ${sessionName}`))
+      try {
+        execSync(`tmux attach -t "${sessionName}"`, { stdio: 'inherit' })
+      } catch {
+        this.log(styles.muted(`Session "${sessionName}" is running in detached mode.`))
+        this.log(styles.muted(`Attach with: tmux attach -t "${sessionName}"`))
+      }
+    } else {
+      this.log(styles.muted(`Attach with: prlt session attach ${sessionName}`))
+    }
+
+    this.log('')
+  }
+}

--- a/apps/cli/src/commands/session/index.ts
+++ b/apps/cli/src/commands/session/index.ts
@@ -3,12 +3,13 @@ import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
 
 export default class Session extends PMOCommand {
-  static description = 'Manage agent tmux sessions (list, attach, detach)'
+  static description = 'Manage agent tmux sessions (list, attach, create, detach)'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> list',
     '<%= config.bin %> <%= command.id %> attach TKT-347-implement',
+    '<%= config.bin %> <%= command.id %> create my-session',
   ]
 
   static flags = {
@@ -30,6 +31,7 @@ export default class Session extends PMOCommand {
       message: 'Session Management - What would you like to do?',
       choices: [
         { name: 'List active sessions', value: 'list', command: 'prlt session list --json' },
+        { name: 'Create a new session', value: 'create', command: 'prlt session create --json' },
         { name: 'Attach to a session', value: 'attach', command: 'prlt session attach --json' },
         { name: 'Check agent health', value: 'health', command: 'prlt session health --json' },
         { name: 'Cancel', value: 'cancel' },
@@ -44,6 +46,9 @@ export default class Session extends PMOCommand {
     switch (action) {
       case 'list':
         await this.config.runCommand('session:list', [])
+        break
+      case 'create':
+        await this.config.runCommand('session:create', [])
         break
       case 'attach':
         await this.config.runCommand('session:attach', [])


### PR DESCRIPTION
## Summary

Resolves TKT-948: Add 'session create' command for new tmux sessions

## Description

Add a 'prlt session create' subcommand to create new tmux sessions under the session namespace. Currently prlt session only supports list, attach, and health. A create command would let users spin up new named tmux sessions directly from prlt without dropping to raw tmux commands.

## Changes

- 09aea189 chore(TKT-948): add session create command for new tmux sessions
- 25ebe542 fix(TKT-994): register missing command paths for template, link, theme, and agent temp commands (#425)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
