### PR TITLE
chore: bump version to 0.3.41

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump CLI version to 0.3.41 following init hook and non-TTY fixes (#514)

🤖 Generated with [Claude Code](https://claude.com/claude-code)