### PR TITLE
TKT-1035: Bug: MCP epic_show output exceeds tool result limit (89k chars for one epic)

### DIFF
--- a/apps/cli/src/lib/mcp/tools/epic.ts
+++ b/apps/cli/src/lib/mcp/tools/epic.ts
@@ -99,9 +99,14 @@ export function registerEpicTools(server: McpServer, ctx: McpToolContext): void 
             text: JSON.stringify({
               success: true,
               epic: {
-                ...epic,
+                id: epic.id,
+                projectId: epic.projectId,
+                title: epic.title,
+                status: epic.status,
+                position: epic.position,
+                specId: epic.specId,
                 ticketCount: tickets.length,
-                tickets: tickets.map((t: Ticket) => ({ id: t.id, title: t.title, statusName: t.statusName, priority: t.priority })),
+                tickets: tickets.map((t: Ticket) => ({ id: t.id, title: t.title, statusName: t.statusName, priority: t.priority, category: t.category })),
                 createdAt: epic.createdAt.toISOString(),
                 updatedAt: epic.updatedAt.toISOString(),
               },


### PR DESCRIPTION
## Summary

Resolves TKT-1035: Bug: MCP epic_show output exceeds tool result limit (89k chars for one epic)

## Description

## Problem

`mcp__prlt__epic_show` returns all linked tickets with their full descriptions. For EPIC-047 ("Ship: Core Product") the output is 89,146 characters, exceeding the MCP tool result limit.

## Fix

Strip descriptions from the tickets array in epic_show results. Return epic metadata + list of ticket summaries (id, title, status, priority, category). Same pattern as TKT-1036.

## Resolved Ambiguities

**Q1 (RESOLVED):** Always strip descriptions from embedded ticket lists. Use ticket_show for full details.

## Reproduction

Call `epic_show` with `id=EPIC-047`. Output is 89k chars.

## Changes

- e95f383b fix(TKT-1035): strip epic description and add category to ticket summaries in epic_show to reduce output size

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
