### PR TITLE
chore: bump version to 0.3.46

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump version from 0.3.45 to 0.3.46
- Includes 12 merged PRs: TKT-117, 1028, 1029, 1031, 1032, 1074, 1094, 1112, 1115, 1133, 1134, 1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)