### PR TITLE
TKT-1017: Guard against duplicate PRs: check if PR already exists for branch before creating

### DIFF
--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -318,6 +318,24 @@ export default class WorkReady extends PMOCommand {
     try {
       const baseBranch = getDefaultBaseBranch();
 
+      // Check if PR already exists for this branch
+      const existingPR = getPRForBranch(currentBranch);
+      if (existingPR) {
+        if (existingPR.state === 'MERGED') {
+          this.log(styles.muted(`   PR #${existingPR.number} already merged: ${existingPR.url}`));
+          return existingPR.url;
+        }
+        if (existingPR.state === 'OPEN') {
+          // Push any unpushed commits so the existing PR is up to date
+          if (hasUnpushedCommits(currentBranch)) {
+            this.log(styles.muted(`   Pushing unpushed commits to existing PR...`));
+            pushBranch(currentBranch);
+          }
+          this.log(styles.muted(`   PR #${existingPR.number} already exists: ${existingPR.url}`));
+          return existingPR.url;
+        }
+      }
+
       // Push branch if needed
       if (!hasBranchBeenPushed(currentBranch)) {
         this.log(styles.muted(`   Pushing branch to origin...`));


### PR DESCRIPTION
## Summary

Resolves TKT-1017: Guard against duplicate PRs: check if PR already exists for branch before creating

## Description

When an agent is respawned on a branch that already has a merged or open PR, it creates a duplicate PR. This happens because the PR creation logic doesn't check for existing PRs on the same branch.

**Fix:** Before creating a PR, run `gh pr list --head {branch}` to check if one already exists. If a PR is already open, update it instead. If merged, skip PR creation.

One-liner guard in the PR creation logic — likely in the action's end prompt or in the `prlt work ready --pr` flow.

## Changes

- 5ae0c881 fix(TKT-1017): guard against duplicate PRs in handlePRCreation

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
