### PR TITLE
TKT-1061: Add input validation (min 0/1) to MCP ticket_list limit/offset params

### DIFF
--- a/apps/cli/src/lib/mcp/tools/ticket.ts
+++ b/apps/cli/src/lib/mcp/tools/ticket.ts
@@ -25,8 +25,8 @@ export function registerTicketTools(server: McpServer, ctx: McpToolContext): voi
       label: z.string().optional().describe('Filter by label name'),
       label_group: z.string().optional().describe('Filter by label group name'),
       all_projects: z.boolean().optional().describe('List from all projects'),
-      limit: z.number().optional().describe('Maximum number of tickets to return (default: 50)'),
-      offset: z.number().optional().describe('Number of tickets to skip for pagination (default: 0)'),
+      limit: z.number().min(1).optional().describe('Maximum number of tickets to return (default: 50)'),
+      offset: z.number().min(0).optional().describe('Number of tickets to skip for pagination (default: 0)'),
     },
     async (params) => {
       try {


### PR DESCRIPTION
## Summary

Resolves TKT-1061: Add input validation (min 0/1) to MCP ticket_list limit/offset params

## Description

## Problem
The MCP `ticket_list` tool accepts `limit` and `offset` parameters (added in TKT-1036) but has no input validation. Negative values for `limit` or `offset` produce unexpected results from `Array.slice()`. `limit: 0` returns an empty array.

## Fix
In `apps/cli/src/lib/mcp/tools/ticket.ts`, add Zod constraints:
- `limit: z.number().min(1).optional()` (default 50)
- `offset: z.number().min(0).optional()` (default 0)

## Scope
Single file, ~2 lines changed.

## Changes

- f80038c4 fix(TKT-1061): add min validation to MCP ticket_list limit/offset params

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
