### PR TITLE
TKT-1058: 1 e2e test fail: MCP server tool count mismatch (136 vs expected 125)

### DIFF
--- a/apps/cli/test/e2e/mcp-server.test.ts
+++ b/apps/cli/test/e2e/mcp-server.test.ts
@@ -1,7 +1,7 @@
 /**
  * Comprehensive E2E tests for MCP Server
  *
- * Tests all 125 MCP tools exposed by the mcp-server command.
+ * Tests MCP tools exposed by the mcp-server command.
  * Uses isolated test environments to prevent pollution of real workspace data.
  */
 
@@ -163,10 +163,10 @@ describe('MCP Server E2E Tests', function (this: Mocha.Suite) {
       expect(response.result?.serverInfo?.name).to.equal('prlt');
     });
 
-    it('should list all 125 tools', () => {
+    it('should list all tools', () => {
       const response = mcpCall([INIT_MSG, INITIALIZED_MSG, LIST_TOOLS_MSG]);
       expect(response.result?.tools).to.be.an('array');
-      expect(response.result?.tools?.length).to.equal(125);
+      expect(response.result?.tools?.length).to.be.at.least(125);
     });
 
     it('should have tools capability', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-1058: 1 e2e test fail: MCP server tool count mismatch (136 vs expected 125)

## Description

**Problem:** `mcp-server.test.ts` hardcodes `expected 125 tools` but MCP server now exposes 136.

**File to fix:** `apps/cli/test/e2e/mcp-server.test.ts`

**Fix:** Change the test name and assertion from `125` to `136`. Or better, make it a `>=` check so it doesn't break every time a tool is added:
```ts
expect(tools.length).to.be.at.least(125)
```

**Verify:** `cd apps/cli && pnpm test:e2e -- --grep "MCP Server"`

## Changes

- 5aeee32c fix(TKT-1058): fix MCP server tool count assertion to use at.least(125) instead of equal(125)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
