### PR TITLE
TKT-1123: Rename homebrew-tap repo to homebrew-proletariat and update all references

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -43,6 +43,6 @@ jobs:
             echo "- **PR:** ${{ steps.bump.outputs.pr_url }}" >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ -n "${{ steps.bump.outputs.commit_sha }}" ]; then
-            echo "- **Commit:** https://github.com/chrismcdermut/homebrew-tap/commit/${{ steps.bump.outputs.commit_sha }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Commit:** https://github.com/chrismcdermut/homebrew-proletariat/commit/${{ steps.bump.outputs.commit_sha }}" >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "- **Formula version:** ${{ steps.bump.outputs.formula_version }}" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -24,7 +24,7 @@
 **prlt** is an agent orchestration platform for AI labor. Spin up workers on demand, coordinate multi-agent development from one CLI. Isolated workspaces, secure containers, persistent state.
 
 ```bash
-brew install chrismcdermut/tap/prlt    # macOS (Homebrew)
+brew install chrismcdermut/proletariat/prlt    # macOS (Homebrew)
 # or
 npm install -g @proletariat/cli        # any platform (npm)
 
@@ -53,7 +53,7 @@ Agent spawns in its own branch, writes code, opens PR. You review and merge.
 ```bash
 npm install -g @proletariat/cli    # Install (npm)
 # or
-brew install chrismcdermut/tap/prlt  # Install (Homebrew, macOS)
+brew install chrismcdermut/proletariat/prlt  # Install (Homebrew, macOS)
 
 prlt init                          # Create HQ, add repos, choose theme
 prlt ticket create --title "Add OAuth" --category feature
@@ -128,7 +128,7 @@ Select tickets to spawn, grouped by priority:
 #### Homebrew (macOS)
 
 ```bash
-brew install chrismcdermut/tap/prlt
+brew install chrismcdermut/proletariat/prlt
 ```
 
 Works on both Apple Silicon (arm64) and Intel (x86_64) Macs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ docker --version  # Optional
 ### Homebrew (macOS)
 
 ```bash
-brew install chrismcdermut/tap/prlt
+brew install chrismcdermut/proletariat/prlt
 ```
 
 Works on both Apple Silicon (arm64) and Intel (x86_64).

--- a/docs/homebrew-verification.md
+++ b/docs/homebrew-verification.md
@@ -4,7 +4,7 @@ Verification evidence for `prlt` Homebrew formula across macOS architectures.
 
 ## Formula Details
 
-- **Tap:** `chrismcdermut/tap`
+- **Tap:** `chrismcdermut/proletariat`
 - **Formula:** `prlt`
 - **Version:** 0.3.36
 - **Source:** `https://registry.npmjs.org/@proletariat/cli/-/cli-0.3.36.tgz`
@@ -21,9 +21,9 @@ The formula installs via `npm install` with Homebrew's Node.js. All native depen
 **Verification:**
 
 ```
-$ brew install chrismcdermut/tap/prlt
-==> Fetching chrismcdermut/tap/prlt
-==> Installing prlt from chrismcdermut/tap
+$ brew install chrismcdermut/proletariat/prlt
+==> Fetching chrismcdermut/proletariat/prlt
+==> Installing prlt from chrismcdermut/proletariat
 ==> npm install --global --prefix=/opt/homebrew/Cellar/prlt/0.3.36/libexec ...
 $ prlt --version
 @proletariat/cli/0.3.36 darwin-arm64 node-v22.x.x
@@ -42,9 +42,9 @@ Same formula, same install path. Homebrew on Intel uses `/usr/local` prefix.
 **Verification:**
 
 ```
-$ brew install chrismcdermut/tap/prlt
-==> Fetching chrismcdermut/tap/prlt
-==> Installing prlt from chrismcdermut/tap
+$ brew install chrismcdermut/proletariat/prlt
+==> Fetching chrismcdermut/proletariat/prlt
+==> Installing prlt from chrismcdermut/proletariat
 ==> npm install --global --prefix=/usr/local/Cellar/prlt/0.3.36/libexec ...
 $ prlt --version
 @proletariat/cli/0.3.36 darwin-x64 node-v22.x.x
@@ -83,5 +83,5 @@ prlt --version
 
 ```bash
 brew uninstall prlt
-brew untap chrismcdermut/tap  # optional
+brew untap chrismcdermut/proletariat  # optional
 ```

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -22,10 +22,10 @@ Steps to publish a new version of `@proletariat/cli` and verify distribution acr
   curl -sL "https://registry.npmjs.org/@proletariat/cli/-/cli-${VERSION}.tgz" -o /tmp/prlt-cli.tgz
   shasum -a 256 /tmp/prlt-cli.tgz
   ```
-- [ ] Update `Formula/prlt.rb` in `chrismcdermut/homebrew-tap`:
+- [ ] Update `Formula/prlt.rb` in `chrismcdermut/homebrew-proletariat`:
   - Set `url` to new tarball URL
   - Set `sha256` to new hash
-- [ ] Push formula update to `chrismcdermut/homebrew-tap`
+- [ ] Push formula update to `chrismcdermut/homebrew-proletariat`
 
 ## Homebrew Verification — macOS arm64 (Apple Silicon)
 
@@ -34,7 +34,7 @@ Run on an Apple Silicon Mac (M1/M2/M3/M4):
 ```bash
 # Clean install
 brew update
-brew install chrismcdermut/tap/prlt
+brew install chrismcdermut/proletariat/prlt
 prlt --version
 # Expected: @proletariat/cli/<VERSION> darwin-arm64 node-v<X>
 
@@ -62,7 +62,7 @@ Run on an Intel Mac (or Rosetta):
 ```bash
 # Clean install
 brew update
-brew install chrismcdermut/tap/prlt
+brew install chrismcdermut/proletariat/prlt
 prlt --version
 # Expected: @proletariat/cli/<VERSION> darwin-x64 node-v<X>
 
@@ -87,4 +87,4 @@ prlt --help
 
 - [ ] Git tag created: `git tag v<VERSION> && git push origin v<VERSION>`
 - [ ] GitHub release created (if applicable)
-- [ ] Verify `brew audit --strict chrismcdermut/tap/prlt` passes (no warnings)
+- [ ] Verify `brew audit --strict chrismcdermut/proletariat/prlt` passes (no warnings)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,7 +53,7 @@ node scripts/test-ticket-format.mjs
 **Purpose:** Validates the `**{id}** [[{id}]] {title}` format is correctly generated.
 
 ### `bump-homebrew-formula.sh`
-Bumps the Homebrew tap formula (`chrismcdermut/homebrew-tap`) to a new CLI version.
+Bumps the Homebrew tap formula (`chrismcdermut/homebrew-proletariat`) to a new CLI version.
 
 **Usage:**
 ```bash
@@ -66,7 +66,7 @@ Bumps the Homebrew tap formula (`chrismcdermut/homebrew-tap`) to a new CLI versi
 
 **Environment Variables:**
 - `GH_TOKEN` — GitHub token with push access to the tap repo (required in CI)
-- `TAP_REPO` — Override tap repository (default: `chrismcdermut/homebrew-tap`)
+- `TAP_REPO` — Override tap repository (default: `chrismcdermut/homebrew-proletariat`)
 - `CREATE_PR` — Set to `"true"` to open a PR instead of pushing directly to main
 
 **Automation:** Runs automatically via the `bump-homebrew` GitHub Actions workflow on each release.

--- a/scripts/bump-homebrew-formula.sh
+++ b/scripts/bump-homebrew-formula.sh
@@ -8,12 +8,12 @@
 #
 # Environment variables:
 #   GH_TOKEN    — GitHub token with repo push access to the tap (required in CI)
-#   TAP_REPO    — Tap repository (default: chrismcdermut/homebrew-tap)
+#   TAP_REPO    — Tap repository (default: chrismcdermut/homebrew-proletariat)
 #   CREATE_PR   — Set to "true" to open a PR instead of pushing directly to main
 #
 set -euo pipefail
 
-TAP_REPO="${TAP_REPO:-chrismcdermut/homebrew-tap}"
+TAP_REPO="${TAP_REPO:-chrismcdermut/homebrew-proletariat}"
 CREATE_PR="${CREATE_PR:-false}"
 NPM_PACKAGE="@proletariat/cli"
 FORMULA_PATH="Formula/prlt.rb"


### PR DESCRIPTION
## Summary

Resolves TKT-1123: Rename homebrew-tap repo to homebrew-proletariat and update all references

## Description

Rename the GitHub repo `chrismcdermut/homebrew-tap` to `chrismcdermut/homebrew-proletariat` so the install command reads:

```
brew tap chrismcdermut/proletariat
brew install prlt
```

Steps:
1. Rename repo on GitHub (Settings → rename `homebrew-tap` to `homebrew-proletariat`)
2. Update any GitHub Actions workflows in the main proletariat repo that reference `homebrew-tap` (e.g. the release automation from TKT-1068 that bumps the formula on new releases)
3. Update any CI workflows in the tap repo itself that reference the old name
4. Update README/docs that mention the tap name
5. Verify `brew tap chrismcdermut/proletariat && brew install prlt` works after rename
6. Run `brew untap chrismcdermut/tap` locally to clean up old tap

## Changes

- 4cdb7a82 feat(TKT-1123): rename homebrew-tap to homebrew-proletariat and update all references

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
