### PR TITLE
TKT-1034: Bug: MCP board_show output exceeds tool result limit (136k chars, no pagination)

### DIFF
--- a/apps/cli/src/lib/mcp/tools/board.ts
+++ b/apps/cli/src/lib/mcp/tools/board.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { Column, Ticket } from '../../pmo/types.js'
 import type { McpToolContext } from '../types.js'
-import { errorResponse, strictTool } from '../helpers.js'
+import { formatTicket, errorResponse, strictTool } from '../helpers.js'
 
 export function registerBoardTools(server: McpServer, ctx: McpToolContext): void {
   strictTool(server,
@@ -35,10 +35,8 @@ export function registerBoardTools(server: McpServer, ctx: McpToolContext): void
                   position: col.position,
                   ticketCount: col.tickets.length,
                   tickets: col.tickets.map((t: Ticket) => ({
-                    id: t.id,
-                    title: t.title,
-                    priority: t.priority,
-                    assignee: t.assignee,
+                    ...formatTicket(t),
+                    labels: t.labels,
                   })),
                 })),
                 updatedAt: board.updatedAt.toISOString(),

--- a/apps/cli/test/e2e/mcp-server.test.ts
+++ b/apps/cli/test/e2e/mcp-server.test.ts
@@ -440,6 +440,28 @@ describe('MCP Server E2E Tests', function (this: Mocha.Suite) {
       expect(result.board).to.have.property('columns');
     });
 
+    it('board_show - should return summary fields without description', () => {
+      const result = callTool('board_show', { project: projectId });
+      expect(result.success).to.be.true;
+      const board = result.board as any;
+      const columns = board.columns;
+      // Find the column containing our test ticket
+      const colWithTicket = columns.find((c: any) => c.tickets.length > 0);
+      expect(colWithTicket).to.exist;
+      const ticket = colWithTicket.tickets[0];
+      // Should have summary fields (id, title always present)
+      expect(ticket).to.have.property('id');
+      expect(ticket).to.have.property('title');
+      // Should have labels array (newly added summary field)
+      expect(ticket).to.have.property('labels').that.is.an('array');
+      // Should NOT have description (stripped for size)
+      expect(ticket).to.not.have.property('description');
+      // Should NOT have heavy fields
+      expect(ticket).to.not.have.property('subtasks');
+      expect(ticket).to.not.have.property('metadata');
+      expect(ticket).to.not.have.property('acceptanceCriteria');
+    });
+
     it('board_columns - should list columns', () => {
       const result = callTool('board_columns', { project: projectId });
       expect(result.success).to.be.true;


### PR DESCRIPTION
## Summary

Resolves TKT-1034: Bug: MCP board_show output exceeds tool result limit (136k chars, no pagination)

## Description

## Problem

`mcp__prlt__board_show` returns the entire board as a single JSON blob. With 694 tickets across 11 columns, the output is 136,764 characters, which exceeds the MCP tool result size limit.

## Fix

Strip descriptions from board_show ticket results. Return only summary fields per ticket: id, title, status, priority, category, labels, assignee. Same pattern as TKT-1036.

## Resolved Ambiguities

**Q1 (RESOLVED):** Always strip descriptions. Board view should show ticket summaries, not full content.

## Reproduction

Call `board_show` on project PROJ-001 with 694 tickets. Output is 136k chars.

## Changes

- e89bdd51 fix(TKT-1034): use formatTicket + labels in board_show to strip descriptions and heavy fields

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
