### PR TITLE
TKT-1095: Consolidate PR flags: make --create-pr canonical, keep --no-pr compatibility

### DIFF
--- a/apps/cli/src/commands/work/spawn-all.ts
+++ b/apps/cli/src/commands/work/spawn-all.ts
@@ -27,7 +27,7 @@ export default class WorkSpawnAll extends PMOCommand {
       default: false,
     }),
     'create-pr': Flags.boolean({
-      description: 'Create PR when work is ready',
+      description: 'Create PR when work is ready (canonical flag for PR behavior)',
       default: false,
     }),
     executor: Flags.string({

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -45,6 +45,7 @@ export default class WorkSpawn extends PMOCommand {
     '<%= config.bin %> <%= command.id %> --count 5 --category ship --action implement  # Filtered by category',
     '<%= config.bin %> <%= command.id %> --count 5 --priority P0 --action implement  # Filtered by priority',
     '<%= config.bin %> <%= command.id %> --count 10 --diet --category ship,grow --action groom  # Combined',
+    '<%= config.bin %> <%= command.id %> TKT-001 TKT-002 --create-pr  # Create PR when work is ready',
   ]
 
   static flags = {
@@ -114,11 +115,11 @@ export default class WorkSpawn extends PMOCommand {
       default: false,
     }),
     'create-pr': Flags.boolean({
-      description: 'Create PR when work is ready (batch mode only)',
+      description: 'Create PR when work is ready (canonical flag for PR behavior, batch mode only)',
       default: false,
     }),
     'no-pr': Flags.boolean({
-      description: 'Do not create PR when work is ready (batch mode only)',
+      description: '[deprecated: use --create-pr instead] Skip PR creation (batch mode only)',
       default: false,
     }),
     action: Flags.string({
@@ -176,6 +177,11 @@ export default class WorkSpawn extends PMOCommand {
         this.exit(1)
       }
       this.error(message)
+    }
+
+    // Deprecation guidance for --no-pr
+    if (flags['no-pr']) {
+      this.warn('--no-pr is deprecated. Omit --create-pr instead (PR creation is off by default). --no-pr will continue to work.')
     }
 
     // Parse ticket IDs from args (everything after flags)
@@ -336,6 +342,7 @@ export default class WorkSpawn extends PMOCommand {
           } else if (allFlagsProvided && !flags.yes) {
             // All flags provided but no --yes: return confirmation_needed with plan
             const metadata = createMetadata('work spawn', flags)
+            metadata.resolvedPRMode = flags['create-pr'] ? 'create-pr' : 'no-pr'
 
             // Build the confirm command with --yes
             const ticketIds = ticketsToSpawn.map(t => t.id).join(' ')
@@ -668,6 +675,7 @@ export default class WorkSpawn extends PMOCommand {
         // In JSON mode without --yes, return confirmation_needed
         if (jsonMode && !flags.yes) {
           const metadata = createMetadata('work spawn', flags)
+          metadata.resolvedPRMode = flags['create-pr'] ? 'create-pr' : 'no-pr'
           const ticketIds = ticketsToSpawn.map(t => t.id).join(' ')
           let confirmCmd = `prlt work spawn ${ticketIds}`
           if (flags.action) confirmCmd += ` --action ${flags.action}`
@@ -1552,16 +1560,20 @@ export default class WorkSpawn extends PMOCommand {
 
       // Output results
       if (jsonMode) {
-        // Output JSON execution results
+        // Output JSON execution results with resolved PR mode
+        const spawnMetadata = createMetadata('work spawn', flags)
+        spawnMetadata.resolvedPRMode = flags['create-pr'] ? 'create-pr' : 'no-pr'
         outputExecutionResultAsJson(
           executionResults,
           successCount,
           failCount,
-          createMetadata('work spawn', flags)
+          spawnMetadata
         )
       } else {
+        const resolvedPRMode = flags['create-pr'] ? 'create-pr' : 'no-pr'
         this.log('')
         this.log(styles.success(`✓ Spawn results: ${successCount} started, ${failCount} failed`))
+        this.log(styles.muted(`   PR mode: ${resolvedPRMode}`))
       }
     } catch (error) {
       db.close()

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -107,6 +107,7 @@ export default class WorkStart extends PMOCommand {
 
   static examples = [
     '<%= config.bin %> <%= command.id %> TKT-001',
+    '<%= config.bin %> <%= command.id %> TKT-001 --create-pr  # Create PR when work is ready',
     '<%= config.bin %> <%= command.id %> TKT-001 --mode foreground',
     '<%= config.bin %> <%= command.id %> TKT-001 --mode tmux',
     '<%= config.bin %> <%= command.id %> TKT-001 --mode terminal',
@@ -175,11 +176,11 @@ export default class WorkStart extends PMOCommand {
       default: false,
     }),
     'create-pr': Flags.boolean({
-      description: 'Create PR when work is ready',
+      description: 'Create PR when work is ready (canonical flag for PR behavior)',
       default: false,
     }),
     'no-pr': Flags.boolean({
-      description: 'Do not create PR when work is ready',
+      description: '[deprecated: use --create-pr instead] Skip PR creation when work is ready',
       default: false,
     }),
     output: Flags.string({
@@ -232,6 +233,11 @@ export default class WorkStart extends PMOCommand {
     // Check for conflicting PR flags
     if (flags['create-pr'] && flags['no-pr']) {
       this.error('--create-pr and --no-pr are mutually exclusive');
+    }
+
+    // Deprecation guidance for --no-pr
+    if (flags['no-pr']) {
+      this.warn('--no-pr is deprecated. Omit --create-pr instead (PR creation is off by default). --no-pr will continue to work.')
     }
 
     // Handle --skip-permissions flag (alias for --permission-mode danger)
@@ -327,6 +333,7 @@ export default class WorkStart extends PMOCommand {
         if (allFlagsProvided && !flags.yes) {
           // All flags provided but no --yes: return confirmation_needed with plan
           const metadata = createMetadata('work start', flags)
+          metadata.resolvedPRMode = flags['create-pr'] ? 'create-pr' : 'no-pr'
 
           // Build the confirm command with --yes
           let confirmCmd = `prlt work start ${ticketId}`
@@ -1430,9 +1437,8 @@ export default class WorkStart extends PMOCommand {
         }
 
         this.log(styles.muted(`   Output: ${outputMode === 'interactive' ? 'streaming (watch Claude work)' : 'print (final result only)'}`))
-        if (ghAvailable) {
-          this.log(styles.muted(`   Create PR: ${createPR ? 'yes (when work is ready)' : 'no'}`))
-        }
+        this.log(styles.muted(`   PR mode: ${createPR ? 'create-pr' : 'no-pr'}${ghAvailable ? '' : ' (gh CLI not available)'}`))
+
         this.log(styles.muted(`   Worktree: ${worktreePath}`))
         this.log(styles.muted(`   Branch: ${branch}`))
         this.log('')
@@ -1765,7 +1771,9 @@ export default class WorkStart extends PMOCommand {
 
         // Output results
         if (jsonMode) {
-          // Output JSON execution result
+          // Output JSON execution result with resolved PR mode
+          const metadata = createMetadata('work start', flags)
+          metadata.resolvedPRMode = createPR ? 'create-pr' : 'no-pr'
           outputExecutionResultAsJson(
             [{
               workId: execution.id,
@@ -1777,7 +1785,7 @@ export default class WorkStart extends PMOCommand {
             }],
             1,
             0,
-            createMetadata('work start', flags)
+            metadata
           )
         } else {
           this.log('')
@@ -1791,7 +1799,9 @@ export default class WorkStart extends PMOCommand {
       } else {
         executionStorage.updateStatus(execution.id, 'failed')
         if (jsonMode) {
-          // Output JSON failure result
+          // Output JSON failure result with resolved PR mode
+          const failMetadata = createMetadata('work start', flags)
+          failMetadata.resolvedPRMode = createPR ? 'create-pr' : 'no-pr'
           outputExecutionResultAsJson(
             [{
               workId: execution.id,
@@ -1801,7 +1811,7 @@ export default class WorkStart extends PMOCommand {
             }],
             0,
             1,
-            createMetadata('work start', flags)
+            failMetadata
           )
         } else {
           this.error(`Failed to start work: ${result.error}`)

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -74,7 +74,7 @@ export default class WorkWatch extends PMOCommand {
       default: false,
     }),
     'create-pr': Flags.boolean({
-      description: 'Create PR when work is ready',
+      description: 'Create PR when work is ready (canonical flag for PR behavior)',
       default: false,
     }),
   }

--- a/apps/cli/src/lib/prompt-json.ts
+++ b/apps/cli/src/lib/prompt-json.ts
@@ -93,6 +93,8 @@ export interface OutputMetadata {
   flags: Record<string, unknown>
   /** Timestamp of the output */
   timestamp?: string
+  /** Resolved PR mode after flag precedence ('create-pr' | 'no-pr') */
+  resolvedPRMode?: string
 }
 
 /**

--- a/apps/cli/test/commands/work-spawn.test.ts
+++ b/apps/cli/test/commands/work-spawn.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Root directory for the CLI - needed for @oclif/test to find commands
+const root = path.resolve(__dirname, '../..');
+
+// Isolated env to prevent test commands from polluting production database
+function getIsolatedEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.PRLT_HQ_PATH;
+  delete env.PRLT_PMO_PATH;
+  delete env.PRLT_DATABASE_PATH;
+  delete env.PRLT_CONFIG_PATH;
+  delete env.DEVCONTAINER;
+  delete env.PRLT_TEST_ENV;
+  return env;
+}
+
+// Helper to run CLI commands directly and get stdout
+function runCli(args: string[]): string {
+  const binPath = path.join(root, 'bin', 'run.js');
+  try {
+    return execSync(`node ${binPath} ${args.join(' ')}`, {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: getIsolatedEnv(),
+    });
+  } catch (error: unknown) {
+    // Return stdout even on error (for --help commands that may exit with code 0)
+    return (error as { stdout?: string })?.stdout || '';
+  }
+}
+
+// Helper to run CLI and capture stderr (for error testing)
+function runCliWithError(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const binPath = path.join(root, 'bin', 'run.js');
+  try {
+    const stdout = execSync(`node ${binPath} ${args.join(' ')}`, {
+      cwd: root,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: getIsolatedEnv(),
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+      exitCode: err.status || 1,
+    };
+  }
+}
+
+/**
+ * Tests for work spawn command
+ * TKT-1095: Consolidated PR flags
+ */
+describe('Work Spawn Command', () => {
+  let helpOutput: string;
+
+  before(() => {
+    // Get help output once for all tests
+    helpOutput = runCli(['work', 'spawn', '--help']);
+  });
+
+  describe('Consolidated PR Flags (TKT-1095)', () => {
+    it('--create-pr is described as canonical flag in help', () => {
+      expect(helpOutput).to.contain('canonical');
+      expect(helpOutput).to.match(/--create-pr.*canonical/s);
+    });
+
+    it('--no-pr is marked as deprecated in help', () => {
+      expect(helpOutput).to.contain('deprecated');
+      expect(helpOutput).to.match(/--no-pr.*deprecated/s);
+    });
+
+    it('--create-pr example is shown in help', () => {
+      expect(helpOutput).to.contain('--create-pr');
+    });
+
+    it('source code emits resolvedPRMode in JSON metadata', () => {
+      const spawnTsPath = path.resolve(__dirname, '../../src/commands/work/spawn.ts');
+      const source = fs.readFileSync(spawnTsPath, 'utf-8');
+      // Verify the source sets resolvedPRMode on metadata
+      expect(source).to.include('resolvedPRMode');
+    });
+
+    it('source code emits PR mode in human output', () => {
+      const spawnTsPath = path.resolve(__dirname, '../../src/commands/work/spawn.ts');
+      const source = fs.readFileSync(spawnTsPath, 'utf-8');
+      // Verify the source displays PR mode in console output
+      expect(source).to.include('PR mode:');
+    });
+
+    it('source code emits deprecation warning when --no-pr is used', () => {
+      const spawnTsPath = path.resolve(__dirname, '../../src/commands/work/spawn.ts');
+      const source = fs.readFileSync(spawnTsPath, 'utf-8');
+      // Verify the source has deprecation warning for --no-pr
+      expect(source).to.include("--no-pr is deprecated");
+      expect(source).to.include("Omit --create-pr instead");
+    });
+  });
+
+  describe('Command Help', () => {
+    it('work spawn help shows usage', () => {
+      expect(helpOutput).to.contain('USAGE');
+      expect(helpOutput).to.contain('work spawn');
+    });
+
+    it('shows PR creation flags', () => {
+      expect(helpOutput).to.contain('--create-pr');
+      expect(helpOutput).to.contain('--no-pr');
+    });
+  });
+});

--- a/apps/cli/test/commands/work-start.test.ts
+++ b/apps/cli/test/commands/work-start.test.ts
@@ -219,4 +219,73 @@ describe('Work Start Command', () => {
       expect(helpOutput).to.match(/--focus.*background/is);
     });
   });
+
+  describe('Consolidated PR Flags (TKT-1095)', () => {
+    it('--create-pr is described as canonical flag in help', () => {
+      expect(helpOutput).to.contain('canonical');
+      expect(helpOutput).to.match(/--create-pr.*canonical/s);
+    });
+
+    it('--no-pr is marked as deprecated in help', () => {
+      expect(helpOutput).to.contain('deprecated');
+      expect(helpOutput).to.match(/--no-pr.*deprecated/s);
+    });
+
+    it('--create-pr example is shown in help', () => {
+      expect(helpOutput).to.contain('--create-pr');
+    });
+
+    it('source code emits deprecation warning when --no-pr is used', () => {
+      const startTsPath = path.resolve(__dirname, '../../src/commands/work/start.ts');
+      const source = fs.readFileSync(startTsPath, 'utf-8');
+      // Verify the source has deprecation warning for --no-pr
+      expect(source).to.include("--no-pr is deprecated");
+      expect(source).to.include("Omit --create-pr instead");
+    });
+
+    it('--no-pr still works (backward compatibility)', () => {
+      // --no-pr should not produce a fatal error when used alone
+      const result = runCliWithError([
+        'work', 'start', 'TKT-999',
+        '--no-pr',
+      ]);
+      // Should NOT fail with a flag parsing error
+      // It may fail for other reasons (e.g., PMO not found), but not flag rejection
+      expect(result.stderr).to.not.contain('Unexpected argument');
+      expect(result.stderr).to.not.contain('is not a valid flag');
+    });
+
+    it('--create-pr alone does not trigger deprecation warning path', () => {
+      const startTsPath = path.resolve(__dirname, '../../src/commands/work/start.ts');
+      const source = fs.readFileSync(startTsPath, 'utf-8');
+      // The deprecation warning is only triggered for --no-pr, not --create-pr
+      // Check that the conditional is specific to no-pr
+      expect(source).to.include("if (flags['no-pr'])");
+      expect(source).to.not.include("if (flags['create-pr'])  {\n      this.warn");
+    });
+
+    it('source code maintains mutual exclusion for both flags', () => {
+      const startTsPath = path.resolve(__dirname, '../../src/commands/work/start.ts');
+      const source = fs.readFileSync(startTsPath, 'utf-8');
+      // Verify mutual exclusion check still exists
+      expect(source).to.include("flags['create-pr'] && flags['no-pr']");
+      expect(source).to.include('mutually exclusive');
+    });
+
+    it('source code emits resolvedPRMode in JSON metadata', () => {
+      const startTsPath = path.resolve(__dirname, '../../src/commands/work/start.ts');
+      const source = fs.readFileSync(startTsPath, 'utf-8');
+      // Verify the source sets resolvedPRMode on metadata
+      expect(source).to.include('resolvedPRMode');
+      expect(source).to.include("'create-pr'");
+      expect(source).to.include("'no-pr'");
+    });
+
+    it('source code emits PR mode in human output', () => {
+      const startTsPath = path.resolve(__dirname, '../../src/commands/work/start.ts');
+      const source = fs.readFileSync(startTsPath, 'utf-8');
+      // Verify the source displays PR mode in console output
+      expect(source).to.include('PR mode:');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Resolves TKT-1095: Consolidate PR flags: make --create-pr canonical, keep --no-pr compatibility

## Description

## Problem
PR behavior is split across `--create-pr` and `--no-pr`, which is useful for overrides but confusing in day-to-day usage.

Current behavior is technically valid, but the CLI surface treats both flags as first-class and this increases accidental `--no-pr` usage in scripted/agent runs.

## Goal
Consolidate PR flag UX around a single canonical flag while preserving backward compatibility.

## Requirements
- R1: Make `--create-pr` the canonical documented flag in help text, examples, and command hints.
- R2: Keep `--no-pr` working as a compatibility override (no breaking change).
- R3: Add deprecation-style guidance when `--no-pr` is used (clear message, non-fatal).
- R4: Ensure deterministic precedence:
  - `--create-pr` => true
  - `--no-pr` => false
  - both => existing mutual-exclusion error
  - neither => resolved default/prompt logic
- R5: Emit resolved PR mode in both human output and JSON metadata for `work start` and `work spawn`.
- R6: Add regression tests for conflicts, compatibility, and resolved-mode reporting.

## Acceptance Criteria
- [ ] `work start --help` and docs present `--create-pr` as canonical; `--no-pr` is marked compatibility/deprecated wording.
- [ ] Existing scripts that pass `--no-pr` still work unchanged.
- [ ] Console output clearly states resolved PR mode before execution.
- [ ] JSON output includes resolved PR mode field consumed by automation.
- [ ] Tests cover create/no-pr precedence and output behavior.

## Scope
In scope: CLI flag/help text, prompt/summary output, JSON metadata shape, tests.
Out of scope: changing GitHub PR creation backend behavior.

## Depends On
- TKT-1094 (parent UX issue)


## Changes

- 0e7e6216 refactor(TKT-1095): consolidate PR flags: make --create-pr canonical, keep --no-pr compatibility with deprecation warning, emit resolved PR mode in output and JSON metadata, add regression tests

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
