### PR TITLE
feat: add orchestrator command namespace

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -1,0 +1,161 @@
+import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
+import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+
+export default class OrchestratorAttach extends PromptCommand {
+  static description = 'Attach to the running orchestrator tmux session'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --current-terminal',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    'current-terminal': Flags.boolean({
+      char: 'c',
+      description: 'Attach in current terminal instead of new tab',
+      default: false,
+    }),
+    terminal: Flags.string({
+      char: 't',
+      description: 'Terminal app to use (iTerm, Terminal, Ghostty)',
+      default: 'iTerm',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(OrchestratorAttach)
+    const jsonMode = shouldOutputJson(flags)
+
+    // Check if orchestrator session exists
+    const hostSessions = getHostTmuxSessionNames()
+    if (!hostSessions.includes(ORCHESTRATOR_SESSION_NAME)) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'NOT_RUNNING',
+          'Orchestrator is not running. Start it with: prlt orchestrator start',
+          createMetadata('orchestrator attach', flags),
+        )
+        return
+      }
+      this.log('')
+      this.log(styles.warning('Orchestrator is not running.'))
+      this.log(styles.muted('Start it with: prlt orchestrator start'))
+      this.log('')
+      return
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        sessionId: ORCHESTRATOR_SESSION_NAME,
+        status: 'attaching',
+      }, createMetadata('orchestrator attach', flags as Record<string, unknown>))
+      return
+    }
+
+    this.log('')
+    this.log(styles.info(`Attaching to orchestrator session: ${ORCHESTRATOR_SESSION_NAME}`))
+
+    if (flags['current-terminal']) {
+      try {
+        execSync(`tmux attach -t "${ORCHESTRATOR_SESSION_NAME}"`, { stdio: 'inherit' })
+      } catch {
+        this.error(`Failed to attach to orchestrator session "${ORCHESTRATOR_SESSION_NAME}"`)
+      }
+    } else {
+      await this.openInNewTab(flags.terminal)
+    }
+  }
+
+  private async openInNewTab(terminalApp: string): Promise<void> {
+    const title = 'Orchestrator'
+    const attachCmd = `tmux attach -t "${ORCHESTRATOR_SESSION_NAME}"`
+
+    const baseDir = path.join(os.homedir(), '.proletariat', 'scripts')
+    fs.mkdirSync(baseDir, { recursive: true })
+    const scriptPath = path.join(baseDir, `attach-orch-${Date.now()}.sh`)
+
+    const script = `#!/bin/bash
+# Set terminal tab title
+echo -ne "\\033]0;${title}\\007"
+echo -ne "\\033]1;${title}\\007"
+
+echo "Attaching to: ${ORCHESTRATOR_SESSION_NAME}"
+${attachCmd}
+
+# Clean up
+rm -f "${scriptPath}"
+exec $SHELL
+`
+    fs.writeFileSync(scriptPath, script, { mode: 0o755 })
+
+    try {
+      switch (terminalApp) {
+        case 'iTerm':
+          execSync(`osascript -e '
+            tell application "iTerm"
+              activate
+              tell current window
+                set newTab to (create tab with default profile)
+                tell current session of newTab
+                  set name to "${title}"
+                  write text "${scriptPath}"
+                end tell
+              end tell
+            end tell
+          '`)
+          break
+
+        case 'Ghostty':
+          execSync(`osascript -e '
+            tell application "Ghostty"
+              activate
+            end tell
+            tell application "System Events"
+              tell process "Ghostty"
+                keystroke "t" using command down
+                delay 0.3
+                keystroke "${scriptPath}"
+                keystroke return
+              end tell
+            end tell
+          '`)
+          break
+
+        case 'Terminal':
+        default:
+          execSync(`osascript -e '
+            tell application "Terminal"
+              activate
+              tell application "System Events"
+                tell process "Terminal"
+                  keystroke "t" using command down
+                end tell
+              end tell
+              delay 0.3
+              do script "${scriptPath}" in front window
+            end tell
+          '`)
+          break
+      }
+
+      this.log(styles.success('Opened new tab and attaching to orchestrator'))
+    } catch (error) {
+      this.error(`Failed to open terminal tab: ${error instanceof Error ? error.message : error}`)
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrator/index.ts
+++ b/apps/cli/src/commands/orchestrator/index.ts
@@ -1,0 +1,61 @@
+
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+
+export default class Orchestrator extends PMOCommand {
+  static description = 'Manage the orchestrator agent (start, attach, status, stop)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> start',
+    '<%= config.bin %> <%= command.id %> attach',
+    '<%= config.bin %> <%= command.id %> status',
+    '<%= config.bin %> <%= command.id %> stop',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false }
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Orchestrator)
+
+    const jsonModeConfig = shouldOutputJson(flags) ? { flags, commandName: 'orchestrator' } : null
+
+    const { action } = await this.prompt<{ action: string }>([{
+      type: 'list',
+      name: 'action',
+      message: 'Orchestrator - What would you like to do?',
+      choices: [
+        { name: 'Start orchestrator', value: 'start', command: 'prlt orchestrator start --json' },
+        { name: 'Attach to orchestrator', value: 'attach', command: 'prlt orchestrator attach --json' },
+        { name: 'Check orchestrator status', value: 'status', command: 'prlt orchestrator status --json' },
+        { name: 'Stop orchestrator', value: 'stop', command: 'prlt orchestrator stop --json' },
+        { name: 'Cancel', value: 'cancel' },
+      ],
+    }], jsonModeConfig)
+
+    if (action === 'cancel') {
+      return
+    }
+
+    switch (action) {
+      case 'start':
+        await this.config.runCommand('orchestrator:start', [])
+        break
+      case 'attach':
+        await this.config.runCommand('orchestrator:attach', [])
+        break
+      case 'status':
+        await this.config.runCommand('orchestrator:status', [])
+        break
+      case 'stop':
+        await this.config.runCommand('orchestrator:stop', [])
+        break
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -1,0 +1,335 @@
+import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import Database from 'better-sqlite3'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { findHQRoot } from '../../lib/workspace.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+  buildPromptConfig,
+  outputPromptAsJson,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import {
+  OutputMode,
+  ExecutionContext,
+  ExecutorType,
+  DEFAULT_EXECUTION_CONFIG,
+} from '../../lib/execution/types.js'
+import { runExecution } from '../../lib/execution/runners.js'
+import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
+import { ExecutionStorage } from '../../lib/execution/storage.js'
+import {
+  loadExecutionConfig,
+  getTerminalApp,
+  promptTerminalPreference,
+  getShell,
+  promptShellPreference,
+  hasTerminalPreference,
+  hasShellPreference,
+} from '../../lib/execution/config.js'
+
+export const ORCHESTRATOR_SESSION_NAME = 'prlt-orchestrator-main'
+
+export default class OrchestratorStart extends PromptCommand {
+  static description = 'Start the orchestrator agent in a tmux session'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --executor codex',
+    '<%= config.bin %> <%= command.id %> --skip-permissions',
+    '<%= config.bin %> <%= command.id %> --prompt "coordinate all agents on TKT-100"',
+    '<%= config.bin %> <%= command.id %> --background',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    prompt: Flags.string({
+      char: 'p',
+      description: 'Initial prompt for the orchestrator',
+    }),
+    action: Flags.string({
+      char: 'A',
+      description: 'Load an action by name from the actions table (uses its prompt)',
+    }),
+    executor: Flags.string({
+      char: 'e',
+      description: 'Executor type',
+      options: ['claude-code', 'codex', 'aider', 'custom'],
+    }),
+    'skip-permissions': Flags.boolean({
+      description: 'Run with --dangerously-skip-permissions',
+      default: false,
+      exclusive: ['sandboxed'],
+    }),
+    sandboxed: Flags.boolean({
+      description: 'Run in sandboxed mode (requires approval for dangerous operations)',
+      default: false,
+      exclusive: ['skip-permissions'],
+    }),
+    background: Flags.boolean({
+      char: 'b',
+      description: 'Start detached (don\'t open terminal tab)',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(OrchestratorStart)
+    const jsonMode = shouldOutputJson(flags)
+
+    // Check if orchestrator is already running
+    const hostSessions = getHostTmuxSessionNames()
+    if (hostSessions.includes(ORCHESTRATOR_SESSION_NAME)) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'ALREADY_RUNNING',
+          `Orchestrator is already running (session: ${ORCHESTRATOR_SESSION_NAME}). Use "prlt orchestrator attach" to reattach.`,
+          createMetadata('orchestrator start', flags),
+        )
+        return
+      }
+
+      this.log('')
+      this.log(styles.warning(`Orchestrator is already running (session: ${ORCHESTRATOR_SESSION_NAME})`))
+      this.log('')
+
+      const { choice } = await this.prompt<{ choice: string }>([{
+        type: 'list',
+        name: 'choice',
+        message: 'What would you like to do?',
+        choices: [
+          { name: 'Attach to running orchestrator', value: 'attach', command: 'prlt orchestrator attach --json' },
+          { name: 'Cancel', value: 'cancel' },
+        ],
+      }], jsonMode ? { flags, commandName: 'orchestrator start' } : null)
+
+      if (choice === 'attach') {
+        await this.config.runCommand('orchestrator:attach', [])
+      }
+      return
+    }
+
+    // Resolve HQ path
+    const hqPath = findHQRoot(process.cwd())
+    if (!hqPath) {
+      if (jsonMode) {
+        outputErrorAsJson('NO_HQ', 'Not in an HQ workspace. Run "prlt init" first.', createMetadata('orchestrator start', flags))
+        return
+      }
+      this.error('Not in an HQ workspace. Run "prlt init" first.')
+    }
+
+    // Executor selection
+    let selectedExecutor: ExecutorType
+    if (flags.executor) {
+      selectedExecutor = flags.executor as ExecutorType
+    } else {
+      const executorChoices = [
+        { name: 'Claude Code', value: 'claude-code', command: 'prlt orchestrator start --executor claude-code --json' },
+        { name: 'Codex', value: 'codex', command: 'prlt orchestrator start --executor codex --json' },
+        { name: 'Aider', value: 'aider', command: 'prlt orchestrator start --executor aider --json' },
+        { name: 'Custom', value: 'custom', command: 'prlt orchestrator start --executor custom --json' },
+      ]
+      const executorMessage = 'Select executor:'
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'executor', executorMessage, executorChoices),
+          createMetadata('orchestrator start', flags),
+        )
+        return
+      }
+
+      const { executor } = await this.prompt<{ executor: ExecutorType }>([{
+        type: 'list',
+        name: 'executor',
+        message: executorMessage,
+        choices: executorChoices,
+      }])
+      selectedExecutor = executor
+    }
+
+    // Permission mode selection
+    let sandboxed: boolean
+    if (flags['skip-permissions']) {
+      sandboxed = false
+    } else if (flags.sandboxed) {
+      sandboxed = true
+    } else {
+      const permissionChoices = [
+        { name: 'Sandboxed (requires approval for dangerous operations)', value: 'sandboxed', command: 'prlt orchestrator start --sandboxed --json' },
+        { name: 'Accept all (--dangerously-skip-permissions)', value: 'skip', command: 'prlt orchestrator start --skip-permissions --json' },
+      ]
+      const permissionMessage = 'Select permission mode:'
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'permissionMode', permissionMessage, permissionChoices),
+          createMetadata('orchestrator start', flags),
+        )
+        return
+      }
+
+      const { permissionMode } = await this.prompt<{ permissionMode: string }>([{
+        type: 'list',
+        name: 'permissionMode',
+        message: permissionMessage,
+        choices: permissionChoices,
+      }])
+      sandboxed = permissionMode === 'sandboxed'
+    }
+
+    // Resolve action prompt
+    let actionPrompt = flags.prompt
+    let actionName = 'orchestrate'
+
+    if (flags.action && !actionPrompt) {
+      // Load action from DB
+      const dbPath = path.join(hqPath, '.proletariat', 'workspace.db')
+      if (fs.existsSync(dbPath)) {
+        let db: Database.Database | null = null
+        try {
+          db = new Database(dbPath)
+          const row = db.prepare('SELECT prompt, name FROM actions WHERE id = ? OR name = ?').get(flags.action, flags.action) as { prompt: string; name: string } | undefined
+          if (row) {
+            actionPrompt = row.prompt
+            actionName = row.name
+          } else {
+            if (jsonMode) {
+              outputErrorAsJson('ACTION_NOT_FOUND', `Action "${flags.action}" not found.`, createMetadata('orchestrator start', flags))
+              return
+            }
+            this.error(`Action "${flags.action}" not found.`)
+          }
+        } finally {
+          db?.close()
+        }
+      }
+    }
+
+    // Build execution context
+    // Use ticketId='prlt', actionName='orchestrator', agentName='main'
+    // so buildSessionName produces 'prlt-orchestrator-main'
+    const context: ExecutionContext = {
+      ticketId: 'prlt',
+      ticketTitle: 'Orchestrator',
+      agentName: 'main',
+      agentDir: hqPath,
+      worktreePath: hqPath,
+      branch: 'main',
+      actionName: 'orchestrator',
+      actionPrompt,
+      modifiesCode: false,
+      hqPath,
+    }
+
+    // Build execution config
+    const executionConfig = { ...DEFAULT_EXECUTION_CONFIG }
+    executionConfig.outputMode = 'interactive' as OutputMode
+    executionConfig.sandboxed = sandboxed
+
+    // Load saved preferences from workspace DB
+    const dbPath = path.join(hqPath, '.proletariat', 'workspace.db')
+    let db: Database.Database | null = null
+    try {
+      if (fs.existsSync(dbPath)) {
+        db = new Database(dbPath)
+        const savedConfig = loadExecutionConfig(db)
+        executionConfig.terminal = savedConfig.terminal
+        executionConfig.shell = savedConfig.shell
+        executionConfig.tmux = savedConfig.tmux
+      }
+    } catch {
+      // Ignore config loading errors, use defaults
+    }
+
+    // If no terminal preference saved, prompt for it (first run only)
+    if (!jsonMode && db) {
+      if (!hasTerminalPreference(db)) {
+        executionConfig.terminal.app = await promptTerminalPreference(db)
+      } else {
+        executionConfig.terminal.app = await getTerminalApp(db)
+      }
+
+      if (!hasShellPreference(db)) {
+        executionConfig.shell = await promptShellPreference(db)
+      } else {
+        executionConfig.shell = await getShell(db)
+      }
+    }
+
+    // Show what we're doing
+    if (!jsonMode) {
+      this.log('')
+      this.log(styles.muted(`   Starting orchestrator...`))
+      this.log(styles.muted(`   Executor: ${selectedExecutor}`))
+      this.log(styles.muted(`   Permission mode: ${sandboxed ? 'sandboxed' : 'skip-permissions'}`))
+      this.log(styles.muted(`   Directory: ${hqPath}`))
+      if (actionPrompt) {
+        this.log(styles.muted(`   Prompt: "${actionPrompt.substring(0, 60)}${actionPrompt.length > 60 ? '...' : ''}"`))
+      }
+      this.log('')
+    }
+
+    // Launch orchestrator
+    const displayMode = flags.background ? 'background' : 'terminal'
+    const result = await runExecution('host', context, selectedExecutor, executionConfig, {
+      displayMode,
+    })
+
+    if (result.success) {
+      // Create execution record so `prlt session poke orchestrator "message"` works
+      if (db) {
+        try {
+          const executionStorage = new ExecutionStorage(db)
+          executionStorage.createExecution({
+            ticketId: 'ORCH',
+            agentName: 'orchestrator',
+            executor: selectedExecutor,
+            environment: 'host',
+            displayMode,
+            sandboxed,
+            sessionId: result.sessionId || ORCHESTRATOR_SESSION_NAME,
+          })
+        } catch {
+          // Non-fatal: poke won't work but orchestrator is running
+        }
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson({
+          sessionId: result.sessionId || ORCHESTRATOR_SESSION_NAME,
+          executor: selectedExecutor,
+          sandboxed,
+          displayMode,
+          directory: hqPath,
+        }, createMetadata('orchestrator start', flags as Record<string, unknown>))
+      }
+
+      if (flags.background) {
+        this.log(styles.success(`Orchestrator started in background`))
+        this.log(styles.muted(`   Session: ${result.sessionId || ORCHESTRATOR_SESSION_NAME}`))
+        this.log(styles.muted(`   Attach with: prlt orchestrator attach`))
+      } else {
+        this.log(styles.success(`Orchestrator started`))
+        if (result.sessionId) {
+          this.log(styles.muted(`   Session: ${result.sessionId}`))
+        }
+      }
+    } else {
+      if (jsonMode) {
+        outputErrorAsJson('EXECUTION_FAILED', `Failed to start orchestrator: ${result.error}`, createMetadata('orchestrator start', flags))
+      }
+      this.error(`Failed to start orchestrator: ${result.error}`)
+    }
+
+    if (db) {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrator/status.ts
+++ b/apps/cli/src/commands/orchestrator/status.ts
@@ -1,0 +1,75 @@
+import { Flags } from '@oclif/core'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { getHostTmuxSessionNames, captureTmuxPane } from '../../lib/execution/session-utils.js'
+import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+
+export default class OrchestratorStatus extends PromptCommand {
+  static description = 'Check if the orchestrator is running'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --peek',
+    '<%= config.bin %> <%= command.id %> --peek --lines 50',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    peek: Flags.boolean({
+      description: 'Show recent output from the orchestrator',
+      default: false,
+    }),
+    lines: Flags.integer({
+      description: 'Number of lines to show when peeking',
+      default: 20,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(OrchestratorStatus)
+    const jsonMode = shouldOutputJson(flags)
+
+    const hostSessions = getHostTmuxSessionNames()
+    const isRunning = hostSessions.includes(ORCHESTRATOR_SESSION_NAME)
+
+    let recentOutput: string | null = null
+    if (isRunning && flags.peek) {
+      recentOutput = captureTmuxPane(ORCHESTRATOR_SESSION_NAME, flags.lines)
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        running: isRunning,
+        sessionId: isRunning ? ORCHESTRATOR_SESSION_NAME : null,
+        ...(recentOutput !== null && { recentOutput }),
+      }, createMetadata('orchestrator status', flags as Record<string, unknown>))
+      return
+    }
+
+    this.log('')
+    if (isRunning) {
+      this.log(styles.success(`Orchestrator is running`))
+      this.log(styles.muted(`   Session: ${ORCHESTRATOR_SESSION_NAME}`))
+      this.log(styles.muted(`   Attach: prlt orchestrator attach`))
+      this.log(styles.muted(`   Poke:   prlt session poke orchestrator "message"`))
+
+      if (recentOutput) {
+        this.log('')
+        this.log(styles.header('Recent output:'))
+        this.log(styles.muted('─'.repeat(60)))
+        this.log(recentOutput)
+        this.log(styles.muted('─'.repeat(60)))
+      }
+    } else {
+      this.log(styles.muted('Orchestrator is not running.'))
+      this.log(styles.muted('Start it with: prlt orchestrator start'))
+    }
+    this.log('')
+  }
+}

--- a/apps/cli/src/commands/orchestrator/stop.ts
+++ b/apps/cli/src/commands/orchestrator/stop.ts
@@ -1,0 +1,125 @@
+import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import Database from 'better-sqlite3'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { findHQRoot } from '../../lib/workspace.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
+import { ExecutionStorage } from '../../lib/execution/storage.js'
+import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+
+export default class OrchestratorStop extends PromptCommand {
+  static description = 'Stop the running orchestrator'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --force',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(OrchestratorStop)
+    const jsonMode = shouldOutputJson(flags)
+
+    // Check if orchestrator session exists
+    const hostSessions = getHostTmuxSessionNames()
+    if (!hostSessions.includes(ORCHESTRATOR_SESSION_NAME)) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'NOT_RUNNING',
+          'Orchestrator is not running.',
+          createMetadata('orchestrator stop', flags),
+        )
+        return
+      }
+      this.log('')
+      this.log(styles.muted('Orchestrator is not running.'))
+      this.log('')
+      return
+    }
+
+    // Confirm unless --force
+    if (!flags.force && !jsonMode) {
+      const { confirmed } = await this.prompt<{ confirmed: boolean }>([{
+        type: 'list',
+        name: 'confirmed',
+        message: 'Stop the orchestrator?',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false },
+        ],
+      }])
+
+      if (!confirmed) {
+        this.log(styles.muted('Cancelled.'))
+        return
+      }
+    }
+
+    // Kill the tmux session
+    try {
+      execSync(`tmux kill-session -t "${ORCHESTRATOR_SESSION_NAME}"`, { stdio: 'pipe' })
+    } catch (error) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'KILL_FAILED',
+          `Failed to stop orchestrator: ${error instanceof Error ? error.message : error}`,
+          createMetadata('orchestrator stop', flags),
+        )
+        return
+      }
+      this.error(`Failed to stop orchestrator: ${error instanceof Error ? error.message : error}`)
+    }
+
+    // Update execution record to stopped
+    const hqPath = findHQRoot(process.cwd())
+    if (hqPath) {
+      const dbPath = path.join(hqPath, '.proletariat', 'workspace.db')
+      if (fs.existsSync(dbPath)) {
+        let db: Database.Database | null = null
+        try {
+          db = new Database(dbPath)
+          const executionStorage = new ExecutionStorage(db)
+          const running = executionStorage.listExecutions({ agentName: 'orchestrator', status: 'running' })
+          const starting = executionStorage.listExecutions({ agentName: 'orchestrator', status: 'starting' })
+          for (const exec of [...running, ...starting]) {
+            executionStorage.updateStatus(exec.id, 'stopped')
+          }
+        } catch {
+          // Non-fatal
+        } finally {
+          db?.close()
+        }
+      }
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        sessionId: ORCHESTRATOR_SESSION_NAME,
+        status: 'stopped',
+      }, createMetadata('orchestrator stop', flags as Record<string, unknown>))
+      return
+    }
+
+    this.log('')
+    this.log(styles.success('Orchestrator stopped.'))
+    this.log('')
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `prlt orchestrator` namespace with **start**, **attach**, **status**, and **stop** subcommands
- Orchestrator runs in a `prlt-orchestrator-main` tmux session on host for reattachability
- Dynamic executor selection at start time (Claude Code, Codex, Aider, Custom) via menu or `--executor` flag
- Permission mode choice (sandboxed vs skip-permissions) via menu or flags
- Creates execution record in DB so `prlt session poke orchestrator "message"` works out of the box
- Full JSON mode support on all subcommands for AI agent integration

## New Commands
| Command | Description |
|---------|-------------|
| `prlt orchestrator` | Namespace menu (Start, Attach, Status, Stop) |
| `prlt orchestrator start` | Spawn orchestrator in tmux with executor/permission selection |
| `prlt orchestrator attach` | Reattach to running orchestrator (new tab or `--current-terminal`) |
| `prlt orchestrator status` | Check running status, optional `--peek` for recent output |
| `prlt orchestrator stop` | Kill orchestrator session with list confirmation (`--force` to skip) |

## Test plan
- [ ] `pnpm build` compiles cleanly
- [ ] `prlt orchestrator --help` shows subcommands
- [ ] `prlt orchestrator start` prompts for executor and permissions, creates tmux session
- [ ] `prlt orchestrator status` shows running
- [ ] `prlt orchestrator status --peek` shows recent output
- [ ] `prlt orchestrator attach` reattaches in new tab
- [ ] `prlt session poke orchestrator "hello"` sends message
- [ ] `prlt orchestrator stop` kills session
- [ ] `prlt orchestrator start --json` outputs JSON prompt config
- [ ] `prlt orchestrator status --json` outputs JSON status

🤖 Generated with [Claude Code](https://claude.com/claude-code)