### PR TITLE
TKT-1038: Bug: MCP branch_where schema missing required `search` parameter

### DIFF
--- a/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
+++ b/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
@@ -237,11 +237,13 @@ export function registerBranchTools(server: McpServer, ctx: McpToolContext): voi
 
   strictTool(server,
     'branch_where',
-    'Show which ticket/branch you are on',
-    {},
-    async () => {
+    'Find which directory a branch is checked out in',
+    {
+      search: z.string().describe('Branch name or ticket ID to search for'),
+    },
+    async (params) => {
       try {
-        const output = ctx.runCommand('prlt branch where')
+        const output = ctx.runCommand(`prlt branch where ${params.search}`)
         return textResponse(output)
       } catch (error) {
         return errorResponse(error)


### PR DESCRIPTION
## Summary

Resolves TKT-1038: Bug: MCP branch_where schema missing required `search` parameter

## Description

## Problem

`mcp__prlt__branch_where` MCP tool definition has no parameters, but the underlying CLI command requires a positional `SEARCH` argument. Calling it returns:

```
Error: Missing 1 required arg:
  search  Branch name or ticket ID to search for
```

## Expected Behavior

The MCP tool schema should include a required `search` parameter (string) for the branch name or ticket ID to search for.

## Reproduction

Call `branch_where` with no parameters. Gets a CLI usage error.

## Impact

branch_where is completely unusable via MCP — the tool schema doesn't expose the required argument.

## Changes

- 6672ff8b fix(TKT-1038): fix branch_where MCP tool schema to include required search parameter

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
