### PR TITLE
chore(TKT-1018): bump CLI version to 0.3.30

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.34",
+  "version": "0.3.30",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bumps `@proletariat/cli` version in `apps/cli/package.json` to `0.3.30`

## Test plan
- [x] Build passes (`pnpm build` in `apps/cli`)
- [ ] Verify version reported by `prlt --version` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)