### PR TITLE
fix: map danger mode to executor-native flags (Codex yolo, Claude skip-permissions)

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -207,9 +207,9 @@ export function getExecutorCommand(executor: ExecutorType, prompt: string, skipP
       // Manual mode - will prompt for each action (still interactive, no -p)
       return { cmd: 'claude', args: [prompt] }
     case 'codex':
-      // Codex has its own danger-mode flag; do not use Claude flags here.
+      // Map danger mode to Codex-native autonomy mode.
       return skipPermissions
-        ? { cmd: 'codex', args: ['--dangerously-bypass-approvals-and-sandbox', '--prompt', prompt] }
+        ? { cmd: 'codex', args: ['--yolo', '--prompt', prompt] }
         : { cmd: 'codex', args: ['--prompt', prompt] }
     case 'aider':
       return { cmd: 'aider', args: ['--message', prompt] }

--- a/apps/cli/test/unit/codex-runtime.test.ts
+++ b/apps/cli/test/unit/codex-runtime.test.ts
@@ -60,16 +60,17 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with --prompt flag', () => {
+      it('should return codex command with --yolo and --prompt in danger mode', () => {
         const result = getExecutorCommand('codex', testPrompt, true)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
       })
 
-      it('should return same command regardless of skipPermissions', () => {
+      it('should map skipPermissions=false to non-yolo command', () => {
         const withSkip = getExecutorCommand('codex', testPrompt, true)
         const withoutSkip = getExecutorCommand('codex', testPrompt, false)
-        expect(withSkip).to.deep.equal(withoutSkip)
+        expect(withSkip.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(withoutSkip.args).to.deep.equal(['--prompt', testPrompt])
       })
 
       it('should not include claude-specific flags', () => {
@@ -127,7 +128,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should use codex binary for codex executor (not hardcoded claude)', () => {
       const result = getExecutorCommand('codex', 'build the feature')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--prompt', 'build the feature'])
+      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'build the feature'])
     })
 
     it('should use aider binary for aider executor (not hardcoded claude)', () => {
@@ -150,7 +151,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should use codex binary for codex executor on VM', () => {
       const result = getExecutorCommand('codex', 'implement on VM')
       expect(result.cmd).to.equal('codex')
-      expect(result.args[0]).to.equal('--prompt')
+      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'implement on VM'])
     })
 
     it('should use aider binary for aider executor on VM', () => {
@@ -204,7 +205,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should handle empty prompts', () => {
       const result = getExecutorCommand('codex', '')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--prompt', ''])
+      expect(result.args).to.deep.equal(['--yolo', '--prompt', ''])
     })
   })
 

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -315,19 +315,19 @@ describe('Execution Utils', () => {
       ...overrides,
     })
 
-    it('should generate codex command with --prompt and no Claude-only flags', () => {
+    it('should generate codex command with --yolo + --prompt in danger mode and no Claude-only flags', () => {
       const command = buildDevcontainerCommand(
         makeContext(),
         'codex',
         '/workspace/repo/.prlt-prompt.txt',
         'abc123',
         'interactive',
-        true,
+        false,
         'background'
       )
 
       expect(command).to.include('docker exec')
-      expect(command).to.include('codex --prompt "$(cat /workspace/repo/.prlt-prompt.txt)"')
+      expect(command).to.include('codex --yolo --prompt "$(cat /workspace/repo/.prlt-prompt.txt)"')
       expect(command).to.not.include('--permission-mode bypassPermissions')
       expect(command).to.not.include('--dangerously-skip-permissions')
       expect(command).to.not.include(' -p ')
@@ -361,10 +361,10 @@ describe('Execution Utils', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with danger flag and --prompt when skipPermissions=true', () => {
+      it('should return codex command with --yolo and --prompt when skipPermissions=true', () => {
         const result = getExecutorCommand('codex', testPrompt)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--dangerously-bypass-approvals-and-sandbox', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
       })
 
       it('should NOT include Claude-specific flags', () => {
@@ -374,10 +374,10 @@ describe('Execution Utils', () => {
         expect(result.args).to.not.include('bypassPermissions')
       })
 
-      it('should apply skipPermissions parameter using Codex-native flag', () => {
+      it('should apply Codex-native --yolo when skipPermissions=true', () => {
         const resultTrue = getExecutorCommand('codex', testPrompt, true)
         const resultFalse = getExecutorCommand('codex', testPrompt, false)
-        expect(resultTrue.args).to.include('--dangerously-bypass-approvals-and-sandbox')
+        expect(resultTrue.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
         expect(resultFalse.args).to.deep.equal(['--prompt', testPrompt])
       })
     })


### PR DESCRIPTION
## Summary\n- map danger mode at UX/runtime layer per executor\n- use `--yolo` for Codex when danger mode is selected\n- keep Claude danger mapping on `--dangerously-skip-permissions`\n- preserve environment/runtime separation (host vs docker)\n\n## Testing\n- pnpm --dir apps/cli exec mocha --forbid-only test/unit/execution-utils.test.ts --grep "TKT-1005|getExecutorCommand \(TKT-1005\)|buildDevcontainerCommand \(TKT-1005\)"\n- pnpm --dir apps/cli exec mocha --forbid-only test/unit/codex-runtime.test.ts