### PR TITLE
fix: resolve agent directories for both staff and temp agents

### DIFF
--- a/apps/cli/src/commands/agent/list.ts
+++ b/apps/cli/src/commands/agent/list.ts
@@ -5,7 +5,8 @@ import * as fs from 'node:fs';
 import {
   getWorkspaceInfo,
   getAllAgentsStatus,
-  getAgentTmuxSessions
+  getAgentTmuxSessions,
+  resolveAgentDir
 } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { shouldOutputJson } from '../../lib/prompt-json.js';
@@ -169,7 +170,7 @@ export default class List extends PMOCommand {
               this.log(chalk.white(`   Completed: ${agentStatus.completedTickets.length} ticket(s)`));
             }
           } else {
-            const agentDir = path.join(workspaceInfo.agentsPath, agentStatus.name);
+            const agentDir = resolveAgentDir(workspaceInfo, agentStatus.name);
             const dirExists = fs.existsSync(agentDir);
 
             if (dirExists) {

--- a/apps/cli/src/commands/agent/login.ts
+++ b/apps/cli/src/commands/agent/login.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo, formatAgentList } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, formatAgentList, resolveAgentDir } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
   isDockerRunning,
@@ -104,7 +104,7 @@ export default class Login extends PMOCommand {
       this.error(`Agent "${agentName}" not found. Available: ${formatAgentList(workspaceInfo.agents)}`);
     }
 
-    const agentDir = path.join(workspaceInfo.agentsPath, agentName!);
+    const agentDir = resolveAgentDir(workspaceInfo, agentName!);
 
     // Check if Docker config exists
     const dockerfilePath = path.join(agentDir, '.devcontainer', 'Dockerfile');

--- a/apps/cli/src/commands/agent/rebuild.ts
+++ b/apps/cli/src/commands/agent/rebuild.ts
@@ -4,7 +4,7 @@ import { promisify } from 'node:util';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, resolveAgentDir } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { isDockerRunning } from '../../lib/execution/runners.js';
 import {
@@ -97,8 +97,7 @@ export default class AgentRebuild extends PMOCommand {
 
     this.log(colors.primary(`🔨 Rebuilding agent: ${agentName}\n`));
 
-    const agentsPath = path.join(workspaceInfo.path, 'agents', 'staff');
-    const agentDir = path.join(agentsPath, agentName);
+    const agentDir = resolveAgentDir(workspaceInfo, agentName);
 
     try {
       this.log(colors.textSecondary('  Building devcontainer...'));

--- a/apps/cli/src/commands/agent/shell.ts
+++ b/apps/cli/src/commands/agent/shell.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { execSync, spawn } from 'node:child_process';
 import Database from 'better-sqlite3';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo, getAgentTmuxSessions, formatAgentList } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, getAgentTmuxSessions, formatAgentList, resolveAgentDir } from '../../lib/agents/commands.js';
 import { hasDevcontainerConfig } from '../../lib/execution/devcontainer.js';
 import { getTerminalApp } from '../../lib/execution/config.js';
 import { TerminalApp } from '../../lib/execution/types.js';
@@ -141,7 +141,7 @@ export default class Shell extends PMOCommand {
       this.log(colors.warning('\nProceeding with new shell - be careful of conflicts!\n'));
     }
 
-    const agentDir = path.join(workspaceInfo.agentsPath, agentName!);
+    const agentDir = resolveAgentDir(workspaceInfo, agentName!);
 
     // Check if agent has devcontainer
     const hasDevcontainer = hasDevcontainerConfig(agentDir);

--- a/apps/cli/src/commands/agent/status.ts
+++ b/apps/cli/src/commands/agent/status.ts
@@ -5,7 +5,8 @@ import {
   getAgentStatus,
   getAllAgentsStatus,
   WorkspaceInfo,
-  formatAgentList
+  formatAgentList,
+  resolveAgentDir
 } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
@@ -116,7 +117,7 @@ export default class Status extends PMOCommand {
           name: agentName,
           type: agent.type,
           exists: agentStatus.exists,
-          path: `${workspaceInfo.agentsPath}/${agentName}`,
+          path: resolveAgentDir(workspaceInfo, agentName),
           branch: agentStatus.branch,
           repositories: agentStatus.repositories.map(r => ({
             name: r.name,
@@ -144,7 +145,7 @@ export default class Status extends PMOCommand {
     }
 
     // Location
-    this.log(`📍 Location: ${colors.path(`${workspaceInfo.agentsPath}/${agentName}`)}`);
+    this.log(`📍 Location: ${colors.path(resolveAgentDir(workspaceInfo, agentName))}`);
 
     // Branch info
     if (agentStatus.branch) {

--- a/apps/cli/src/commands/agent/visit.ts
+++ b/apps/cli/src/commands/agent/visit.ts
@@ -1,7 +1,7 @@
 import { Args } from '@oclif/core';
 import * as path from 'node:path';
 import { colors } from '../../lib/colors.js';
-import { getWorkspaceInfo, formatAgentList } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, formatAgentList, resolveAgentDir } from '../../lib/agents/commands.js';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
   shouldOutputJson,
@@ -98,7 +98,7 @@ export default class Visit extends PMOCommand {
     }
 
     // Calculate path to agent directory
-    const agentDir = path.join(workspaceInfo.agentsPath, agentName!);
+    const agentDir = resolveAgentDir(workspaceInfo, agentName!);
     const relativePath = path.relative(process.cwd(), agentDir);
 
     // Display navigation command

--- a/apps/cli/src/commands/staff/list.ts
+++ b/apps/cli/src/commands/staff/list.ts
@@ -4,7 +4,8 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import {
   getWorkspaceInfo,
-  getAllAgentsStatus
+  getAllAgentsStatus,
+  resolveAgentDir
 } from '../../lib/agents/commands.js';
 import { shouldOutputJson } from '../../lib/prompt-json.js';
 import { machineOutputFlags } from '../../lib/pmo/index.js';
@@ -93,7 +94,7 @@ export default class List extends Command {
             this.log(chalk.white(`   Completed: ${agentStatus.completedTickets.length} ticket(s)`));
           }
         } else {
-          const agentDir = path.join(workspaceInfo.agentsPath, agentStatus.name);
+          const agentDir = resolveAgentDir(workspaceInfo, agentStatus.name);
           const dirExists = fs.existsSync(agentDir);
 
           if (dirExists) {

--- a/apps/cli/src/commands/work/revise.ts
+++ b/apps/cli/src/commands/work/revise.ts
@@ -6,7 +6,7 @@ import Database from 'better-sqlite3'
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js'
 import { getWorkColumnSetting, findColumnByName } from '../../lib/pmo/utils.js'
 import { styles } from '../../lib/styles.js'
-import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import { getWorkspaceInfo, resolveAgentDir } from '../../lib/agents/commands.js'
 import {
   DisplayMode,
   SessionManager,
@@ -233,8 +233,8 @@ export default class WorkRevise extends PMOCommand {
         )
       }
 
-      // Find worktree path
-      const agentDir = path.join(workspaceInfo.agentsPath, agentName)
+      // Find worktree path (handles staff and temp agents)
+      const agentDir = resolveAgentDir(workspaceInfo, agentName)
       if (!fs.existsSync(agentDir)) {
         db.close()
         this.error(`Agent directory not found at ${agentDir}.`)

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -23,6 +23,7 @@ import {
   killTmuxSession,
   findWorktreeForBranch,
   WorkspaceInfo,
+  resolveAgentDir,
 } from '../../lib/agents/commands.js'
 import { Agent } from '../../lib/database/index.js'
 import {
@@ -1922,7 +1923,7 @@ export default class WorkStart extends PMOCommand {
 
     // Check Docker credentials if any agents use devcontainers
     const anyUseDevcontainer = availableAgents.some(agent => {
-      const agentDir = path.join(workspaceInfo.agentsPath, agent.name)
+      const agentDir = resolveAgentDir(workspaceInfo, agent.name)
       return hasDevcontainerConfig(agentDir) && !flags['run-on-host']
     })
 
@@ -2103,8 +2104,8 @@ export default class WorkStart extends PMOCommand {
 
     // Note: Ticket assignee update moved to after successful spawn
 
-    // Find agent directory and worktree
-    const agentDir = path.join(workspaceInfo.agentsPath, agentName)
+    // Find agent directory and worktree (handles staff and temp agents)
+    const agentDir = resolveAgentDir(workspaceInfo, agentName)
     if (!fs.existsSync(agentDir)) {
       throw new Error(`Agent directory not found: ${agentDir}`)
     }

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path'
 import Database from 'better-sqlite3'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { styles } from '../../lib/styles.js'
-import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import { getWorkspaceInfo, resolveAgentDir } from '../../lib/agents/commands.js'
 import { ExecutionStorage } from '../../lib/execution/storage.js'
 import { hasDevcontainerConfig } from '../../lib/execution/devcontainer.js'
 import {
@@ -183,7 +183,7 @@ export default class WorkWatch extends PMOCommand {
 
       // Check if any agent has devcontainer
       const hasDevcontainer = workspaceInfo.agents.some(agent => {
-        const agentDir = path.join(workspaceInfo.agentsPath, agent.name)
+        const agentDir = resolveAgentDir(workspaceInfo, agent.name)
         return hasDevcontainerConfig(agentDir)
       })
 

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -37,6 +37,45 @@ import { getGitIdentity } from '../pr/index.js';
 import { getPMOContext } from '../pmo/index.js';
 
 /**
+ * Resolve the directory for an agent, cascading through resolution strategies.
+ * Handles both staff (persistent) and temp (ephemeral) agents.
+ *
+ * Resolution order:
+ * 1. Check agent's worktree_path from DB (most reliable)
+ * 2. Check ephemeral directory if agent type is ephemeral
+ * 3. Check both directories on disk as fallback
+ * 4. Fall back to staff path (caller handles missing dir error)
+ */
+export function resolveAgentDir(workspaceInfo: WorkspaceInfo, agentName: string): string {
+  const agent = workspaceInfo.agents.find(a => a.name === agentName)
+
+  // 1. Check DB worktree_path (most reliable - set during agent creation)
+  if (agent?.worktree_path) {
+    const fullWorktreePath = path.join(workspaceInfo.path, agent.worktree_path)
+    // worktree_path may point to repo subdir (e.g. agents/staff/altman/proletariat)
+    // Go up to the agent dir level
+    const agentDir = path.dirname(fullWorktreePath)
+    if (fs.existsSync(agentDir)) return agentDir
+  }
+
+  // 2. Check ephemeral directory if agent type is ephemeral
+  if (agent?.type === 'ephemeral') {
+    const ephemeralDir = path.join(workspaceInfo.path, 'agents', workspaceInfo.ephemeralAgentsDir, agentName)
+    if (fs.existsSync(ephemeralDir)) return ephemeralDir
+  }
+
+  // 3. Check both directories on disk (handles DB inconsistencies)
+  const tempDir = path.join(workspaceInfo.path, 'agents', workspaceInfo.ephemeralAgentsDir, agentName)
+  if (fs.existsSync(tempDir)) return tempDir
+
+  const staffDir = path.join(workspaceInfo.agentsPath, agentName)
+  if (fs.existsSync(staffDir)) return staffDir
+
+  // 4. Fall back to staff path - caller will handle the missing dir error
+  return staffDir
+}
+
+/**
  * Format a list of agents for display in error messages.
  * Truncates long lists to avoid overwhelming output.
  */
@@ -238,15 +277,8 @@ export function getAgentStatus(workspaceInfo: WorkspaceInfo, agentName: string):
   // Get worktrees from database to find actual agent location
   const worktrees = getAgentWorktrees(workspaceInfo.path, agentName);
 
-  // Derive agent directory from worktree path, or fall back to default
-  let agentDir = path.join(workspaceInfo.agentsPath, agentName);
-  if (worktrees.length > 0) {
-    // worktree_path is like "agents/staff/altman/proletariat-altman"
-    // Agent dir is the parent: "agents/staff/altman"
-    const worktreePath = worktrees[0].worktree_path;
-    const agentDirRelative = path.dirname(worktreePath);
-    agentDir = path.join(workspaceInfo.path, agentDirRelative);
-  }
+  // Resolve agent directory (handles both staff and temp agents)
+  const agentDir = resolveAgentDir(workspaceInfo, agentName);
 
   const dirExists = fs.existsSync(agentDir);
 
@@ -409,7 +441,7 @@ export async function removeAgentsFromWorkspace(workspaceInfo: WorkspaceInfo, ag
 
   for (const agentName of agentNames) {
     try {
-      const agentDir = path.join(workspaceInfo.agentsPath, agentName);
+      const agentDir = resolveAgentDir(workspaceInfo, agentName);
 
       // Stop and remove Docker container if it exists
       try {

--- a/apps/cli/src/lib/execution/spawner.ts
+++ b/apps/cli/src/lib/execution/spawner.ts
@@ -12,7 +12,7 @@ import Database from 'better-sqlite3'
 import { SQLiteStorage } from '../pmo/storage-sqlite.js'
 import { autoExportToBoard } from '../pmo/index.js'
 import { getWorkColumnSetting, findColumnByName } from '../pmo/utils.js'
-import { WorkspaceInfo } from '../agents/commands.js'
+import { WorkspaceInfo, resolveAgentDir } from '../agents/commands.js'
 import { findHQRoot } from '../repos/index.js'
 import { hasGitHubRemote } from '../repos/git.js'
 import { ExecutionStorage } from './storage.js'
@@ -295,8 +295,8 @@ export async function spawnAgentForTicket(
   const log = options.log || (() => {})
   const executor = options.executor || DEFAULT_EXECUTION_CONFIG.defaultExecutor
 
-  // Determine agent directory and worktree path
-  const agentDir = path.join(workspaceInfo.agentsPath, agentName)
+  // Determine agent directory and worktree path (handles staff and temp agents)
+  const agentDir = resolveAgentDir(workspaceInfo, agentName)
   if (!fs.existsSync(agentDir)) {
     return {
       success: false,


### PR DESCRIPTION
## Summary
- Added `resolveAgentDir()` helper in `lib/agents/commands.ts` that cascades through: DB worktree_path -> ephemeral dir -> disk fallback -> staff default
- Replaced 13 hardcoded `path.join(workspaceInfo.agentsPath, agentName)` calls across 12 files
- Temp/ephemeral agents in `agents/temp/` now resolve correctly instead of always looking in `agents/staff/`

## Files changed (12)
- `lib/agents/commands.ts` - Added `resolveAgentDir()`, fixed `getAgentStatus()` and `removeAgentsFromWorkspace()`
- `lib/execution/spawner.ts` - Fixed `spawnAgentForTicket()`
- `commands/work/start.ts` - Fixed batch devcontainer check and `startBatchTicket()`
- `commands/work/revise.ts` - Fixed agent dir resolution
- `commands/work/watch.ts` - Fixed devcontainer check
- `commands/agent/visit.ts`, `shell.ts`, `login.ts`, `list.ts`, `rebuild.ts`, `status.ts` - Fixed agent dir resolution
- `commands/staff/list.ts` - Fixed dir display

## Test plan
- [ ] `prlt work start` with a temp agent should find its directory in `agents/temp/`
- [ ] `prlt work start` with a staff agent should still work as before
- [ ] `prlt agent status <temp-agent>` should show correct path
- [ ] `prlt agent visit <temp-agent>` should navigate to correct directory
- [ ] Build passes: `cd apps/cli && pnpm build`

Fixes TKT-1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)