### PR TITLE
TKT-1057: 1 unit test fail: ExecutionView missing 'failed' status in listExecutions

### DIFF
--- a/apps/cli/test/unit/execution-view.test.ts
+++ b/apps/cli/test/unit/execution-view.test.ts
@@ -254,7 +254,7 @@ describe('ExecutionView', () => {
       const statuses = ['starting', 'running', 'completed', 'failed', 'stopped']
 
       for (const status of statuses) {
-        storage.createExecution({
+        const exec = storage.createExecution({
           ticketId: `TKT-${status}`,
           agentName: 'agent-status',
           executor: 'claude-code',
@@ -263,11 +263,8 @@ describe('ExecutionView', () => {
           sandboxed: true,
         })
 
-        const executions = storage.listExecutions({ limit: 1 })
-        const execId = executions[0].id
-
         if (status !== 'starting') {
-          storage.updateStatus(execId, status as 'running' | 'completed' | 'failed' | 'stopped')
+          storage.updateStatus(exec.id, status as 'running' | 'completed' | 'failed' | 'stopped')
         }
       }
 


### PR DESCRIPTION
## Summary

Resolves TKT-1057: 1 unit test fail: ExecutionView missing 'failed' status in listExecutions

## Description

**Problem:** Unit test expects `listExecutions` to include `'failed'` status but it only returns `['stopped', 'starting', ...]`.

**File to fix:** `apps/cli/test/unit/execution-view.test.ts` (line 238)

**Fix approach:**
1. Check `apps/cli/src/lib/database/` for execution status enum/types
2. If `'failed'` is a valid execution status in the schema, fix `listExecutions` to include it
3. If `'failed'` was removed as a status, update the test assertion

**Verify:** `cd apps/cli && npx mocha --forbid-only "test/unit/execution-view.test.ts"`

## Changes

- 54fe0cc5 fix(TKT-1057): fix flaky test: use createExecution return value instead of listExecutions to avoid started_at timestamp collisions

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
