### PR TITLE
fix: add post_install to Homebrew formula for better-sqlite3 native module

### DIFF
--- a/scripts/bump-homebrew-formula.sh
+++ b/scripts/bump-homebrew-formula.sh
@@ -81,10 +81,40 @@ fi
 
 echo "==> Updating formula…"
 
-# Replace the url line
-sed -i "s|url \".*\"|url \"${TARBALL_URL}\"|" "$FORMULA_FILE"
-# Replace the sha256 line
-sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" "$FORMULA_FILE"
+# Write the complete formula to ensure post_install is always present.
+# Homebrew's std_npm_args passes --ignore-scripts by default, which prevents
+# better-sqlite3's native module from being compiled. The post_install step
+# rebuilds the native module after npm install completes.
+cat > "$FORMULA_FILE" <<FORMULA
+class Prlt < Formula
+  desc "Agent orchestration platform for AI labor"
+  homepage "https://proletariat.ai/"
+  url "${TARBALL_URL}"
+  sha256 "${SHA256}"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  def post_install
+    # Homebrew's std_npm_args uses --ignore-scripts, which skips better-sqlite3's
+    # native module compilation. Rebuild it here so the CLI can use SQLite.
+    cd libexec/"lib/node_modules/@proletariat/cli" do
+      system "npm", "rebuild", "better-sqlite3"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/prlt --version")
+    # Verify better-sqlite3 native module works by creating an HQ (uses SQLite)
+    assert_match '"success": true', shell_output("#{bin}/prlt init --json --name test-hq --no-pmo")
+  end
+end
+FORMULA
 
 echo "==> Updated formula:"
 cat "$FORMULA_FILE"


### PR DESCRIPTION
## Summary

- Homebrew's `std_npm_args` passes `--ignore-scripts` by default, which skips better-sqlite3's native module compilation during `brew install`
- This causes a crash on any command that uses SQLite (`prlt init`, ticket operations, etc.) on fresh installs
- Adds a `post_install` step to the formula that runs `npm rebuild better-sqlite3` after install
- Updates the bump script to write the complete formula template (instead of sed-replacing url/sha256) to ensure `post_install` is never lost on version bumps
- Adds a stronger test that verifies SQLite actually works by creating an HQ

## Test plan

- [x] Verified `brew reinstall prlt` runs `npm rebuild better-sqlite3` during post_install
- [x] Verified `prlt init --json` works after fresh reinstall (SQLite native module loads correctly)
- [x] Verified the ABI version matches Homebrew's node version

Fixes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)