### PR TITLE
TKT-1039: Bug: MCP agent_status returns interactive prompt menu instead of data

### DIFF
--- a/apps/cli/src/commands/agent/status.ts
+++ b/apps/cli/src/commands/agent/status.ts
@@ -3,6 +3,7 @@ import { colors, format } from '../../lib/colors.js';
 import {
   getWorkspaceInfo,
   getAgentStatus,
+  getAllAgentsStatus,
   WorkspaceInfo,
   formatAgentList
 } from '../../lib/agents/commands.js';
@@ -10,6 +11,7 @@ import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
   shouldOutputJson,
   outputErrorAsJson,
+  outputSuccessAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js';
 
@@ -55,6 +57,14 @@ export default class Status extends PMOCommand {
     }
 
     let agentName = args.name;
+
+    // In JSON mode with no agent specified, return all agent statuses
+    if (jsonMode && !agentName) {
+      const allStatuses = getAllAgentsStatus(workspaceInfo);
+      outputSuccessAsJson({
+        agents: allStatuses,
+      }, createMetadata('agent status', flags));
+    }
 
     // Agent mode config for prompts
     const agentConfig = jsonMode ? { flags, commandName: 'agent status' } : null;

--- a/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
+++ b/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
@@ -28,11 +28,29 @@ export function registerAgentTools(server: McpServer, ctx: McpToolContext): void
 
   strictTool(server,
     'agent_status',
-    'Check agent status',
-    {},
-    async () => {
+    'Check agent status. With agent param, returns that agent\'s status. Without, auto-detects current agent or returns all agent statuses.',
+    { agent: z.string().optional().describe('Agent name. If omitted, auto-detects current agent or returns all.') },
+    async (params) => {
       try {
-        const output = ctx.runCommand('prlt agent status --json 2>/dev/null || prlt agent status')
+        if (params.agent) {
+          const output = ctx.runCommand(`prlt agent status ${params.agent} --json`)
+          return textResponse(output)
+        }
+
+        // Try auto-detecting current agent via whoami
+        try {
+          const whoamiOutput = ctx.runCommand('prlt whoami --json')
+          const whoami = JSON.parse(whoamiOutput)
+          if (whoami.agent) {
+            const output = ctx.runCommand(`prlt agent status ${whoami.agent} --json`)
+            return textResponse(output)
+          }
+        } catch {
+          // whoami failed or no agent detected, fall through
+        }
+
+        // No agent detected - return all agent statuses
+        const output = ctx.runCommand('prlt agent status --json')
         return textResponse(output)
       } catch (error) {
         return errorResponse(error)


### PR DESCRIPTION
## Summary

Resolves TKT-1039: Bug: MCP agent_status returns interactive prompt menu instead of data

## Description

## Problem

`mcp__prlt__agent_status` returns a `type: "prompt"` response with a list of agents to select from, instead of returning actual status data. The MCP tool schema has no parameters, and the CLI command requires an agent name.

The response is also duplicated — the same JSON prompt object appears twice in the output, suggesting a serialization bug on top of the wrong-response-type issue.

## Expected Behavior

Either:
1. The MCP tool should accept an optional `agent` parameter. Without it, return all agent statuses. With it, return that specific agent's status.
2. Or at minimum, the MCP tool should resolve the current agent (from `whoami`) and return its status.

## Reproduction

Call `agent_status` with no parameters. Get back a prompt menu with 100+ agent choices, duplicated.

## Impact

agent_status is unusable via MCP. Also the duplicated output wastes tokens.

## Changes

- 91fa3140 fix(TKT-1039): fix MCP agent_status returning prompt instead of data

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
