### PR TITLE
TKT-1043: Bug: `category list` CLI requires --type flag but MCP tool doesn't pass it

### DIFF
--- a/apps/cli/src/commands/category/list.ts
+++ b/apps/cli/src/commands/category/list.ts
@@ -2,12 +2,13 @@ import { Flags } from '@oclif/core';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { shouldOutputJson } from '../../lib/prompt-json.js';
 import { styles } from '../../lib/styles.js';
-import { Category, CategoryType } from '../../lib/pmo/types.js';
+import { Category, CategoryFilter, CategoryType } from '../../lib/pmo/types.js';
 
 export default class CategoryList extends PMOCommand {
   static description = 'List categories for ticket or status types';
 
   static examples = [
+    '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --type ticket',
     '<%= config.bin %> <%= command.id %> --type status',
     '<%= config.bin %> <%= command.id %> --type ticket --builtin',
@@ -18,9 +19,8 @@ export default class CategoryList extends PMOCommand {
     ...pmoBaseFlags,
     type: Flags.string({
       char: 't',
-      description: 'Category type to list',
+      description: 'Category type to list (omit to list all)',
       options: ['ticket', 'status'],
-      required: true,
     }),
     builtin: Flags.boolean({
       description: 'Show only built-in categories',
@@ -42,9 +42,10 @@ export default class CategoryList extends PMOCommand {
 
   async execute(): Promise<void> {
     const { flags } = await this.parse(CategoryList);
-    const categoryType = flags.type as CategoryType;
+    const categoryType = flags.type as CategoryType | undefined;
 
-    const filter: { type: CategoryType; isBuiltin?: boolean } = { type: categoryType };
+    const filter: CategoryFilter = {};
+    if (categoryType) filter.type = categoryType;
     if (flags.builtin) filter.isBuiltin = true;
     if (flags.custom) filter.isBuiltin = false;
 
@@ -56,16 +57,43 @@ export default class CategoryList extends PMOCommand {
     }
 
     if (categories.length === 0) {
-      this.log(styles.muted(`\nNo ${categoryType} categories found.`));
-      this.log(styles.muted(`Create one: prlt category create --type ${categoryType}`));
+      const typeStr = categoryType ? `${categoryType} ` : '';
+      this.log(styles.muted(`\nNo ${typeStr}categories found.`));
+      this.log(styles.muted(`Create one: prlt category create --type ticket`));
       return;
     }
 
-    const typeLabel = categoryType === 'ticket' ? 'Ticket' : 'Status';
-    this.log(`\n📁 ${styles.emphasis(`${typeLabel} Categories`)}`);
-    this.log('═'.repeat(60));
+    if (categoryType) {
+      // Single type: show as before
+      const typeLabel = categoryType === 'ticket' ? 'Ticket' : 'Status';
+      this.log(`\n📁 ${styles.emphasis(`${typeLabel} Categories`)}`);
+      this.log('═'.repeat(60));
+      this.printCategoryGroup(categories, flags);
+      this.log('');
+      this.log(styles.muted(`Create new: prlt category create --type ${categoryType} <name>`));
+      this.log('');
+    } else {
+      // All types: group by type
+      const ticketCategories = categories.filter(c => c.type === 'ticket');
+      const statusCategories = categories.filter(c => c.type === 'status');
 
-    // Group by builtin vs custom
+      if (ticketCategories.length > 0) {
+        this.log(`\n📁 ${styles.emphasis('Ticket Categories')}`);
+        this.log('═'.repeat(60));
+        this.printCategoryGroup(ticketCategories, flags);
+      }
+
+      if (statusCategories.length > 0) {
+        this.log(`\n📁 ${styles.emphasis('Status Categories')}`);
+        this.log('═'.repeat(60));
+        this.printCategoryGroup(statusCategories, flags);
+      }
+
+      this.log('');
+    }
+  }
+
+  private printCategoryGroup(categories: Category[], flags: { builtin?: boolean; custom?: boolean }): void {
     const builtinCategories = categories.filter(c => c.isBuiltin);
     const customCategories = categories.filter(c => !c.isBuiltin);
 
@@ -84,10 +112,6 @@ export default class CategoryList extends PMOCommand {
         this.printCategory(category);
       }
     }
-
-    this.log('');
-    this.log(styles.muted(`Create new: prlt category create --type ${categoryType} <name>`));
-    this.log('');
   }
 
   private printCategory(category: Category): void {


### PR DESCRIPTION
## Summary

Resolves TKT-1043: Bug: `category list` CLI requires --type flag but MCP tool doesn't pass it

## Description

## Problem

`prlt category list --machine` fails with:
```
Error: Missing required flag type
```

The `--type` flag (ticket|status) is required by the CLI command, but:
1. The MCP tool `category_list` has `type` as optional in its schema
2. When MCP calls without type, the CLI errors out
3. The MCP tool works because it uses the storage layer directly, bypassing the CLI

## Expected Behavior

Either:
1. CLI should make `--type` optional and return all categories when omitted (matching MCP behavior)
2. Or MCP schema should mark `type` as required

The MCP tool currently returns both ticket and status categories when called without a type filter, which is the better UX.

## Reproduction

```bash
prlt category list --machine  # Error: Missing required flag type
prlt category list --type ticket --machine  # works
```

## Changes

- 6b8e075d fix(TKT-1043): make --type flag optional in category list CLI to match MCP behavior

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
