### PR TITLE
TKT-635: Audit CLI flags vs interactive prompts for consistency

### DIFF
--- a/apps/cli/src/commands/work/revise.ts
+++ b/apps/cli/src/commands/work/revise.ts
@@ -35,6 +35,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { FlagResolver } from '../../lib/flags/index.js'
 
 export default class WorkRevise extends PMOCommand {
   static description = 'Address PR feedback on a ticket (fetches reviews/comments and spawns agent)'
@@ -54,10 +55,10 @@ export default class WorkRevise extends PMOCommand {
 
   static flags = {
     ...pmoBaseFlags,
-    mode: Flags.string({
+    display: Flags.string({
       char: 'd',
-      description: 'Runtime mode',
-      options: ['foreground', 'background', 'tmux', 'terminal', 'devcontainer'],
+      description: 'Display mode (terminal=new tab, background=detached)',
+      options: ['terminal', 'background'],
     }),
     executor: Flags.string({
       char: 'e',
@@ -79,11 +80,38 @@ export default class WorkRevise extends PMOCommand {
       options: ['tmux', 'direct'],
       default: 'tmux',
     }),
+    'permission-mode': Flags.string({
+      description: 'Permission mode for Claude Code (danger=skip checks, safe=require approval)',
+      options: ['danger', 'safe'],
+    }),
+    'skip-permissions': Flags.boolean({
+      description: 'Skip permission checks (shorthand for --permission-mode danger)',
+      default: false,
+    }),
+    focus: Flags.boolean({
+      description: 'Bring terminal to foreground when opening new tabs (default: opens in background)',
+      default: false,
+    }),
+    clone: Flags.boolean({
+      description: 'Use independent git clone instead of worktree (more isolation, no real-time sync)',
+      default: false,
+    }),
   }
 
   async execute(): Promise<void> {
     const { args, flags } = await this.parse(WorkRevise)
     const projectId = (flags as { project?: string }).project
+
+    // Handle --skip-permissions flag (alias for --permission-mode danger)
+    if (flags['skip-permissions'] && flags['permission-mode']) {
+      this.error(
+        'Cannot use both --skip-permissions and --permission-mode flags.\n' +
+        'Use only one: --skip-permissions OR --permission-mode danger/safe'
+      )
+    }
+    if (flags['skip-permissions']) {
+      flags['permission-mode'] = 'danger'
+    }
 
     // Check if JSON output mode is active
     const jsonMode = shouldOutputJson(flags)
@@ -280,43 +308,64 @@ export default class WorkRevise extends PMOCommand {
       let displayMode: DisplayMode = 'terminal'
       let sandboxed = false
 
-      const reviseJsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'work revise' } : null
-
       if (hasDevcontainer && !flags['run-on-host']) {
         environment = 'devcontainer'
 
-        const { selectedDisplay } = await this.prompt<{ selectedDisplay: string }>([
-          {
+        if (flags.display) {
+          displayMode = flags.display as DisplayMode
+        } else {
+          // Prompt for display mode using FlagResolver
+          const displayResolver = new FlagResolver<{ display?: string }>({
+            commandName: 'work revise',
+            baseCommand: `prlt work revise ${ticketId}`,
+            jsonMode,
+            flags: {},
+          })
+
+          displayResolver.addPrompt({
+            flagName: 'display',
             type: 'list',
-            name: 'selectedDisplay',
             message: 'How should the agent output be displayed?',
-            choices: [
-              { name: 'terminal     - New terminal window', value: 'terminal', command: `prlt work revise ${ticketId} --mode terminal --json` },
-              { name: 'background   - Runs detached, reattach with: prlt session attach', value: 'background', command: `prlt work revise ${ticketId} --mode background --json` },
-            ],
             default: 'terminal',
-          },
-        ], reviseJsonModeConfig)
-        displayMode = selectedDisplay as DisplayMode
-      } else if (flags.mode) {
+            choices: () => [
+              { name: 'terminal     - New terminal window', value: 'terminal' },
+              { name: 'background   - Runs detached, reattach with: prlt session attach', value: 'background' },
+            ],
+          })
+
+          const displayResult = await displayResolver.resolve()
+          displayMode = displayResult.display as DisplayMode
+        }
+      } else if (flags.display) {
         // Host environment: terminal/background are display modes
-        displayMode = flags.mode as DisplayMode
+        displayMode = flags.display as DisplayMode
       }
 
       // Permission mode
-      const { permissionMode } = await this.prompt<{ permissionMode: string }>([
-        {
+      if (flags['permission-mode']) {
+        sandboxed = flags['permission-mode'] === 'safe'
+      } else {
+        const permResolver = new FlagResolver<{ 'permission-mode'?: string }>({
+          commandName: 'work revise',
+          baseCommand: `prlt work revise ${ticketId}`,
+          jsonMode,
+          flags: {},
+        })
+
+        permResolver.addPrompt({
+          flagName: 'permission-mode',
           type: 'list',
-          name: 'permissionMode',
           message: 'Permission mode for Claude Code:',
-          choices: [
-            { name: 'danger - Skip permission checks (faster for revisions)', value: 'danger', command: `prlt work revise ${ticketId} --json` },
-            { name: 'safe   - Requires approval for dangerous operations', value: 'safe', command: `prlt work revise ${ticketId} --json` },
-          ],
           default: 'danger',
-        },
-      ], reviseJsonModeConfig)
-      sandboxed = permissionMode === 'safe'
+          choices: () => [
+            { name: 'danger - Skip permission checks (faster for revisions)', value: 'danger' },
+            { name: 'safe   - Requires approval for dangerous operations', value: 'safe' },
+          ],
+        })
+
+        const permResult = await permResolver.resolve()
+        sandboxed = permResult['permission-mode'] === 'safe'
+      }
 
       const executor = (flags.executor as ExecutorType) || DEFAULT_EXECUTION_CONFIG.defaultExecutor
 

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -109,8 +109,12 @@ export default class WorkSpawn extends PMOCommand {
       description: 'Output mode (batch mode only)',
       options: ['interactive', 'print'],
     }),
+    'permission-mode': Flags.string({
+      description: 'Permission mode for Claude Code (danger=skip checks, safe=require approval)',
+      options: ['danger', 'safe'],
+    }),
     'skip-permissions': Flags.boolean({
-      description: 'Skip permission prompts - danger mode (batch mode only)',
+      description: 'Skip permission checks (shorthand for --permission-mode danger)',
       default: false,
     }),
     'create-pr': Flags.boolean({
@@ -165,6 +169,17 @@ export default class WorkSpawn extends PMOCommand {
 
   async execute(): Promise<void> {
     const { flags, argv } = await this.parse(WorkSpawn)
+
+    // Handle --skip-permissions flag (alias for --permission-mode danger)
+    if (flags['skip-permissions'] && flags['permission-mode']) {
+      this.error(
+        'Cannot use both --skip-permissions and --permission-mode flags.\n' +
+        'Use only one: --skip-permissions OR --permission-mode danger/safe'
+      )
+    }
+    if (flags['skip-permissions']) {
+      flags['permission-mode'] = 'danger'
+    }
 
     // Check if JSON output mode is active
     const jsonMode = shouldOutputJson(flags)
@@ -327,7 +342,7 @@ export default class WorkSpawn extends PMOCommand {
           // Check if all required flags for non-interactive execution are provided
           const hasAction = !!flags.action
           const hasDisplay = !!flags.display || flags['run-on-host']
-          const hasPermissions = flags['skip-permissions'] || flags['per-ticket'] // per-ticket mode prompts individually
+          const hasPermissions = flags['permission-mode'] || flags['skip-permissions'] || flags['per-ticket'] // per-ticket mode prompts individually
           const allFlagsProvided = hasAction && hasDisplay && hasPermissions
 
           if (allFlagsProvided && flags.yes) {
@@ -343,7 +358,8 @@ export default class WorkSpawn extends PMOCommand {
             if (flags.action) confirmCmd += ` --action ${flags.action}`
             if (flags.display) confirmCmd += ` --display ${flags.display}`
             if (flags['run-on-host']) confirmCmd += ' --run-on-host'
-            if (flags['skip-permissions']) confirmCmd += ' --skip-permissions'
+            if (flags['permission-mode']) confirmCmd += ` --permission-mode ${flags['permission-mode']}`
+            else if (flags['skip-permissions']) confirmCmd += ' --skip-permissions'
             if (flags.executor) confirmCmd += ` --executor ${flags.executor}`
             if (flags.session) confirmCmd += ` --session ${flags.session}`
             if (flags['create-pr']) confirmCmd += ' --create-pr'
@@ -360,7 +376,7 @@ export default class WorkSpawn extends PMOCommand {
               })),
               action: flags.action,
               display: flags.display || (flags['run-on-host'] ? 'host' : 'devcontainer'),
-              permissions: flags['skip-permissions'] ? 'danger' : 'safe',
+              permissions: flags['permission-mode'] || (flags['skip-permissions'] ? 'danger' : 'safe'),
               count: ticketsToSpawn.length,
             }
 
@@ -673,7 +689,8 @@ export default class WorkSpawn extends PMOCommand {
           if (flags.action) confirmCmd += ` --action ${flags.action}`
           if (flags.display) confirmCmd += ` --display ${flags.display}`
           if (flags['run-on-host']) confirmCmd += ' --run-on-host'
-          if (flags['skip-permissions']) confirmCmd += ' --skip-permissions'
+          if (flags['permission-mode']) confirmCmd += ` --permission-mode ${flags['permission-mode']}`
+          else if (flags['skip-permissions']) confirmCmd += ' --skip-permissions'
           if (flags.executor) confirmCmd += ` --executor ${flags.executor}`
           if (flags.session) confirmCmd += ` --session ${flags.session}`
           if (flags['create-pr']) confirmCmd += ' --create-pr'
@@ -1002,7 +1019,7 @@ export default class WorkSpawn extends PMOCommand {
       let batchDisplay = flags.display
       let batchOutput = flags.output
       // Track permission mode - default to 'safe', check flag to determine if prompting needed
-      let batchPermissionMode: PermissionMode = flags['skip-permissions'] ? 'danger' : 'safe'
+      let batchPermissionMode: PermissionMode = flags['permission-mode'] ? flags['permission-mode'] as PermissionMode : (flags['skip-permissions'] ? 'danger' : 'safe')
       let batchCreatePr = flags['create-pr']
       let batchNoPr = flags['no-pr']
       let batchRunOnHost = flags['run-on-host']
@@ -1119,7 +1136,7 @@ export default class WorkSpawn extends PMOCommand {
         }
 
         // Check if any explicit settings were provided via flags
-        const hasExplicitSettings = flags.display || flags.output || flags['skip-permissions'] ||
+        const hasExplicitSettings = flags.display || flags.output || flags['permission-mode'] || flags['skip-permissions'] ||
           flags['create-pr'] || flags['no-pr'] || flags['run-on-host']
 
         // Offer to use default settings if no explicit flags provided
@@ -1360,8 +1377,8 @@ export default class WorkSpawn extends PMOCommand {
           batchOutput = 'interactive'
         }
 
-        // Prompt for permissions mode if not explicitly set via --skip-permissions flag
-        if (!flags['skip-permissions']) {
+        // Prompt for permissions mode if not explicitly set via --permission-mode or --skip-permissions flag
+        if (!flags['permission-mode'] && !flags['skip-permissions']) {
           // Use FlagResolver for permission mode
           const permissionResolver = new FlagResolver<{ permissionMode?: string }>({
             commandName: 'work spawn',

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -64,13 +64,17 @@ export default class WorkWatch extends PMOCommand {
       description: 'Check once and exit (no continuous watching)',
       default: false,
     }),
-    mode: Flags.string({
+    display: Flags.string({
       char: 'd',
-      description: 'Display mode for agent output',
+      description: 'Display mode for agent output (terminal=new tab, background=detached)',
       options: ['terminal', 'background'],
     }),
+    'permission-mode': Flags.string({
+      description: 'Permission mode for Claude Code (danger=skip checks, safe=require approval)',
+      options: ['danger', 'safe'],
+    }),
     'skip-permissions': Flags.boolean({
-      description: 'Skip permission prompts (danger mode)',
+      description: 'Skip permission checks (shorthand for --permission-mode danger)',
       default: false,
     }),
     'create-pr': Flags.boolean({
@@ -95,6 +99,17 @@ export default class WorkWatch extends PMOCommand {
 
   async execute(): Promise<void> {
     const { flags } = await this.parse(WorkWatch)
+
+    // Handle --skip-permissions flag (alias for --permission-mode danger)
+    if (flags['skip-permissions'] && flags['permission-mode']) {
+      this.error(
+        'Cannot use both --skip-permissions and --permission-mode flags.\n' +
+        'Use only one: --skip-permissions OR --permission-mode danger/safe'
+      )
+    }
+    if (flags['skip-permissions']) {
+      flags['permission-mode'] = 'danger'
+    }
 
     // Check if JSON output mode is active
     const jsonMode = shouldOutputJson(flags)
@@ -191,7 +206,7 @@ export default class WorkWatch extends PMOCommand {
       this.environment = 'host'
       this.displayMode = 'terminal'
 
-      if (!flags.mode) {
+      if (!flags.display) {
         if (hasDevcontainer) {
           const envChoices = [
             { name: '🐳 devcontainer (sandboxed, recommended)', value: 'devcontainer' },
@@ -281,7 +296,7 @@ export default class WorkWatch extends PMOCommand {
         const displayResult = await displayResolver.resolve()
         this.displayMode = displayResult.selectedDisplay as DisplayMode
       } else {
-        this.displayMode = flags.mode as DisplayMode
+        this.displayMode = flags.display as DisplayMode
         this.environment = hasDevcontainer && isDockerRunning() ? 'devcontainer' : 'host'
       }
 
@@ -289,7 +304,7 @@ export default class WorkWatch extends PMOCommand {
       const promptResult = await promptExecutionSettings(db, {
         displayMode: this.displayMode,
         environment: this.environment,
-        skipPermissions: flags['skip-permissions'] ? true : undefined,
+        skipPermissions: flags['permission-mode'] === 'danger' || flags['skip-permissions'] ? true : undefined,
         createPR: flags['create-pr'] ? true : undefined,
         log: (msg) => this.log(styles.header(msg)),
         jsonMode: jsonMode ? { flags, commandName: 'work watch' } : undefined,

--- a/apps/cli/test/unit/work-flag-consistency.test.ts
+++ b/apps/cli/test/unit/work-flag-consistency.test.ts
@@ -1,0 +1,196 @@
+import { expect } from 'chai';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Root directory for the CLI
+const root = path.resolve(__dirname, '../..');
+
+// Isolated env to prevent test commands from polluting production database
+function getIsolatedEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.PRLT_HQ_PATH;
+  delete env.PRLT_PMO_PATH;
+  delete env.PRLT_DATABASE_PATH;
+  delete env.PRLT_CONFIG_PATH;
+  delete env.DEVCONTAINER;
+  delete env.PRLT_TEST_ENV;
+  return env;
+}
+
+// Helper to run CLI commands directly and get stdout
+function runCli(args: string[]): string {
+  const binPath = path.join(root, 'bin', 'run.js');
+  try {
+    return execSync(`node ${binPath} ${args.join(' ')}`, {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: getIsolatedEnv(),
+    });
+  } catch (error: unknown) {
+    return (error as { stdout?: string })?.stdout || '';
+  }
+}
+
+
+/**
+ * Tests for flag consistency across work commands
+ * TKT-635: Audit CLI flags vs interactive prompts for consistency
+ */
+describe('Work Command Flag Consistency (TKT-635)', () => {
+  // Cache help outputs for all commands
+  const helpOutputs: Record<string, string> = {};
+
+  before(() => {
+    helpOutputs.start = runCli(['work', 'start', '--help']);
+    helpOutputs.spawn = runCli(['work', 'spawn', '--help']);
+    helpOutputs.revise = runCli(['work', 'revise', '--help']);
+    helpOutputs.watch = runCli(['work', 'watch', '--help']);
+  });
+
+  describe('--display flag consistency (not --mode)', () => {
+    it('work start uses --display', () => {
+      expect(helpOutputs.start).to.contain('--display');
+    });
+
+    it('work spawn uses --display', () => {
+      expect(helpOutputs.spawn).to.contain('--display');
+      expect(helpOutputs.spawn).to.not.match(/--mode\b/);
+    });
+
+    it('work revise uses --display (not --mode)', () => {
+      expect(helpOutputs.revise).to.contain('--display');
+      expect(helpOutputs.revise).to.not.match(/--mode\b/);
+    });
+
+    it('work watch uses --display (not --mode)', () => {
+      expect(helpOutputs.watch).to.contain('--display');
+      expect(helpOutputs.watch).to.not.match(/--mode\b/);
+    });
+  });
+
+  describe('--permission-mode flag consistency', () => {
+    it('work start has --permission-mode', () => {
+      expect(helpOutputs.start).to.contain('--permission-mode');
+    });
+
+    it('work spawn has --permission-mode', () => {
+      expect(helpOutputs.spawn).to.contain('--permission-mode');
+    });
+
+    it('work revise has --permission-mode', () => {
+      expect(helpOutputs.revise).to.contain('--permission-mode');
+    });
+
+    it('work watch has --permission-mode', () => {
+      expect(helpOutputs.watch).to.contain('--permission-mode');
+    });
+
+    it('all commands with --permission-mode offer danger and safe options', () => {
+      for (const cmd of ['start', 'spawn', 'revise', 'watch']) {
+        expect(helpOutputs[cmd]).to.contain('danger');
+        expect(helpOutputs[cmd]).to.contain('safe');
+      }
+    });
+  });
+
+  describe('--skip-permissions flag consistency', () => {
+    it('work start has --skip-permissions', () => {
+      expect(helpOutputs.start).to.contain('--skip-permissions');
+    });
+
+    it('work spawn has --skip-permissions', () => {
+      expect(helpOutputs.spawn).to.contain('--skip-permissions');
+    });
+
+    it('work revise has --skip-permissions', () => {
+      expect(helpOutputs.revise).to.contain('--skip-permissions');
+    });
+
+    it('work watch has --skip-permissions', () => {
+      expect(helpOutputs.watch).to.contain('--skip-permissions');
+    });
+  });
+
+  describe('--skip-permissions describes shorthand', () => {
+    it('work revise --skip-permissions is described as shorthand', () => {
+      expect(helpOutputs.revise).to.contain('shorthand');
+    });
+
+    it('work spawn --skip-permissions is described as shorthand', () => {
+      expect(helpOutputs.spawn).to.contain('shorthand');
+    });
+
+    it('work watch --skip-permissions is described as shorthand', () => {
+      expect(helpOutputs.watch).to.contain('shorthand');
+    });
+  });
+
+  describe('--focus flag consistency', () => {
+    it('work start has --focus', () => {
+      expect(helpOutputs.start).to.contain('--focus');
+    });
+
+    it('work spawn has --focus', () => {
+      expect(helpOutputs.spawn).to.contain('--focus');
+    });
+
+    it('work revise has --focus', () => {
+      expect(helpOutputs.revise).to.contain('--focus');
+    });
+  });
+
+  describe('--clone flag consistency', () => {
+    it('work start has --clone', () => {
+      expect(helpOutputs.start).to.contain('--clone');
+    });
+
+    it('work spawn has --clone', () => {
+      expect(helpOutputs.spawn).to.contain('--clone');
+    });
+
+    it('work revise has --clone', () => {
+      expect(helpOutputs.revise).to.contain('--clone');
+    });
+  });
+
+  describe('--json flag consistency', () => {
+    it('work start has --json', () => {
+      expect(helpOutputs.start).to.contain('--json');
+    });
+
+    it('work spawn has --json', () => {
+      expect(helpOutputs.spawn).to.contain('--json');
+    });
+
+    it('work revise has --json', () => {
+      expect(helpOutputs.revise).to.contain('--json');
+    });
+
+    it('work watch has --json', () => {
+      expect(helpOutputs.watch).to.contain('--json');
+    });
+  });
+
+  describe('display mode options', () => {
+    it('work revise offers terminal and background', () => {
+      expect(helpOutputs.revise).to.contain('terminal');
+      expect(helpOutputs.revise).to.contain('background');
+    });
+
+    it('work watch offers terminal and background', () => {
+      expect(helpOutputs.watch).to.contain('terminal');
+      expect(helpOutputs.watch).to.contain('background');
+    });
+
+    it('work start offers foreground, terminal, and background', () => {
+      expect(helpOutputs.start).to.contain('foreground');
+      expect(helpOutputs.start).to.contain('terminal');
+      expect(helpOutputs.start).to.contain('background');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves TKT-635: Audit CLI flags vs interactive prompts for consistency

## Description

Audit all work commands to ensure CLI flags, interactive prompts, and JSON mode outputs are aligned.

## Background
Found drift between --mode and --display flags in work start/spawn. Consolidated to just --display, but there may be other inconsistencies.

## Scope
All work commands: start, spawn, ready, complete, revise, watch, spawn-all, index

## Detailed Audit Findings

### Critical Issues (Must Fix)

**Issue 1: --mode vs --display flag inconsistency**
- `work revise` (line 62-66): Uses `--mode` with options `foreground|background|tmux|terminal|devcontainer`
- `work watch` (line 71-74): Uses `--mode` with options `terminal|background`
- `work start` and `work spawn`: Use `--display` with options `foreground|terminal|background`
- **Fix**: Rename `--mode` to `--display` in `revise` and `watch` commands

**Issue 2: Missing JSON mode outputs**
- `work revise`: Ticket selection prompt (line 164-175) not output as JSON
- `work revise`: Display mode prompt (line 289-301) not output as JSON
- `work revise`: Permission mode prompt (line 308-320) not output as JSON
- `work watch`: Environment selection prompt not output as JSON
- `work watch`: Display mode prompt not output as JSON
- **Fix**: Add `outputPromptAsJson()` calls for all interactive prompts

### Medium Issues (Should Fix)

**Issue 3: Permission flag inconsistency**
- `work start`: Has both `--skip-permissions` AND `--permission-mode` (with conflict check)
- `work spawn`: Only has `--skip-permissions`
- `work revise`: Neither flag (prompts interactively only)
- `work watch`: Only has `--skip-permissions`
- **Fix**: Standardize on `--permission-mode danger|safe` with `--skip-permissions` as shorthand

**Issue 4: Missing flags in some commands**
- `--focus` flag: Present in `work start`, `work spawn` but missing from `revise`, `watch`
- `--clone` flag: Present in `work start`, `work spawn` but missing from `revise`
- `--session` flag: Inconsistent defaults/presence across commands
- **Fix**: Add missing flags where applicable

### Minor Issues (Nice to Have)

**Issue 5: work revise still references deprecated patterns**
- Line 302-305: Uses `flags.mode` directly instead of `flags.display`
- Early Docker/devcontainer checks (lines 111-129) don't give retry option like `work start`

**Issue 6: Inconsistent display mode options**
- `work revise` offers: `terminal`, `background`
- `work start` offers: `foreground`, `terminal`, `background`
- `work watch` offers: `terminal`, `background`
- **Note**: `foreground` makes sense only for single-ticket work, current behavior is reasonable

## Flags Per Command (Current State)

| Flag | start | spawn | ready | complete | revise | watch | spawn-all |
|------|-------|-------|-------|----------|--------|-------|-----------|
| --json | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
| --display | ✓ | ✓ | ✗ | ✗ | ✗* | ✗* | ✗ |
| --mode | ✗ | ✗ | ✗ | ✗ | ✓* | ✓* | ✗ |
| --executor | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ |
| --permission-mode | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
| --skip-permissions | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ |
| --run-on-host | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ |
| --focus | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
| --clone | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
| --session | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ |
| --create-pr | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ |
| --no-pr | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ |
| --pr | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
| --draft | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
| --force | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ |

*Issue: These should use --display not --mode

## Technical Notes
- Primary files to modify: `apps/cli/src/commands/work/revise.ts`, `apps/cli/src/commands/work/watch.ts`
- Pattern to follow: Use `work start` as the canonical reference for flag naming and JSON mode implementation
- The `prompt-json.js` utilities (`outputPromptAsJson`, `buildPromptConfig`, etc.) provide the standard pattern

## Changes

- a46a84f2 chore(TKT-635): audit and fix CLI flag consistency across work commands

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
