### PR TITLE
chore: bump to 0.3.38 for MCP registry publish

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {

--- a/apps/cli/server.json
+++ b/apps/cli/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "apps/cli"
   },
-  "version": "0.3.37",
+  "version": "0.3.38",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@proletariat/cli",
-      "version": "0.3.37",
+      "version": "0.3.38",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump to trigger npm publish with mcpName field, enabling MCP Registry registration.