### PR TITLE
TKT-1016: Groom action should not create PRs by default

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -1307,9 +1307,12 @@ export default class WorkStart extends PMOCommand {
       } else if (flags['no-pr']) {
         createPR = false
       } else if (ghAvailable) {
-        // In JSON mode with --yes, default to creating PR for code-modifying actions
-        if (jsonMode && flags.yes) {
-          createPR = context.modifiesCode !== false
+        if (context.modifiesCode === false) {
+          // Non-code-modifying actions (groom, review, resolve) default to no PR
+          createPR = false
+        } else if (jsonMode && flags.yes) {
+          // In JSON mode with --yes, default to creating PR for code-modifying actions
+          createPR = true
         } else {
           // Use FlagResolver for PR choice
           const prResolver = new FlagResolver<{ prChoice?: string }>({

--- a/apps/cli/src/lib/pmo/storage/actions.ts
+++ b/apps/cli/src/lib/pmo/storage/actions.ts
@@ -215,7 +215,7 @@ export class ActionStorage {
         ? (JSON.parse(row.default_category) as StateCategory[])
         : undefined,
       defaultMoveToCategory: row.default_category as StateCategory | undefined,
-      modifiesCode: row.is_builtin === 1,
+      modifiesCode: row.modifies_code === 1,
       isBuiltin: row.is_builtin === 1,
       createdAt: new Date(row.created_at),
     }

--- a/apps/cli/src/lib/pmo/storage/types.ts
+++ b/apps/cli/src/lib/pmo/storage/types.ts
@@ -187,6 +187,7 @@ export interface WorkActionRow {
   prompt: string
   end_prompt: string | null
   default_category: string | null
+  modifies_code: number
   is_builtin: number
   position: number
   created_at: string


### PR DESCRIPTION
## Summary

Resolves TKT-1016: Groom action should not create PRs by default

## Description

When spawning with `--action groom`, the agent creates a PR even though groom doesn't make code changes — it only analyzes the ticket and updates the description. This leads to empty/unnecessary PRs and duplicates when the ticket is later spawned for implementation.

**Example:** TKT-1002 had PR #423 from groom and PR #424 from implement on the same branch.

## Requirements

- **R1:** Actions with `modifiesCode: false` (groom, review, resolve) must default to `--no-pr` behavior — no PR created, no PR prompt shown
- **R2:** Actions with `modifiesCode: true` (implement, test, continue, revise) must default to `--create-pr` behavior (current behavior, unchanged)
- **R3:** Explicit `--create-pr` or `--no-pr` flags must always override the action-based default, regardless of `modifiesCode`
- **R4:** In JSON mode with `--yes` (agent/batch mode), `modifiesCode` should auto-determine the PR default without prompting

## Affected Code Paths

| File | Path | Notes |
|------|------|-------|
| spawn.ts | `apps/cli/src/commands/work/spawn.ts` | Batch mode PR logic (~L1388-1426), per-ticket mode (~L1429-1434) |
| start.ts | `apps/cli/src/commands/work/start.ts` | PR prompt logic (~L1300-1336) — interactive mode still defaults to "yes" for all actions |
| base.ts | `apps/cli/src/lib/pmo/storage/base.ts` | Built-in action definitions with `modifiesCode` field |

## Implementation Notes

- The `modifiesCode` field already exists on actions (defined in `types.ts`, stored in DB schema with `default: true`)
- Built-in actions already have correct `modifiesCode` values: groom=false, review=false, resolve=false, implement=true, test=true, continue=true, revise=true
- `spawn.ts` batch mode already checks `modifiesCode` and sets `batchNoPr = true` for non-code actions (this may have been partially fixed)
- `start.ts` interactive mode still shows PR prompt with default "yes" for all actions, including groom — should either skip the prompt or default to "no" for `modifiesCode: false` actions
- In `start.ts` JSON+yes mode (L1312), `context.modifiesCode !== false` is already used correctly

## Changes

- b28ebb9e fix(TKT-1016): fix: groom action should not create PRs by default

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
