### PR TITLE
TKT-1047: Bug: CLI treats positional args as subcommands for `epic show`, `workflow show`, etc.

### DIFF
--- a/apps/cli/src/commands/epic/show.ts
+++ b/apps/cli/src/commands/epic/show.ts
@@ -1,0 +1,19 @@
+import { Args } from '@oclif/core';
+import { pmoBaseFlags } from '../../lib/pmo/index.js';
+import EpicView from './view.js';
+
+export default class EpicShow extends EpicView {
+  static description = 'View epic details and linked tickets (alias for epic view)';
+  static hidden = true;
+
+  static args = {
+    id: Args.string({
+      description: 'Epic ID',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+}

--- a/apps/cli/src/commands/ticket/show.ts
+++ b/apps/cli/src/commands/ticket/show.ts
@@ -1,0 +1,19 @@
+import { Args } from '@oclif/core';
+import { pmoBaseFlags } from '../../lib/pmo/index.js';
+import TicketView from './view.js';
+
+export default class TicketShow extends TicketView {
+  static description = 'View detailed ticket information (alias for ticket view)';
+  static hidden = true;
+
+  static args = {
+    ticketId: Args.string({
+      description: 'Ticket ID to view - prompts with dropdown if not provided',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+}

--- a/apps/cli/src/commands/ticket/view.ts
+++ b/apps/cli/src/commands/ticket/view.ts
@@ -8,8 +8,6 @@ import {
 } from '../../lib/prompt-json.js';
 
 export default class TicketView extends PMOCommand {
-  static aliases = ['ticket:show'];
-
   static description = 'View detailed ticket information';
 
   static examples = [

--- a/apps/cli/src/commands/workflow/show.ts
+++ b/apps/cli/src/commands/workflow/show.ts
@@ -1,0 +1,19 @@
+import { Args } from '@oclif/core';
+import { pmoBaseFlags } from '../../lib/pmo/index.js';
+import WorkflowView from './view.js';
+
+export default class WorkflowShow extends WorkflowView {
+  static description = 'View details of a workflow (alias for workflow view)';
+  static hidden = true;
+
+  static args = {
+    id: Args.string({
+      description: 'Workflow ID - prompts with dropdown if not provided',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+}


### PR DESCRIPTION
## Summary

Resolves TKT-1047: Bug: CLI treats positional args as subcommands for `epic show`, `workflow show`, etc.

## Description

## Problem

Several CLI commands that take an ID as a positional argument fail because oclif interprets the argument as a subcommand name:

```bash
prlt epic show EPIC-044 --machine
# Error: command epic:show:EPIC-044 not found

prlt workflow show 5-tool-v2 --machine  
# Error: command workflow:show:5-tool-v2 not found
```

Meanwhile these commands don't even exist — the CLI has `epic view` and `workflow view` instead. But even if we use the right command name, the positional arg pattern works for some commands (`ticket view TKT-975`) but not others.

## Root Cause

Likely oclif topic/command configuration. When a command like `epic` has subcommands, oclif greedily matches additional tokens as subcommand names rather than arguments.

## Commands affected
- `prlt epic show EPIC-044` → command not found (correct command is `epic view`)
- `prlt workflow show 5-tool-v2` → command not found
- The MCP layer maps `epic_show` → storage API, so this only affects the CLI

## Expected Behavior

Positional ID arguments should be parsed correctly, not treated as subcommand names.

## Changes

- 22f12841 fix(TKT-1047): add show command aliases for epic, workflow, and ticket view commands

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
