### PR TITLE
TKT-1133: Docker agents should always run inside tmux, not print mode

### DIFF
--- a/apps/cli/src/lib/execution/spawner.ts
+++ b/apps/cli/src/lib/execution/spawner.ts
@@ -547,11 +547,20 @@ export async function spawnAgentForTicket(
   // Load execution config (use passed config or load from db)
   const executionConfig = options.executionConfig || loadExecutionConfig(db)
   executionConfig.sandboxed = sandboxed
-  // Use print mode for background, interactive for terminal/tmux
-  executionConfig.outputMode = displayMode === 'background' ? 'print' : 'interactive'
 
   // Run execution
-  const sessionManager = options.sessionManager || 'direct'
+  // Default to tmux for session persistence (enables peek/poke/attach)
+  const sessionManager = options.sessionManager || 'tmux'
+
+  // Determine output mode:
+  // - Devcontainer with tmux: always interactive (no -p flag) so Claude runs with TUI
+  //   inside tmux, enabling session peek/poke/attach for Docker agents
+  // - Otherwise: print mode for background (logs only), interactive for terminal/tmux
+  if (environment === 'devcontainer' && sessionManager === 'tmux') {
+    executionConfig.outputMode = 'interactive'
+  } else {
+    executionConfig.outputMode = displayMode === 'background' ? 'print' : 'interactive'
+  }
   const result = await runExecution(environment, context, executor, executionConfig, {
     displayMode,
     sessionManager: environment === 'devcontainer' ? sessionManager : undefined,


### PR DESCRIPTION
## Summary

Resolves TKT-1133: Docker agents should always run inside tmux, not print mode

## Description

## Problem
`prlt work start` with `--environment devcontainer` launches Claude Code with `-p` (print mode) inside containers instead of in a tmux session. This means:
- `session peek` can't see them (no tmux session to capture)
- `session poke` can't send messages
- `session attach` can't connect
- No scrollback or history
- Only way to monitor is reading raw log files

## Current behavior
Container runs: `claude --permission-mode bypassPermissions --dangerously-skip-permissions -p "$(cat prompt.txt)"`

## Expected behavior
Container should run Claude Code inside a tmux session, same as host mode. The `-p` flag should not be used for Docker agents.

Something like:
```
tmux new-session -d -s <sessionId> 'claude --permission-mode bypassPermissions --dangerously-skip-permissions "prompt"'
```

This enables peek/poke/attach to work for Docker agents, which is critical for orchestration.

## Context
- Print mode makes Docker agents completely opaque to the monitoring toolchain
- TKT-1132 (peek doesn't work for Docker) is partly caused by this - even if peek could reach into containers, there's no tmux session to capture
- The orchestrator needs visibility into agent progress

## Changes

- 9aec85a3 fix(TKT-1133): docker agents always run inside tmux instead of print mode

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
