### PR TITLE
TKT-1111: Fix e2e CI native module setup: better-sqlite3 binding missing in tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Native module CI expectations:
+# - better-sqlite3 requires a native .node binding compiled for the exact Node.js ABI in use.
+# - pnpm-workspace.yaml lists better-sqlite3 under ignoredBuiltDependencies, so pnpm install
+#   alone will NOT compile the binding. An explicit `npm rebuild better-sqlite3` is required.
+# - The pnpm store cache key MUST include the Node.js version to prevent restoring bindings
+#   compiled for a different ABI (cross-ABI cache poisoning).
+# - A verification step runs `require('better-sqlite3')` before tests to fail fast with
+#   clear diagnostics if the native binding is missing or incompatible.
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,12 +36,14 @@ jobs:
         shell: bash
         run: echo "store-path=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+      # Cache key includes Node.js version to avoid restoring native bindings compiled
+      # for a different ABI when lts/* resolves to a new Node.js release.
       - uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -61,15 +72,43 @@ jobs:
         shell: bash
         run: echo "store-path=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+      # Cache key includes Node.js version to avoid cross-ABI cache poisoning.
       - uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Rebuild better-sqlite3 native binding for the current Node.js ABI.
+      # pnpm skips this during install because better-sqlite3 is in ignoredBuiltDependencies.
+      - name: Rebuild better-sqlite3 native binding
+        run: npm rebuild better-sqlite3
+        working-directory: apps/cli
+
+      # Fail fast if the native binding is missing or was compiled for a different ABI.
+      - name: Verify better-sqlite3 native binding
+        run: |
+          node -e "
+            try {
+              require('better-sqlite3');
+              console.log('better-sqlite3 loaded successfully');
+              console.log('Node version:', process.version);
+              console.log('ABI version:', process.versions.modules);
+              console.log('Platform:', process.platform, process.arch);
+            } catch (err) {
+              console.error('Failed to load better-sqlite3:');
+              console.error(err.message);
+              console.error('Node version:', process.version);
+              console.error('ABI version:', process.versions.modules);
+              console.error('Platform:', process.platform, process.arch);
+              process.exit(1);
+            }
+          "
+        working-directory: apps/cli
 
       - name: Build
         run: pnpm -r build
@@ -98,15 +137,43 @@ jobs:
         shell: bash
         run: echo "store-path=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+      # Cache key includes Node.js version to avoid cross-ABI cache poisoning.
       - uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Rebuild better-sqlite3 native binding for the current Node.js ABI.
+      # pnpm skips this during install because better-sqlite3 is in ignoredBuiltDependencies.
+      - name: Rebuild better-sqlite3 native binding
+        run: npm rebuild better-sqlite3
+        working-directory: apps/cli
+
+      # Fail fast if the native binding is missing or was compiled for a different ABI.
+      - name: Verify better-sqlite3 native binding
+        run: |
+          node -e "
+            try {
+              require('better-sqlite3');
+              console.log('better-sqlite3 loaded successfully');
+              console.log('Node version:', process.version);
+              console.log('ABI version:', process.versions.modules);
+              console.log('Platform:', process.platform, process.arch);
+            } catch (err) {
+              console.error('Failed to load better-sqlite3:');
+              console.error(err.message);
+              console.error('Node version:', process.version);
+              console.error('ABI version:', process.versions.modules);
+              console.error('Platform:', process.platform, process.arch);
+              process.exit(1);
+            }
+          "
+        working-directory: apps/cli
 
       - name: Build
         run: pnpm -r build

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -109,7 +109,7 @@
     "directory": "apps/cli"
   },
   "scripts": {
-    "postinstall": "npm rebuild better-sqlite3 2>/dev/null || true",
+    "postinstall": "npm rebuild better-sqlite3 || echo 'WARNING: npm rebuild better-sqlite3 failed. Native binding may be missing.'",
     "build": "shx rm -rf dist && tsc -b",
     "rebuild": "pnpm install && pnpm build",
     "clean": "shx rm -rf dist",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,5 @@ packages:
   - apps/*
   - packages/*
 ignoredBuiltDependencies:
-  - better-sqlite3
   - unrs-resolver
   - yarn


### PR DESCRIPTION
## Summary

Resolves TKT-1111: Fix e2e CI native module setup: better-sqlite3 binding missing in tests workflow

## Description

## Problem
`e2e-tests` on PR #498 repeatedly fail with missing `better-sqlite3` native binding (`Could not locate the bindings file`). The native `.node` binary is either never compiled or is compiled for a different Node.js ABI than the runtime version.

## Root Cause Analysis

**RC1: `ignoredBuiltDependencies` suppresses native build**
`pnpm-workspace.yaml` lists `better-sqlite3` under `ignoredBuiltDependencies`, which tells pnpm to skip running native build scripts during `pnpm install --frozen-lockfile`. The binding is never compiled during the CI install step.

**RC2: `postinstall` script silently swallows rebuild failures**
`apps/cli/package.json` has `"postinstall": "npm rebuild better-sqlite3 2>/dev/null || true"` which redirects stderr to `/dev/null` and unconditionally succeeds. If the rebuild fails (missing build tools, wrong Node ABI, etc.), CI silently continues with no binding present.

**RC3: pnpm store cache key doesn't include Node.js version**
The cache key `${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}` does not incorporate the Node.js version. When `lts/*` resolves to a new Node version, a cached native binary compiled for a previous ABI is restored, resulting in an incompatible binding.

**RC4: No pre-test native module verification**
There is no CI step that verifies `require('better-sqlite3')` actually loads before running the full e2e suite, so the failure is discovered deep in test output rather than immediately with an actionable message.

## Requirements

- R1: Ensure `better-sqlite3` native binding is correctly compiled for the CI runtime Node.js version in every job that runs tests.
- R2: Either remove `better-sqlite3` from `ignoredBuiltDependencies` or add an explicit `npx --yes node-gyp rebuild` / `npm rebuild better-sqlite3` step in CI that does NOT swallow errors.
- R3: Include Node.js version in the pnpm store cache key to prevent cross-ABI cache poisoning.
- R4: Add a pre-test verification step in CI that runs `node -e "require('better-sqlite3')"` and fails fast with clear diagnostics (Node version, expected binding path, ABI version).
- R5: Fix the `postinstall` script in `apps/cli/package.json` to not swallow errors silently (remove `2>/dev/null || true` or at minimum log the error before continuing).
- R6: Add inline comments in `test.yml` documenting native module CI expectations.

## Scope
- `.github/workflows/test.yml` — cache key fix, add rebuild step, add verification step, add comments
- `apps/cli/package.json` — fix `postinstall` script error handling
- `pnpm-workspace.yaml` — evaluate removing `better-sqlite3` from `ignoredBuiltDependencies`

## References
- PR #498 (failing CI run)

## Changes

- bf2e74b7 fix(TKT-1111): fix e2e CI native module setup: better-sqlite3 binding missing in tests workflow

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
