### PR TITLE
TKT-1044: Bug: `work status` CLI command doesn't exist but MCP tool exposes it

### DIFF
--- a/apps/cli/src/commands/work/index.ts
+++ b/apps/cli/src/commands/work/index.ts
@@ -30,6 +30,7 @@ export default class Work extends PMOCommand {
     // Execution actions first (most common), then ownership
     // Each choice includes the full command for AI agents to execute
     const menuChoices = [
+      { id: 'status', name: 'View work status (in-progress tickets)', command: `prlt work status -P ${projectId} --json` },
       { id: 'start', name: 'Start work (launch single agent)', command: `prlt work start -P ${projectId} --json` },
       { id: 'resolve', name: 'Resolve questions (agent-assisted)', command: `prlt work resolve -P ${projectId} --json` },
       { id: 'spawn', name: 'Spawn work (batch by column)', command: `prlt work spawn -P ${projectId} --json` },
@@ -57,6 +58,9 @@ export default class Work extends PMOCommand {
     // Pass --project to avoid re-prompting for project selection
     const projectArgs = ['--project', projectId];
     switch (action) {
+      case 'status':
+        await this.config.runCommand('work:status', projectArgs);
+        break;
       case 'start':
         await this.config.runCommand('work:start', projectArgs);
         break;

--- a/apps/cli/src/commands/work/status.ts
+++ b/apps/cli/src/commands/work/status.ts
@@ -1,0 +1,79 @@
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { styles, formatPriority } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+
+export default class WorkStatus extends PMOCommand {
+  static description = 'Show current work status (in-progress tickets)';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(WorkStatus);
+    const projectId = (flags as { project?: string }).project;
+
+    const jsonMode = shouldOutputJson(flags);
+
+    // List all tickets, optionally filtered by project
+    const tickets = await this.storage.listTickets(projectId, { allProjects: !projectId });
+    const inProgress = tickets.filter(t => t.statusCategory === 'started' && t.assignee);
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          inProgressCount: inProgress.length,
+          tickets: inProgress.map(t => ({
+            id: t.id,
+            title: t.title,
+            assignee: t.assignee,
+            statusName: t.statusName,
+            priority: t.priority,
+            projectId: t.projectId,
+            branch: t.branch,
+          })),
+        },
+        createMetadata('work status', flags),
+      );
+      return;
+    }
+
+    // Interactive mode
+    if (inProgress.length === 0) {
+      this.log(styles.info('No in-progress work found.'));
+      return;
+    }
+
+    this.log(styles.title(`\nWork In Progress (${inProgress.length})`));
+    this.log(styles.muted('─'.repeat(60)));
+
+    for (const ticket of inProgress) {
+      const priority = formatPriority(ticket.priority);
+      this.log(`  ${styles.code(ticket.id)} ${ticket.title} ${priority}`);
+      const details = [
+        ticket.assignee ? `Assignee: ${ticket.assignee}` : null,
+        ticket.statusName ? `Status: ${ticket.statusName}` : null,
+        ticket.projectId ? `Project: ${ticket.projectId}` : null,
+        ticket.branch ? `Branch: ${ticket.branch}` : null,
+      ].filter(Boolean).join(' | ');
+      if (details) {
+        this.log(styles.muted(`     ${details}`));
+      }
+    }
+
+    this.log('');
+  }
+}

--- a/apps/cli/src/lib/mcp/tools/board.ts
+++ b/apps/cli/src/lib/mcp/tools/board.ts
@@ -10,7 +10,7 @@ import { errorResponse, strictTool } from '../helpers.js'
 
 export function registerBoardTools(server: McpServer, ctx: McpToolContext): void {
   strictTool(server,
-    'board_show',
+    'board_view',
     'Show the kanban board',
     { project: z.string().optional().describe('Project ID') },
     async (params) => {

--- a/apps/cli/src/lib/mcp/tools/epic.ts
+++ b/apps/cli/src/lib/mcp/tools/epic.ts
@@ -85,7 +85,7 @@ export function registerEpicTools(server: McpServer, ctx: McpToolContext): void 
   )
 
   strictTool(server,
-    'epic_show',
+    'epic_view',
     'Get epic details with tickets',
     { id: z.string().describe('Epic ID') },
     async (params) => {

--- a/apps/cli/src/lib/mcp/tools/spec.ts
+++ b/apps/cli/src/lib/mcp/tools/spec.ts
@@ -83,7 +83,7 @@ export function registerSpecTools(server: McpServer, ctx: McpToolContext): void 
   )
 
   strictTool(server,
-    'spec_show',
+    'spec_view',
     'Get spec details',
     { id: z.string().describe('Spec ID') },
     async (params) => {

--- a/apps/cli/test/e2e/mcp-server.test.ts
+++ b/apps/cli/test/e2e/mcp-server.test.ts
@@ -434,8 +434,8 @@ describe('MCP Server E2E Tests', function (this: Mocha.Suite) {
       createTestTicket(db, projectId, { id: 'TKT-BOARD-1', title: 'Board Test Ticket' });
     });
 
-    it('board_show - should show board', () => {
-      const result = callTool('board_show', { project: projectId });
+    it('board_view - should show board', () => {
+      const result = callTool('board_view', { project: projectId });
       expect(result.success).to.be.true;
       expect(result.board).to.have.property('columns');
     });
@@ -537,8 +537,8 @@ describe('MCP Server E2E Tests', function (this: Mocha.Suite) {
       expect(result.spec).to.have.property('id');
     });
 
-    it('spec_show - should get spec details', () => {
-      const result = callTool('spec_show', { id: specId });
+    it('spec_view - should get spec details', () => {
+      const result = callTool('spec_view', { id: specId });
       expect(result.success).to.be.true;
       expect(result.spec).to.have.property('id', specId);
     });
@@ -609,8 +609,8 @@ describe('MCP Server E2E Tests', function (this: Mocha.Suite) {
       expect(result.epic).to.have.property('id');
     });
 
-    it('epic_show - should get epic details', () => {
-      const result = callTool('epic_show', { id: epicId });
+    it('epic_view - should get epic details', () => {
+      const result = callTool('epic_view', { id: epicId });
       expect(result.success).to.be.true;
       expect(result.epic).to.have.property('id', epicId);
     });


### PR DESCRIPTION
## Summary

Resolves TKT-1044: Bug: `work status` CLI command doesn't exist but MCP tool exposes it

## Description

## Problem

MCP tool names don't match CLI command names, creating confusing asymmetry.

| MCP tool | CLI command | Mismatch |
|----------|-----------|----------|
| `board_show` | `prlt board view` | `show` vs `view` |
| `epic_show` | `prlt epic view` | `show` vs `view` |
| `spec_show` | `prlt spec view` | `show` vs `view` |
| `work_status` | doesn't exist | No CLI equivalent |

## Fix

Rename MCP tools to match the CLI:
- `board_show` → `board_view`
- `epic_show` → `epic_view`
- `spec_show` → `spec_view`
- `work_status` → add `prlt work status` as a new CLI command, then name the MCP tool to match

No external MCP consumers exist (confirmed in TKT-1006), so renaming is not a breaking change.

## Resolved Ambiguities

**Q1 (RESOLVED):** Rename MCP tools to match CLI names. CLI is the source of truth for naming.

## Changes

- 437a6156 fix(TKT-1044): rename MCP tools to match CLI commands and add work status command

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
