### PR TITLE
TKT-1036: Bug: MCP ticket_list returns unbounded results with full descriptions (up to 1.2MB)

### DIFF
--- a/apps/cli/src/lib/mcp/tools/ticket.ts
+++ b/apps/cli/src/lib/mcp/tools/ticket.ts
@@ -12,7 +12,7 @@ import { getWorkspacePriorities, setWorkspacePriorities } from '../../pmo/utils.
 export function registerTicketTools(server: McpServer, ctx: McpToolContext): void {
   strictTool(server,
     'ticket_list',
-    'List tickets with optional filters',
+    'List tickets with optional filters. Returns summary fields only (no descriptions). Use ticket_show for full details.',
     {
       project: z.string().optional().describe('Project ID'),
       column: z.string().optional().describe('Filter by column/status'),
@@ -25,10 +25,12 @@ export function registerTicketTools(server: McpServer, ctx: McpToolContext): voi
       label: z.string().optional().describe('Filter by label name'),
       label_group: z.string().optional().describe('Filter by label group name'),
       all_projects: z.boolean().optional().describe('List from all projects'),
+      limit: z.number().optional().describe('Maximum number of tickets to return (default: 50)'),
+      offset: z.number().optional().describe('Number of tickets to skip for pagination (default: 0)'),
     },
     async (params) => {
       try {
-        const tickets = await ctx.storage.listTickets(
+        const allTickets = await ctx.storage.listTickets(
           params.all_projects ? undefined : params.project,
           {
             column: params.column,
@@ -43,31 +45,31 @@ export function registerTicketTools(server: McpServer, ctx: McpToolContext): voi
             allProjects: params.all_projects,
           }
         )
+        const total = allTickets.length
+        const offset = params.offset ?? 0
+        const limit = params.limit ?? 50
+        const tickets = allTickets.slice(offset, offset + limit)
         return {
           content: [{
             type: 'text' as const,
             text: JSON.stringify({
               success: true,
+              total,
               count: tickets.length,
+              offset,
+              limit,
               tickets: await Promise.all(tickets.map(async (t: Ticket) => {
                 const ticketLabels = await ctx.storage.getLabelsForTicket(t.id)
                 return {
                   id: t.id,
                   title: t.title,
-                  description: t.description,
                   priority: t.priority,
                   category: t.category,
                   statusName: t.statusName,
                   statusCategory: t.statusCategory,
-                  projectId: t.projectId,
                   assignee: t.assignee,
-                  owner: t.owner,
-                  epicId: t.epicId,
-                  branch: t.branch,
                   position: t.position,
                   labels: ticketLabels.map(l => ({ id: l.id, name: l.name, groupName: l.groupName })),
-                  createdAt: t.createdAt.toISOString(),
-                  updatedAt: t.updatedAt.toISOString(),
                 }
               })),
             }, null, 2),

--- a/apps/cli/test/e2e/mcp-server.test.ts
+++ b/apps/cli/test/e2e/mcp-server.test.ts
@@ -196,6 +196,77 @@ describe('MCP Server E2E Tests', function (this: Mocha.Suite) {
       expect(result.tickets).to.be.an('array');
     });
 
+    it('ticket_list - should not include descriptions', () => {
+      createTestTicket(db, projectId, { id: 'TKT-MCP-DESC', title: 'Ticket With Desc', description: 'A long description here' });
+      const result = callTool('ticket_list', { project: projectId });
+      expect(result.success).to.be.true;
+      const tickets = result.tickets as Array<Record<string, unknown>>;
+      tickets.forEach((t) => expect(t).to.not.have.property('description'));
+    });
+
+    it('ticket_list - should return pagination metadata', () => {
+      const result = callTool('ticket_list', { project: projectId });
+      expect(result.success).to.be.true;
+      expect(result).to.have.property('total');
+      expect(result).to.have.property('offset', 0);
+      expect(result).to.have.property('limit', 50);
+    });
+
+    it('ticket_list - should respect limit and offset', () => {
+      // Create several tickets
+      for (let i = 0; i < 5; i++) {
+        createTestTicket(db, projectId, { id: `TKT-MCP-PG${i}`, title: `Paginated ${i}` });
+      }
+      // Total should be 6 (1 from beforeEach + 5 created here)
+      const all = callTool('ticket_list', { project: projectId, limit: 100 });
+      expect((all.tickets as unknown[]).length).to.equal(all.total);
+
+      const page1 = callTool('ticket_list', { project: projectId, limit: 2, offset: 0 });
+      expect(page1.success).to.be.true;
+      expect((page1.tickets as unknown[]).length).to.equal(2);
+      expect(page1.total).to.equal(all.total);
+
+      const page2 = callTool('ticket_list', { project: projectId, limit: 2, offset: 2 });
+      expect(page2.success).to.be.true;
+      expect((page2.tickets as unknown[]).length).to.equal(2);
+
+      // Tickets from page1 and page2 should be different
+      const page1Ids = (page1.tickets as Array<{ id: string }>).map(t => t.id);
+      const page2Ids = (page2.tickets as Array<{ id: string }>).map(t => t.id);
+      page2Ids.forEach(id => expect(page1Ids).to.not.include(id));
+    });
+
+    it('ticket_list - should default limit to 50', () => {
+      const result = callTool('ticket_list', { project: projectId });
+      expect(result.limit).to.equal(50);
+    });
+
+    it('ticket_list - should only return summary fields', () => {
+      const result = callTool('ticket_list', { project: projectId });
+      expect(result.success).to.be.true;
+      const tickets = result.tickets as Array<Record<string, unknown>>;
+      expect(tickets.length).to.be.at.least(1);
+      const ticket = tickets[0];
+      // Should have summary fields
+      expect(ticket).to.have.property('id');
+      expect(ticket).to.have.property('title');
+      expect(ticket).to.have.property('statusName');
+      expect(ticket).to.have.property('statusCategory');
+      expect(ticket).to.have.property('priority');
+      expect(ticket).to.have.property('category');
+      expect(ticket).to.have.property('labels');
+      expect(ticket).to.have.property('assignee');
+      expect(ticket).to.have.property('position');
+      // Should NOT have detail fields
+      expect(ticket).to.not.have.property('description');
+      expect(ticket).to.not.have.property('projectId');
+      expect(ticket).to.not.have.property('owner');
+      expect(ticket).to.not.have.property('epicId');
+      expect(ticket).to.not.have.property('branch');
+      expect(ticket).to.not.have.property('createdAt');
+      expect(ticket).to.not.have.property('updatedAt');
+    });
+
     it('ticket_list - should filter by priority', () => {
       createTestTicket(db, projectId, { id: 'TKT-MCP-P0', title: 'P0 Ticket', priority: 'P0' });
       const result = callTool('ticket_list', { project: projectId, priority: 'P0' });


### PR DESCRIPTION
## Summary

Resolves TKT-1036: Bug: MCP ticket_list returns unbounded results with full descriptions (up to 1.2MB)

## Description

## Problem

`mcp__prlt__ticket_list` returns ALL matching tickets with their FULL descriptions. There's no limit/pagination. Results:
- `search=test` → 521k chars
- `priority=P0` → 403k chars  
- `label=ship` → 1.05MB
- `label_group=Function` → 1.29MB

All exceed the MCP tool result limit and get dumped to temp files.

## Fix

1. **Strip descriptions** from ticket_list results. List endpoints never include descriptions — use `ticket_show` for full details.
2. **Add `limit` and `offset` params** with default limit of 50.
3. Return summary fields only: id, title, status, statusCategory, priority, category, labels, assignee, position.

## Resolved Ambiguities

**Q1 (RESOLVED):** Always strip descriptions from list results. No `summary` param needed.
**Q2 (RESOLVED):** Default limit = 50. Add limit/offset params for pagination.

## Reproduction

Call `ticket_list` with `label=ship` on a project with 694 tickets. Output is 1.05MB.

## Impact

P0 — ticket_list is the primary discovery tool for MCP clients. Completely unusable for any filter matching more than ~20 tickets.

## Changes

- 7ea7434b fix(TKT-1036): strip descriptions and add limit/offset pagination to MCP ticket_list

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
