### PR TITLE
TKT-1041: Bug: MCP session_list returns empty despite running executions

### DIFF
--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -15,6 +15,29 @@ import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
 import { visualPadEnd } from '../../lib/string-utils.js'
 
+/**
+ * Find container sessions using prefix matching.
+ * Handles cases where the stored containerId format differs from docker ps output
+ * (e.g., full 64-char ID vs 12-char short ID).
+ */
+function findContainerSessionsByPrefix(
+  containerTmuxSessions: Map<string, string[]>,
+  containerId: string
+): string[] {
+  // Try exact match first
+  const exact = containerTmuxSessions.get(containerId)
+  if (exact) return exact
+
+  // Fall back to prefix matching (handles short vs full ID mismatches)
+  for (const [key, sessions] of containerTmuxSessions) {
+    if (key.startsWith(containerId) || containerId.startsWith(key)) {
+      return sessions
+    }
+  }
+
+  return []
+}
+
 interface VerifiedSession {
   sessionId: string
   ticketId: string
@@ -95,7 +118,7 @@ export default class SessionList extends PMOCommand {
         // If sessionId is NULL, try to find session by naming convention
         if (!exec.sessionId) {
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId) || []
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
             const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
             if (match) {
               actualSessionId = match
@@ -117,8 +140,8 @@ export default class SessionList extends PMOCommand {
         } else {
           // sessionId is set, verify it exists
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId)
-            exists = containerSessions?.includes(exec.sessionId) ?? false
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
+            exists = containerSessions.includes(exec.sessionId)
             containerId = exec.containerId
           } else {
             exists = hostTmuxSessions.includes(exec.sessionId)
@@ -134,14 +157,15 @@ export default class SessionList extends PMOCommand {
           }
         }
 
-        // Only include if session exists, unless --all flag
-        // Note: actualSessionId is guaranteed non-null here due to continue above
-        if ((exists || flags.all) && actualSessionId) {
+        // Always include sessions from DB that have a sessionId.
+        // When tmux verification fails (e.g., Docker/tmux not accessible from MCP context),
+        // show the session with the DB status instead of silently dropping it.
+        if (actualSessionId) {
           sessions.push({
             sessionId: actualSessionId,
             ticketId: exec.ticketId,
             agentName: exec.agentName,
-            status: exists ? exec.status : 'stale',
+            status: exists ? exec.status : (flags.all ? 'stale' : exec.status),
             environment: isContainer ? 'container' : 'host',
             containerId,
             exists,

--- a/apps/cli/src/lib/execution/storage.ts
+++ b/apps/cli/src/lib/execution/storage.ts
@@ -322,9 +322,9 @@ export class ExecutionStorage {
       let sessionExists = false
 
       if (exec.environment === 'devcontainer' && exec.containerId) {
-        // Check if session exists in container
-        const containerSessions = containerTmuxSessions.get(exec.containerId)
-        sessionExists = containerSessions?.includes(exec.sessionId) ?? false
+        // Check if session exists in container (use prefix matching for ID format differences)
+        const containerSessions = this.findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
+        sessionExists = containerSessions.includes(exec.sessionId)
       } else {
         // Check if session exists on host
         sessionExists = hostTmuxSessions.includes(exec.sessionId)
@@ -338,6 +338,26 @@ export class ExecutionStorage {
     }
 
     return cleanedCount
+  }
+
+  /**
+   * Find container sessions using prefix matching.
+   * Handles cases where the stored containerId format differs from docker ps output.
+   */
+  private findContainerSessionsByPrefix(
+    containerTmuxSessions: Map<string, string[]>,
+    containerId: string
+  ): string[] {
+    const exact = containerTmuxSessions.get(containerId)
+    if (exact) return exact
+
+    for (const [key, sessions] of containerTmuxSessions) {
+      if (key.startsWith(containerId) || containerId.startsWith(key)) {
+        return sessions
+      }
+    }
+
+    return []
   }
 
   /**

--- a/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
+++ b/apps/cli/src/lib/mcp/tools/cli-passthrough.ts
@@ -457,7 +457,7 @@ export function registerUtilityTools(server: McpServer, ctx: McpToolContext): vo
     {},
     async () => {
       try {
-        const output = ctx.runCommand('prlt session list')
+        const output = ctx.runCommand('prlt session list --json')
         return textResponse(output)
       } catch (error) {
         return errorResponse(error)

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -262,8 +262,8 @@ describe('Session Commands E2E Tests', () => {
       expect(sessions).to.be.an('array');
     });
 
-    it('should return empty JSON for seeded executions without tmux (default mode)', () => {
-      // Seed a running execution - but no tmux session exists to verify it
+    it('should return DB-tracked sessions even without tmux verification (default mode)', () => {
+      // Seed a running execution - no tmux session exists to verify it
       seedExecutionRecords([{
         id: 'exec-001',
         ticketId: 'TKT-100',
@@ -272,13 +272,17 @@ describe('Session Commands E2E Tests', () => {
         sessionId: 'TKT-100-implement-bold-turing',
       }]);
 
-      // Without --all, only verified (tmux-backed) sessions are shown
+      // Sessions are always shown from DB, even without tmux verification
+      // (fixes bug where MCP session_list returned empty despite running executions)
       const output = execProduction('session list');
-      const sessions = JSON.parse(output) as Array<{ sessionId: string; status: string }>;
+      const sessions = JSON.parse(output) as Array<{ sessionId: string; status: string; exists: boolean; source: string; ticketId: string }>;
       expect(sessions).to.be.an('array');
-      // No sessions should have status 'running' since tmux verification fails
-      const runningSessions = sessions.filter(s => s.status === 'running');
-      expect(runningSessions).to.have.lengthOf(0);
+      // Filter to DB-sourced sessions for our seeded ticket (host may have real orphan tmux sessions)
+      const dbSessions = sessions.filter(s => s.source === 'db' && s.ticketId === 'TKT-100');
+      expect(dbSessions).to.have.lengthOf(1);
+      expect(dbSessions[0].sessionId).to.equal('TKT-100-implement-bold-turing');
+      expect(dbSessions[0].status).to.equal('running');
+      expect(dbSessions[0].exists).to.equal(false);
     });
 
     it('should show stale sessions with --all flag including ticket ID and agent name', () => {
@@ -468,9 +472,9 @@ describe('Session Commands E2E Tests', () => {
       expect(listChoice).to.not.be.undefined;
       expect(listChoice!.command).to.equal('prlt session list --json');
 
-      // Step 3: Agent executes the list command (strip prlt prefix, remove --json for display output)
-      // Use --all to see stale sessions since there's no real tmux
-      const listOutput = execProduction('session list --all');
+      // Step 3: Agent executes the list command
+      // Sessions now appear without --all since DB-tracked sessions are always shown
+      const listOutput = execProduction('session list');
 
       // Step 4: Verify END RESULT - the seeded session data actually appears (JSON output in non-TTY)
       const sessions = JSON.parse(listOutput) as Array<{ sessionId: string; ticketId: string; agentName: string; status: string }>;
@@ -479,7 +483,8 @@ describe('Session Commands E2E Tests', () => {
       expect(session).to.not.be.undefined;
       expect(session!.agentName).to.equal('swift-hopper');
       expect(session!.sessionId).to.equal('TKT-300-implement-swift-hopper');
-      expect(session!.status).to.equal('stale');
+      // Without tmux verification, sessions show their DB status
+      expect(session!.status).to.equal('running');
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves TKT-1041: Bug: MCP session_list returns empty despite running executions

## Description

## Problem

`mcp__prlt__session_list` returns `[]` (empty array) even though `execution_list` shows 4 actively running executions with session IDs:
- WORK-DC8C72B8 → session TKT-1006-Revise-smart-zhong
- WORK-554FCF05 → session TKT-989-Code-Review-live-spiegel
- WORK-9B6D020C → session TKT-1006-Code-Review-smart-zhong
- WORK-46D9BB73 → session TKT-975-Revise-loose-packard

## Expected Behavior

session_list should discover and list active tmux sessions across running containers and the host.

## Likely Cause

Session discovery may require running tmux commands inside each container. The MCP tool might not be able to reach Docker containers from the agent's context. Or the session discovery logic has a different issue — it works from the host CLI but not from the MCP passthrough.

## Reproduction

1. Have running executions with active tmux sessions (verified via execution_list)
2. Call session_list
3. Get empty array

## Impact

No MCP visibility into active sessions. Can't peek/attach to running agents via MCP toolchain.

## Changes

- dae80a98 fix(TKT-1041): fix MCP session_list returning empty by always including DB-tracked sessions

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
