### PR TITLE
fix(TKT-1098): make session peek resolve active devcontainer tmux sessions

### DIFF
--- a/apps/cli/src/commands/session/attach.ts
+++ b/apps/cli/src/commands/session/attach.ts
@@ -12,6 +12,7 @@ import {
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
   flattenContainerSessions,
+  findContainerSessionsByPrefix,
   findSessionForExecution,
 } from '../../lib/execution/session-utils.js'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
@@ -201,7 +202,7 @@ export default class SessionAttach extends PMOCommand {
         // If sessionId is NULL, try to find session by naming convention
         if (!exec.sessionId) {
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId) || []
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
             const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
             if (match) {
               actualSessionId = match
@@ -223,8 +224,8 @@ export default class SessionAttach extends PMOCommand {
         } else {
           // sessionId is set, verify it exists
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId)
-            exists = containerSessions?.includes(exec.sessionId) ?? false
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
+            exists = containerSessions.includes(exec.sessionId)
             containerId = exec.containerId
           } else {
             exists = hostTmuxSessions.includes(exec.sessionId)

--- a/apps/cli/src/commands/session/health.ts
+++ b/apps/cli/src/commands/session/health.ts
@@ -10,6 +10,7 @@ import {
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
   flattenContainerSessions,
+  findContainerSessionsByPrefix,
   findSessionForExecution,
   captureTmuxPane,
 } from '../../lib/execution/session-utils.js'
@@ -229,7 +230,7 @@ export default class SessionHealth extends PMOCommand {
         // Try to find session if sessionId is NULL
         if (!exec.sessionId) {
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId) || []
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
             const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
             if (match) {
               actualSessionId = match
@@ -246,8 +247,8 @@ export default class SessionHealth extends PMOCommand {
           if (!actualSessionId) continue
         } else {
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId)
-            exists = containerSessions?.includes(exec.sessionId) ?? false
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
+            exists = containerSessions.includes(exec.sessionId)
             containerId = exec.containerId
           } else {
             exists = hostTmuxSessions.includes(exec.sessionId)

--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -9,34 +9,12 @@ import {
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
   flattenContainerSessions,
+  findContainerSessionsByPrefix,
   findSessionForExecution,
 } from '../../lib/execution/session-utils.js'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
 import { visualPadEnd } from '../../lib/string-utils.js'
-
-/**
- * Find container sessions using prefix matching.
- * Handles cases where the stored containerId format differs from docker ps output
- * (e.g., full 64-char ID vs 12-char short ID).
- */
-function findContainerSessionsByPrefix(
-  containerTmuxSessions: Map<string, string[]>,
-  containerId: string
-): string[] {
-  // Try exact match first
-  const exact = containerTmuxSessions.get(containerId)
-  if (exact) return exact
-
-  // Fall back to prefix matching (handles short vs full ID mismatches)
-  for (const [key, sessions] of containerTmuxSessions) {
-    if (key.startsWith(containerId) || containerId.startsWith(key)) {
-      return sessions
-    }
-  }
-
-  return []
-}
 
 interface VerifiedSession {
   sessionId: string

--- a/apps/cli/src/commands/session/peek.ts
+++ b/apps/cli/src/commands/session/peek.ts
@@ -9,6 +9,7 @@ import {
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
   flattenContainerSessions,
+  findContainerSessionsByPrefix,
   findSessionForExecution,
   captureTmuxPane,
 } from '../../lib/execution/session-utils.js'
@@ -74,7 +75,7 @@ export default class SessionPeek extends PMOCommand {
     const jsonMode = shouldOutputJson(flags)
 
     // Discover all verified sessions
-    const sessions = this.getVerifiedSessions(jsonMode, flags)
+    const sessions = this.getVerifiedSessions()
 
     if (sessions.length === 0) {
       if (jsonMode) {
@@ -268,7 +269,7 @@ export default class SessionPeek extends PMOCommand {
    * Get verified sessions from DB that have actual tmux processes.
    * Same discovery pattern as attach.ts and list.ts.
    */
-  private getVerifiedSessions(jsonMode: boolean, flags: Record<string, unknown>): VerifiedSession[] {
+  private getVerifiedSessions(): VerifiedSession[] {
     const sessions: VerifiedSession[] = []
 
     let executionStorage: ExecutionStorage | null = null
@@ -305,7 +306,7 @@ export default class SessionPeek extends PMOCommand {
 
         if (!exec.sessionId) {
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId) || []
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
             const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
             if (match) {
               actualSessionId = match
@@ -322,8 +323,8 @@ export default class SessionPeek extends PMOCommand {
           if (!actualSessionId) continue
         } else {
           if (isContainer && exec.containerId) {
-            const containerSessions = containerTmuxSessions.get(exec.containerId)
-            exists = containerSessions?.includes(exec.sessionId) ?? false
+            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
+            exists = containerSessions.includes(exec.sessionId)
             containerId = exec.containerId
           } else {
             exists = hostTmuxSessions.includes(exec.sessionId)

--- a/apps/cli/src/commands/session/poke.ts
+++ b/apps/cli/src/commands/session/poke.ts
@@ -8,7 +8,7 @@ import { ExecutionStorage } from '../../lib/execution/index.js'
 import {
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
-  flattenContainerSessions,
+  findContainerSessionsByPrefix,
   findSessionForExecution,
 } from '../../lib/execution/session-utils.js'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
@@ -262,7 +262,7 @@ export default class SessionPoke extends PMOCommand {
     if (!exec.sessionId) {
       if (isContainer && exec.containerId) {
         const containerTmuxSessions = getContainerTmuxSessionMap()
-        const containerSessions = containerTmuxSessions.get(exec.containerId) || []
+        const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
         const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
         if (match) {
           actualSessionId = match

--- a/apps/cli/src/lib/execution/session-utils.ts
+++ b/apps/cli/src/lib/execution/session-utils.ts
@@ -144,14 +144,42 @@ export function getContainerTmuxSessionMap(): Map<string, string[]> {
   const sessionMap = new Map<string, string[]>()
 
   try {
-    const containersOutput = execSync(
-      'docker ps --filter "label=devcontainer.local_folder" --format "{{.ID}}"',
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
-    ).trim()
+    const containerIds = new Set<string>()
 
-    if (!containersOutput) return sessionMap
+    // Primary: devcontainer-labeled containers (historical behavior).
+    try {
+      const labeledOutput = execSync(
+        'docker ps --filter "label=devcontainer.local_folder" --format "{{.ID}}"',
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      ).trim()
+      if (labeledOutput) {
+        for (const id of labeledOutput.split('\n')) {
+          if (id.trim()) containerIds.add(id.trim())
+        }
+      }
+    } catch {
+      // Ignore and continue with broad fallback discovery.
+    }
 
-    for (const containerId of containersOutput.split('\n')) {
+    // Fallback: include all running containers so prlt-managed devcontainers
+    // without the devcontainer.local_folder label are still discoverable.
+    try {
+      const allOutput = execSync(
+        'docker ps --format "{{.ID}}"',
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      ).trim()
+      if (allOutput) {
+        for (const id of allOutput.split('\n')) {
+          if (id.trim()) containerIds.add(id.trim())
+        }
+      }
+    } catch {
+      // Docker not available.
+    }
+
+    if (containerIds.size === 0) return sessionMap
+
+    for (const containerId of containerIds) {
       try {
         const tmuxOutput = execSync(
           `docker exec ${containerId} tmux list-sessions -F "#{session_name}" 2>/dev/null`,
@@ -185,6 +213,26 @@ export function flattenContainerSessions(
     }
   })
   return result
+}
+
+/**
+ * Find container sessions using prefix matching.
+ * Handles short vs full container ID mismatches between DB records and docker output.
+ */
+export function findContainerSessionsByPrefix(
+  containerTmuxSessions: Map<string, string[]>,
+  containerId: string
+): string[] {
+  const exact = containerTmuxSessions.get(containerId)
+  if (exact) return exact
+
+  for (const [key, sessions] of containerTmuxSessions) {
+    if (key.startsWith(containerId) || containerId.startsWith(key)) {
+      return sessions
+    }
+  }
+
+  return []
 }
 
 /**

--- a/apps/cli/test/unit/session-utils.test.ts
+++ b/apps/cli/test/unit/session-utils.test.ts
@@ -5,6 +5,7 @@ import {
   buildExpectedSessionName,
   sessionMatchesExecution,
   findSessionForExecution,
+  findContainerSessionsByPrefix,
   KNOWN_ACTIONS,
 } from '../../src/lib/execution/session-utils.js'
 
@@ -228,6 +229,36 @@ describe('Session Utils', () => {
       ]
       const result = findSessionForExecution('TKT-123', 'agent', sessions)
       expect(result).to.equal('TKT-123-Implement-agent')
+    })
+  })
+
+  describe('findContainerSessionsByPrefix', () => {
+    const sessionMap = new Map<string, string[]>([
+      ['977b5fc9f60d', ['TKT-1087-Implement-pure-pichai']],
+      ['abcdef123456', ['TKT-1005-Groom-witty-rabois']],
+    ])
+
+    it('should return exact match when container ID exists', () => {
+      const result = findContainerSessionsByPrefix(sessionMap, '977b5fc9f60d')
+      expect(result).to.deep.equal(['TKT-1087-Implement-pure-pichai'])
+    })
+
+    it('should match when DB has short ID and map has longer prefix', () => {
+      const longMap = new Map<string, string[]>([
+        ['977b5fc9f60d1234', ['TKT-1087-Implement-pure-pichai']],
+      ])
+      const result = findContainerSessionsByPrefix(longMap, '977b5fc9f60d')
+      expect(result).to.deep.equal(['TKT-1087-Implement-pure-pichai'])
+    })
+
+    it('should match when DB has longer ID and map has short ID', () => {
+      const result = findContainerSessionsByPrefix(sessionMap, '977b5fc9f60d1234')
+      expect(result).to.deep.equal(['TKT-1087-Implement-pure-pichai'])
+    })
+
+    it('should return empty array when no matching container exists', () => {
+      const result = findContainerSessionsByPrefix(sessionMap, 'doesnotexist')
+      expect(result).to.deep.equal([])
     })
   })
 


### PR DESCRIPTION
## Summary
- fix container tmux discovery fallback so prlt-managed devcontainers without `devcontainer.local_folder` label are still scanned
- add shared container ID prefix matching helper for short/full ID mismatches
- apply shared helper across session commands (`peek`, `list`, `attach`, `health`, `poke`)
- add regression tests for container ID prefix matching behavior

## Validation
- `cd repos/proletariat/apps/cli && pnpm exec mocha --forbid-only "test/unit/session-utils.test.ts"`
- `cd repos/proletariat/apps/cli && pnpm exec mocha --forbid-only "test/unit/session-peek.test.ts"`
- `cd repos/proletariat/apps/cli && pnpm exec eslint src/lib/execution/session-utils.ts src/commands/session/peek.ts src/commands/session/list.ts src/commands/session/attach.ts src/commands/session/health.ts src/commands/session/poke.ts test/unit/session-utils.test.ts`
