### PR TITLE
chore: bump version to 0.3.42

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump CLI version to 0.3.42 to test the full auto-deploy chain with the homebrew race condition fix (#512)

🤖 Generated with [Claude Code](https://claude.com/claude-code)