### PR TITLE
chore: bump version to 0.3.36

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "author": "Chris McDermut",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump `@proletariat/cli` version from `0.3.35` to `0.3.36`

## Test plan
- [ ] Verify `package.json` version is correct
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)