### PR TITLE
TKT-1031: Agent action prompts should include prlt CLI command reference

### DIFF
--- a/apps/cli/src/lib/pmo/storage/base.ts
+++ b/apps/cli/src/lib/pmo/storage/base.ts
@@ -573,6 +573,50 @@ Example (WRONG - do not do this):
 `.trim()
 
 /**
+ * prlt CLI command reference sections for action prompts.
+ * Each action gets a tailored set of commands relevant to its workflow.
+ */
+const PRLT_COMMANDS_COMMON = `
+## prlt CLI Reference
+
+Use these commands to interact with the ticket system. Always use the global \`prlt\` command.
+
+| Command | Description |
+|---------|-------------|
+| \`prlt ticket show <id>\` | View full ticket details (description, AC, subtasks, labels) |
+| \`prlt ticket edit <id> [flags]\` | Update ticket fields (see flags below) |
+| \`prlt ticket list\` | List tickets on the board |
+| \`prlt whoami\` | Show current agent/user identity |
+
+### Common \`ticket edit\` flags
+| Flag | Description |
+|------|-------------|
+| \`--title "..."\` | Update title |
+| \`--description "..."\` | Update description |
+| \`--priority P0\\|P1\\|P2\\|P3\` | Set priority |
+| \`--category <type>\` | Set category (feature, bug, refactor, etc.) |
+| \`--add-ac "..."\` | Add acceptance criterion |
+| \`--clear-ac\` | Clear all acceptance criteria |
+| \`--add-subtask "..."\` | Add a subtask |
+| \`--clear-subtasks\` | Clear all subtasks |
+| \`--add-label "..."\` | Add a label |
+| \`--remove-label "..."\` | Remove a label |
+| \`--assignee <name>\` | Set assignee |
+| \`--owner <name>\` | Set owner |`
+
+const PRLT_COMMANDS_CODE = `
+| \`prlt commit "message"\` | Create a commit with ticket ID from branch name |
+| \`prlt work ready <id> --pr\` | Mark ticket ready for review and create a PR |`
+
+const PRLT_COMMANDS_REVIEW = `
+| \`prlt ticket move <id>\` | Move ticket to a different column |
+| \`prlt ticket complete <id>\` | Mark ticket as complete (move to Done) |`
+
+const PRLT_COMMANDS_RESOLVE = `
+| \`prlt ticket resolve <id>\` | Interactive resolution of ambiguity questions |
+| \`prlt work resolve <id>\` | Agent-assisted resolution of ambiguity questions |`
+
+/**
  * Seed built-in work actions.
  */
 export function seedBuiltinActions(db: Database.Database): void {
@@ -613,6 +657,15 @@ When questions are added:
 If NO ambiguities are found, add the \`ready\` label instead.
 
 **AI Agent Tip:** When running \`prlt\` commands without all required arguments, use \`--json\` to receive interactive prompts as structured JSON.
+
+### Additional prlt Commands
+| Command | Description |
+|---------|-------------|
+| \`prlt ticket show <id>\` | View full ticket details |
+| \`prlt ticket list\` | List tickets on the board |
+| \`prlt whoami\` | Show current agent/user identity |
+| \`prlt ticket resolve <id>\` | Interactive resolution of ambiguity questions |
+| \`prlt work resolve <id>\` | Agent-assisted resolution of ambiguity questions |
 
 ## Ticket Schema Reference
 
@@ -710,7 +763,10 @@ For each question:
 ## Important
 - This is an INTERACTIVE session - always ask the human before writing answers
 - If the ticket has acceptance criteria or subtasks that need updating based on answers, update those too
-- After resolving, move the ticket to the Ready column if all questions are answered`,
+- After resolving, move the ticket to the Ready column if all questions are answered
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_RESOLVE}`,
       endPrompt: `After resolving all questions:
 1. Update the ticket description with answers below each question
 2. Remove the \`needs-clarification\` label and add \`ready\` label
@@ -753,7 +809,10 @@ prlt commit "implement user validation"
 git push
 \`\`\`
 
-When complete, the ticket should be ready for code review.`,
+When complete, the ticket should be ready for code review.
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_CODE}`,
       endPrompt: `When complete:
 1. **Commit your work** in each repository directory you modified:
    \`\`\`bash
@@ -799,7 +858,10 @@ Continue working on this ticket from where you left off.
 
 \`\`\`bash
 git add -A && prlt commit "your change" && git push
-\`\`\``,
+\`\`\`
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_CODE}`,
       endPrompt: `When complete:
 1. **Commit your work** in each repository directory you modified:
    \`\`\`bash
@@ -843,7 +905,10 @@ After reviewing, determine your verdict:
 - **REQUEST_CHANGES**: There are issues that must be fixed before merging
 - **COMMENT**: General feedback, no blocking issues but some suggestions
 
-Do NOT modify any code. This is a read-only review.`,
+Do NOT modify any code. This is a read-only review.
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_REVIEW}`,
       endPrompt: `When you have finished reviewing, post your review on the PR using \`gh pr review\`.
 
 Choose the appropriate command based on your verdict:
@@ -920,7 +985,11 @@ Review this ticket's implementation thoroughly and fix any issues found:
 
 \`\`\`bash
 git add -A && prlt commit "fix: address code review findings" && git push
-\`\`\``,
+\`\`\`
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_CODE}
+${PRLT_COMMANDS_REVIEW}`,
       endPrompt: `When you have finished reviewing and fixing:
 
 1. **If issues were found and fixed**, post a review summary and push your fixes:
@@ -990,7 +1059,10 @@ Address the feedback on this ticket's pull request:
 
 \`\`\`bash
 git add -A && prlt commit "fix: address PR review feedback" && git push
-\`\`\``,
+\`\`\`
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_CODE}`,
       endPrompt: `After addressing all feedback:
 
 1. **Commit your changes**:
@@ -1199,7 +1271,10 @@ Write comprehensive tests for this ticket's implementation:
 
 \`\`\`bash
 git add -A && prlt commit "add tests for X" && git push
-\`\`\``,
+\`\`\`
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_CODE}`,
       endPrompt: `When complete:
 1. **Commit your tests**:
    \`\`\`bash


### PR DESCRIPTION
## Summary

Resolves TKT-1031: Agent action prompts should include prlt CLI command reference

## Description

## Problem

Spawned agents don't know which `prlt` commands are available to them. When a review agent needs to update a ticket, it searches the filesystem for ticket storage files instead of running `prlt ticket edit TKT-xxx`.

Currently only the groom and implement action prompts mention specific prlt commands (e.g., `prlt commit`, `prlt work ready`, `prlt ticket edit`). Other actions like review, revise, resolve have no prlt command guidance.

## Observed Behavior

A review agent spawned for TKT-989 was asked to update the ticket's open questions. It:
1. Searched for ticket files on disk
2. Tried to find `workspace.db`
3. Explored the PMO directory structure
4. Never discovered it could just run `prlt ticket edit TKT-989 --description "..."`

## Expected Behavior

Every action prompt should include a section listing the prlt commands relevant to that action. For example:

- **Review action**: `prlt ticket edit`, `prlt ticket show`, `prlt ticket add-ac`, `prlt ticket add-label`
- **Revise action**: `prlt commit`, `prlt ticket edit`, `prlt work ready`
- **Groom action**: already has some, but could be more comprehensive
- **All actions**: basic commands like `prlt ticket show <id>`, `prlt whoami`

## Key Files

- `apps/cli/src/lib/pmo/storage/base.ts` — built-in action definitions with prompt/endPrompt fields
- Action prompt templates in the `seedBuiltinActions()` function

## Changes

- 892ca639 feat(TKT-1031): add prlt CLI command references to all action prompts

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
