### PR TITLE
fix: skip init hook during oclif prepack + bump 0.3.39

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {

--- a/apps/cli/server.json
+++ b/apps/cli/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "apps/cli"
   },
-  "version": "0.3.38",
+  "version": "0.3.39",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@proletariat/cli",
-      "version": "0.3.38",
+      "version": "0.3.39",
       "transport": {
         "type": "stdio"
       },

--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -16,6 +16,12 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
     return
   }
 
+  // Skip when running under oclif tooling (manifest, readme generation)
+  // These run commands to scan metadata and should not trigger the init flow
+  if (process.env.OCLIF_COMPILATION || process.argv[1]?.includes('oclif')) {
+    return
+  }
+
   // Skip when --help flag is present - help should always be available
   // Check both process.argv (production CLI) and the oclif-provided argv
   // (programmatic invocation via @oclif/test runCommand)


### PR DESCRIPTION
Fixes npm publish CI failure caused by init hook triggering during oclif readme generation.