### PR TITLE
TKT-1110: Fix unit test flakiness: agent-json-mode help assertions vs workspace preflight output

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -10,14 +10,17 @@ import { findHQRoot } from '../lib/workspace.js'
  * - No workspaces are registered in machine config (~/.proletariat/config.json)
  * - AND they're not currently inside a valid HQ directory
  */
-const hook: Hook<'init'> = async function ({ id, config }) {
+const hook: Hook<'init'> = async function ({ id, argv, config }) {
   // Skip for init command to avoid infinite loop
   if (id === 'init') {
     return
   }
 
-  // Skip when --help flag is present - help should always be available
-  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  // Skip when --help flag is present - help should always be available.
+  // Check both process.argv (direct CLI invocation) and the argv parameter
+  // from oclif (programmatic invocation via @oclif/test's runCommand()).
+  const helpFlags = ['--help', '-h']
+  if (helpFlags.some(f => process.argv.includes(f) || argv?.includes(f))) {
     return
   }
 

--- a/apps/cli/test/unit/agent-json-mode.test.ts
+++ b/apps/cli/test/unit/agent-json-mode.test.ts
@@ -12,6 +12,28 @@ const root = path.resolve(__dirname, '../..');
 /**
  * Unit tests for Agent Command JSON Mode (TKT-741)
  * Tests that agent commands properly support JSON mode output via agentPrompt
+ *
+ * ## Workspace Preconditions
+ *
+ * These tests use @oclif/test's `runCommand()` which invokes commands
+ * programmatically (without setting process.argv). This means:
+ *
+ * 1. The init hook (src/hooks/init.ts) receives --help via oclif's `argv`
+ *    parameter, NOT via process.argv. The hook must check both sources
+ *    to correctly skip first-time-user detection for help requests.
+ *
+ * 2. No workspace/HQ setup is needed because oclif shows help output
+ *    AFTER the init hook runs but BEFORE any command execution. The
+ *    PMOCommand.init() (which requires a database) is never called
+ *    for --help requests.
+ *
+ * 3. The "Agent Command Choice Structure" suite below uses fs.readFileSync
+ *    for static source code analysis and does NOT invoke any commands,
+ *    so it is completely unaffected by workspace state.
+ *
+ * If these tests fail with "No workspace found" errors in CI, the root
+ * cause is likely the init hook not detecting --help from oclif's argv
+ * parameter. See TKT-1110 for details.
  */
 describe('Agent Command JSON Mode (TKT-741)', () => {
 


### PR DESCRIPTION
## Summary\n- isolate  unit assertions from ambient workspace/init output\n- avoid PMO/init side effects contaminating  help snapshots\n- keep production command behavior unchanged while stabilizing CI/local determinism\n\n## Why\nPR #498 remains blocked by unit-test failures tied to help output contamination. This PR contains the focused test/runtime guard updates for TKT-1110.\n\n## Validation\n- run affected unit tests in CI/non-TTY and local contexts\n- confirm  suite passes deterministically\n