### PR TITLE
Fix homebrew bump race condition with npm publish

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,17 +1,19 @@
 name: bump homebrew formula
 
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["publish"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
-        description: "CLI version to bump (e.g. 0.3.36). Defaults to latest release."
+        description: "CLI version to bump (e.g. 0.3.40). Defaults to latest release."
         required: false
 
 jobs:
   bump-formula:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -20,9 +22,6 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.version }}" ]; then
             echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.release.tag_name }}" ]; then
-            # Strip leading 'v' from tag
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
             VERSION=$(node -p "require('./apps/cli/package.json').version")
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Homebrew bump was triggering on `release` simultaneously with npm publish, causing 404s when downloading the tarball
- Now triggers via `workflow_run` after the `publish` workflow completes successfully
- Also skips the bump if npm publish failed

## The chain is now
1. Push to main → `release.yml` creates GitHub Release
2. Release created → `npm-publish.yml` publishes to npm
3. npm publish completes → `bump-homebrew.yml` bumps the formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)