### PR TITLE
TKT-1135: Fix orchestrator attach: default to direct tmux attach, detect terminal emulator

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -20,7 +20,7 @@ import { ORCHESTRATOR_SESSION_NAME } from './start.js'
  * Returns a terminal app name suitable for AppleScript tab creation,
  * or null if detection fails or we're in a remote/headless environment.
  */
-function detectTerminalApp(): string | null {
+export function detectTerminalApp(): string | null {
   // Remote sessions should never attempt AppleScript/GUI operations
   if (process.env.SSH_TTY || process.env.SSH_CONNECTION) {
     return null
@@ -67,6 +67,12 @@ export default class OrchestratorAttach extends PromptCommand {
       char: 't',
       description: 'Terminal app to use for new tab (iTerm, Terminal, Ghostty). Auto-detected if not specified.',
     }),
+    'current-terminal': Flags.boolean({
+      char: 'c',
+      description: '[deprecated] Attach in current terminal (this is now the default behavior)',
+      hidden: true,
+      default: false,
+    }),
   }
 
   async run(): Promise<void> {
@@ -97,6 +103,14 @@ export default class OrchestratorAttach extends PromptCommand {
         status: 'attaching',
       }, createMetadata('orchestrator attach', flags as Record<string, unknown>))
       return
+    }
+
+    if (flags['current-terminal']) {
+      this.log(styles.warning('--current-terminal is deprecated. Direct tmux attach is now the default behavior.'))
+    }
+
+    if (flags.terminal && !flags['new-tab']) {
+      this.log(styles.warning('--terminal has no effect without --new-tab. Ignoring.'))
     }
 
     this.log('')

--- a/apps/cli/src/commands/orchestrator/index.ts
+++ b/apps/cli/src/commands/orchestrator/index.ts
@@ -32,26 +32,28 @@ export default class Orchestrator extends PMOCommand {
     const hostSessions = getHostTmuxSessionNames()
     const isRunning = hostSessions.includes(ORCHESTRATOR_SESSION_NAME)
 
-    const choices = [
-      { name: 'Start orchestrator', value: 'start', command: 'prlt orchestrator start --json' },
-      ...(isRunning ? [{ name: 'Attach to running session', value: 'attach', command: 'prlt orchestrator attach --json' }] : []),
-      { name: 'Attach to orchestrator', value: 'attach', command: 'prlt orchestrator attach --json' },
-      { name: 'Check orchestrator status', value: 'status', command: 'prlt orchestrator status --json' },
-      { name: 'Stop orchestrator', value: 'stop', command: 'prlt orchestrator stop --json' },
-      { name: 'Cancel', value: 'cancel' },
-    ]
-
-    // When running, move "Attach to running session" to the top for visibility
-    // and remove the generic "Attach to orchestrator" to avoid duplication
-    const filteredChoices = isRunning
-      ? choices.filter(c => c.name !== 'Attach to orchestrator')
-      : choices.filter(c => c.name !== 'Attach to running session')
+    // When running, show "Attach to running session" first since that's the likely intent
+    const choices = isRunning
+      ? [
+          { name: 'Attach to running session', value: 'attach', command: 'prlt orchestrator attach --json' },
+          { name: 'Start orchestrator', value: 'start', command: 'prlt orchestrator start --json' },
+          { name: 'Check orchestrator status', value: 'status', command: 'prlt orchestrator status --json' },
+          { name: 'Stop orchestrator', value: 'stop', command: 'prlt orchestrator stop --json' },
+          { name: 'Cancel', value: 'cancel' },
+        ]
+      : [
+          { name: 'Start orchestrator', value: 'start', command: 'prlt orchestrator start --json' },
+          { name: 'Attach to orchestrator', value: 'attach', command: 'prlt orchestrator attach --json' },
+          { name: 'Check orchestrator status', value: 'status', command: 'prlt orchestrator status --json' },
+          { name: 'Stop orchestrator', value: 'stop', command: 'prlt orchestrator stop --json' },
+          { name: 'Cancel', value: 'cancel' },
+        ]
 
     const { action } = await this.prompt<{ action: string }>([{
       type: 'list',
       name: 'action',
       message: 'Orchestrator - What would you like to do?',
-      choices: filteredChoices,
+      choices,
     }], jsonModeConfig)
 
     if (action === 'cancel') {

--- a/apps/cli/test/unit/detect-terminal-app.test.ts
+++ b/apps/cli/test/unit/detect-terminal-app.test.ts
@@ -1,0 +1,94 @@
+import { expect } from 'chai'
+import { detectTerminalApp } from '../../src/commands/orchestrator/attach.js'
+
+describe('detectTerminalApp', () => {
+  const originalEnv = { ...process.env }
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    // Clear all relevant env vars before each test
+    delete process.env.SSH_TTY
+    delete process.env.SSH_CONNECTION
+    delete process.env.DISPLAY
+    delete process.env.WAYLAND_DISPLAY
+    delete process.env.TERM_PROGRAM
+  })
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = { ...originalEnv }
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  describe('remote session detection', () => {
+    it('returns null when SSH_TTY is set', () => {
+      process.env.SSH_TTY = '/dev/pts/0'
+      process.env.TERM_PROGRAM = 'iTerm.app'
+      expect(detectTerminalApp()).to.equal(null)
+    })
+
+    it('returns null when SSH_CONNECTION is set', () => {
+      process.env.SSH_CONNECTION = '192.168.1.1 52000 192.168.1.2 22'
+      process.env.TERM_PROGRAM = 'iTerm.app'
+      expect(detectTerminalApp()).to.equal(null)
+    })
+  })
+
+  describe('headless detection on non-darwin', () => {
+    it('returns null when no DISPLAY or WAYLAND_DISPLAY on linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      process.env.TERM_PROGRAM = 'iTerm.app'
+      expect(detectTerminalApp()).to.equal(null)
+    })
+
+    it('detects terminal when DISPLAY is set on linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      process.env.DISPLAY = ':0'
+      process.env.TERM_PROGRAM = 'iTerm.app'
+      expect(detectTerminalApp()).to.equal('iTerm')
+    })
+
+    it('detects terminal when WAYLAND_DISPLAY is set on linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      process.env.WAYLAND_DISPLAY = 'wayland-0'
+      process.env.TERM_PROGRAM = 'ghostty'
+      expect(detectTerminalApp()).to.equal('Ghostty')
+    })
+  })
+
+  describe('TERM_PROGRAM mapping', () => {
+    beforeEach(() => {
+      // Ensure we're on darwin so the headless check doesn't interfere
+      Object.defineProperty(process, 'platform', { value: 'darwin' })
+    })
+
+    it('returns null when TERM_PROGRAM is not set', () => {
+      expect(detectTerminalApp()).to.equal(null)
+    })
+
+    it('maps iTerm.app to iTerm', () => {
+      process.env.TERM_PROGRAM = 'iTerm.app'
+      expect(detectTerminalApp()).to.equal('iTerm')
+    })
+
+    it('maps ghostty to Ghostty', () => {
+      process.env.TERM_PROGRAM = 'ghostty'
+      expect(detectTerminalApp()).to.equal('Ghostty')
+    })
+
+    it('maps Apple_Terminal to Terminal', () => {
+      process.env.TERM_PROGRAM = 'Apple_Terminal'
+      expect(detectTerminalApp()).to.equal('Terminal')
+    })
+
+    it('maps WezTerm to WezTerm', () => {
+      process.env.TERM_PROGRAM = 'WezTerm'
+      expect(detectTerminalApp()).to.equal('WezTerm')
+    })
+
+    it('returns null for unknown terminal programs', () => {
+      process.env.TERM_PROGRAM = 'alacritty'
+      expect(detectTerminalApp()).to.equal(null)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves TKT-1135: Fix orchestrator attach: default to direct tmux attach, detect terminal emulator

## Description

## Problem

`prlt orchestrator attach` defaults to opening a new iTerm tab via AppleScript. This hangs on remote machines (SSH), headless environments, and non-iTerm terminals. The safe default should be direct `tmux attach`.

## Changes

### 1. Flip the default
- Default should be direct `tmux attach -t` in current terminal (current `--current-terminal` behavior)
- Add `--new-tab` flag for the "open in new terminal tab" behavior (opt-in)

### 2. Detect terminal emulator
Use environment variables to auto-detect and pick the right terminal app:
- `$TERM_PROGRAM` → `iTerm.app`, `ghostty`, `Apple_Terminal`, `WezTerm`, etc.
- `$SSH_TTY` or `$SSH_CONNECTION` → remote session, never try AppleScript
- `$DISPLAY` / headless detection → skip GUI attempts

### 3. Add "attach" to `prlt orchestrator` menu
When running `prlt orchestrator` with no subcommand (if there's an interactive menu), include "Attach to running session" as an option when the orchestrator is already running.

## Files
- `apps/cli/src/commands/orchestrator/attach.ts`
- `apps/cli/src/commands/orchestrator/start.ts` (if menu exists)

## Verify
- `prlt orchestrator attach` over SSH should work immediately (no hang)
- `prlt orchestrator attach --new-tab` should open a tab in detected terminal
- `prlt orchestrator attach --new-tab --terminal Ghostty` should work for explicit override

## Changes

- 125213e8 fix(TKT-1135): fix orchestrator attach: default to direct tmux attach, detect terminal emulator

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
