### PR TITLE
fix: map permission flags to executor runtime (Codex/Claude)

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -204,7 +204,10 @@ export function getExecutorCommand(executor: ExecutorType, prompt: string, skipP
       // Manual mode - will prompt for each action (still interactive, no -p)
       return { cmd: 'claude', args: [prompt] }
     case 'codex':
-      return { cmd: 'codex', args: ['--prompt', prompt] }
+      // Codex has its own danger-mode flag; do not use Claude flags here.
+      return skipPermissions
+        ? { cmd: 'codex', args: ['--dangerously-bypass-approvals-and-sandbox', '--prompt', prompt] }
+        : { cmd: 'codex', args: ['--prompt', prompt] }
     case 'aider':
       return { cmd: 'aider', args: ['--message', prompt] }
     case 'custom':
@@ -1437,7 +1440,7 @@ export function buildDevcontainerCommand(
     executorCmd = `claude ${bypassTrustFlag}${permissionsFlag}${effortFlag}${printFlag}"$(cat ${promptFile})"`
   } else {
     // Non-Claude executors: use getExecutorCommand() to get correct command and args
-    const { cmd, args } = getExecutorCommand(executor, `PLACEHOLDER`, false)
+    const { cmd, args } = getExecutorCommand(executor, `PLACEHOLDER`, !sandboxed)
     // Replace the placeholder prompt with a file read for shell safety
     const argsStr = args.map(a => a === 'PLACEHOLDER' ? `"$(cat ${promptFile})"` : a).join(' ')
     executorCmd = `${cmd} ${argsStr}`

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -361,10 +361,10 @@ describe('Execution Utils', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with --prompt flag', () => {
+      it('should return codex command with danger flag and --prompt when skipPermissions=true', () => {
         const result = getExecutorCommand('codex', testPrompt)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--dangerously-bypass-approvals-and-sandbox', '--prompt', testPrompt])
       })
 
       it('should NOT include Claude-specific flags', () => {
@@ -374,10 +374,11 @@ describe('Execution Utils', () => {
         expect(result.args).to.not.include('bypassPermissions')
       })
 
-      it('should ignore skipPermissions parameter', () => {
+      it('should apply skipPermissions parameter using Codex-native flag', () => {
         const resultTrue = getExecutorCommand('codex', testPrompt, true)
         const resultFalse = getExecutorCommand('codex', testPrompt, false)
-        expect(resultTrue.args).to.deep.equal(resultFalse.args)
+        expect(resultTrue.args).to.include('--dangerously-bypass-approvals-and-sandbox')
+        expect(resultFalse.args).to.deep.equal(['--prompt', testPrompt])
       })
     })
 


### PR DESCRIPTION
## Summary
- map `--skip-permissions` / danger mode to Codex-native flag: `--dangerously-bypass-approvals-and-sandbox`
- keep Claude using Claude-native permission flags
- pass devcontainer non-Claude permission state through command builder (no hardcoded safe path)
- update unit tests for Codex permission mapping behavior

## Why
Host/background codex runs were failing with:
`unexpected argument '--dangerously-skip-permissions'`

This ensures permission-mode semantics are executor-specific.

## Validation
- `pnpm --dir apps/cli exec mocha --forbid-only test/unit/execution-utils.test.ts` (passes)
- full typecheck currently has unrelated pre-existing errors in `src/lib/linear/client.ts` on this branch
