### PR TITLE
TKT-1147: Bug: review-comment action agents merging PRs and running tests instead of just posting comments

### DIFF
--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -1532,28 +1532,36 @@ export default class WorkSpawn extends PMOCommand {
         }
 
         // Prompt for permissions mode if not explicitly set via --skip-permissions flag
+        // Non-code-modifying actions (review, review-comment, groom) default to safe mode
+        // to prevent agents from performing destructive operations like merging PRs
+        const spawnActionModifiesCode = selectedActionDetails?.modifiesCode ?? true
         if (!flags['skip-permissions']) {
-          // Use FlagResolver for permission mode
-          const permissionResolver = new FlagResolver<{ permissionMode?: string }>({
-            commandName: 'work spawn',
-            baseCommand: 'prlt work spawn',
-            jsonMode,
-            flags: {},
-          })
+          if (!spawnActionModifiesCode) {
+            // Non-code-modifying actions automatically use safe mode
+            batchPermissionMode = 'safe'
+          } else {
+            // Use FlagResolver for permission mode
+            const permissionResolver = new FlagResolver<{ permissionMode?: string }>({
+              commandName: 'work spawn',
+              baseCommand: 'prlt work spawn',
+              jsonMode,
+              flags: {},
+            })
 
-          permissionResolver.addPrompt({
-            flagName: 'permissionMode',
-            type: 'list',
-            message: `Permission mode for ${executorName}:`,
-            default: 'danger',
-            choices: () => [
-              { name: '⚠️  danger - Skip permission checks (faster, container provides isolation)', value: 'danger' },
-              { name: '🔒 safe   - Requires approval for dangerous operations', value: 'safe' },
-            ],
-          })
+            permissionResolver.addPrompt({
+              flagName: 'permissionMode',
+              type: 'list',
+              message: `Permission mode for ${executorName}:`,
+              default: 'danger',
+              choices: () => [
+                { name: '⚠️  danger - Skip permission checks (faster, container provides isolation)', value: 'danger' },
+                { name: '🔒 safe   - Requires approval for dangerous operations', value: 'safe' },
+              ],
+            })
 
-          const permissionResult = await permissionResolver.resolve()
-          batchPermissionMode = permissionResult.permissionMode as PermissionMode
+            const permissionResult = await permissionResolver.resolve()
+            batchPermissionMode = permissionResult.permissionMode as PermissionMode
+          }
         }
 
         // Prompt for PR creation if not provided AND action modifies code

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -1353,8 +1353,16 @@ export default class WorkStart extends PMOCommand {
 
       // Prompt for permissions mode (all environments)
       // Use FlagResolver to handle both JSON mode and interactive prompts consistently
+      // Non-code-modifying actions (review, review-comment, groom) default to safe mode
+      // to prevent agents from performing destructive operations like merging PRs
+      const actionModifiesCode = context.modifiesCode !== false
+      const defaultPermissionMode = actionModifiesCode ? 'danger' : 'safe'
+
       if (flags['permission-mode']) {
         sandboxed = flags['permission-mode'] === 'safe'
+      } else if (!actionModifiesCode) {
+        // Non-code-modifying actions automatically use safe mode
+        sandboxed = true
       } else {
         const containerNote = environment === 'devcontainer'
           ? ' (container provides additional isolation)'
@@ -1373,7 +1381,7 @@ export default class WorkStart extends PMOCommand {
           flagName: 'permission-mode',
           type: 'list',
           message: `Permission mode for ${executorName}${containerNote}:`,
-          default: 'danger',
+          default: defaultPermissionMode,
           choices: () => [
             { name: '⚠️  danger - Skip permission checks (faster, container provides isolation)', value: 'danger' },
             { name: '🔒 safe   - Requires approval for dangerous operations', value: 'safe' },
@@ -2236,9 +2244,11 @@ export default class WorkStart extends PMOCommand {
     const useDevcontainer = hasDevcontainer && !flags['run-on-host']
 
     // Non-interactive defaults
+    // Non-code-modifying actions default to safe mode to prevent destructive operations
     const environment: ExecutionEnvironment = useDevcontainer ? 'devcontainer' : 'host'
     const displayMode: DisplayMode = 'terminal'
-    const sandboxed = flags['permission-mode'] === 'safe'
+    const actionModifiesCode = context.modifiesCode !== false
+    const sandboxed = flags['permission-mode'] === 'safe' || (!flags['permission-mode'] && !actionModifiesCode)
     const executor = (flags.executor as ExecutorType) || DEFAULT_EXECUTION_CONFIG.defaultExecutor
     const outputMode: OutputMode = 'interactive'
 

--- a/apps/cli/src/lib/pmo/storage/base.ts
+++ b/apps/cli/src/lib/pmo/storage/base.ts
@@ -904,7 +904,16 @@ After reviewing, determine your verdict:
 - **REQUEST_CHANGES**: There are issues that must be fixed before merging
 - **COMMENT**: General feedback, no blocking issues but some suggestions
 
-Do NOT modify any code. Do NOT attempt to fix any issues. This is a read-only review — report your findings only.
+## STRICT RULES - READ CAREFULLY
+
+- **DO NOT** merge the PR (\`gh pr merge\` is FORBIDDEN)
+- **DO NOT** push any code (\`git push\` is FORBIDDEN)
+- **DO NOT** run tests or test suites
+- **DO NOT** modify, edit, or write any code files
+- **DO NOT** create commits
+- Your ONLY output should be a \`gh pr review\` comment
+- This is a **read-only** review — read the diff, analyze it, post your review, and stop
+
 If you identify issues that need fixing, describe them in your review. A separate action (Review & Fix) will handle fixes.
 
 ${PRLT_COMMANDS_COMMON}
@@ -959,7 +968,7 @@ COMMENT - Some suggestions but no blocking issues."
 
 Format the body with: what looks good, concerns (if any), suggested improvements (if any), and your verdict.
 
-No commits are needed for code review.
+**REMINDER:** Do NOT merge the PR. Do NOT run tests. Do NOT modify code. Only post the review comment above.
 
 **After posting your review**, if you found issues that need fixing, log them on the ticket so another action can address them:
 \`\`\`bash
@@ -970,6 +979,76 @@ prlt ticket edit <TICKET_ID> --add-subtask "Fix: <description of issue>"
       suggestedForCategories: ['started', 'completed'],
       modifiesCode: false,
       position: 4,
+    },
+    {
+      id: 'review-comment',
+      name: 'Review Comment',
+      description: 'Post review comments on a PR without merging, testing, or modifying code',
+      prompt: `${PRLT_USAGE_RULE}
+
+---
+
+# Action: Review Comment
+
+Read the PR diff, analyze the changes, and post a GitHub review comment. That is your ONLY job.
+
+## STRICT RULES - READ CAREFULLY
+
+You are a **read-only** reviewer. You MUST follow these rules:
+
+- **DO NOT** run \`gh pr merge\` — merging is FORBIDDEN
+- **DO NOT** run \`git push\` — pushing is FORBIDDEN
+- **DO NOT** run tests or test suites of any kind
+- **DO NOT** modify, edit, or write any code files
+- **DO NOT** create commits or branches
+- **DO NOT** run any commands that change repository state
+- Your **ONLY** permitted write operation is \`gh pr review\` to post your comment
+
+## What To Do
+
+1. Read the PR diff to understand the changes
+2. Analyze the code for bugs, issues, style, and correctness
+3. Post your review using \`gh pr review\` with the appropriate verdict
+4. **STOP** — do nothing else after posting the review
+
+${PRLT_COMMANDS_COMMON}
+${PRLT_COMMANDS_REVIEW}`,
+      endPrompt: `Post your review on the PR using \`gh pr review\`. This is the ONLY action you should take.
+
+**If approving:**
+\`\`\`bash
+gh pr review --approve --body "## Review
+
+### Summary
+- ...
+
+APPROVED - Looks good to merge."
+\`\`\`
+
+**If requesting changes:**
+\`\`\`bash
+gh pr review --request-changes --body "## Review
+
+### Issues
+- ...
+
+REQUEST CHANGES - Please address the above."
+\`\`\`
+
+**If commenting:**
+\`\`\`bash
+gh pr review --comment --body "## Review
+
+### Feedback
+- ...
+
+COMMENT - Some suggestions, no blockers."
+\`\`\`
+
+**CRITICAL REMINDER:** After posting your review, STOP. Do NOT merge the PR. Do NOT run tests. Do NOT modify code. Do NOT push anything. Your job is done after the \`gh pr review\` command.`,
+      suggestedForCategories: ['completed'],
+      modifiesCode: false,
+      position: 5,
     },
     {
       id: 'review-fix',
@@ -1030,7 +1109,7 @@ ${PRLT_COMMANDS_REVIEW}`,
    \`\`\``,
       suggestedForCategories: ['started', 'completed'],
       modifiesCode: true,
-      position: 5,
+      position: 6,
     },
     {
       id: 'revise',
@@ -1094,7 +1173,7 @@ The PR will be updated automatically with your pushed changes.`,
       suggestedForCategories: ['completed'],
       defaultMoveToCategory: 'started',
       modifiesCode: true,
-      position: 6,
+      position: 7,
     },
     {
       id: 'explore-cli',
@@ -1255,7 +1334,7 @@ tmux_kill_session({ session: "qa-test" })
 \`\`\``,
       suggestedForCategories: [],
       modifiesCode: false,
-      position: 8,
+      position: 9,
     },
     {
       id: 'test',
@@ -1300,7 +1379,7 @@ ${PRLT_COMMANDS_CODE}`,
 **IMPORTANT:** Use the global \`prlt\` command.`,
       suggestedForCategories: ['started', 'completed'],
       modifiesCode: true,
-      position: 7,
+      position: 8,
     },
   ]
 


### PR DESCRIPTION
## Summary

Resolves TKT-1147: Bug: review-comment action agents merging PRs and running tests instead of just posting comments

## Description

The `review-comment` action is supposed to be non-destructive: read the PR diff, analyze it, and post GitHub review comments. Instead, agents are:

1. **Merging PRs** - hot-cook (TKT-1133) ran `gh pr merge 529 --squash` and merged it
2. **Running full e2e test suites** - fleet-siebel (TKT-1115) ran MCP Server E2E Tests instead of just reviewing code

The action prompt needs tighter guardrails:
- Explicitly forbid `gh pr merge`, `git push`, and any write operations
- Explicitly state the ONLY output should be `gh pr review` comments
- Add "DO NOT merge, DO NOT run tests, DO NOT modify code" to the prompt
- Consider using safe permission mode instead of danger mode for review actions

Discovered when spawning 13 review-comment agents against open PRs.

## Changes

- 3aece976 fix(TKT-1147): add review-comment action with strict guardrails and default non-code-modifying actions to safe mode

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
