### PR TITLE
TKT-1110: Fix unit test flakiness: agent-json-mode help assertions vs workspace preflight output

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -10,14 +10,17 @@ import { findHQRoot } from '../lib/workspace.js'
  * - No workspaces are registered in machine config (~/.proletariat/config.json)
  * - AND they're not currently inside a valid HQ directory
  */
-const hook: Hook<'init'> = async function ({ id, config }) {
+const hook: Hook<'init'> = async function ({ id, argv, config }) {
   // Skip for init command to avoid infinite loop
   if (id === 'init') {
     return
   }
 
   // Skip when --help flag is present - help should always be available
-  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  // Check both process.argv (production CLI) and the oclif-provided argv
+  // (programmatic invocation via @oclif/test runCommand)
+  if (process.argv.includes('--help') || process.argv.includes('-h') ||
+      argv?.includes('--help') || argv?.includes('-h')) {
     return
   }
 

--- a/apps/cli/test/unit/agent-json-mode.test.ts
+++ b/apps/cli/test/unit/agent-json-mode.test.ts
@@ -1,5 +1,7 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,10 +12,93 @@ const __dirname = path.dirname(__filename);
 const root = path.resolve(__dirname, '../..');
 
 /**
+ * Environment variables that can cause the init hook or PMOCommand.init()
+ * to detect ambient workspace state and emit preflight output to stdout.
+ * Clearing these ensures help assertions get clean output regardless of
+ * whether the test runs locally (with a valid HQ at /hq) or in CI (no HQ).
+ */
+const WORKSPACE_ENV_VARS = [
+  'PRLT_HQ_PATH',
+  'PRLT_PMO_PATH',
+  'PRLT_DATABASE_PATH',
+  'PRLT_CONFIG_PATH',
+  'DEVCONTAINER',
+  'PRLT_TEST_ENV',
+  'PRLT_JSON',
+  'PRLT_FORCE_TEXT',
+] as const;
+
+/**
+ * Creates a minimal HQ directory structure that satisfies findHQRoot() and
+ * isFirstTimeUser() checks so the init hook does not emit preflight output.
+ * This is lighter than the full createTestEnvironment() from E2E helpers
+ * since --help tests don't need a database or PMO tables.
+ */
+function createMinimalHQDir(): { dir: string; cleanup: () => void } {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-unit-')));
+  const proletariatDir = path.join(dir, '.proletariat');
+  fs.mkdirSync(proletariatDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(proletariatDir, 'config.json'),
+    JSON.stringify({ type: 'hq', name: 'unit-test', hasPmo: false }),
+    'utf-8'
+  );
+  return {
+    dir,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+/**
  * Unit tests for Agent Command JSON Mode (TKT-741)
- * Tests that agent commands properly support JSON mode output via agentPrompt
+ *
+ * These tests use runCommand() to invoke commands with --help and assert on
+ * stdout content. They require workspace isolation because:
+ *
+ * 1. The init hook (src/hooks/init.ts) checks isFirstTimeUser() before every
+ *    command. Without a valid HQ, it emits warning output to stdout.
+ * 2. runCommand() passes args via oclif internals, not process.argv, so the
+ *    init hook's process.argv.includes('--help') check can miss --help.
+ * 3. Non-TTY environments (CI) can trigger JSON auto-detection in commands.
+ *
+ * The before/after hooks below ensure a minimal HQ directory exists and that
+ * environment variables don't leak ambient workspace state into the tests.
  */
 describe('Agent Command JSON Mode (TKT-741)', () => {
+  let hqDir: { dir: string; cleanup: () => void };
+  let originalCwd: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    // Save original state
+    originalCwd = process.cwd();
+    savedEnv = {};
+    for (const key of WORKSPACE_ENV_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    // Force text output in non-TTY environments (CI) so help assertions
+    // see human-readable text, not JSON auto-detected by isNonTTY()
+    process.env.PRLT_FORCE_TEXT = '1';
+
+    // Create minimal HQ so isFirstTimeUser() returns false
+    hqDir = createMinimalHQDir();
+    process.chdir(hqDir.dir);
+  });
+
+  after(() => {
+    // Restore original state
+    process.chdir(originalCwd);
+    hqDir.cleanup();
+    for (const key of WORKSPACE_ENV_VARS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
 
   describe('agent auth', function (this: Mocha.Suite) {
     // First test in suite loads better-sqlite3 native module; allow extra time


### PR DESCRIPTION
## Summary

Resolves TKT-1110: Fix unit test flakiness: agent-json-mode help assertions vs workspace preflight output

## Description

## Problem

`unit-tests` CI failures on PR #498 are dominated by `agent-json-mode.test.ts`. The test assertions expect clean help/flag text on stdout, but command output now returns workspace bootstrap or non-TTY preflight messaging before the expected help content.

### Root Cause Analysis

The unit tests at `apps/cli/test/unit/agent-json-mode.test.ts` use `@oclif/test`'s `runCommand()` to invoke commands with `--help` and assert on stdout content (e.g., `expect(stdout).to.include('--json')`). These assertions break when:

1. **Init hook preflight output** — The `src/hooks/init.ts` hook runs before every command. While it skips when `--help` is present (line 20), it calls `isFirstTimeUser()` which invokes `findHQRoot()` and `readMachineConfig()`. If the test environment lacks a valid workspace/HQ config, the hook may emit warning output to stdout before the help text renders.

2. **PMOCommand.init() side effects** — Agent commands extend `PMOCommand`, whose `init()` method calls `getPMOContext()` (line 132 of `base-command.ts`). Without a proper test workspace, this can emit logger output via `this.pmoLogger()` (styled muted text) that contaminates stdout.

3. **Non-TTY auto-detection** — `prompt-json.ts` has `isNonTTY()` (line 368) that detects piped stdin/stdout. In CI, tests run in non-TTY mode, causing `shouldOutputJson()` to return true and potentially altering command behavior/output.

4. **No environment isolation in unit tests** — Unlike the E2E tests which use `createTestEnvironment()`, `getIsolatedEnv()`, `setupProductionSchema()`, and `addWorkspaceTables()` for full workspace isolation, the unit tests have zero environment setup — they rely solely on `runCommand()` with a `root` path.

### Key Files

- `apps/cli/test/unit/agent-json-mode.test.ts` — 324 lines, two test suites:
  - "Agent Command JSON Mode" — 28 `--help` assertions across 9 agent subcommands
  - "Agent Command Choice Structure" — 8 static analysis tests (source code pattern matching)
- `apps/cli/test/e2e/agent-json-mode.test.ts` — E2E tests (not affected; has full isolation)
- `apps/cli/test/e2e/test-helpers.ts` — Contains `createTestEnvironment()`, `getIsolatedEnv()`, `filterOutput()`, etc.
- `apps/cli/src/hooks/init.ts` — Init hook with first-time-user detection
- `apps/cli/src/lib/pmo/base-command.ts` — PMOCommand base class with `init()` context setup
- `apps/cli/src/lib/prompt-json.ts` — `isNonTTY()` and `shouldOutputJson()` functions

### Requirements

- R1: Unit test `--help` assertions must not depend on ambient workspace state (no HQ config, no machine config, no PMO database required)
- R2: Tests must pass identically in both local dev (TTY) and CI (non-TTY) environments
- R3: The second test suite ("Agent Command Choice Structure") uses `fs.readFileSync` for static analysis and should NOT be affected — verify this
- R4: Fix must not alter production command behavior (init hook, help output, JSON mode detection)
- R5: Add documentation in test file or helpers explaining workspace preconditions for `runCommand()` help tests
- R6: If environment isolation is added, consider extracting reusable helpers that can be shared between unit and E2E tests (avoid duplication with test-helpers.ts)

### Technical Notes

- The init hook already has a `--help` bypass (line 20), but `PMOCommand.init()` does NOT have a similar bypass — this is likely where preflight output leaks in for help invocations
- The E2E `filterOutput()` helper (test-helpers.ts) strips Node/oclif debug noise but is not used by unit tests
- Consider whether unit tests should mock/stub the init hook and PMOCommand.init() rather than creating full workspace environments
- `runCommand()` from `@oclif/test` captures stdout but may not capture stderr separately — verify if some output goes to stderr vs stdout

## Changes

- ea33bfdf fix(TKT-1110): fix init hook --help bypass for oclif argv and add workspace isolation to unit tests

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
