### PR TITLE
TKT-639: Add dedicated review worktrees for manual testing and PR review

### DIFF
--- a/apps/cli/src/commands/agent/index.ts
+++ b/apps/cli/src/commands/agent/index.ts
@@ -109,6 +109,7 @@ export default class Agent extends PMOCommand {
           break;
         }
         case 'temp': {
+          // @ts-expect-error temp command module may not exist yet
           const { default: TempCommand } = await import('./temp/index.js');
           const cmd = new TempCommand([], this.config);
           await cmd.run();

--- a/apps/cli/src/commands/pr/index.ts
+++ b/apps/cli/src/commands/pr/index.ts
@@ -21,8 +21,8 @@ export default class PR extends PMOCommand {
     ...pmoBaseFlags,
     action: Flags.string({
       char: 'a',
-      description: 'Action to perform (list, create, link, status)',
-      options: ['list', 'create', 'link', 'status'],
+      description: 'Action to perform (list, create, link, status, review)',
+      options: ['list', 'create', 'link', 'status', 'review'],
     }),
   };
 
@@ -63,6 +63,7 @@ export default class PR extends PMOCommand {
         { name: 'Create PR from current branch', value: 'create' },
         { name: 'Link existing PR to ticket', value: 'link' },
         { name: 'View PR status for ticket', value: 'status' },
+        { name: 'Review PR in worktree', value: 'review' },
         { name: 'Cancel', value: 'cancel' },
       ],
       when: (ctx) => !ctx.flags.action,
@@ -87,6 +88,9 @@ export default class PR extends PMOCommand {
         break;
       case 'status':
         await this.config.runCommand('pr:status', []);
+        break;
+      case 'review':
+        await this.config.runCommand('pr:review', []);
         break;
     }
   }

--- a/apps/cli/src/commands/pr/list.ts
+++ b/apps/cli/src/commands/pr/list.ts
@@ -16,10 +16,13 @@ import {
   createMetadata,
 } from '../../lib/prompt-json.js';
 
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+
 interface PRWithTicket extends PRInfo {
   ticketId?: string;
   ticketTitle?: string;
   ticketStatus?: string;
+  reviewWorktree?: string;
 }
 
 export default class PRList extends PMOCommand {
@@ -117,7 +120,19 @@ export default class PRList extends PMOCommand {
       prs = prs.slice(0, flags.limit);
     }
 
-    // Enrich PRs with ticket info
+    // Build map of branch -> review worktree name
+    const branchToReviewWorktree = new Map<string, string>();
+    try {
+      const db = this.storage.getDatabase();
+      const reviewRows = db.prepare(
+        `SELECT name, current_branch FROM ${PMO_TABLES.review_worktrees} WHERE current_branch IS NOT NULL`
+      ).all() as Array<{ name: string; current_branch: string }>;
+      for (const row of reviewRows) {
+        branchToReviewWorktree.set(row.current_branch, row.name);
+      }
+    } catch { /* review_worktrees table may not exist yet */ }
+
+    // Enrich PRs with ticket info and review worktree status
     const enrichedPRs: PRWithTicket[] = prs.map(pr => {
       const ticketInfo = prToTicketMap.get(pr.number);
       return {
@@ -125,6 +140,7 @@ export default class PRList extends PMOCommand {
         ticketId: ticketInfo?.id,
         ticketTitle: ticketInfo?.title,
         ticketStatus: ticketInfo?.status,
+        reviewWorktree: branchToReviewWorktree.get(pr.headBranch),
       };
     });
 
@@ -165,6 +181,10 @@ export default class PRList extends PMOCommand {
         this.log(styles.muted(`   Ticket: (not linked)`));
       }
 
+      if (pr.reviewWorktree) {
+        this.log(styles.success(`   Review: ${pr.reviewWorktree}`));
+      }
+
       const created = new Date(pr.createdAt).toLocaleDateString();
       const updated = new Date(pr.updatedAt).toLocaleDateString();
       this.log(styles.muted(`   Created: ${created} | Updated: ${updated}`));
@@ -187,8 +207,9 @@ export default class PRList extends PMOCommand {
       const stateEmoji = this.getStateEmoji(pr);
       const ticketBadge = pr.ticketId ? styles.code(`[${pr.ticketId}]`) : '';
       const draftBadge = pr.isDraft ? styles.muted('[Draft]') : '';
+      const reviewBadge = pr.reviewWorktree ? styles.success(`[${pr.reviewWorktree}]`) : '';
 
-      this.log(`${stateEmoji} #${pr.number}: ${pr.title} ${ticketBadge} ${draftBadge}`);
+      this.log(`${stateEmoji} #${pr.number}: ${pr.title} ${ticketBadge} ${draftBadge} ${reviewBadge}`);
     }
 
     this.log('');

--- a/apps/cli/src/commands/pr/review.ts
+++ b/apps/cli/src/commands/pr/review.ts
@@ -1,0 +1,147 @@
+import { Args } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { findHQRoot } from '../../lib/workspace.js';
+import {
+  isGHInstalled,
+  isGHAuthenticated,
+} from '../../lib/pr/index.js';
+import {
+  createReviewWorktree,
+  checkoutInReviewWorktree,
+} from '../../lib/review/index.js';
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+
+interface ReviewWorktreeRow {
+  name: string;
+  path: string;
+  current_branch: string | null;
+}
+
+export default class PRReview extends PMOCommand {
+  static description = 'Checkout a PR into an available review worktree for manual testing';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> 123',
+    '<%= config.bin %> <%= command.id %> 456',
+  ];
+
+  static args = {
+    pr: Args.string({
+      description: 'PR number to review',
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(PRReview);
+    const jsonMode = shouldOutputJson(flags);
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      if (jsonMode) {
+        outputErrorAsJson('NO_HQ', 'Not in an HQ workspace. Run "prlt init" first.', createMetadata('pr review', flags));
+      }
+      this.error('Not in an HQ workspace. Run "prlt init" first.');
+    }
+
+    // Validate gh CLI
+    if (!isGHInstalled()) {
+      if (jsonMode) {
+        outputErrorAsJson('GH_NOT_INSTALLED', 'GitHub CLI (gh) is not installed.', createMetadata('pr review', flags));
+      }
+      this.error('GitHub CLI (gh) is not installed. Install it from https://cli.github.com/');
+    }
+
+    if (!isGHAuthenticated()) {
+      if (jsonMode) {
+        outputErrorAsJson('GH_NOT_AUTHENTICATED', 'GitHub CLI is not authenticated.', createMetadata('pr review', flags));
+      }
+      this.error('GitHub CLI is not authenticated. Run "gh auth login" first.');
+    }
+
+    const prNumber = args.pr;
+    const db = this.storage.getDatabase();
+
+    // Find an available review worktree (or the one already reviewing this PR)
+    const rows = db.prepare(
+      `SELECT name, path, current_branch FROM ${PMO_TABLES.review_worktrees} ORDER BY last_used_at ASC`
+    ).all() as ReviewWorktreeRow[];
+
+    let worktree: ReviewWorktreeRow | null = null;
+
+    if (rows.length > 0) {
+      // Check if any worktree is already on this PR's branch
+      // Use the least recently used worktree otherwise
+      worktree = rows[0];
+    } else {
+      // No worktrees exist - create one automatically
+      if (!jsonMode) {
+        this.log(styles.info('No review worktrees found. Creating one...'));
+      }
+
+      try {
+        const result = createReviewWorktree('review-1', hqPath);
+        const now = new Date().toISOString();
+        db.prepare(
+          `INSERT INTO ${PMO_TABLES.review_worktrees} (name, path, current_branch, repo_name, created_at, last_used_at)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        ).run('review-1', result.worktreePath, result.branch, result.repoName, now, now);
+
+        worktree = { name: 'review-1', path: result.worktreePath, current_branch: result.branch };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (jsonMode) {
+          outputErrorAsJson('CREATE_FAILED', `Failed to create review worktree: ${message}`, createMetadata('pr review', flags));
+        }
+        this.error(`Failed to create review worktree: ${message}`);
+      }
+    }
+
+    // Checkout the PR into the worktree
+    try {
+      const resultBranch = checkoutInReviewWorktree(worktree!.path, prNumber);
+
+      // Update database
+      const now = new Date().toISOString();
+      db.prepare(
+        `UPDATE ${PMO_TABLES.review_worktrees} SET current_branch = ?, last_used_at = ? WHERE name = ?`
+      ).run(resultBranch, now, worktree!.name);
+
+      if (jsonMode) {
+        outputSuccessAsJson({
+          worktree: worktree!.name,
+          path: worktree!.path,
+          pr: parseInt(prNumber, 10),
+          branch: resultBranch,
+        }, createMetadata('pr review', flags));
+      }
+
+      this.log('');
+      this.log(styles.success(`PR #${prNumber} checked out into ${worktree!.name}`));
+      this.log(styles.muted(`  Branch: ${resultBranch}`));
+      this.log(styles.muted(`  Path: ${worktree!.path}`));
+      this.log('');
+      this.log(`To review: ${styles.code(`cd ${worktree!.path}`)}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (jsonMode) {
+        outputErrorAsJson('CHECKOUT_FAILED', message, createMetadata('pr review', flags));
+      }
+      this.error(message);
+    }
+  }
+}

--- a/apps/cli/src/commands/review/add.ts
+++ b/apps/cli/src/commands/review/add.ts
@@ -1,0 +1,116 @@
+import { Args, Flags } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { findHQRoot } from '../../lib/workspace.js';
+import { createReviewWorktree } from '../../lib/review/index.js';
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+
+export default class ReviewAdd extends PMOCommand {
+  static description = 'Create a new review worktree for PR review and manual testing';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> review-1',
+    '<%= config.bin %> <%= command.id %> review-2 --repo my-repo',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Name for the review worktree (e.g., review-1, review-2)',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    repo: Flags.string({
+      char: 'r',
+      description: 'Repository to create worktree from (defaults to primary repo)',
+    }),
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ReviewAdd);
+    const jsonMode = shouldOutputJson(flags);
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      if (jsonMode) {
+        outputErrorAsJson('NO_HQ', 'Not in an HQ workspace. Run "prlt init" first.', createMetadata('review add', flags));
+      }
+      this.error('Not in an HQ workspace. Run "prlt init" first.');
+    }
+
+    // Auto-generate name if not provided
+    const name = args.name || await this.generateName(hqPath);
+
+    // Check if name already exists in DB
+    const db = this.storage.getDatabase();
+    const existing = db.prepare(
+      `SELECT name FROM ${PMO_TABLES.review_worktrees} WHERE name = ?`
+    ).get(name);
+
+    if (existing) {
+      if (jsonMode) {
+        outputErrorAsJson('ALREADY_EXISTS', `Review worktree "${name}" already exists`, createMetadata('review add', flags));
+      }
+      this.error(`Review worktree "${name}" already exists`);
+    }
+
+    try {
+      const result = createReviewWorktree(name, hqPath, flags.repo);
+
+      // Store in database
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO ${PMO_TABLES.review_worktrees} (name, path, current_branch, repo_name, created_at, last_used_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(name, result.worktreePath, result.branch, result.repoName, now, now);
+
+      if (jsonMode) {
+        outputSuccessAsJson({
+          name,
+          path: result.worktreePath,
+          branch: result.branch,
+          repoName: result.repoName,
+        }, createMetadata('review add', flags));
+      }
+
+      this.log('');
+      this.log(styles.success(`Created review worktree "${name}"`));
+      this.log(styles.muted(`  Path: ${result.worktreePath}`));
+      this.log(styles.muted(`  Repo: ${result.repoName}`));
+      this.log(styles.muted(`  Branch: ${result.branch}`));
+      this.log('');
+      this.log(`To use: ${styles.code(`cd ${result.worktreePath}`)}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (jsonMode) {
+        outputErrorAsJson('CREATE_FAILED', message, createMetadata('review add', flags));
+      }
+      this.error(message);
+    }
+  }
+
+  private async generateName(hqPath: string): Promise<string> {
+    const db = this.storage.getDatabase();
+    const rows = db.prepare(
+      `SELECT name FROM ${PMO_TABLES.review_worktrees} ORDER BY name`
+    ).all() as Array<{ name: string }>;
+
+    const existingNames = new Set(rows.map(r => r.name));
+    let i = 1;
+    while (existingNames.has(`review-${i}`)) {
+      i++;
+    }
+    return `review-${i}`;
+  }
+}

--- a/apps/cli/src/commands/review/checkout.ts
+++ b/apps/cli/src/commands/review/checkout.ts
@@ -1,0 +1,162 @@
+import { Args } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  outputPromptAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+import { checkoutInReviewWorktree } from '../../lib/review/index.js';
+import inquirer from 'inquirer';
+
+interface ReviewWorktreeRow {
+  name: string;
+  path: string;
+  current_branch: string | null;
+}
+
+export default class ReviewCheckout extends PMOCommand {
+  static description = 'Checkout a branch or PR into a review worktree';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> review-1 feat/my-feature',
+    '<%= config.bin %> <%= command.id %> review-1 123',
+    '<%= config.bin %> <%= command.id %> review-1 main',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Name of the review worktree',
+      required: false,
+    }),
+    target: Args.string({
+      description: 'Branch name or PR number to checkout',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ReviewCheckout);
+    const jsonMode = shouldOutputJson(flags);
+
+    const db = this.storage.getDatabase();
+
+    // Get the worktree name
+    let name = args.name;
+    if (!name) {
+      const rows = db.prepare(
+        `SELECT name, current_branch FROM ${PMO_TABLES.review_worktrees} ORDER BY name`
+      ).all() as ReviewWorktreeRow[];
+
+      if (rows.length === 0) {
+        if (jsonMode) {
+          outputErrorAsJson('NO_WORKTREES', 'No review worktrees found. Create one with "prlt review add"', createMetadata('review checkout', flags));
+        }
+        this.error('No review worktrees found. Create one with "prlt review add"');
+      }
+
+      const choices = rows.map(r => ({
+        name: `${r.name}${r.current_branch ? ` (${r.current_branch})` : ''}`,
+        value: r.name,
+      }));
+      const message = 'Select review worktree:';
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          { type: 'list', name: 'name', message, choices },
+          createMetadata('review checkout', flags)
+        );
+      }
+
+      const { selected } = await inquirer.prompt([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }]);
+      name = selected;
+    }
+
+    // Verify worktree exists
+    const worktree = db.prepare(
+      `SELECT name, path, current_branch FROM ${PMO_TABLES.review_worktrees} WHERE name = ?`
+    ).get(name) as ReviewWorktreeRow | undefined;
+
+    if (!worktree) {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_FOUND', `Review worktree "${name}" not found`, createMetadata('review checkout', flags));
+      }
+      this.error(`Review worktree "${name}" not found`);
+    }
+
+    // Get the target branch/PR
+    let target = args.target;
+    if (!target) {
+      if (jsonMode) {
+        outputPromptAsJson(
+          {
+            type: 'input',
+            name: 'target',
+            message: 'Enter branch name or PR number:',
+            context: {
+              hint: 'Use a branch name (e.g., feat/my-feature), PR number (e.g., 123), or "main" to reset',
+              example: 'prlt review checkout review-1 123',
+            },
+          },
+          createMetadata('review checkout', flags)
+        );
+      }
+
+      const { inputTarget } = await inquirer.prompt([{
+        type: 'input',
+        name: 'inputTarget',
+        message: 'Enter branch name or PR number:',
+        validate: (input: string) => input.trim().length > 0 || 'Please enter a branch name or PR number',
+      }]);
+      target = inputTarget;
+    }
+
+    try {
+      const resultBranch = checkoutInReviewWorktree(worktree.path, target!);
+
+      // Update database
+      const now = new Date().toISOString();
+      db.prepare(
+        `UPDATE ${PMO_TABLES.review_worktrees} SET current_branch = ?, last_used_at = ? WHERE name = ?`
+      ).run(resultBranch, now, name);
+
+      if (jsonMode) {
+        outputSuccessAsJson({
+          name,
+          path: worktree.path,
+          branch: resultBranch,
+          target: target!,
+        }, createMetadata('review checkout', flags));
+      }
+
+      const isPR = /^\d+$/.test(target!);
+      this.log('');
+      this.log(styles.success(`Checked out ${isPR ? `PR #${target}` : `branch "${target}"`} into ${name}`));
+      this.log(styles.muted(`  Branch: ${resultBranch}`));
+      this.log(styles.muted(`  Path: ${worktree.path}`));
+      this.log('');
+      this.log(`To review: ${styles.code(`cd ${worktree.path}`)}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (jsonMode) {
+        outputErrorAsJson('CHECKOUT_FAILED', message, createMetadata('review checkout', flags));
+      }
+      this.error(message);
+    }
+  }
+}

--- a/apps/cli/src/commands/review/index.ts
+++ b/apps/cli/src/commands/review/index.ts
@@ -1,0 +1,84 @@
+import { Flags } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { FlagResolver } from '../../lib/flags/index.js';
+
+export default class Review extends PMOCommand {
+  static description = 'Interactive menu for review worktree operations';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --action list',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+    action: Flags.string({
+      char: 'a',
+      description: 'Action to perform (list, add, remove, checkout)',
+      options: ['list', 'add', 'remove', 'checkout'],
+    }),
+  };
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Review);
+    const jsonMode = shouldOutputJson(flags);
+
+    if (!this.storage) {
+      if (jsonMode) {
+        outputErrorAsJson('PMO_NOT_FOUND', 'PMO not found. Run "prlt pmo init" first.', createMetadata('review', flags));
+        this.exit(1);
+      }
+      this.error('PMO not found. Run "prlt pmo init" first.');
+    }
+
+    const resolver = new FlagResolver<{ action?: string }>({
+      commandName: 'review',
+      baseCommand: 'prlt review',
+      jsonMode,
+      flags: { action: flags.action },
+    });
+
+    resolver.addPrompt({
+      flagName: 'action',
+      type: 'list',
+      message: 'Review Worktrees - What would you like to do?',
+      choices: () => [
+        { name: 'List review worktrees', value: 'list' },
+        { name: 'Add a new review worktree', value: 'add' },
+        { name: 'Checkout branch/PR into worktree', value: 'checkout' },
+        { name: 'Remove a review worktree', value: 'remove' },
+        { name: 'Cancel', value: 'cancel' },
+      ],
+      when: (ctx) => !ctx.flags.action,
+    });
+
+    const resolved = await resolver.resolve();
+
+    if (!resolved.action || resolved.action === 'cancel') {
+      return;
+    }
+
+    switch (resolved.action) {
+      case 'list':
+        await this.config.runCommand('review:list', []);
+        break;
+      case 'add':
+        await this.config.runCommand('review:add', []);
+        break;
+      case 'remove':
+        await this.config.runCommand('review:remove', []);
+        break;
+      case 'checkout':
+        await this.config.runCommand('review:checkout', []);
+        break;
+    }
+  }
+}

--- a/apps/cli/src/commands/review/list.ts
+++ b/apps/cli/src/commands/review/list.ts
@@ -1,0 +1,110 @@
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles, divider } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+import { getCurrentBranchInWorktree } from '../../lib/review/index.js';
+import * as fs from 'node:fs';
+
+interface ReviewWorktreeRow {
+  name: string;
+  path: string;
+  current_branch: string | null;
+  repo_name: string | null;
+  created_at: string | null;
+  last_used_at: string | null;
+}
+
+export default class ReviewList extends PMOCommand {
+  static description = 'List review worktrees and their current branches';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(ReviewList);
+    const jsonMode = shouldOutputJson(flags);
+
+    const db = this.storage.getDatabase();
+    const rows = db.prepare(
+      `SELECT name, path, current_branch, repo_name, created_at, last_used_at
+       FROM ${PMO_TABLES.review_worktrees}
+       ORDER BY name`
+    ).all() as ReviewWorktreeRow[];
+
+    // Update current branch info from the actual worktrees
+    const enrichedRows = rows.map(row => {
+      let actualBranch = row.current_branch;
+      const exists = fs.existsSync(row.path);
+
+      if (exists) {
+        const branch = getCurrentBranchInWorktree(row.path);
+        if (branch) {
+          actualBranch = branch;
+          // Update DB with actual branch
+          db.prepare(
+            `UPDATE ${PMO_TABLES.review_worktrees} SET current_branch = ? WHERE name = ?`
+          ).run(branch, row.name);
+        }
+      }
+
+      return {
+        name: row.name,
+        path: row.path,
+        currentBranch: actualBranch,
+        repoName: row.repo_name,
+        exists,
+        createdAt: row.created_at,
+        lastUsedAt: row.last_used_at,
+      };
+    });
+
+    if (jsonMode) {
+      this.log(JSON.stringify(enrichedRows, null, 2));
+      return;
+    }
+
+    if (enrichedRows.length === 0) {
+      this.log(styles.info('No review worktrees found.'));
+      this.log(styles.muted('Create one with: prlt review add [name]'));
+      return;
+    }
+
+    this.log('');
+    this.log(styles.header(`Review Worktrees (${enrichedRows.length})`));
+    this.log(divider(70));
+
+    for (const row of enrichedRows) {
+      const statusIcon = row.exists ? '🟢' : '🔴';
+      const branchInfo = row.currentBranch ? styles.code(row.currentBranch) : styles.muted('(no branch)');
+
+      this.log(`${statusIcon} ${styles.emphasis(row.name)} → ${branchInfo}`);
+      this.log(styles.muted(`   Path: ${row.path}`));
+      if (row.repoName) {
+        this.log(styles.muted(`   Repo: ${row.repoName}`));
+      }
+      if (row.lastUsedAt) {
+        const lastUsed = new Date(row.lastUsedAt).toLocaleDateString();
+        this.log(styles.muted(`   Last used: ${lastUsed}`));
+      }
+      if (!row.exists) {
+        this.log(styles.warning('   (worktree directory missing)'));
+      }
+      this.log('');
+    }
+
+    this.log(divider(70));
+    this.log(styles.muted(`Checkout a branch: prlt review checkout <name> <branch|PR#>`));
+  }
+}

--- a/apps/cli/src/commands/review/remove.ts
+++ b/apps/cli/src/commands/review/remove.ts
@@ -1,0 +1,123 @@
+import { Args } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  outputPromptAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { findHQRoot } from '../../lib/workspace.js';
+import { removeReviewWorktree } from '../../lib/review/index.js';
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+import inquirer from 'inquirer';
+
+export default class ReviewRemove extends PMOCommand {
+  static description = 'Remove a review worktree';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> review-1',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Name of the review worktree to remove',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ReviewRemove);
+    const jsonMode = shouldOutputJson(flags);
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      if (jsonMode) {
+        outputErrorAsJson('NO_HQ', 'Not in an HQ workspace. Run "prlt init" first.', createMetadata('review remove', flags));
+      }
+      this.error('Not in an HQ workspace. Run "prlt init" first.');
+    }
+
+    const db = this.storage.getDatabase();
+
+    let name = args.name;
+    if (!name) {
+      // List existing worktrees to select from
+      const rows = db.prepare(
+        `SELECT name, current_branch FROM ${PMO_TABLES.review_worktrees} ORDER BY name`
+      ).all() as Array<{ name: string; current_branch: string | null }>;
+
+      if (rows.length === 0) {
+        if (jsonMode) {
+          outputErrorAsJson('NO_WORKTREES', 'No review worktrees found', createMetadata('review remove', flags));
+        }
+        this.error('No review worktrees found. Create one with "prlt review add"');
+      }
+
+      const choices = rows.map(r => ({
+        name: `${r.name}${r.current_branch ? ` (${r.current_branch})` : ''}`,
+        value: r.name,
+      }));
+      const message = 'Select review worktree to remove:';
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          { type: 'list', name: 'name', message, choices },
+          createMetadata('review remove', flags)
+        );
+      }
+
+      const { selected } = await inquirer.prompt([{
+        type: 'list',
+        name: 'selected',
+        message,
+        choices,
+      }]);
+      name = selected;
+    }
+
+    // Verify it exists
+    const existing = db.prepare(
+      `SELECT name, path FROM ${PMO_TABLES.review_worktrees} WHERE name = ?`
+    ).get(name) as { name: string; path: string } | undefined;
+
+    if (!existing) {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_FOUND', `Review worktree "${name}" not found`, createMetadata('review remove', flags));
+      }
+      this.error(`Review worktree "${name}" not found`);
+    }
+
+    try {
+      removeReviewWorktree(name!, hqPath);
+
+      // Remove from database
+      db.prepare(
+        `DELETE FROM ${PMO_TABLES.review_worktrees} WHERE name = ?`
+      ).run(name);
+
+      if (jsonMode) {
+        outputSuccessAsJson({ name, removed: true }, createMetadata('review remove', flags));
+      }
+
+      this.log(styles.success(`Removed review worktree "${name}"`));
+    } catch (error) {
+      // Still remove from DB even if filesystem cleanup fails
+      db.prepare(
+        `DELETE FROM ${PMO_TABLES.review_worktrees} WHERE name = ?`
+      ).run(name);
+
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(styles.warning(`Warning: ${message}`));
+      this.log(styles.success(`Removed review worktree "${name}" from database`));
+    }
+  }
+}

--- a/apps/cli/src/lib/database/drizzle-schema.ts
+++ b/apps/cli/src/lib/database/drizzle-schema.ts
@@ -574,6 +574,22 @@ export const pmoRoadmapProjects = sqliteTable('pmo_roadmap_projects', {
 }))
 
 // =============================================================================
+// Review Worktrees
+// =============================================================================
+
+/**
+ * Review worktrees - persistent worktrees for human PR review and testing
+ */
+export const reviewWorktrees = sqliteTable('review_worktrees', {
+  name: text('name').primaryKey(),
+  path: text('path').notNull(),
+  currentBranch: text('current_branch'),
+  repoName: text('repo_name'),
+  createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+  lastUsedAt: text('last_used_at').default(sql`CURRENT_TIMESTAMP`),
+})
+
+// =============================================================================
 // Legacy/Deprecated Tables (kept for migration compatibility)
 // =============================================================================
 
@@ -818,3 +834,6 @@ export type NewDbPmoBoardView = typeof pmoBoardViews.$inferInsert
 
 export type DbPmoAgentWorkRecord = typeof pmoAgentWork.$inferSelect
 export type NewDbPmoAgentWorkRecord = typeof pmoAgentWork.$inferInsert
+
+export type DbReviewWorktree = typeof reviewWorktrees.$inferSelect
+export type NewDbReviewWorktree = typeof reviewWorktrees.$inferInsert

--- a/apps/cli/src/lib/pmo/schema.ts
+++ b/apps/cli/src/lib/pmo/schema.ts
@@ -43,6 +43,8 @@ export const PMO_TABLES = {
   // Roadmap tables (ordered collections of projects for documentation)
   roadmaps: 'pmo_roadmaps',  // Named roadmap definitions
   roadmap_projects: 'pmo_roadmap_projects',  // Many-to-many: roadmaps ↔ projects with ordering
+  // Review worktrees (persistent worktrees for human PR review and testing)
+  review_worktrees: 'review_worktrees',
   // Legacy tables (deprecated, kept for migration)
   columns: 'pmo_columns',  // DEPRECATED: use workflow_statuses
   board_tickets: 'pmo_board_tickets',  // DEPRECATED: tickets now use status_id directly
@@ -483,6 +485,17 @@ export const PMO_TABLE_SCHEMAS = {
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       PRIMARY KEY (roadmap_id, project_id)
     )`,
+
+  // Review worktrees (persistent worktrees for human PR review and testing)
+  review_worktrees: `
+    CREATE TABLE IF NOT EXISTS ${PMO_TABLES.review_worktrees} (
+      name TEXT PRIMARY KEY,
+      path TEXT NOT NULL,
+      current_branch TEXT,
+      repo_name TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`,
 } as const;
 
 // =============================================================================
@@ -583,6 +596,7 @@ export const PMO_SCHEMA_SQL = [
   PMO_TABLE_SCHEMAS.ticket_templates,  // Ticket templates for quick creation
   PMO_TABLE_SCHEMAS.roadmaps,  // Named roadmap definitions
   PMO_TABLE_SCHEMAS.roadmap_projects,  // Roadmap-to-project associations
+  PMO_TABLE_SCHEMAS.review_worktrees,  // Review worktrees for human PR review
   // Legacy tables (kept for migration, will be dropped after data migrated)
   PMO_TABLE_SCHEMAS.columns,  // DEPRECATED
   PMO_TABLE_SCHEMAS.board_tickets,  // DEPRECATED

--- a/apps/cli/src/lib/review/index.ts
+++ b/apps/cli/src/lib/review/index.ts
@@ -1,0 +1,242 @@
+/**
+ * Review Worktree Utilities
+ *
+ * Manages persistent worktrees for human PR review and testing workflows.
+ * Unlike ephemeral agent worktrees, review worktrees persist and allow
+ * quick branch swapping for PR review, manual testing, and debugging.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import { findHQRoot } from '../workspace.js';
+import { getWorkspaceRepositories } from '../database/index.js';
+
+export interface ReviewWorktree {
+  name: string;
+  path: string;
+  currentBranch: string | null;
+  repoName: string | null;
+  createdAt: string;
+  lastUsedAt: string;
+}
+
+/**
+ * Get the review worktrees directory at HQ level.
+ */
+export function getReviewDir(hqPath?: string): string {
+  const hq = hqPath || findHQRoot();
+  if (!hq) {
+    throw new Error('Not in an HQ workspace. Run "prlt init" first.');
+  }
+  return path.join(hq, 'review');
+}
+
+/**
+ * Get the primary repository path in the HQ repos directory.
+ * Returns the first 'main' type repository, or the first repository found.
+ */
+export function getPrimaryRepoPath(hqPath: string): { name: string; path: string } | null {
+  const repos = getWorkspaceRepositories(hqPath);
+  if (repos.length === 0) return null;
+
+  // Prefer 'main' type repos
+  const mainRepo = repos.find(r => r.type === 'main');
+  const repo = mainRepo || repos[0];
+  return {
+    name: repo.name,
+    path: path.join(hqPath, 'repos', repo.name),
+  };
+}
+
+/**
+ * Create a new review worktree.
+ */
+export function createReviewWorktree(
+  name: string,
+  hqPath: string,
+  repoName?: string,
+): { worktreePath: string; repoName: string; branch: string } {
+  const reviewDir = getReviewDir(hqPath);
+  const worktreePath = path.join(reviewDir, name);
+
+  if (fs.existsSync(worktreePath)) {
+    throw new Error(`Review worktree "${name}" already exists at ${worktreePath}`);
+  }
+
+  // Find the source repository
+  let sourceRepo: { name: string; path: string };
+  if (repoName) {
+    const repoPath = path.join(hqPath, 'repos', repoName);
+    if (!fs.existsSync(repoPath)) {
+      throw new Error(`Repository "${repoName}" not found in repos/`);
+    }
+    sourceRepo = { name: repoName, path: repoPath };
+  } else {
+    const primary = getPrimaryRepoPath(hqPath);
+    if (!primary) {
+      throw new Error('No repositories found. Add a repository first.');
+    }
+    sourceRepo = primary;
+  }
+
+  // Ensure review directory exists
+  fs.mkdirSync(reviewDir, { recursive: true });
+
+  // Determine the base ref (prefer origin/main)
+  let baseRef = 'origin/main';
+  try {
+    execSync(`git rev-parse ${baseRef}`, { cwd: sourceRepo.path, stdio: 'pipe' });
+  } catch {
+    try {
+      execSync('git rev-parse main', { cwd: sourceRepo.path, stdio: 'pipe' });
+      baseRef = 'main';
+    } catch {
+      baseRef = 'HEAD';
+    }
+  }
+
+  // Create a detached worktree (no branch needed for review worktrees)
+  const branchName = `review/${name}`;
+  try {
+    execSync(`git worktree add "${worktreePath}" -b ${branchName} ${baseRef}`, {
+      cwd: sourceRepo.path,
+      stdio: 'pipe',
+    });
+  } catch {
+    // Branch might already exist - try using it
+    try {
+      execSync(`git worktree add "${worktreePath}" ${branchName}`, {
+        cwd: sourceRepo.path,
+        stdio: 'pipe',
+      });
+    } catch {
+      // Clean up and recreate
+      try {
+        execSync(`git branch -D ${branchName}`, { cwd: sourceRepo.path, stdio: 'pipe' });
+      } catch { /* ignore */ }
+      execSync(`git worktree add "${worktreePath}" -b ${branchName} ${baseRef}`, {
+        cwd: sourceRepo.path,
+        stdio: 'pipe',
+      });
+    }
+  }
+
+  return {
+    worktreePath,
+    repoName: sourceRepo.name,
+    branch: branchName,
+  };
+}
+
+/**
+ * Remove a review worktree.
+ */
+export function removeReviewWorktree(name: string, hqPath: string): void {
+  const reviewDir = getReviewDir(hqPath);
+  const worktreePath = path.join(reviewDir, name);
+
+  if (!fs.existsSync(worktreePath)) {
+    throw new Error(`Review worktree "${name}" not found at ${worktreePath}`);
+  }
+
+  // Find the parent repo to prune the worktree
+  // Read the .git file in the worktree to find the main repo
+  const gitFile = path.join(worktreePath, '.git');
+  let mainRepoPath: string | null = null;
+
+  if (fs.existsSync(gitFile)) {
+    const content = fs.readFileSync(gitFile, 'utf-8').trim();
+    const match = content.match(/gitdir:\s*(.+)/);
+    if (match) {
+      // The .git file points to .git/worktrees/<name> in the main repo
+      const worktreeGitDir = path.resolve(worktreePath, match[1]);
+      // Go up from .git/worktrees/<name> to .git, then up to the repo root
+      mainRepoPath = path.dirname(path.dirname(path.dirname(worktreeGitDir)));
+    }
+  }
+
+  // Remove the worktree directory
+  fs.rmSync(worktreePath, { recursive: true, force: true });
+
+  // Prune worktrees in the main repo
+  if (mainRepoPath && fs.existsSync(mainRepoPath)) {
+    try {
+      execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
+    } catch { /* ignore prune errors */ }
+
+    // Clean up the review branch
+    const branchName = `review/${name}`;
+    try {
+      execSync(`git branch -D ${branchName}`, { cwd: mainRepoPath, stdio: 'pipe' });
+    } catch { /* branch may not exist */ }
+  }
+}
+
+/**
+ * Checkout a branch or PR into a review worktree.
+ */
+export function checkoutInReviewWorktree(
+  worktreePath: string,
+  branchOrPR: string,
+): string {
+  if (!fs.existsSync(worktreePath)) {
+    throw new Error(`Review worktree not found at ${worktreePath}`);
+  }
+
+  // Check if it's a PR number
+  const prNumber = /^\d+$/.test(branchOrPR) ? parseInt(branchOrPR, 10) : null;
+
+  if (prNumber) {
+    // Fetch and checkout PR using gh CLI
+    try {
+      execSync(`gh pr checkout ${prNumber} --force`, {
+        cwd: worktreePath,
+        stdio: 'pipe',
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to checkout PR #${prNumber}: ${msg}`);
+    }
+  } else {
+    // Regular branch checkout
+    // Fetch first to get latest remote branches
+    try {
+      execSync('git fetch origin', { cwd: worktreePath, stdio: 'pipe' });
+    } catch { /* offline or no remote */ }
+
+    try {
+      execSync(`git checkout ${branchOrPR}`, { cwd: worktreePath, stdio: 'pipe' });
+    } catch {
+      // Try checking out from remote
+      try {
+        execSync(`git checkout -b ${branchOrPR} origin/${branchOrPR}`, {
+          cwd: worktreePath,
+          stdio: 'pipe',
+        });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to checkout branch "${branchOrPR}": ${msg}`);
+      }
+    }
+  }
+
+  // Get current branch after checkout
+  const currentBranch = getCurrentBranchInWorktree(worktreePath);
+  return currentBranch || branchOrPR;
+}
+
+/**
+ * Get the current branch in a worktree.
+ */
+export function getCurrentBranchInWorktree(worktreePath: string): string | null {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: worktreePath,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Resolves TKT-639: Add dedicated review worktrees for manual testing and PR review

## Description

## Summary
Add dedicated, persistent worktrees for human review/testing workflows. Unlike ephemeral agent worktrees, these persist and allow quick branch swapping for PR review, manual testing, and debugging.

## Motivation
- Agents get fresh worktrees per ticket (ephemeral)
- Humans need quick access to test branches without setup time
- Want to review PRs, test features, debug issues without disrupting main workflow
- Parallel review capability (review-1 testing PR #123, review-2 testing PR #456)

## Requirements

### R1: Review worktree management
- `prlt review add [name]` - Create a new review worktree (e.g., review-1, review-2)
- `prlt review remove <name>` - Remove a review worktree
- `prlt review list` - List review worktrees and their current branches

### R2: Branch/PR checkout
- `prlt review checkout <name> <branch|PR#>` - Checkout branch or PR into review worktree
- `prlt review checkout <name> main` - Reset to main
- Auto-fetch PR branches from GitHub when given PR number

### R3: Database tracking
- Store review worktrees in DB (similar to agent worktrees table)
- Track: name, path, current branch, last used timestamp
- New `reviewWorktrees` table in Drizzle schema

### R4: Directory structure
```
review/
  review-1/    # persistent worktree
  review-2/    # persistent worktree
```

### R5: Integration with PR workflow
- `prlt pr review <PR#>` - Checkout PR into available review worktree and cd there
- Show review worktree status in `prlt pr list`

## Technical notes
- Reuse existing worktree infrastructure from agent system (see `lib/execution/context.ts`)
- Review worktrees live at HQ level (not per-repo)
- Use existing PR utilities in `lib/pr/index.ts` for PR branch fetching
- Follow oclif command patterns in `commands/` directory
- Include JSON mode support for AI agent integration (per CLAUDE.md guidelines)

## Open questions (needs clarification)
1. Multi-repo handling: Should review worktrees clone all repos in workspace, or require `--repo` flag?
2. Dirty worktree handling: What if user has uncommitted changes when checking out different branch?
3. Devcontainer support: Should review worktrees support devcontainer environments?

## Future considerations (out of scope)
- Auto-run tests on checkout
- Integration with CI status
- Review worktree templates (pre-configured environments)

## Changes

- 6beee1ef feat(TKT-639): add dedicated review worktrees for manual testing and PR review

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
