### PR TITLE
TKT-1015: Ticket IDs not unique across projects in same HQ

### DIFF
--- a/apps/cli/src/lib/pmo/storage/index.ts
+++ b/apps/cli/src/lib/pmo/storage/index.ts
@@ -87,6 +87,7 @@ import { ViewStorage } from './views.js'
 import { RoadmapStorage } from './roadmaps.js'
 import { CategoryStorage } from './categories.js'
 import { LabelStorage } from './labels.js'
+import { ENTITY_PREFIXES } from '../utils.js'
 
 const T = PMO_TABLES
 
@@ -1113,6 +1114,24 @@ export class SQLiteStorage implements PMOStorage {
           insertMeta.run(ticket.id, key, value)
         }
       }
+    }
+
+    // Update the global ticket ID counter to stay ahead of all existing ticket IDs.
+    // This ensures generateEntityId never produces a duplicate TKT-NNN, even when
+    // tickets are inserted directly from board markdown across multiple projects.
+    const ticketPrefix = ENTITY_PREFIXES.ticket
+    const prefixLen = ticketPrefix.length + 1 // "TKT-" = 4 chars
+    const maxResult = this.db.prepare(
+      `SELECT MAX(CAST(SUBSTR(id, ${prefixLen + 1}) AS INTEGER)) as max_num FROM ${T.tickets}`
+    ).get() as { max_num: number | null } | undefined
+    const maxExistingId = maxResult?.max_num || 0
+
+    if (maxExistingId > 0) {
+      const nextId = maxExistingId + 1
+      this.db.prepare(`
+        INSERT INTO ${T.settings} (key, value) VALUES ('next_ticket_id', ?)
+        ON CONFLICT(key) DO UPDATE SET value = MAX(CAST(value AS INTEGER), ?)
+      `).run(String(nextId), String(nextId))
     }
   }
 

--- a/apps/cli/src/lib/pmo/utils.ts
+++ b/apps/cli/src/lib/pmo/utils.ts
@@ -74,10 +74,13 @@ interface DatabaseLike {
  *
  * Format: TKT-001, EPIC-001, SPEC-001, PROJ-001
  *
- * Uses pmo_settings table to track the next ID for each entity type.
+ * Uses a GLOBAL counter in pmo_settings (key: next_{entityType}_id) shared
+ * across ALL projects in the workspace. This ensures IDs like TKT-001 are
+ * unique across the entire HQ, not just within a single project.
+ *
  * IDs are zero-padded to 3 digits (001-999), then expand (1000+).
  *
- * Self-healing: If counter is behind MAX(id) in the table, auto-corrects.
+ * Self-healing: If counter is behind MAX(id) across all projects, auto-corrects.
  *
  * @param db - Database instance with prepare method
  * @param entityType - Type of entity (ticket, epic, spec, project)


### PR DESCRIPTION
## Summary

Resolves TKT-1015: Ticket IDs not unique across projects in same HQ

## Description

When an HQ has multiple projects (e.g., distill-kanban and distill), ticket IDs like TKT-001 can exist in different projects. This is confusing when viewing the board or running prlt commands — it's unclear which TKT-001 is being referenced.

**Expected:** Either globally unique IDs across the HQ, or project-prefixed IDs (e.g., DISTILL-001 vs KANBAN-001).

**Current behavior:** Same TKT-NNN IDs reused across projects in the same workspace.

Source: GitHub issue #415 by @justinnnnnnnn

## Changes

- 64adeabc fix(TKT-1015): fix(TKT-1015): update tests for project-prefixed ticket IDs and add deriveProjectPrefix tests
- 15370a3d fix(TKT-1015): update ID detection to support project-specific prefixes
- 1b64cfca fix(TKT-1015): add project prefix for unique ticket IDs across projects

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
