### PR TITLE
TKT-1102: Add `prlt qa` command to spawn exploratory QA agent without a ticket

### DIFF
--- a/apps/cli/src/commands/qa/index.ts
+++ b/apps/cli/src/commands/qa/index.ts
@@ -44,6 +44,8 @@ const CATCHALL_DEVCONTAINER_IMAGE = 'ghcr.io/chrismcdermut/proletariat-claude:la
 export default class QA extends PromptCommand {
   static description = 'Spawn an exploratory QA agent to autonomously test the CLI (no ticket required)'
 
+  static aliases = ['explore']
+
   static examples = [
     '<%= config.bin %> <%= command.id %>                      # Quick launch QA agent',
     '<%= config.bin %> <%= command.id %> --seed                # Seed test data first',


### PR DESCRIPTION
## Summary

Resolves TKT-1102: Add `prlt qa` command to spawn exploratory QA agent without a ticket

## Description

Currently running the explore-cli action requires creating a ticket and spawning it (`prlt work spawn <ticket> --action explore-cli`). This is unnecessary overhead for ad-hoc QA runs.

Add a `prlt qa` (or `prlt explore`) command that:
- Spins up an ephemeral agent in Docker directly (no ticket required)
- Loads the explore-cli action prompt automatically
- Optionally seeds test data (`--seed` flag to run seed-explore-data.mjs)
- Starts tmux session inside container, launches prlt, and lets the agent explore
- Files bug tickets for anything it finds broken (using the PMO MCP tools)
- Cleans up container when done

Bonus: `--watch` flag to stream the agent's tmux screen to your terminal so you can watch it navigate in real-time.

This makes regression testing a one-liner: `prlt qa`

## Changes

- 6d4a08d0 feat(TKT-1102): add explore alias for qa command
- 0231e4d8 feat(TKT-1102): add prlt qa command for ephemeral exploratory QA agent

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
