### PR TITLE
Bump version to 0.3.40

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {

--- a/apps/cli/server.json
+++ b/apps/cli/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "apps/cli"
   },
-  "version": "0.3.39",
+  "version": "0.3.40",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@proletariat/cli",
-      "version": "0.3.39",
+      "version": "0.3.40",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Version bump to trigger first npm publish via OIDC trusted publisher

## Test plan
- [ ] Merge and create release
- [ ] Verify npm-publish workflow succeeds with OIDC auth
- [ ] Confirm `@proletariat/cli@0.3.40` appears on npmjs.com with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)