### PR TITLE
fix(TKT-1161): sanitize special chars in buildSessionName

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -32,8 +32,11 @@ import { readDevcontainerJson } from './devcontainer.js'
  * Example: "TKT-347-implement-altman"
  */
 export function buildSessionName(context: ExecutionContext): string {
-  // Sanitize action name: replace spaces and special chars with hyphens for shell safety
-  const action = (context.actionName || 'work').replace(/\s+/g, '-')
+  // Sanitize action name: strip non-alphanumeric chars for shell/tmux safety (& breaks paths)
+  const action = (context.actionName || 'work')
+    .replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
   const agent = context.agentName || 'agent'
   return `${context.ticketId}-${action}-${agent}`
 }


### PR DESCRIPTION
## Summary
- Fixes `buildSessionName()` to strip all non-alphanumeric characters (except `.`, `-`, `_`) from action names
- Action names like "Review & Comment" previously broke shell paths and tmux sessions due to `&`
- The whitespace-only regex `\s+` is replaced with a strict character allowlist

## Test plan
- [ ] Verify `buildSessionName` with action name "Review & Comment" produces `TKT-xxx-Review-Comment-agent`
- [ ] Verify existing action names like "implement" still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)