### PR TITLE
chore: add MCP registry metadata and bump to 0.3.37

### DIFF
--- a/apps/cli/.gitignore
+++ b/apps/cli/.gitignore
@@ -14,3 +14,5 @@ pnpm-lock.yaml
 
 .claude
 .pmo
+.mcpregistry_*
+.smithery/

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "author": "Chris McDermut",
+  "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {
     "access": "public"
   },

--- a/apps/cli/server.json
+++ b/apps/cli/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.chrismcdermut/proletariat-cli",
+  "description": "Agent orchestration platform - multi-agent spawning, tickets, boards, and workflows",
+  "repository": {
+    "url": "https://github.com/chrismcdermut/proletariat",
+    "source": "github",
+    "subfolder": "apps/cli"
+  },
+  "version": "0.3.37",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@proletariat/cli",
+      "version": "0.3.37",
+      "transport": {
+        "type": "stdio"
+      },
+      "arguments": ["mcp-server"]
+    }
+  ]
+}

--- a/apps/cli/smithery.yaml
+++ b/apps/cli/smithery.yaml
@@ -1,0 +1,10 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties: {}
+  commandFunction:
+    |-
+    config => ({ command: 'npx', args: ['-y', '@proletariat/cli', 'mcp-server'] })


### PR DESCRIPTION
## Summary
- Add `server.json` for Official MCP Registry at registry.modelcontextprotocol.io
- Add `smithery.yaml` for Smithery registry
- Add `mcpName` field to `package.json` (required by MCP Registry for npm verification)
- Bump version to 0.3.37
- Add `.mcpregistry_*` and `.smithery/` to `.gitignore`

## Test plan
- [x] Build passes
- [x] `mcp-publisher validate` passes on server.json
- [ ] After merge + npm publish, run `mcp-publisher publish` to register

🤖 Generated with [Claude Code](https://claude.com/claude-code)