### PR TITLE
TKT-1055: Unit test TTY detection tests fail in non-TTY environment (5 tests)

### DIFF
--- a/apps/cli/test/unit/flag-resolver.test.ts
+++ b/apps/cli/test/unit/flag-resolver.test.ts
@@ -286,33 +286,40 @@ describe('FlagResolver', () => {
 });
 
 describe('shouldOutputJson', () => {
-  let originalIsTTY: boolean | undefined;
+  let originalStdoutIsTTY: boolean | undefined;
+  let originalStdinIsTTY: boolean | undefined;
 
   beforeEach(() => {
-    originalIsTTY = process.stdout.isTTY;
+    originalStdoutIsTTY = process.stdout.isTTY;
+    originalStdinIsTTY = process.stdin.isTTY;
   });
 
   afterEach(() => {
-    Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
   });
 
   it('should return true when json flag is true', () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     expect(shouldOutputJson({ json: true })).to.be.true;
   });
 
   it('should return true in non-TTY environment', () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     expect(shouldOutputJson({})).to.be.true;
   });
 
   it('should return false when no flags and in TTY environment', () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     expect(shouldOutputJson({})).to.be.false;
   });
 
   it('should return false when json flag is explicitly false in TTY', () => {
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     expect(shouldOutputJson({ json: false })).to.be.false;
   });
 });

--- a/apps/cli/test/unit/prompt-json.test.ts
+++ b/apps/cli/test/unit/prompt-json.test.ts
@@ -18,24 +18,31 @@ describe('prompt-json', () => {
     });
 
     it('returns false when stdout is a TTY', () => {
-      const originalIsTTY = process.stdout.isTTY;
+      const originalStdoutIsTTY = process.stdout.isTTY;
+      const originalStdinIsTTY = process.stdin.isTTY;
       Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
       expect(isNonTTY()).to.be.false;
-      Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
     });
   });
 
   describe('shouldOutputJson', () => {
-    let originalIsTTY: boolean | undefined;
+    let originalStdoutIsTTY: boolean | undefined;
+    let originalStdinIsTTY: boolean | undefined;
 
     beforeEach(() => {
-      originalIsTTY = process.stdout.isTTY;
+      originalStdoutIsTTY = process.stdout.isTTY;
+      originalStdinIsTTY = process.stdin.isTTY;
       // Default to TTY mode for tests
       Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     });
 
     afterEach(() => {
-      Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
     });
 
     it('returns true when json flag is true', () => {

--- a/apps/cli/test/unit/spec-edit.test.ts
+++ b/apps/cli/test/unit/spec-edit.test.ts
@@ -256,13 +256,16 @@ describe('Spec Edit Command', () => {
     // The shouldOutputJson function only sees { json: true }
 
     it('should return false when no flags are set in TTY', () => {
-      const originalIsTTY = process.stdout.isTTY;
+      const originalStdoutIsTTY = process.stdout.isTTY;
+      const originalStdinIsTTY = process.stdin.isTTY;
       Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
 
       expect(shouldOutputJson({ json: false })).to.be.false;
       expect(shouldOutputJson({})).to.be.false;
 
-      Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
     });
   });
 

--- a/apps/cli/test/unit/spec-json-mode.test.ts
+++ b/apps/cli/test/unit/spec-json-mode.test.ts
@@ -519,13 +519,16 @@ describe('Spec Commands JSON Mode with FlagResolver', () => {
     });
 
     it('should return false when --json flag is not set in TTY', () => {
-      const originalIsTTY = process.stdout.isTTY;
+      const originalStdoutIsTTY = process.stdout.isTTY;
+      const originalStdinIsTTY = process.stdin.isTTY;
       Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
 
       expect(shouldOutputJson({ json: false })).to.be.false;
       expect(shouldOutputJson({})).to.be.false;
 
-      Object.defineProperty(process.stdout, 'isTTY', { value: originalIsTTY, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+      Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
     });
 
     it('should return true in non-TTY environment', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-1055: Unit test TTY detection tests fail in non-TTY environment (5 tests)

## Description

**Problem:** 5 unit tests fail because they test `isNonTTY` returning `false` and `shouldOutputJson` returning `false` when `--json` is not set, but mocha runs in non-TTY mode.

**Files to fix:**
- `apps/cli/test/unit/prompt-json.test.ts` (tests #13, #14, #15)
- `apps/cli/test/unit/flag-resolver.test.ts` (tests #11, #12)
- `apps/cli/test/unit/spec-edit.test.ts` (test #16)
- `apps/cli/test/unit/spec-json-mode.test.ts` (test #17)

**Fix approach:** Mock `process.stdout.isTTY` in these tests:
```ts
beforeEach(() => { Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true }) })
afterEach(() => { Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true }) })
```
Or skip with `.skip` and add comment explaining they only pass in TTY environments.

**Verify:** `cd apps/cli && npx mocha --forbid-only "test/unit/prompt-json.test.ts" "test/unit/flag-resolver.test.ts" "test/unit/spec-edit.test.ts" "test/unit/spec-json-mode.test.ts"`

## Changes

- 556746c2 fix(TKT-1055): mock both process.stdout.isTTY and process.stdin.isTTY in TTY detection tests to fix failures in non-TTY environments

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
