### PR TITLE
TKT-1130: Ensure tmux sessions support text highlighting and scroll in iTerm

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
+import Database from 'better-sqlite3'
 import { PromptCommand } from '../../lib/prompt-command.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
 import {
@@ -13,6 +14,8 @@ import {
 } from '../../lib/prompt-json.js'
 import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import { loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
 import { ORCHESTRATOR_SESSION_NAME } from './start.js'
 
 /**
@@ -116,6 +119,25 @@ export default class OrchestratorAttach extends PromptCommand {
     this.log('')
     this.log(styles.info(`Attaching to orchestrator session: ${ORCHESTRATOR_SESSION_NAME}`))
 
+    // Determine if we should use tmux control mode (-u -CC) for iTerm
+    let useControlMode = false
+    try {
+      const workspaceInfo = getWorkspaceInfo()
+      const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+      const db = new Database(dbPath)
+      try {
+        const config = loadExecutionConfig(db)
+        const termApp = detectTerminalApp()
+        if (termApp === 'iTerm') {
+          useControlMode = shouldUseControlMode('iTerm', config.tmux.controlMode)
+        }
+      } finally {
+        db.close()
+      }
+    } catch {
+      // Not in a workspace or DB not available - fall back to no control mode
+    }
+
     if (flags['new-tab']) {
       // Determine terminal app: explicit flag > auto-detect > error
       const terminalApp = flags.terminal ?? detectTerminalApp()
@@ -124,26 +146,28 @@ export default class OrchestratorAttach extends PromptCommand {
         this.log(styles.muted('Falling back to direct tmux attach in current terminal.'))
         this.log(styles.muted('Tip: Use --terminal <app> to specify your terminal (iTerm, Terminal, Ghostty).'))
         this.log('')
-        this.attachInCurrentTerminal()
+        this.attachInCurrentTerminal(useControlMode)
         return
       }
-      await this.openInNewTab(terminalApp)
+      await this.openInNewTab(terminalApp, useControlMode)
     } else {
-      this.attachInCurrentTerminal()
+      this.attachInCurrentTerminal(useControlMode)
     }
   }
 
-  private attachInCurrentTerminal(): void {
+  private attachInCurrentTerminal(useControlMode: boolean): void {
     try {
-      execSync(`tmux attach -t "${ORCHESTRATOR_SESSION_NAME}"`, { stdio: 'inherit' })
+      const tmuxAttach = buildTmuxAttachCommand(useControlMode)
+      execSync(`${tmuxAttach} -t "${ORCHESTRATOR_SESSION_NAME}"`, { stdio: 'inherit' })
     } catch {
       this.error(`Failed to attach to orchestrator session "${ORCHESTRATOR_SESSION_NAME}"`)
     }
   }
 
-  private async openInNewTab(terminalApp: string): Promise<void> {
+  private async openInNewTab(terminalApp: string, useControlMode: boolean): Promise<void> {
     const title = 'Orchestrator'
-    const attachCmd = `tmux attach -t "${ORCHESTRATOR_SESSION_NAME}"`
+    const tmuxAttach = buildTmuxAttachCommand(useControlMode)
+    const attachCmd = `${tmuxAttach} -t "${ORCHESTRATOR_SESSION_NAME}"`
 
     const baseDir = path.join(os.homedir(), '.proletariat', 'scripts')
     fs.mkdirSync(baseDir, { recursive: true })

--- a/apps/cli/src/commands/session/attach.ts
+++ b/apps/cli/src/commands/session/attach.ts
@@ -6,7 +6,8 @@ import * as os from 'node:os'
 import Database from 'better-sqlite3'
 import { styles } from '../../lib/styles.js'
 import { getWorkspaceInfo } from '../../lib/agents/commands.js'
-import { ExecutionStorage } from '../../lib/execution/index.js'
+import { ExecutionStorage, loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
+import { detectTerminalApp } from '../orchestrator/attach.js'
 import {
   parseSessionName,
   getHostTmuxSessionNames,
@@ -147,11 +148,30 @@ export default class SessionAttach extends PMOCommand {
     this.log('')
     this.log(styles.info(`Attaching to session: ${selectedSession.sessionId}`))
 
+    // Determine if we should use tmux control mode (-u -CC) for iTerm
+    let useControlMode = false
+    try {
+      const workspaceInfo = getWorkspaceInfo()
+      const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+      const db = new Database(dbPath)
+      try {
+        const config = loadExecutionConfig(db)
+        const termApp = detectTerminalApp()
+        if (termApp === 'iTerm') {
+          useControlMode = shouldUseControlMode('iTerm', config.tmux.controlMode)
+        }
+      } finally {
+        db.close()
+      }
+    } catch {
+      // Not in a workspace or DB not available - fall back to no control mode
+    }
+
     // Default to new tab unless --current-terminal is specified
     if (flags['current-terminal']) {
-      await this.attachInCurrentTerminal(selectedSession)
+      await this.attachInCurrentTerminal(selectedSession, useControlMode)
     } else {
-      await this.attachInNewTab(selectedSession, flags.terminal)
+      await this.attachInNewTab(selectedSession, flags.terminal, useControlMode)
     }
   }
 
@@ -297,12 +317,13 @@ export default class SessionAttach extends PMOCommand {
   /**
    * Attach to session in current terminal
    */
-  private async attachInCurrentTerminal(session: SessionChoice): Promise<void> {
+  private async attachInCurrentTerminal(session: SessionChoice, useControlMode: boolean): Promise<void> {
     try {
+      const tmuxAttach = buildTmuxAttachCommand(useControlMode, session.type === 'container')
       if (session.type === 'container' && session.containerId) {
-        execSync(`docker exec -it ${session.containerId} tmux attach -t "${session.sessionId}"`, { stdio: 'inherit' })
+        execSync(`docker exec -it ${session.containerId} ${tmuxAttach} -t "${session.sessionId}"`, { stdio: 'inherit' })
       } else {
-        execSync(`tmux attach -t "${session.sessionId}"`, { stdio: 'inherit' })
+        execSync(`${tmuxAttach} -t "${session.sessionId}"`, { stdio: 'inherit' })
       }
     } catch {
       this.error(`Failed to attach to ${session.type} session "${session.sessionId}"`)
@@ -312,7 +333,7 @@ export default class SessionAttach extends PMOCommand {
   /**
    * Attach to session in a new terminal tab
    */
-  private async attachInNewTab(session: SessionChoice, terminalApp: string): Promise<void> {
+  private async attachInNewTab(session: SessionChoice, terminalApp: string, useControlMode: boolean): Promise<void> {
     // Build a readable title for the tab
     const title = `${session.ticketId} (${session.agentName})`
 
@@ -322,9 +343,10 @@ export default class SessionAttach extends PMOCommand {
     const scriptPath = path.join(baseDir, `attach-${Date.now()}.sh`)
 
     // Different attach command for container vs host sessions
+    const tmuxAttach = buildTmuxAttachCommand(useControlMode, session.type === 'container')
     const attachCmd = session.type === 'container' && session.containerId
-      ? `docker exec -it ${session.containerId} tmux -u attach -t "${session.sessionId}"`
-      : `tmux attach -t "${session.sessionId}"`
+      ? `docker exec -it ${session.containerId} ${tmuxAttach} -t "${session.sessionId}"`
+      : `${tmuxAttach} -t "${session.sessionId}"`
 
     const script = `#!/bin/bash
 # Set terminal tab title

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,12 @@
     },
     "apps/cli": {
       "name": "@proletariat/cli",
-      "version": "0.3.44",
+      "version": "0.3.46",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
+        "@linear/sdk": "^76.0.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@oclif/core": "^4",
         "@oclif/plugin-autocomplete": "^3",
@@ -2554,6 +2555,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -3900,6 +3910,18 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@linear/sdk": {
+      "version": "76.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-76.0.0.tgz",
+      "integrity": "sha512-Xt0x5Kl6qBoWhGFypb8ykyP+c5kT7scmRPs1uJidSPOaRgkMJ/4y41QpmZCWCBUMmZtf/O0VktgQio6rLXT94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -10100,6 +10122,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
+      "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",


### PR DESCRIPTION
## Summary

Resolves TKT-1130: Ensure tmux sessions support text highlighting and scroll in iTerm

## Description

## Problem

`prlt orchestrator attach` (and `prlt session attach`) uses plain `tmux attach` which doesn't support native mouse events, text highlighting, or scroll in iTerm. The docker runner already uses `tmux -u -CC attach` when in iTerm with controlMode enabled, but orchestrator/session attach doesn't.

## Requirements

1. **Never assume iTerm** - must work from SSH (Termius, etc.), headless, and other terminals
2. **When iTerm is detected + controlMode enabled** -> use `tmux -u -CC attach` for native mouse/scroll
3. **Otherwise** -> plain `tmux attach` (current behavior, already correct)
4. The `--new-tab` path should also use `-u -CC` when in iTerm

## Files
- `apps/cli/src/commands/orchestrator/attach.ts` - add controlMode check to both paths
- `apps/cli/src/commands/session/attach.ts` - same fix

## Implementation
- Use existing `detectTerminalApp()` to check if iTerm
- Read config for `tmux.controlMode`
- If iTerm + controlMode: `tmux -u -CC attach -t "${session}"`
- Otherwise: `tmux attach -t "${session}"`

## Changes

- def6a178 fix(TKT-1130): use tmux -u -CC for iTerm control mode in orchestrator and session attach

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
