### PR TITLE
TKT-1112: Fix workspace e2e output contract drift across interactive/non-TTY/JSON modes

### DIFF
--- a/apps/cli/test/e2e/test-helpers.ts
+++ b/apps/cli/test/e2e/test-helpers.ts
@@ -939,3 +939,98 @@ export function execWithForce(cmd: string): string {
     .replace(' -m', '');
   return execProduction(`${cleanCmd} --force`);
 }
+
+// =============================================================================
+// Output Mode Helpers
+// =============================================================================
+// These helpers explicitly control the output mode for E2E tests, preventing
+// accidental coupling to non-TTY auto-detection behavior.
+//
+// - execAsHuman(): Forces human-readable text output via PRLT_FORCE_TEXT=1.
+//   Use for tests that assert on styled text (e.g., "Registered workspace").
+//
+// - execAsAgent(): Appends --json flag for explicit JSON/machine-readable output.
+//   Use for tests that parse JSON responses or test agent workflows.
+//
+// Tests should NOT rely on the implicit non-TTY → JSON auto-detection, except
+// for tests that specifically verify that behavior (e.g., prune dry-run safety).
+// =============================================================================
+
+/**
+ * Execute a CLI command forcing human-readable text output.
+ *
+ * Sets PRLT_FORCE_TEXT=1 to override non-TTY auto-detection in execSync,
+ * ensuring the CLI outputs styled text instead of JSON envelopes.
+ *
+ * Use this for tests that assert on human-readable output strings like
+ * "Registered workspace", "Active workspace set to", etc.
+ *
+ * @param cmd - CLI command to run (without 'prlt' prefix)
+ * @param env - Additional environment variables to merge
+ * @returns Filtered command output (human-readable text)
+ */
+export function execAsHuman(cmd: string, env: NodeJS.ProcessEnv = {}): string {
+  try {
+    const binPath = getBinPath();
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...getIsolatedEnv(),
+      PRLT_FORCE_TEXT: '1',
+      ...env,
+    };
+
+    const result = execSync(`node ${binPath} ${cmd}`, {
+      encoding: 'utf-8',
+      cwd: process.cwd(),
+      env: baseEnv,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return filterOutput(result);
+  } catch (error: unknown) {
+    const execError = error as ExecError;
+    const stdout = execError.stdout || '';
+    const stderr = execError.stderr || '';
+    if (stdout.trim()) {
+      return filterOutput(stdout);
+    }
+    return filterOutput(stderr) || filterOutput(execError.message || 'Unknown error');
+  }
+}
+
+/**
+ * Execute a CLI command in agent/JSON mode with explicit --json flag.
+ *
+ * Appends --json to the command to explicitly request JSON output,
+ * rather than relying on non-TTY auto-detection.
+ *
+ * Use this for tests that parse JSON responses or simulate agent workflows.
+ *
+ * @param cmd - CLI command to run (without 'prlt' prefix). --json is appended automatically.
+ * @param env - Additional environment variables to merge
+ * @returns Filtered command output (JSON string)
+ */
+export function execAsAgent(cmd: string, env: NodeJS.ProcessEnv = {}): string {
+  const jsonCmd = cmd.includes('--json') ? cmd : `${cmd} --json`;
+  try {
+    const binPath = getBinPath();
+    const baseEnv: NodeJS.ProcessEnv = {
+      ...getIsolatedEnv(),
+      ...env,
+    };
+
+    const result = execSync(`node ${binPath} ${jsonCmd}`, {
+      encoding: 'utf-8',
+      cwd: process.cwd(),
+      env: baseEnv,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return filterOutput(result);
+  } catch (error: unknown) {
+    const execError = error as ExecError;
+    const stdout = execError.stdout || '';
+    const stderr = execError.stderr || '';
+    if (stdout.trim()) {
+      return filterOutput(stdout);
+    }
+    return filterOutput(stderr) || filterOutput(execError.message || 'Unknown error');
+  }
+}

--- a/apps/cli/test/e2e/workspace-agent-flow.test.ts
+++ b/apps/cli/test/e2e/workspace-agent-flow.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { execSync } from 'node:child_process';
-import { filterOutput, getIsolatedEnv, getBinPath, extractJson } from './test-helpers.js';
+import { filterOutput, getIsolatedEnv, getBinPath, extractJson, execAsHuman, execAsAgent } from './test-helpers.js';
 
 /**
  * Response type for JSON prompt output from workspace commands with --json flag.
@@ -59,42 +59,46 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   }
 
   /**
-   * Execute a workspace command with HOME isolation.
-   * Sets HOME to testDir so machine config is isolated.
-   * Sets PRLT_HQ_PATH to testWorkspace1 to bypass the init hook
-   * (which redirects to "init" flow when no workspace is detected).
+   * Workspace-specific env vars shared by all exec helpers in this suite.
+   * Sets HOME to testDir for machine config isolation and PRLT_HQ_PATH
+   * to bypass the init hook.
    */
-  function execWorkspace(cmd: string): string {
-    try {
-      const binPath = getBinPath();
-      const env = {
-        ...getIsolatedEnv(),
-        HOME: testDir,
-        PRLT_HQ_PATH: testWorkspace1,
-        PRLT_TEST_ENV: 'true',
-      };
-
-      const result = execSync(`node ${binPath} ${cmd}`, {
-        encoding: 'utf-8',
-        cwd: process.cwd(),
-        env,
-        maxBuffer: 10 * 1024 * 1024,
-      });
-      return filterOutput(result);
-    } catch (error: unknown) {
-      const execError = error as { stdout?: string; stderr?: string; message?: string };
-      const stdout = execError.stdout || '';
-      const stderr = execError.stderr || '';
-      return filterOutput(stdout + stderr) || execError.message || 'Unknown error';
-    }
+  function getWorkspaceEnv(): NodeJS.ProcessEnv {
+    return {
+      HOME: testDir,
+      PRLT_HQ_PATH: testWorkspace1,
+      PRLT_TEST_ENV: 'true',
+    };
   }
 
   /**
-   * Execute a workspace command and parse JSON output.
-   * Uses --json flag for machine-readable output.
+   * Execute a workspace command in human-readable text mode.
+   * Uses PRLT_FORCE_TEXT=1 to override non-TTY auto-detection in execSync.
+   *
+   * Output mode: HUMAN-READABLE TEXT
+   */
+  function execHuman(cmd: string): string {
+    return execAsHuman(cmd, getWorkspaceEnv());
+  }
+
+  /**
+   * Execute a workspace command in explicit JSON/agent mode.
+   * Appends --json flag to explicitly request JSON output.
+   *
+   * Output mode: JSON (explicit --json flag)
+   */
+  function execJson(cmd: string): string {
+    return execAsAgent(cmd, getWorkspaceEnv());
+  }
+
+  /**
+   * Execute a workspace command with --json and parse the JSON response.
+   * Uses explicit --json flag for machine-readable output.
+   *
+   * Output mode: JSON (explicit --json flag)
    */
   function execWorkspaceJson<T>(cmd: string): T | null {
-    const output = execWorkspace(cmd);
+    const output = execJson(cmd);
     return extractJson<T>(output);
   }
 
@@ -150,9 +154,10 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // workspace add - Register workspace
   // ===========================================================================
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('workspace add', () => {
     it('should register a workspace and verify config updated', () => {
-      const output = execWorkspace(`workspace add ${testWorkspace1}`);
+      const output = execHuman(`workspace add ${testWorkspace1}`);
 
       expect(output).to.include('Registered workspace');
       expect(output).to.include('workspace-alpha');
@@ -167,7 +172,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should register with custom name via --name flag', () => {
-      const output = execWorkspace(`workspace add ${testWorkspace1} --name "Custom HQ Name"`);
+      const output = execHuman(`workspace add ${testWorkspace1} --name "Custom HQ Name"`);
 
       expect(output).to.include('Registered workspace');
       expect(output).to.include('Custom HQ Name');
@@ -178,7 +183,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should set first workspace as active automatically', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
       const config = readMachineConfig();
       const active = config.activeHeadquarters || config.activeWorkspace;
@@ -186,8 +191,8 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should register multiple workspaces', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       const config = readMachineConfig();
       const hqs = (config.headquarters || config.workspaces) as Array<{ path: string }>;
@@ -198,20 +203,20 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       const nonWorkspace = path.join(testDir, 'not-a-workspace');
       fs.mkdirSync(nonWorkspace, { recursive: true });
 
-      const output = execWorkspace(`workspace add ${nonWorkspace}`);
+      const output = execHuman(`workspace add ${nonWorkspace}`);
 
       expect(output).to.include('Not a valid workspace');
     });
 
     it('should reject non-existent path', () => {
-      const output = execWorkspace(`workspace add ${path.join(testDir, 'nonexistent')}`);
+      const output = execHuman(`workspace add ${path.join(testDir, 'nonexistent')}`);
 
       expect(output).to.include('does not exist');
     });
 
     it('should detect already registered workspace', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      const output = execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      const output = execHuman(`workspace add ${testWorkspace1}`);
 
       expect(output).to.include('already registered');
     });
@@ -222,34 +227,38 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // ===========================================================================
 
   describe('workspace list', () => {
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should show no workspaces when none registered', () => {
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
       expect(output).to.include('No workspaces found');
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should list registered workspaces', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
 
       expect(output).to.include('workspace-alpha');
       expect(output).to.include('workspace-beta');
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should show active workspace marker', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
 
       expect(output).to.include('(active)');
     });
 
+    // Output mode: JSON (explicit --json flag via execJson)
     it('should output valid JSON with --json flag', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
-      const output = execWorkspace('workspace list --json');
+      const output = execJson('workspace list');
       const json = JSON.parse(output);
 
       expect(json.workspaces).to.be.an('array');
@@ -259,10 +268,11 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       expect(json.workspaces[1].name).to.equal('workspace-beta');
     });
 
+    // Output mode: JSON (explicit --json flag via execJson)
     it('should indicate active workspace in JSON output', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
-      const output = execWorkspace('workspace list --json');
+      const output = execJson('workspace list');
       const json = JSON.parse(output);
 
       expect(json.activeWorkspace).to.equal(testWorkspace1);
@@ -271,11 +281,12 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       expect(activeWs.path).to.equal(testWorkspace1);
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should warn about stale registrations', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
       fs.rmSync(testWorkspace1, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
       expect(output).to.include('Path no longer exists');
     });
   });
@@ -284,14 +295,15 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // workspace use - Set active workspace
   // ===========================================================================
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('workspace use', () => {
     beforeEach(() => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
     });
 
     it('should switch active workspace by name', () => {
-      const output = execWorkspace('workspace use workspace-beta');
+      const output = execHuman('workspace use workspace-beta');
 
       expect(output).to.include('Active workspace set to');
       expect(output).to.include('workspace-beta');
@@ -302,24 +314,25 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should switch active workspace by path', () => {
-      const output = execWorkspace(`workspace use ${testWorkspace2}`);
+      const output = execHuman(`workspace use ${testWorkspace2}`);
 
       expect(output).to.include('Active workspace set to');
       expect(output).to.include('workspace-beta');
     });
 
+    // Output mode: JSON (explicit --json flag via execJson) — verifies end state
     it('should verify end state: config reflects new active workspace', () => {
-      execWorkspace('workspace use workspace-beta');
+      execHuman('workspace use workspace-beta');
 
       // Verify via list --json
-      const listOutput = execWorkspace('workspace list --json');
+      const listOutput = execJson('workspace list');
       const json = JSON.parse(listOutput);
 
       expect(json.activeWorkspace).to.equal(testWorkspace2);
     });
 
     it('should reject non-existent workspace name', () => {
-      const output = execWorkspace('workspace use nonexistent');
+      const output = execHuman('workspace use nonexistent');
 
       expect(output).to.include('Workspace not found');
     });
@@ -327,7 +340,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     it('should reject workspace with deleted path', () => {
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace use workspace-beta');
+      const output = execHuman('workspace use workspace-beta');
 
       expect(output).to.include('no longer exists');
     });
@@ -337,14 +350,15 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // workspace remove - Unregister workspace
   // ===========================================================================
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('workspace remove', () => {
     beforeEach(() => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
     });
 
     it('should unregister workspace by name and preserve files', () => {
-      const output = execWorkspace('workspace remove workspace-alpha');
+      const output = execHuman('workspace remove workspace-alpha');
 
       expect(output).to.include('Unregistered workspace');
       expect(output).to.include('NOT deleted');
@@ -360,24 +374,25 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should unregister workspace by path', () => {
-      const output = execWorkspace(`workspace remove ${testWorkspace1}`);
+      const output = execHuman(`workspace remove ${testWorkspace1}`);
 
       expect(output).to.include('Unregistered workspace');
     });
 
     it('should clear active workspace when removing active one', () => {
       // workspace-alpha is active (first registered)
-      execWorkspace('workspace remove workspace-alpha');
+      execHuman('workspace remove workspace-alpha');
 
       const config = readMachineConfig();
       // activeHeadquarters should be null after removing the active workspace
       expect(config.activeHeadquarters).to.be.null;
     });
 
+    // Output mode: JSON (explicit --json flag via execJson) — verifies end state
     it('should verify end state: removed workspace absent from list', () => {
-      execWorkspace('workspace remove workspace-alpha');
+      execHuman('workspace remove workspace-alpha');
 
-      const listOutput = execWorkspace('workspace list --json');
+      const listOutput = execJson('workspace list');
       const json = JSON.parse(listOutput);
 
       const names = json.workspaces.map((w: { name: string }) => w.name);
@@ -386,7 +401,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should reject non-existent workspace', () => {
-      const output = execWorkspace('workspace remove nonexistent');
+      const output = execHuman('workspace remove nonexistent');
 
       expect(output).to.include('Workspace not found');
     });
@@ -396,6 +411,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // JSON mode prompt schema - workspace remove disambiguation
   // ===========================================================================
 
+  // Output mode: JSON (explicit --json flag via execWorkspaceJson)
   describe('workspace remove --json (disambiguation prompt)', () => {
     let sameNameWorkspace1: string;
     let sameNameWorkspace2: string;
@@ -409,12 +425,12 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       createTestWorkspace(sameNameWorkspace2);
 
       // Register both with the same name
-      execWorkspace(`workspace add ${sameNameWorkspace1} --name "shared-name"`);
-      execWorkspace(`workspace add ${sameNameWorkspace2} --name "shared-name"`);
+      execHuman(`workspace add ${sameNameWorkspace1} --name "shared-name"`);
+      execHuman(`workspace add ${sameNameWorkspace2} --name "shared-name"`);
     });
 
     it('should output prompt schema with choices when name is ambiguous', () => {
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace remove shared-name --json');
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace remove shared-name');
 
       expect(json).to.not.be.null;
       expect(json!.prompt).to.not.be.null;
@@ -425,7 +441,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should include choices with command field for agent navigation', () => {
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace remove shared-name --json');
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace remove shared-name');
 
       expect(json).to.not.be.null;
       const choices = json!.prompt.choices!;
@@ -443,14 +459,15 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should include metadata with command name', () => {
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace remove shared-name --json');
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace remove shared-name');
 
       expect(json).to.not.be.null;
       expect(json!.metadata.command).to.equal('workspace remove');
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should resolve when using full path (no disambiguation needed)', () => {
-      const output = execWorkspace(`workspace remove ${sameNameWorkspace1}`);
+      const output = execHuman(`workspace remove ${sameNameWorkspace1}`);
 
       expect(output).to.include('Unregistered workspace');
 
@@ -466,6 +483,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // JSON mode prompt schema - workspace use disambiguation
   // ===========================================================================
 
+  // Output mode: JSON (explicit --json flag via execWorkspaceJson)
   describe('workspace use --json (disambiguation prompt)', () => {
     let sameNameWorkspace1: string;
     let sameNameWorkspace2: string;
@@ -479,12 +497,12 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       createTestWorkspace(sameNameWorkspace2);
 
       // Register both with the same name
-      execWorkspace(`workspace add ${sameNameWorkspace1} --name "duplicate-name"`);
-      execWorkspace(`workspace add ${sameNameWorkspace2} --name "duplicate-name"`);
+      execHuman(`workspace add ${sameNameWorkspace1} --name "duplicate-name"`);
+      execHuman(`workspace add ${sameNameWorkspace2} --name "duplicate-name"`);
     });
 
     it('should output prompt schema with choices when name is ambiguous', () => {
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name --json');
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name');
 
       expect(json).to.not.be.null;
       expect(json!.prompt).to.not.be.null;
@@ -495,7 +513,7 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should include choices with command field for agent navigation', () => {
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name --json');
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name');
 
       expect(json).to.not.be.null;
       const choices = json!.prompt.choices!;
@@ -513,14 +531,15 @@ describe('Workspace Commands E2E - Agent Flow', () => {
     });
 
     it('should include metadata with command name', () => {
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name --json');
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name');
 
       expect(json).to.not.be.null;
       expect(json!.metadata.command).to.equal('workspace use');
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should resolve when using full path (no disambiguation needed)', () => {
-      const output = execWorkspace(`workspace use ${sameNameWorkspace2}`);
+      const output = execHuman(`workspace use ${sameNameWorkspace2}`);
 
       expect(output).to.include('Active workspace set to');
 
@@ -530,9 +549,11 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       expect(active).to.equal(sameNameWorkspace2);
     });
 
+    // Output mode: JSON for initial prompt (via execWorkspaceJson),
+    // then HUMAN-READABLE TEXT for follow-up action (via execHuman)
     it('agent can follow command from choice to complete the action', () => {
-      // Step 1: Agent gets disambiguation prompt
-      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name --json');
+      // Step 1: Agent gets disambiguation prompt (JSON mode)
+      const json = execWorkspaceJson<PromptJsonResponse>('workspace use duplicate-name');
       expect(json).to.not.be.null;
 
       // Step 2: Agent picks the second choice and extracts the command
@@ -540,11 +561,12 @@ describe('Workspace Commands E2E - Agent Flow', () => {
       const secondChoice = choices[1];
       expect(secondChoice.command).to.be.a('string');
 
-      // Step 3: Agent executes the command from the choice (without prlt prefix, without --json to actually perform the action)
+      // Step 3: Agent executes the command from the choice
+      // (without prlt prefix, without --json to actually perform the action)
       const followUpCmd = secondChoice.command!
         .replace('prlt ', '')
         .replace(' --json', '');
-      const result = execWorkspace(followUpCmd);
+      const result = execHuman(followUpCmd);
 
       expect(result).to.include('Active workspace set to');
 
@@ -559,36 +581,38 @@ describe('Workspace Commands E2E - Agent Flow', () => {
   // Full workflow: add → use → list → remove
   // ===========================================================================
 
+  // Output mode: Mixed — HUMAN-READABLE TEXT for actions (via execHuman),
+  // JSON for verification steps (via execJson with explicit --json flag)
   describe('full workflow: add → use → list → remove', () => {
     it('should complete full lifecycle', () => {
-      // Step 1: Add two workspaces
-      const addOutput1 = execWorkspace(`workspace add ${testWorkspace1}`);
+      // Step 1: Add two workspaces (text mode)
+      const addOutput1 = execHuman(`workspace add ${testWorkspace1}`);
       expect(addOutput1).to.include('Registered workspace');
 
-      const addOutput2 = execWorkspace(`workspace add ${testWorkspace2}`);
+      const addOutput2 = execHuman(`workspace add ${testWorkspace2}`);
       expect(addOutput2).to.include('Registered workspace');
 
-      // Step 2: List and verify both present
-      const listJson = execWorkspace('workspace list --json');
+      // Step 2: List and verify both present (JSON mode, explicit --json)
+      const listJson = execJson('workspace list');
       const list = JSON.parse(listJson);
       expect(list.workspaces).to.have.length(2);
 
-      // Step 3: Switch to second workspace
-      const useOutput = execWorkspace('workspace use workspace-beta');
+      // Step 3: Switch to second workspace (text mode)
+      const useOutput = execHuman('workspace use workspace-beta');
       expect(useOutput).to.include('Active workspace set to');
       expect(useOutput).to.include('workspace-beta');
 
-      // Step 4: Verify active workspace changed
-      const listJson2 = execWorkspace('workspace list --json');
+      // Step 4: Verify active workspace changed (JSON mode, explicit --json)
+      const listJson2 = execJson('workspace list');
       const list2 = JSON.parse(listJson2);
       expect(list2.activeWorkspace).to.equal(testWorkspace2);
 
-      // Step 5: Remove first workspace
-      const removeOutput = execWorkspace('workspace remove workspace-alpha');
+      // Step 5: Remove first workspace (text mode)
+      const removeOutput = execHuman('workspace remove workspace-alpha');
       expect(removeOutput).to.include('Unregistered workspace');
 
-      // Step 6: Verify only one workspace remains, active still set
-      const listJson3 = execWorkspace('workspace list --json');
+      // Step 6: Verify only one workspace remains (JSON mode, explicit --json)
+      const listJson3 = execJson('workspace list');
       const list3 = JSON.parse(listJson3);
       expect(list3.workspaces).to.have.length(1);
       expect(list3.workspaces[0].name).to.equal('workspace-beta');

--- a/apps/cli/test/e2e/workspace-commands.test.ts
+++ b/apps/cli/test/e2e/workspace-commands.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { filterOutput, getIsolatedEnv, getBinPath } from './test-helpers.js';
+import { filterOutput, getIsolatedEnv, getBinPath, execAsHuman, execAsAgent } from './test-helpers.js';
 import { execSync } from 'node:child_process';
 
 /**
@@ -59,34 +59,54 @@ describe('Workspace Commands E2E Tests', () => {
   });
 
   /**
-   * Execute a workspace command with proper isolation.
-   * Sets HOME to testDir so machine config is isolated.
-   * Sets PRLT_HQ_PATH to testWorkspace1 to bypass the init hook
-   * (which redirects to "init" flow when no workspace is detected).
+   * Workspace-specific env vars shared by all exec helpers in this suite.
+   * Sets HOME to testDir for machine config isolation and PRLT_HQ_PATH
+   * to bypass the init hook.
    */
+  function getWorkspaceEnv(): NodeJS.ProcessEnv {
+    return {
+      HOME: testDir,
+      PRLT_HQ_PATH: testWorkspace1,
+      PRLT_TEST_ENV: 'true',
+    };
+  }
+
   /**
-   * Execute a workspace command with proper isolation.
-   * @param cmd - The CLI command to run
-   * @param options.forceText - Force text output mode (default: true).
-   *   Set to false for tests that specifically verify non-TTY behavior.
+   * Execute a workspace command in human-readable text mode.
+   * Uses PRLT_FORCE_TEXT=1 to override non-TTY auto-detection.
+   *
+   * Output mode: HUMAN-READABLE TEXT
    */
-  function execWorkspace(cmd: string, options?: { forceText?: boolean }): string {
-    const forceText = options?.forceText ?? true;
+  function execHuman(cmd: string): string {
+    return execAsHuman(cmd, getWorkspaceEnv());
+  }
+
+  /**
+   * Execute a workspace command in explicit JSON/agent mode.
+   * Appends --json flag to explicitly request JSON output.
+   *
+   * Output mode: JSON (explicit --json flag)
+   */
+  function execJson(cmd: string): string {
+    return execAsAgent(cmd, getWorkspaceEnv());
+  }
+
+  /**
+   * Execute a workspace command in raw non-TTY mode (no PRLT_FORCE_TEXT, no --json).
+   * The CLI auto-detects non-TTY and outputs JSON automatically.
+   *
+   * Output mode: NON-TTY AUTO-DETECTED (for testing non-TTY safety behavior)
+   *
+   * Only use this for tests that specifically verify non-TTY auto-detection behavior,
+   * such as prune dry-run safety defaults.
+   */
+  function execNonTTY(cmd: string): string {
     try {
       const binPath = getBinPath();
       const env: NodeJS.ProcessEnv = {
         ...getIsolatedEnv(),
-        HOME: testDir,
-        PRLT_HQ_PATH: testWorkspace1,
-        PRLT_TEST_ENV: 'true',
+        ...getWorkspaceEnv(),
       };
-
-      // Force text output mode even though execSync creates a non-TTY child process.
-      // Without this, shouldOutputJson() returns true in non-TTY environments,
-      // causing commands to output JSON instead of the styled text we assert on.
-      if (forceText) {
-        env.PRLT_FORCE_TEXT = '1';
-      }
 
       const result = execSync(`node ${binPath} ${cmd}`, {
         encoding: 'utf-8',
@@ -102,9 +122,10 @@ describe('Workspace Commands E2E Tests', () => {
     }
   }
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('prlt workspace add', () => {
     it('should register a workspace', () => {
-      const output = execWorkspace(`workspace add ${testWorkspace1}`);
+      const output = execHuman(`workspace add ${testWorkspace1}`);
 
       expect(output).to.include('Registered workspace');
       expect(output).to.include('workspace-one');
@@ -119,7 +140,7 @@ describe('Workspace Commands E2E Tests', () => {
     });
 
     it('should register with custom name', () => {
-      const output = execWorkspace(`workspace add ${testWorkspace1} --name "My Custom Name"`);
+      const output = execHuman(`workspace add ${testWorkspace1} --name "My Custom Name"`);
 
       expect(output).to.include('Registered workspace');
       expect(output).to.include('My Custom Name');
@@ -133,47 +154,50 @@ describe('Workspace Commands E2E Tests', () => {
       const nonWorkspace = path.join(testDir, 'not-a-workspace');
       fs.mkdirSync(nonWorkspace, { recursive: true });
 
-      const output = execWorkspace(`workspace add ${nonWorkspace}`);
+      const output = execHuman(`workspace add ${nonWorkspace}`);
 
       expect(output).to.include('Not a valid workspace');
     });
 
     it('should reject already registered workspace', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      const output = execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      const output = execHuman(`workspace add ${testWorkspace1}`);
 
       expect(output).to.include('already registered');
     });
   });
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
+  // except --json test which uses explicit --json flag (via execJson)
   describe('prlt workspace list', () => {
     it('should show no workspaces when none registered', () => {
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
       expect(output).to.include('No workspaces found');
     });
 
     it('should list registered workspaces', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
 
       expect(output).to.include('workspace-one');
       expect(output).to.include('workspace-two');
     });
 
     it('should show active workspace marker', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
 
       expect(output).to.include('(active)');
     });
 
+    // Output mode: JSON (explicit --json flag via execJson)
     it('should support --json flag', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
-      const output = execWorkspace('workspace list --json');
+      const output = execJson('workspace list');
       const json = JSON.parse(output);
 
       expect(json.workspaces).to.be.an('array');
@@ -184,23 +208,24 @@ describe('Workspace Commands E2E Tests', () => {
 
     it('should warn about stale registrations', () => {
       // Register workspace then delete it
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
       fs.rmSync(testWorkspace1, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace list');
+      const output = execHuman('workspace list');
 
       expect(output).to.include('Path no longer exists');
     });
   });
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('prlt workspace use', () => {
     beforeEach(() => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
     });
 
     it('should switch active workspace by name', () => {
-      const output = execWorkspace('workspace use workspace-two');
+      const output = execHuman('workspace use workspace-two');
 
       expect(output).to.include('Active workspace set to');
       expect(output).to.include('workspace-two');
@@ -211,14 +236,14 @@ describe('Workspace Commands E2E Tests', () => {
     });
 
     it('should switch active workspace by path', () => {
-      const output = execWorkspace(`workspace use ${testWorkspace2}`);
+      const output = execHuman(`workspace use ${testWorkspace2}`);
 
       expect(output).to.include('Active workspace set to');
       expect(output).to.include('workspace-two');
     });
 
     it('should reject non-existent workspace', () => {
-      const output = execWorkspace('workspace use nonexistent');
+      const output = execHuman('workspace use nonexistent');
 
       expect(output).to.include('Workspace not found');
     });
@@ -226,20 +251,21 @@ describe('Workspace Commands E2E Tests', () => {
     it('should reject deleted workspace path', () => {
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace use workspace-two');
+      const output = execHuman('workspace use workspace-two');
 
       expect(output).to.include('no longer exists');
     });
   });
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('prlt workspace remove', () => {
     beforeEach(() => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
     });
 
     it('should unregister workspace by name', () => {
-      const output = execWorkspace('workspace remove workspace-one');
+      const output = execHuman('workspace remove workspace-one');
 
       expect(output).to.include('Unregistered workspace');
       expect(output).to.include('NOT deleted');
@@ -255,14 +281,14 @@ describe('Workspace Commands E2E Tests', () => {
     });
 
     it('should unregister workspace by path', () => {
-      const output = execWorkspace(`workspace remove ${testWorkspace1}`);
+      const output = execHuman(`workspace remove ${testWorkspace1}`);
 
       expect(output).to.include('Unregistered workspace');
     });
 
     it('should clear active workspace if removed', () => {
       // workspace-one should be active (first registered)
-      execWorkspace('workspace remove workspace-one');
+      execHuman('workspace remove workspace-one');
 
       const configPath = path.join(testDir, '.proletariat', 'config.json');
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
@@ -270,17 +296,18 @@ describe('Workspace Commands E2E Tests', () => {
     });
 
     it('should reject non-existent workspace', () => {
-      const output = execWorkspace('workspace remove nonexistent');
+      const output = execHuman('workspace remove nonexistent');
 
       expect(output).to.include('Workspace not found');
     });
   });
 
+  // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
   describe('workspace registration in prlt init', () => {
     it('should auto-register workspace on init', () => {
       // This would require full init flow which is interactive
       // Just verify the machine config can be created via add command
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
       const configPath = path.join(testDir, '.proletariat', 'config.json');
       expect(fs.existsSync(configPath)).to.be.true;
@@ -291,17 +318,18 @@ describe('Workspace Commands E2E Tests', () => {
     });
   });
 
+  // Output mode: JSON (explicit --json flag via execJson)
   describe('workspace discovery priority', () => {
     it('should use directory workspace over registry activeWorkspace', () => {
       // Register workspace1 as active
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
       // Change to workspace2 directory (but don't register it)
       process.chdir(testWorkspace2);
 
       // When in a workspace directory, it should use THAT workspace
       // not the registry's activeWorkspace (supports multi-agent scenarios)
-      const output = execWorkspace('workspace list --json');
+      const output = execJson('workspace list');
       const json = JSON.parse(output);
 
       // The activeWorkspace in the registry is still workspace1
@@ -314,22 +342,24 @@ describe('Workspace Commands E2E Tests', () => {
   });
 
   describe('prlt workspace prune', () => {
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should show no stale entries when all paths exist', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace1}`);
 
-      const output = execWorkspace('workspace prune --dry-run');
+      const output = execHuman('workspace prune --dry-run');
 
       expect(output).to.include('No stale entries found');
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should detect stale workspace registrations', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace prune --dry-run');
+      const output = execHuman('workspace prune --dry-run');
 
       expect(output).to.include('Stale workspace registrations');
       expect(output).to.include('workspace-two');
@@ -337,14 +367,15 @@ describe('Workspace Commands E2E Tests', () => {
       expect(output).to.include('[DRY RUN]');
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should remove stale entries with --force flag', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace prune --force');
+      const output = execHuman('workspace prune --force');
 
       expect(output).to.include('Pruned');
       expect(output).to.include('1 workspace registration(s)');
@@ -357,17 +388,20 @@ describe('Workspace Commands E2E Tests', () => {
       expect(hqs[0].name).to.equal('workspace-one');
     });
 
+    // Output mode: NON-TTY AUTO-DETECTED (via execNonTTY — no PRLT_FORCE_TEXT, no --json)
+    // This test specifically verifies the non-TTY safety behavior:
+    // when no --dry-run or --force is given in a non-TTY environment,
+    // the CLI defaults to dry-run to prevent accidental data loss.
     it('should default to dry-run in non-TTY mode', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
       // Running without --dry-run or --force in non-TTY (execSync) should default to dry-run.
       // In non-TTY mode, the CLI outputs JSON automatically (no --json flag needed).
-      // Use forceText: false so the CLI sees itself as non-TTY (the actual behavior under test).
-      const output = execWorkspace('workspace prune', { forceText: false });
+      const output = execNonTTY('workspace prune');
       const json = JSON.parse(output);
 
       expect(json.dryRun).to.be.true;
@@ -383,14 +417,15 @@ describe('Workspace Commands E2E Tests', () => {
       expect(hqs).to.have.length(2);
     });
 
+    // Output mode: JSON (explicit --json flag via execJson)
     it('should support --json flag with --dry-run', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace prune --dry-run --json');
+      const output = execJson('workspace prune --dry-run');
       const json = JSON.parse(output);
 
       expect(json.dryRun).to.be.true;
@@ -401,16 +436,17 @@ describe('Workspace Commands E2E Tests', () => {
       expect(json.totalRemoved).to.equal(0);
     });
 
+    // Output mode: NON-TTY AUTO-DETECTED (via execNonTTY — no PRLT_FORCE_TEXT, with --json)
+    // Tests that --json without --force still defaults to dry-run in non-TTY.
     it('should default to dry-run in JSON mode without --force (non-TTY)', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
       // In non-TTY (execSync), --json without --force defaults to dry-run.
-      // Use forceText: false so the CLI sees itself as non-TTY (the actual behavior under test).
-      const output = execWorkspace('workspace prune --json', { forceText: false });
+      const output = execNonTTY('workspace prune --json');
       const json = JSON.parse(output);
 
       expect(json.dryRun).to.be.true;
@@ -418,14 +454,15 @@ describe('Workspace Commands E2E Tests', () => {
       expect(json.totalRemoved).to.equal(0);
     });
 
+    // Output mode: JSON (explicit --json flag via execJson)
     it('should report totalRemoved when pruning with --force --json', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace prune --force --json');
+      const output = execJson('workspace prune --force');
       const json = JSON.parse(output);
 
       expect(json.dryRun).to.be.false;
@@ -433,14 +470,15 @@ describe('Workspace Commands E2E Tests', () => {
       expect(json.totalRemoved).to.equal(1);
     });
 
+    // Output mode: HUMAN-READABLE TEXT (via execHuman / PRLT_FORCE_TEXT=1)
     it('should not delete anything with --dry-run even when --force is set', () => {
-      execWorkspace(`workspace add ${testWorkspace1}`);
-      execWorkspace(`workspace add ${testWorkspace2}`);
+      execHuman(`workspace add ${testWorkspace1}`);
+      execHuman(`workspace add ${testWorkspace2}`);
 
       // Delete workspace2 from disk
       fs.rmSync(testWorkspace2, { recursive: true, force: true });
 
-      const output = execWorkspace('workspace prune --dry-run --force');
+      const output = execHuman('workspace prune --dry-run --force');
 
       expect(output).to.include('[DRY RUN]');
 


### PR DESCRIPTION
## Summary

Resolves TKT-1112: Fix workspace e2e output contract drift across interactive/non-TTY/JSON modes

## Description

## Problem
Multiple workspace-related e2e tests fail because expected human-readable strings (e.g. "Registered workspace") now return JSON envelopes or different non-TTY output contracts. The root cause is that `shouldOutputJson()` in `prompt-json.ts` auto-detects non-TTY environments (via `isNonTTY()`), so tests run via `execSync` (which is non-TTY) receive JSON output even when the test expects human-readable text.

## Root Cause Analysis
- `shouldOutputJson()` (apps/cli/src/lib/prompt-json.ts:386-394) returns `true` when `isNonTTY()` is true, which it always is in `execSync` (test execution context)
- Tests in `workspace-commands.test.ts` that assert human-readable strings (e.g. `expect(output).to.include('Registered workspace')`) fail because the actual output is a JSON envelope like `{"type":"success","result":{...}}`
- Tests that parse JSON without `--json` flag work accidentally (they get JSON due to non-TTY auto-detection), but this coupling is fragile
- The `workspace-agent-flow.test.ts` correctly uses `--json` flags explicitly and is better aligned

## Affected Files
- `apps/cli/test/e2e/workspace-commands.test.ts` — 14 tests mixing human-readable and JSON expectations without explicit mode control
- `apps/cli/test/e2e/workspace-agent-flow.test.ts` — 18 tests, mostly well-aligned but some follow-up commands strip `--json` and expect human-readable text in non-TTY
- `apps/cli/test/e2e/test-helpers.ts` — missing mode-selection helpers (e.g., `execAsHuman`, `execAsAgent`)
- `apps/cli/src/lib/prompt-json.ts` — `shouldOutputJson()` and `isNonTTY()` define the output contract

## Requirements
- R1: Tests that assert human-readable output must explicitly opt into human-readable mode (e.g. via `PRLT_OUTPUT_FORMAT=plain` env var or a test helper that forces TTY-like behavior)
- R2: Tests that assert JSON output must explicitly use `--json` or `--machine` flags, not rely on non-TTY auto-detection
- R3: Add `execAsHuman(cmd)` and `execAsAgent(cmd)` helper functions to `test-helpers.ts` that set the correct env vars/flags per mode
- R4: Each test should document which output mode it is testing (interactive text, JSON/machine, or non-TTY default)
- R5: The `workspace prune` non-TTY dry-run behavior (line 346-365 of workspace-commands.test.ts) needs special attention — it tests non-TTY detection specifically, so it must use neither --json nor force-human mode

## Flagged Ambiguities
- **Output contract decision needed**: Should non-TTY default remain JSON (current behavior), or should it change to human-readable requiring explicit `--json`? The ticket description mentions "non-TTY auto-json" as a mode, but TKT-1100 may be planning to change this. The fix approach depends on which contract is canonical.
- **Scope of "workspace-related"**: The description says "workspace commands" but the same pattern (brittle text assertions in non-TTY) likely affects other command e2e tests (autocomplete-setup, config-commands). Should this ticket cover all e2e tests or just workspace?

## Changes

- 8a3a8eb6 fix(TKT-1112): fix workspace e2e output contract drift across interactive/non-TTY/JSON modes

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
