### PR TITLE
TKT-1037: Bug: MCP branch_list fails with "Not in a git repository" from agent workspace

### DIFF
--- a/apps/cli/src/commands/branch/list.ts
+++ b/apps/cli/src/commands/branch/list.ts
@@ -2,10 +2,12 @@ import { Flags } from '@oclif/core'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { styles } from '../../lib/styles.js'
 import {
+  BranchInfo,
   BRANCH_TYPES,
   listBranches,
   isGitRepo,
 } from '../../lib/branch/index.js'
+import { getWorkspaceRepoInfo } from '../../lib/repos/index.js'
 import { isNonTTY } from '../../lib/prompt-json.js'
 import { visualPadEnd } from '../../lib/string-utils.js'
 
@@ -51,13 +53,15 @@ export default class BranchList extends PMOCommand {
       flags.format = 'json'
     }
 
-    // Check if in git repo
-    if (!isGitRepo()) {
-      this.error('Not in a git repository.')
-    }
+    let branches: BranchInfo[]
 
-    // Get branches
-    let branches = listBranches(undefined, flags.all)
+    if (isGitRepo()) {
+      // In a git repo - list branches for current repo
+      branches = listBranches(undefined, flags.all)
+    } else {
+      // Not in a git repo - list branches across all registered HQ repos
+      branches = this.listBranchesAcrossRepos(flags.all)
+    }
 
     // Filter by type
     if (flags.type) {
@@ -73,6 +77,9 @@ export default class BranchList extends PMOCommand {
       return
     }
 
+    // Check if we have multi-repo results
+    const hasRepoInfo = branches.some((b) => b.repo)
+
     // Output based on format
     switch (flags.format) {
       case 'json':
@@ -80,32 +87,56 @@ export default class BranchList extends PMOCommand {
         break
 
       case 'compact':
-        this.outputCompact(branches)
+        this.outputCompact(branches, hasRepoInfo)
         break
 
       case 'table':
       default:
-        this.outputTable(branches)
+        this.outputTable(branches, hasRepoInfo)
         break
     }
   }
 
-  private outputTable(branches: ReturnType<typeof listBranches>): void {
+  private listBranchesAcrossRepos(includeRemote: boolean): BranchInfo[] {
+    let repoInfo
+    try {
+      repoInfo = getWorkspaceRepoInfo()
+    } catch {
+      this.error('Not in a git repository and no HQ workspace found.')
+    }
+
+    const allBranches: BranchInfo[] = []
+
+    for (const repo of repoInfo.repositories) {
+      if (repo.status === 'missing') continue
+      const repoBranches = listBranches(repo.fullPath, includeRemote)
+      for (const branch of repoBranches) {
+        branch.repo = repo.name
+        allBranches.push(branch)
+      }
+    }
+
+    return allBranches
+  }
+
+  private outputTable(branches: BranchInfo[], hasRepoInfo = false): void {
     this.log('')
     this.log(styles.header(`🌿 Branches (${branches.length})`))
     this.log('')
 
     // Header
+    const repoHeader = hasRepoInfo ? visualPadEnd('Repo', 18) : ''
     this.log(
       styles.muted(
-        visualPadEnd('Name', 35) +
+        repoHeader +
+          visualPadEnd('Name', 35) +
           visualPadEnd('Type', 8) +
           visualPadEnd('Owner', 12) +
           visualPadEnd('Description', 25) +
           'Status'
       )
     )
-    this.log('─'.repeat(90))
+    this.log('─'.repeat(hasRepoInfo ? 108 : 90))
 
     // Rows
     for (const branch of branches) {
@@ -114,6 +145,7 @@ export default class BranchList extends PMOCommand {
       const typeDisplay = branch.type || '-'
       const ownerDisplay = branch.owner || '-'
       const descDisplay = branch.description || '-'
+      const repoCol = hasRepoInfo ? visualPadEnd((branch.repo || '-').substring(0, 16), 18) : ''
 
       let status = 'local'
       if (branch.tracking) {
@@ -125,6 +157,7 @@ export default class BranchList extends PMOCommand {
 
       this.log(
         marker +
+          repoCol +
           nameStyle(visualPadEnd(branch.name.substring(0, 33), 33)) +
           visualPadEnd(typeDisplay, 8) +
           visualPadEnd(ownerDisplay.substring(0, 10), 12) +
@@ -138,16 +171,17 @@ export default class BranchList extends PMOCommand {
     this.log('')
   }
 
-  private outputCompact(branches: ReturnType<typeof listBranches>): void {
+  private outputCompact(branches: BranchInfo[], hasRepoInfo = false): void {
     this.log('')
 
     for (const branch of branches) {
       const marker = branch.current ? '* ' : '  '
       const icon = branch.type ? '🌿' : '  '
       const typeInfo = branch.type ? ` (${branch.type})` : ''
+      const repoPrefix = hasRepoInfo && branch.repo ? `[${branch.repo}] ` : ''
       const nameStyle = branch.current ? styles.success : (s: string) => s
 
-      this.log(`${icon} ${marker}${nameStyle(branch.name)}${styles.muted(typeInfo)}`)
+      this.log(`${icon} ${marker}${repoPrefix}${nameStyle(branch.name)}${styles.muted(typeInfo)}`)
     }
 
     this.log('')

--- a/apps/cli/src/lib/branch/index.ts
+++ b/apps/cli/src/lib/branch/index.ts
@@ -296,6 +296,7 @@ export interface BranchInfo {
   agent?: string
   description?: string
   tracking?: string
+  repo?: string
 }
 
 /**

--- a/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
+++ b/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
@@ -205,7 +205,7 @@ export function registerRepoTools(server: McpServer, ctx: McpToolContext): void 
 export function registerBranchTools(server: McpServer, ctx: McpToolContext): void {
   strictTool(server,
     'branch_list',
-    'List branches',
+    'List branches (across all HQ repos if not in a git repo)',
     {},
     async () => {
       try {


### PR DESCRIPTION
## Summary

Resolves TKT-1037: Bug: MCP branch_list fails with "Not in a git repository" from agent workspace

## Description

## Problem

`mcp__prlt__branch_list` returns: `Error: Not in a git repository.`

The MCP tool runs the CLI in the agent's working directory (`agents/staff/prlttest1`), which is not a git repo. The command should operate against the HQ's registered repositories, not the current working directory.

## Expected Behavior

branch_list should list branches across all registered HQ repos (same repos shown by `repo_list`), regardless of the agent's CWD.

## Reproduction

Call `branch_list` from any agent workspace that isn't itself a git repo.

## Impact

branch_list is completely broken for any agent that doesn't happen to be sitting in a git repo directory.

## Changes

- 296bc892 fix(TKT-1037): fix branch_list to list across all HQ repos when not in a git repo

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
