### PR TITLE
chore: bump version to 0.3.43

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump CLI version to 0.3.43 to trigger a Homebrew formula update with the better-sqlite3 post_install fix from #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)