### PR TITLE
TKT-988: Auto-cleanup Docker containers after background work completes

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -115,6 +115,50 @@ export function configureITermTmuxWindowMode(mode: 'tab' | 'window'): void {
 }
 
 // =============================================================================
+// Background Mode Cleanup Helpers (TKT-988)
+// =============================================================================
+
+/**
+ * Build the tmux script that runs inside the container.
+ * In background mode: kills PID 1 (sleep infinity) after Claude exits to stop/remove container.
+ * In terminal/foreground mode: drops into exec bash for user inspection.
+ */
+export function buildTmuxScript(sessionName: string, claudeCmd: string, displayMode: DisplayMode): string {
+  if (displayMode === 'background') {
+    return `#!/bin/bash
+export TERM=xterm-256color
+export COLORTERM=truecolor
+unset CI
+echo "🚀 Starting: ${sessionName}"
+echo ""
+${claudeCmd}
+echo ""
+echo "✅ Agent work complete. Cleaning up container..."
+kill 1
+`
+  }
+  return `#!/bin/bash
+export TERM=xterm-256color
+export COLORTERM=truecolor
+unset CI
+echo "🚀 Starting: ${sessionName}"
+echo ""
+${claudeCmd}
+echo ""
+echo "✅ Agent work complete. Press Enter to close or run more commands."
+exec bash
+`
+}
+
+/**
+ * Get the auto-remove flags for docker run based on display mode.
+ * Background mode containers get --rm so Docker removes them when they stop.
+ */
+export function getDockerAutoRemoveFlags(displayMode: DisplayMode): string[] {
+  return displayMode === 'background' ? ['--rm'] : []
+}
+
+// =============================================================================
 // Docker Credential Helpers
 // =============================================================================
 
@@ -855,7 +899,8 @@ function createDockerContainer(
   context: ExecutionContext,
   containerName: string,
   imageName: string,
-  config: ExecutionConfig
+  config: ExecutionConfig,
+  displayMode: DisplayMode = 'terminal'
 ): boolean {
   // Build mount flags
   // KEY: Use a named Docker volume for Claude credentials - this is how devcontainer.json
@@ -913,12 +958,17 @@ function createDockerContainer(
     // Note: After firewall is set up, the container is network-restricted
   ]
 
+  // Auto-remove container on stop for background mode (R5)
+  // Background containers should be cleaned up after work completes — nobody will attach to inspect
+  const autoRemoveFlags = getDockerAutoRemoveFlags(displayMode)
+
   try {
     const createCmd = [
       'docker run -d',
       `--name ${containerName}`,
       '--user node',
       '-w /workspace',
+      ...autoRemoveFlags,
       ...mounts,
       ...envVars,
       ...resourceFlags,
@@ -1037,7 +1087,8 @@ function runContainerSetup(containerId: string, sandboxed: boolean = true): bool
  */
 function ensureDockerContainer(
   context: ExecutionContext,
-  config: ExecutionConfig
+  config: ExecutionConfig,
+  displayMode: DisplayMode = 'terminal'
 ): string | null {
   const containerName = getContainerName(context.agentName)
   const imageName = getImageName(context.agentName)
@@ -1069,7 +1120,7 @@ function ensureDockerContainer(
 
   // Create and start container
   console.debug(`[runners:docker] Creating container ${containerName}`)
-  if (!createDockerContainer(context, containerName, imageName, config)) {
+  if (!createDockerContainer(context, containerName, imageName, config, displayMode)) {
     return null
   }
 
@@ -1285,7 +1336,7 @@ export async function runDevcontainer(
 
     // Start or reuse container using raw Docker commands
     // No devcontainer CLI required!
-    const containerId = ensureDockerContainer(context, config)
+    const containerId = ensureDockerContainer(context, config, displayMode)
     if (!containerId) {
       return {
         success: false,
@@ -1676,21 +1727,10 @@ async function runDevcontainerInTmux(
     const cmdMatch = devcontainerCmd.match(/bash -c '(.+)'$/)
     const claudeCmd = cmdMatch ? cmdMatch[1] : devcontainerCmd
 
-    // Create a script inside the container that runs claude and keeps shell open
-    // TERM must be set for Claude's TUI to render properly
-    // Unset CI to prevent Claude from detecting CI environment which suppresses TUI output
-    // Note: We keep DEVCONTAINER set so prlt workspace detection works correctly
-    const tmuxScript = `#!/bin/bash
-export TERM=xterm-256color
-export COLORTERM=truecolor
-unset CI
-echo "🚀 Starting: ${sessionName}"
-echo ""
-${claudeCmd}
-echo ""
-echo "✅ Agent work complete. Press Enter to close or run more commands."
-exec bash
-`
+    // Create a script inside the container that runs claude
+    // Background mode (R1): kills PID 1 to stop container after completion
+    // Terminal/foreground mode (R2): drops into exec bash for user inspection
+    const tmuxScript = buildTmuxScript(sessionName, claudeCmd, displayMode)
     const scriptPath = `/tmp/prlt-${sessionName}.sh`
 
     // Write script and start tmux session inside container

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -7,6 +7,8 @@ import {
   shouldUseControlMode,
   buildTmuxMouseOption,
   buildTmuxAttachCommand,
+  buildTmuxScript,
+  getDockerAutoRemoveFlags,
 } from '../../src/lib/execution/runners.js'
 import type { ExecutionContext, DisplayMode, TerminalApp } from '../../src/lib/execution/types.js'
 
@@ -292,6 +294,80 @@ describe('Execution Utils', () => {
       const mode: DisplayMode = 'background'
       expect(mode).to.equal('background')
       // Note: Actual execution tested in e2e tests
+    })
+  })
+
+  describe('Background Mode Container Cleanup (TKT-988)', () => {
+    describe('buildTmuxScript', () => {
+      const sessionName = 'TKT-988-implement-test-agent'
+      const claudeCmd = 'claude --permission-mode bypassPermissions "$(cat /tmp/prompt.txt)"'
+
+      it('should use kill 1 instead of exec bash in background mode', () => {
+        const script = buildTmuxScript(sessionName, claudeCmd, 'background')
+        expect(script).to.include('kill 1')
+        expect(script).to.not.include('exec bash')
+      })
+
+      it('should show cleanup message in background mode', () => {
+        const script = buildTmuxScript(sessionName, claudeCmd, 'background')
+        expect(script).to.include('Cleaning up container...')
+      })
+
+      it('should use exec bash in terminal mode (regression)', () => {
+        const script = buildTmuxScript(sessionName, claudeCmd, 'terminal')
+        expect(script).to.include('exec bash')
+        expect(script).to.not.include('kill 1')
+      })
+
+      it('should use exec bash in foreground mode (regression)', () => {
+        const script = buildTmuxScript(sessionName, claudeCmd, 'foreground')
+        expect(script).to.include('exec bash')
+        expect(script).to.not.include('kill 1')
+      })
+
+      it('should show inspection message in terminal mode', () => {
+        const script = buildTmuxScript(sessionName, claudeCmd, 'terminal')
+        expect(script).to.include('Press Enter to close or run more commands')
+      })
+
+      it('should include claude command in all modes', () => {
+        for (const mode of ['background', 'terminal', 'foreground'] as DisplayMode[]) {
+          const script = buildTmuxScript(sessionName, claudeCmd, mode)
+          expect(script).to.include(claudeCmd)
+        }
+      })
+
+      it('should set TERM and COLORTERM in all modes', () => {
+        for (const mode of ['background', 'terminal', 'foreground'] as DisplayMode[]) {
+          const script = buildTmuxScript(sessionName, claudeCmd, mode)
+          expect(script).to.include('export TERM=xterm-256color')
+          expect(script).to.include('export COLORTERM=truecolor')
+        }
+      })
+
+      it('should unset CI in all modes', () => {
+        for (const mode of ['background', 'terminal', 'foreground'] as DisplayMode[]) {
+          const script = buildTmuxScript(sessionName, claudeCmd, mode)
+          expect(script).to.include('unset CI')
+        }
+      })
+    })
+
+    describe('getDockerAutoRemoveFlags', () => {
+      it('should return --rm for background mode', () => {
+        const flags = getDockerAutoRemoveFlags('background')
+        expect(flags).to.deep.equal(['--rm'])
+      })
+
+      it('should return empty array for terminal mode', () => {
+        const flags = getDockerAutoRemoveFlags('terminal')
+        expect(flags).to.deep.equal([])
+      })
+
+      it('should return empty array for foreground mode', () => {
+        const flags = getDockerAutoRemoveFlags('foreground')
+        expect(flags).to.deep.equal([])
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

Resolves TKT-988: Auto-cleanup Docker containers after background work completes

## Description

When agents run in background mode (`-d background`), the Docker container stays alive after Claude Code exits because the script drops into `exec bash` (runners.ts:1692) and the container entrypoint is `sleep infinity` (runners.ts:927). Nobody is going to attach to inspect — the work is done.

**Current behavior:**
- Claude exits → script prints "Agent work complete" → `exec bash` keeps tmux session alive → container stays running forever
- Container only gets cleaned up when the *next* spawn for the same agent runs `docker rm -f` (runners.ts:1042-1048)
- Meanwhile it sits there consuming memory/CPU for nothing

**Desired behavior:**
- For `-d background`: Claude exits → container stops and removes itself
- For `-d terminal`/`-d foreground`: Keep current behavior (user may want to inspect)

## Requirements

- **R1:** When `displayMode` is `background`, the Docker container must be stopped and removed after Claude Code exits
- **R2:** When `displayMode` is `terminal` or `foreground`, the current behavior (`exec bash` for user inspection) must be preserved unchanged
- **R3:** Execution status must be marked `completed` before container cleanup begins (already handled by watcher — verify this)
- **R4:** If Claude Code crashes or fails in background mode, the container should still be cleaned up (no orphaned containers)
- **R5:** Add `--rm` flag to `docker run` for background-mode containers so Docker handles removal automatically on container stop

## Key Code Locations

- **Container creation**: `runners.ts:854-937` — `createDockerContainer()`, entrypoint is `sleep infinity` (line 927)
- **Container cleanup on re-spawn**: `runners.ts:1042-1055` — `ensureDockerContainer()` does `docker rm -f`
- **Script generation**: `runners.ts:1683-1693` — `runDevcontainerInTmux()`, script ends with `exec bash` (line 1692)
- **Display mode parameter**: `runners.ts:1179-1228` — `buildDevcontainerCommand()` receives `displayMode` but doesn't use it for script behavior

## Technical Note

Simply replacing `exec bash` with `exit 0` is **insufficient** because `sleep infinity` runs as PID 1 in the container. When the tmux script exits, the container remains alive via PID 1. The implementation must also terminate the PID 1 process to trigger a container stop, which combined with `--rm` will auto-remove the container.

**Q1:** How should the container's `sleep infinity` PID 1 process be terminated when the script exits in background mode? Options: (a) change the container entrypoint for background mode to run the tmux command directly instead of `sleep infinity`, (b) have the script send `kill 1` before exiting to terminate the container from within, or (c) handle cleanup externally via the watcher/spawner process after execution completes.

## Changes

- 8cffed0c fix(TKT-988): auto-cleanup Docker containers after background work completes

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
