### PR TITLE
TKT-1062: Extract shared formatTicketJson helper to deduplicate ticket/move.ts JSON output

### DIFF
--- a/apps/cli/src/commands/ticket/move.ts
+++ b/apps/cli/src/commands/ticket/move.ts
@@ -11,6 +11,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js';
+import { formatTicket } from '../../lib/mcp/helpers.js';
 
 export default class TicketMove extends PMOCommand {
   static description = 'Move ticket(s) to a different column';
@@ -243,20 +244,7 @@ export default class TicketMove extends PMOCommand {
     if (jsonMode) {
       this.log(JSON.stringify({
         success: true,
-        ticket: {
-          id: moved.id,
-          title: moved.title,
-          priority: moved.priority,
-          category: moved.category,
-          statusName: moved.statusName,
-          statusCategory: moved.statusCategory,
-          projectId: moved.projectId,
-          assignee: moved.assignee,
-          owner: moved.owner,
-          branch: moved.branch,
-          epicId: moved.epicId,
-          position: moved.position,
-        },
+        ticket: formatTicket(moved),
       }, null, 2));
       return;
     }
@@ -430,20 +418,7 @@ export default class TicketMove extends PMOCommand {
         if (jsonMode && updatedTicket) {
           this.log(JSON.stringify({
             success: true,
-            ticket: {
-              id: updatedTicket.id,
-              title: updatedTicket.title,
-              priority: updatedTicket.priority,
-              category: updatedTicket.category,
-              statusName: updatedTicket.statusName,
-              statusCategory: updatedTicket.statusCategory,
-              projectId: updatedTicket.projectId,
-              assignee: updatedTicket.assignee,
-              owner: updatedTicket.owner,
-              branch: updatedTicket.branch,
-              epicId: updatedTicket.epicId,
-              position: updatedTicket.position,
-            },
+            ticket: formatTicket(updatedTicket),
           }, null, 2));
           return;
         }
@@ -468,20 +443,7 @@ export default class TicketMove extends PMOCommand {
     if (jsonMode) {
       this.log(JSON.stringify({
         success: true,
-        ticket: {
-          id: movedTicket.id,
-          title: movedTicket.title,
-          priority: movedTicket.priority,
-          category: movedTicket.category,
-          statusName: movedTicket.statusName,
-          statusCategory: movedTicket.statusCategory,
-          projectId: movedTicket.projectId,
-          assignee: movedTicket.assignee,
-          owner: movedTicket.owner,
-          branch: movedTicket.branch,
-          epicId: movedTicket.epicId,
-          position: movedTicket.position,
-        },
+        ticket: formatTicket(movedTicket),
       }, null, 2));
       return;
     }


### PR DESCRIPTION
## Summary

Resolves TKT-1062: Extract shared formatTicketJson helper to deduplicate ticket/move.ts JSON output

## Description

## Problem
In `apps/cli/src/commands/ticket/move.ts` (from TKT-1042), the same 12-field ticket JSON serialization block is repeated 3 times across the column-move, cross-project-move-loop, and cross-project-move-end code paths. If `formatTicket()` fields change, all 3 blocks need manual updates.

## Fix
Import `formatTicket` from `apps/cli/src/lib/mcp/helpers.ts` (or create a shared CLI helper) and use it in all 3 JSON output blocks in `ticket/move.ts`. This ensures CLI JSON output stays in sync with MCP tool responses automatically.

## Scope
1 file changed, possibly 1 helper file if a CLI-specific formatter is needed.

## Changes

- a60da079 feat(TKT-1062): extract shared formatTicketJson helper to deduplicate ticket/move.ts JSON output

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
