### PR TITLE
TKT-495: Detect and clean up stale agent_work records on spawn

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -9,6 +9,7 @@ import {
   killTmuxSession
 } from '../../lib/agents/commands.js'
 import { isDockerRunning, isGitHubTokenAvailable, isDevcontainerCliInstalled } from '../../lib/execution/runners.js'
+import { ExecutionStorage } from '../../lib/execution/storage.js'
 import { PermissionMode } from '../../lib/execution/types.js'
 import {
   shouldOutputJson,
@@ -915,6 +916,14 @@ export default class WorkSpawn extends PMOCommand {
 
       // Note: With ephemeral agents, we don't need to check availability
       // Each ticket will get its own ephemeral agent created on-demand
+
+      // Clean up stale execution records before checking availability (TKT-495)
+      // This fixes agents appearing "busy" when their tmux sessions have terminated
+      const executionStorage = new ExecutionStorage(db)
+      const cleanedUp = executionStorage.cleanupStaleExecutions()
+      if (cleanedUp > 0 && !jsonMode) {
+        this.log(styles.muted(`Cleaned up ${cleanedUp} stale execution(s)`))
+      }
 
       // Check for tickets with existing tmux sessions (active work)
       const ticketsWithActiveSessions: Array<{ ticketId: string; sessionName: string; agent: string }> = []


### PR DESCRIPTION
## Summary

Resolves TKT-495: Detect and clean up stale agent_work records on spawn

## Description

## Problem

When spawning work, the CLI checks agent_work.status = 'running' to determine agent availability. If tmux sessions die or are killed without cleanup, these records remain 'running' forever, making agents appear busy when they're idle.

## Current Behavior
- Agent work records set to 'running' when spawn starts
- No automatic cleanup when tmux session ends/dies unexpectedly
- `prlt agent list` shows 24 active agents
- `prlt work spawn` says only 4 available (because 20 have stale 'running' records)

## Root Cause Analysis
A `cleanupStaleExecutions()` method exists in `storage.ts:288-341` and is called in `work/start.ts` before agent selection. However:
1. `work/spawn.ts` may not call this cleanup before determining availability
2. Edge cases in detection logic may miss stale sessions

## Requirements
- R1: spawn.ts MUST call cleanupStaleExecutions() before determining agent availability
- R2: start.ts MUST continue calling cleanupStaleExecutions() before agent selection
- R3: Cleanup logic must reliably detect when tmux session no longer exists
- R4: Cleanup must work for both 'host' and 'devcontainer' environments
- R5: No false positives - active sessions must never be marked as stale

## Technical Context
- Existing cleanup method: `apps/cli/src/lib/execution/storage.ts:288-341`
- Session management: `apps/cli/src/lib/agents/commands.ts:667-787`
- Detection queries tmux via `tmux list-sessions -F "#{session_name}"`
- For devcontainer: uses `docker exec` to check tmux inside container

## Files to Modify
- `apps/cli/src/commands/work/spawn.ts` - Add cleanupStaleExecutions() call before availability check
- `apps/cli/src/lib/execution/storage.ts` - Verify/fix cleanup logic edge cases
- `apps/cli/src/commands/work/start.ts` - Verify existing cleanup calls are correct

## Open Questions (for implementation)
- Q1: Should we add a standalone `prlt work cleanup` command for manual cleanup?
- Q2: Should we log cleanup actions for debugging?

## Changes

- ea3e2d5a fix(TKT-495): add cleanupStaleExecutions call to spawn.ts before availability check

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
