### PR TITLE
TKT-1068: Automate Homebrew formula bump on CLI release

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,0 +1,48 @@
+name: bump homebrew formula
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "CLI version to bump (e.g. 0.3.36). Defaults to latest release."
+        required: false
+
+jobs:
+  bump-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.release.tag_name }}" ]; then
+            # Strip leading 'v' from tag
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(node -p "require('./apps/cli/package.json').version")
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump Homebrew formula
+        id: bump
+        run: bash scripts/bump-homebrew-formula.sh "${{ steps.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "### Homebrew Formula Bump" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.bump.outputs.pr_url }}" ]; then
+            echo "- **PR:** ${{ steps.bump.outputs.pr_url }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -n "${{ steps.bump.outputs.commit_sha }}" ]; then
+            echo "- **Commit:** https://github.com/chrismcdermut/homebrew-tap/commit/${{ steps.bump.outputs.commit_sha }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "- **Formula version:** ${{ steps.bump.outputs.formula_version }}" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,25 @@ node scripts/test-ticket-format.mjs
 
 **Purpose:** Validates the `**{id}** [[{id}]] {title}` format is correctly generated.
 
+### `bump-homebrew-formula.sh`
+Bumps the Homebrew tap formula (`chrismcdermut/homebrew-tap`) to a new CLI version.
+
+**Usage:**
+```bash
+# Bump to a specific version
+./scripts/bump-homebrew-formula.sh 0.4.0
+
+# Auto-detect version from apps/cli/package.json
+./scripts/bump-homebrew-formula.sh
+```
+
+**Environment Variables:**
+- `GH_TOKEN` — GitHub token with push access to the tap repo (required in CI)
+- `TAP_REPO` — Override tap repository (default: `chrismcdermut/homebrew-tap`)
+- `CREATE_PR` — Set to `"true"` to open a PR instead of pushing directly to main
+
+**Automation:** Runs automatically via the `bump-homebrew` GitHub Actions workflow on each release.
+
 ## Notes
 
 - These scripts are development utilities, not production code

--- a/scripts/bump-homebrew-formula.sh
+++ b/scripts/bump-homebrew-formula.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# bump-homebrew-formula.sh — Update the Homebrew tap formula for @proletariat/cli
+#
+# Usage:
+#   ./scripts/bump-homebrew-formula.sh [version]
+#
+# If version is not provided, reads from apps/cli/package.json.
+#
+# Environment variables:
+#   GH_TOKEN    — GitHub token with repo push access to the tap (required in CI)
+#   TAP_REPO    — Tap repository (default: chrismcdermut/homebrew-tap)
+#   CREATE_PR   — Set to "true" to open a PR instead of pushing directly to main
+#
+set -euo pipefail
+
+TAP_REPO="${TAP_REPO:-chrismcdermut/homebrew-tap}"
+CREATE_PR="${CREATE_PR:-false}"
+NPM_PACKAGE="@proletariat/cli"
+FORMULA_PATH="Formula/prlt.rb"
+
+# ---------------------------------------------------------------------------
+# Resolve version
+# ---------------------------------------------------------------------------
+if [ -n "${1:-}" ]; then
+  VERSION="$1"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+  VERSION="$(node -p "require('$REPO_ROOT/apps/cli/package.json').version")"
+fi
+
+echo "==> Bumping Homebrew formula to version ${VERSION}"
+
+# ---------------------------------------------------------------------------
+# Fetch the npm tarball URL and compute sha256
+# ---------------------------------------------------------------------------
+TARBALL_URL="https://registry.npmjs.org/${NPM_PACKAGE}/-/cli-${VERSION}.tgz"
+echo "==> Fetching tarball: ${TARBALL_URL}"
+
+# Retry a few times — the tarball may not be available immediately after publish
+MAX_RETRIES=5
+RETRY_DELAY=10
+for i in $(seq 1 "$MAX_RETRIES"); do
+  HTTP_CODE=$(curl -s -o /tmp/prlt-tarball.tgz -w '%{http_code}' -L "$TARBALL_URL")
+  if [ "$HTTP_CODE" = "200" ]; then
+    break
+  fi
+  if [ "$i" -eq "$MAX_RETRIES" ]; then
+    echo "ERROR: Failed to download tarball after ${MAX_RETRIES} attempts (HTTP ${HTTP_CODE})"
+    exit 1
+  fi
+  echo "    Tarball not ready (HTTP ${HTTP_CODE}), retrying in ${RETRY_DELAY}s… (${i}/${MAX_RETRIES})"
+  sleep "$RETRY_DELAY"
+done
+
+SHA256=$(shasum -a 256 /tmp/prlt-tarball.tgz | awk '{print $1}')
+echo "==> SHA256: ${SHA256}"
+rm -f /tmp/prlt-tarball.tgz
+
+# ---------------------------------------------------------------------------
+# Clone the tap repo
+# ---------------------------------------------------------------------------
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Cloning ${TAP_REPO}…"
+if [ -n "${GH_TOKEN:-}" ]; then
+  git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" "$WORK_DIR/tap"
+else
+  git clone --depth 1 "https://github.com/${TAP_REPO}.git" "$WORK_DIR/tap"
+fi
+
+# ---------------------------------------------------------------------------
+# Update the formula
+# ---------------------------------------------------------------------------
+FORMULA_FILE="$WORK_DIR/tap/${FORMULA_PATH}"
+if [ ! -f "$FORMULA_FILE" ]; then
+  echo "ERROR: Formula not found at ${FORMULA_PATH}"
+  exit 1
+fi
+
+echo "==> Updating formula…"
+
+# Replace the url line
+sed -i "s|url \".*\"|url \"${TARBALL_URL}\"|" "$FORMULA_FILE"
+# Replace the sha256 line
+sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" "$FORMULA_FILE"
+
+echo "==> Updated formula:"
+cat "$FORMULA_FILE"
+
+# ---------------------------------------------------------------------------
+# Commit and push (or open PR)
+# ---------------------------------------------------------------------------
+cd "$WORK_DIR/tap"
+git config user.email "release-bot@proletariat.ai"
+git config user.name "proletariat-release-bot"
+
+# Check if anything actually changed
+if git diff --quiet; then
+  echo "==> Formula already up to date — nothing to commit."
+  exit 0
+fi
+
+BRANCH="bump-prlt-${VERSION}"
+
+if [ "$CREATE_PR" = "true" ]; then
+  git checkout -b "$BRANCH"
+  git add "$FORMULA_PATH"
+  git commit -m "chore: bump prlt to ${VERSION}"
+  git push origin "$BRANCH"
+  PR_URL=$(gh pr create \
+    --repo "$TAP_REPO" \
+    --title "chore: bump prlt to ${VERSION}" \
+    --body "Automated formula bump for @proletariat/cli v${VERSION}." \
+    --head "$BRANCH" \
+    --base main)
+  echo "==> Pull request created: ${PR_URL}"
+  echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT:-/dev/null}"
+else
+  git add "$FORMULA_PATH"
+  git commit -m "chore: bump prlt to ${VERSION}"
+  git push origin main
+  COMMIT_SHA=$(git rev-parse HEAD)
+  echo "==> Pushed to main: https://github.com/${TAP_REPO}/commit/${COMMIT_SHA}"
+  echo "commit_sha=${COMMIT_SHA}" >> "${GITHUB_OUTPUT:-/dev/null}"
+fi
+
+echo "==> Formula version: ${VERSION}"
+echo "formula_version=${VERSION}" >> "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
## Summary

Resolves TKT-1068: Automate Homebrew formula bump on CLI release

## Description

Execution child of TKT-1065.

Scope
- Implement release automation from `proletariat` release/tag to tap formula bump.
- Update formula version and sha256 automatically.
- Open PR (or commit) to tap and run CI checks.

Done when
- New CLI release can trigger formula bump without manual formula editing.
- Automation output includes resulting formula version and commit/PR link.


## Changes

- ac95fbbc release(TKT-1068): automate homebrew formula bump on CLI release

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
