### PR TITLE
fix: improve orchestrator start UX

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -16,7 +16,7 @@ import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
 import { getWorkspaceInfo } from '../../lib/agents/commands.js'
 import { loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
-import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+import { buildOrchestratorSessionName } from './start.js'
 
 /**
  * Detect the terminal emulator from environment variables.
@@ -62,6 +62,10 @@ export default class OrchestratorAttach extends PromptCommand {
 
   static flags = {
     ...machineOutputFlags,
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the orchestrator session to attach to (default: main)',
+    }),
     'new-tab': Flags.boolean({
       description: 'Open in a new terminal tab instead of attaching in the current terminal',
       default: false,
@@ -81,10 +85,11 @@ export default class OrchestratorAttach extends PromptCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(OrchestratorAttach)
     const jsonMode = shouldOutputJson(flags)
+    const sessionName = buildOrchestratorSessionName(flags.name || 'main')
 
     // Check if orchestrator session exists
     const hostSessions = getHostTmuxSessionNames()
-    if (!hostSessions.includes(ORCHESTRATOR_SESSION_NAME)) {
+    if (!hostSessions.includes(sessionName)) {
       if (jsonMode) {
         outputErrorAsJson(
           'NOT_RUNNING',
@@ -102,7 +107,7 @@ export default class OrchestratorAttach extends PromptCommand {
 
     if (jsonMode) {
       outputSuccessAsJson({
-        sessionId: ORCHESTRATOR_SESSION_NAME,
+        sessionId: sessionName,
         status: 'attaching',
       }, createMetadata('orchestrator attach', flags as Record<string, unknown>))
       return
@@ -117,7 +122,7 @@ export default class OrchestratorAttach extends PromptCommand {
     }
 
     this.log('')
-    this.log(styles.info(`Attaching to orchestrator session: ${ORCHESTRATOR_SESSION_NAME}`))
+    this.log(styles.info(`Attaching to orchestrator session: ${sessionName}`))
 
     // Determine if we should use tmux control mode (-u -CC) for iTerm
     let useControlMode = false
@@ -146,28 +151,28 @@ export default class OrchestratorAttach extends PromptCommand {
         this.log(styles.muted('Falling back to direct tmux attach in current terminal.'))
         this.log(styles.muted('Tip: Use --terminal <app> to specify your terminal (iTerm, Terminal, Ghostty).'))
         this.log('')
-        this.attachInCurrentTerminal(useControlMode)
+        this.attachInCurrentTerminal(useControlMode, sessionName)
         return
       }
-      await this.openInNewTab(terminalApp, useControlMode)
+      await this.openInNewTab(terminalApp, useControlMode, sessionName)
     } else {
-      this.attachInCurrentTerminal(useControlMode)
+      this.attachInCurrentTerminal(useControlMode, sessionName)
     }
   }
 
-  private attachInCurrentTerminal(useControlMode: boolean): void {
+  private attachInCurrentTerminal(useControlMode: boolean, sessionName: string): void {
     try {
       const tmuxAttach = buildTmuxAttachCommand(useControlMode)
-      execSync(`${tmuxAttach} -t "${ORCHESTRATOR_SESSION_NAME}"`, { stdio: 'inherit' })
+      execSync(`${tmuxAttach} -t "${sessionName}"`, { stdio: 'inherit' })
     } catch {
-      this.error(`Failed to attach to orchestrator session "${ORCHESTRATOR_SESSION_NAME}"`)
+      this.error(`Failed to attach to orchestrator session "${sessionName}"`)
     }
   }
 
-  private async openInNewTab(terminalApp: string, useControlMode: boolean): Promise<void> {
+  private async openInNewTab(terminalApp: string, useControlMode: boolean, sessionName: string): Promise<void> {
     const title = 'Orchestrator'
     const tmuxAttach = buildTmuxAttachCommand(useControlMode)
-    const attachCmd = `${tmuxAttach} -t "${ORCHESTRATOR_SESSION_NAME}"`
+    const attachCmd = `${tmuxAttach} -t "${sessionName}"`
 
     const baseDir = path.join(os.homedir(), '.proletariat', 'scripts')
     fs.mkdirSync(baseDir, { recursive: true })
@@ -178,7 +183,7 @@ export default class OrchestratorAttach extends PromptCommand {
 echo -ne "\\033]0;${title}\\007"
 echo -ne "\\033]1;${title}\\007"
 
-echo "Attaching to: ${ORCHESTRATOR_SESSION_NAME}"
+echo "Attaching to: ${sessionName}"
 ${attachCmd}
 
 # Clean up

--- a/apps/cli/src/commands/orchestrator/index.ts
+++ b/apps/cli/src/commands/orchestrator/index.ts
@@ -2,7 +2,7 @@
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
 import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
-import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+import { findRunningOrchestratorSessions } from './start.js'
 
 export default class Orchestrator extends PMOCommand {
   static description = 'Manage the orchestrator agent (start, attach, status, stop)'
@@ -30,7 +30,7 @@ export default class Orchestrator extends PMOCommand {
 
     // Check if orchestrator is currently running to offer contextual options
     const hostSessions = getHostTmuxSessionNames()
-    const isRunning = hostSessions.includes(ORCHESTRATOR_SESSION_NAME)
+    const isRunning = findRunningOrchestratorSessions(hostSessions).length > 0
 
     // When running, show "Attach to running session" first since that's the likely intent
     const choices = isRunning

--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -16,6 +16,7 @@ import {
 import { styles } from '../../lib/styles.js'
 import {
   OutputMode,
+  DisplayMode,
   ExecutionContext,
   ExecutorType,
   DEFAULT_EXECUTION_CONFIG,
@@ -26,14 +27,31 @@ import { ExecutionStorage } from '../../lib/execution/storage.js'
 import {
   loadExecutionConfig,
   getTerminalApp,
-  promptTerminalPreference,
   getShell,
-  promptShellPreference,
-  hasTerminalPreference,
-  hasShellPreference,
+  detectShell,
+  detectTerminalApp,
 } from '../../lib/execution/config.js'
 
-export const ORCHESTRATOR_SESSION_NAME = 'prlt-orchestrator-main'
+/**
+ * Build orchestrator tmux session name.
+ * Default: 'prlt-orchestrator-main'
+ * With --name: 'prlt-orchestrator-{name}'
+ */
+export function buildOrchestratorSessionName(name: string = 'main'): string {
+  const safeName = name
+    .replace(/[^a-zA-Z0-9._-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return `prlt-orchestrator-${safeName || 'main'}`
+}
+
+/**
+ * Find running orchestrator session(s) by prefix match.
+ * Returns all tmux session names that start with 'prlt-orchestrator-'.
+ */
+export function findRunningOrchestratorSessions(hostSessions: string[]): string[] {
+  return hostSessions.filter(s => s.startsWith('prlt-orchestrator-'))
+}
 
 export default class OrchestratorStart extends PromptCommand {
   static description = 'Start the orchestrator agent in a tmux session'
@@ -71,45 +89,59 @@ export default class OrchestratorStart extends PromptCommand {
       default: false,
       exclusive: ['skip-permissions'],
     }),
+    name: Flags.string({
+      char: 'n',
+      description: 'Name for the orchestrator session (default: main)',
+    }),
     background: Flags.boolean({
       char: 'b',
       description: 'Start detached (don\'t open terminal tab)',
       default: false,
+      exclusive: ['foreground'],
+    }),
+    foreground: Flags.boolean({
+      char: 'f',
+      description: 'Attach to the tmux session in the current terminal (blocking)',
+      default: false,
+      exclusive: ['background'],
     }),
   }
 
   async run(): Promise<void> {
     const { flags } = await this.parse(OrchestratorStart)
     const jsonMode = shouldOutputJson(flags)
+    const orchestratorName = flags.name || 'main'
+    const sessionName = buildOrchestratorSessionName(orchestratorName)
 
     // Check if orchestrator is already running
     const hostSessions = getHostTmuxSessionNames()
-    if (hostSessions.includes(ORCHESTRATOR_SESSION_NAME)) {
+    if (hostSessions.includes(sessionName)) {
       if (jsonMode) {
         outputErrorAsJson(
           'ALREADY_RUNNING',
-          `Orchestrator is already running (session: ${ORCHESTRATOR_SESSION_NAME}). Use "prlt orchestrator attach" to reattach.`,
+          `Orchestrator is already running (session: ${sessionName}). Use "prlt orchestrator attach${flags.name ? ` --name ${flags.name}` : ''}" to reattach.`,
           createMetadata('orchestrator start', flags),
         )
         return
       }
 
       this.log('')
-      this.log(styles.warning(`Orchestrator is already running (session: ${ORCHESTRATOR_SESSION_NAME})`))
+      this.log(styles.warning(`Orchestrator is already running (session: ${sessionName})`))
       this.log('')
 
+      const attachArgs = flags.name ? ['--name', flags.name] : []
       const { choice } = await this.prompt<{ choice: string }>([{
         type: 'list',
         name: 'choice',
         message: 'What would you like to do?',
         choices: [
-          { name: 'Attach to running orchestrator', value: 'attach', command: 'prlt orchestrator attach --json' },
+          { name: 'Attach to running orchestrator', value: 'attach', command: `prlt orchestrator attach${flags.name ? ` --name ${flags.name}` : ''} --json` },
           { name: 'Cancel', value: 'cancel' },
         ],
       }], jsonMode ? { flags, commandName: 'orchestrator start' } : null)
 
       if (choice === 'attach') {
-        await this.config.runCommand('orchestrator:attach', [])
+        await this.config.runCommand('orchestrator:attach', attachArgs)
       }
       return
     }
@@ -213,12 +245,12 @@ export default class OrchestratorStart extends PromptCommand {
     }
 
     // Build execution context
-    // Use ticketId='prlt', actionName='orchestrator', agentName='main'
-    // so buildSessionName produces 'prlt-orchestrator-main'
+    // Use ticketId='prlt', actionName='orchestrator', agentName=orchestratorName
+    // so buildSessionName produces 'prlt-orchestrator-{name}'
     const context: ExecutionContext = {
       ticketId: 'prlt',
       ticketTitle: 'Orchestrator',
-      agentName: 'main',
+      agentName: orchestratorName,
       agentDir: hqPath,
       worktreePath: hqPath,
       branch: 'main',
@@ -248,18 +280,56 @@ export default class OrchestratorStart extends PromptCommand {
       // Ignore config loading errors, use defaults
     }
 
-    // If no terminal preference saved, prompt for it (first run only)
-    if (!jsonMode && db) {
-      if (!hasTerminalPreference(db)) {
-        executionConfig.terminal.app = await promptTerminalPreference(db)
-      } else {
-        executionConfig.terminal.app = await getTerminalApp(db)
+    // Auto-detect shell (never prompt for orchestrator)
+    if (db) {
+      executionConfig.shell = await getShell(db)
+    } else {
+      executionConfig.shell = detectShell() || 'zsh'
+    }
+
+    // Determine display mode
+    let displayMode: DisplayMode
+    if (flags.background) {
+      displayMode = 'background'
+    } else if (flags.foreground) {
+      displayMode = 'foreground'
+    } else {
+      const displayChoices = [
+        { name: 'New terminal tab — opens attached to the tmux session', value: 'terminal', command: `prlt orchestrator start${flags.name ? ` --name ${flags.name}` : ''} --json` },
+        { name: 'Current session — attach to tmux here (foreground, blocking)', value: 'foreground', command: `prlt orchestrator start${flags.name ? ` --name ${flags.name}` : ''} --foreground --json` },
+        { name: 'Background — start detached, attach later', value: 'background', command: `prlt orchestrator start${flags.name ? ` --name ${flags.name}` : ''} --background --json` },
+      ]
+      const displayMessage = 'How do you want to view the orchestrator?'
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'displayMode', displayMessage, displayChoices),
+          createMetadata('orchestrator start', flags),
+        )
+        return
       }
 
-      if (!hasShellPreference(db)) {
-        executionConfig.shell = await promptShellPreference(db)
+      const { displayMode: selectedMode } = await this.prompt<{ displayMode: DisplayMode }>([{
+        type: 'list',
+        name: 'displayMode',
+        message: displayMessage,
+        choices: displayChoices,
+      }], jsonMode ? { flags, commandName: 'orchestrator start' } : null)
+      displayMode = selectedMode
+    }
+
+    // For 'terminal' display mode, auto-detect terminal app
+    if (displayMode === 'terminal') {
+      if (db) {
+        executionConfig.terminal.app = await getTerminalApp(db)
       } else {
-        executionConfig.shell = await getShell(db)
+        const detected = detectTerminalApp()
+        if (detected) {
+          executionConfig.terminal.app = detected
+        } else {
+          // Can't detect terminal and no db to prompt — fall back to foreground
+          displayMode = 'foreground'
+        }
       }
     }
 
@@ -269,7 +339,11 @@ export default class OrchestratorStart extends PromptCommand {
       this.log(styles.muted(`   Starting orchestrator...`))
       this.log(styles.muted(`   Executor: ${selectedExecutor}`))
       this.log(styles.muted(`   Permission mode: ${sandboxed ? 'sandboxed' : 'skip-permissions'}`))
+      this.log(styles.muted(`   Display mode: ${displayMode}`))
       this.log(styles.muted(`   Directory: ${hqPath}`))
+      if (orchestratorName !== 'main') {
+        this.log(styles.muted(`   Name: ${orchestratorName}`))
+      }
       if (actionPrompt) {
         this.log(styles.muted(`   Prompt: "${actionPrompt.substring(0, 60)}${actionPrompt.length > 60 ? '...' : ''}"`))
       }
@@ -277,7 +351,6 @@ export default class OrchestratorStart extends PromptCommand {
     }
 
     // Launch orchestrator
-    const displayMode = flags.background ? 'background' : 'terminal'
     const result = await runExecution('host', context, selectedExecutor, executionConfig, {
       displayMode,
     })
@@ -294,7 +367,7 @@ export default class OrchestratorStart extends PromptCommand {
             environment: 'host',
             displayMode,
             sandboxed,
-            sessionId: result.sessionId || ORCHESTRATOR_SESSION_NAME,
+            sessionId: result.sessionId || sessionName,
           })
         } catch {
           // Non-fatal: poke won't work but orchestrator is running
@@ -303,18 +376,19 @@ export default class OrchestratorStart extends PromptCommand {
 
       if (jsonMode) {
         outputSuccessAsJson({
-          sessionId: result.sessionId || ORCHESTRATOR_SESSION_NAME,
+          sessionId: result.sessionId || sessionName,
           executor: selectedExecutor,
           sandboxed,
           displayMode,
           directory: hqPath,
+          name: orchestratorName,
         }, createMetadata('orchestrator start', flags as Record<string, unknown>))
       }
 
-      if (flags.background) {
+      if (displayMode === 'background') {
         this.log(styles.success(`Orchestrator started in background`))
-        this.log(styles.muted(`   Session: ${result.sessionId || ORCHESTRATOR_SESSION_NAME}`))
-        this.log(styles.muted(`   Attach with: prlt orchestrator attach`))
+        this.log(styles.muted(`   Session: ${result.sessionId || sessionName}`))
+        this.log(styles.muted(`   Attach with: prlt orchestrator attach${flags.name ? ` --name ${flags.name}` : ''}`))
       } else {
         this.log(styles.success(`Orchestrator started`))
         if (result.sessionId) {

--- a/apps/cli/src/commands/orchestrator/status.ts
+++ b/apps/cli/src/commands/orchestrator/status.ts
@@ -8,7 +8,7 @@ import {
 } from '../../lib/prompt-json.js'
 import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames, captureTmuxPane } from '../../lib/execution/session-utils.js'
-import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+import { buildOrchestratorSessionName } from './start.js'
 
 export default class OrchestratorStatus extends PromptCommand {
   static description = 'Check if the orchestrator is running'
@@ -21,6 +21,10 @@ export default class OrchestratorStatus extends PromptCommand {
 
   static flags = {
     ...machineOutputFlags,
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the orchestrator session to check (default: main)',
+    }),
     peek: Flags.boolean({
       description: 'Show recent output from the orchestrator',
       default: false,
@@ -34,19 +38,20 @@ export default class OrchestratorStatus extends PromptCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(OrchestratorStatus)
     const jsonMode = shouldOutputJson(flags)
+    const sessionName = buildOrchestratorSessionName(flags.name || 'main')
 
     const hostSessions = getHostTmuxSessionNames()
-    const isRunning = hostSessions.includes(ORCHESTRATOR_SESSION_NAME)
+    const isRunning = hostSessions.includes(sessionName)
 
     let recentOutput: string | null = null
     if (isRunning && flags.peek) {
-      recentOutput = captureTmuxPane(ORCHESTRATOR_SESSION_NAME, flags.lines)
+      recentOutput = captureTmuxPane(sessionName, flags.lines)
     }
 
     if (jsonMode) {
       outputSuccessAsJson({
         running: isRunning,
-        sessionId: isRunning ? ORCHESTRATOR_SESSION_NAME : null,
+        sessionId: isRunning ? sessionName : null,
         ...(recentOutput !== null && { recentOutput }),
       }, createMetadata('orchestrator status', flags as Record<string, unknown>))
       return
@@ -55,7 +60,7 @@ export default class OrchestratorStatus extends PromptCommand {
     this.log('')
     if (isRunning) {
       this.log(styles.success(`Orchestrator is running`))
-      this.log(styles.muted(`   Session: ${ORCHESTRATOR_SESSION_NAME}`))
+      this.log(styles.muted(`   Session: ${sessionName}`))
       this.log(styles.muted(`   Attach: prlt orchestrator attach`))
       this.log(styles.muted(`   Poke:   prlt session poke orchestrator "message"`))
 

--- a/apps/cli/src/commands/orchestrator/stop.ts
+++ b/apps/cli/src/commands/orchestrator/stop.ts
@@ -15,7 +15,7 @@ import {
 import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
 import { ExecutionStorage } from '../../lib/execution/storage.js'
-import { ORCHESTRATOR_SESSION_NAME } from './start.js'
+import { buildOrchestratorSessionName } from './start.js'
 
 export default class OrchestratorStop extends PromptCommand {
   static description = 'Stop the running orchestrator'
@@ -27,6 +27,10 @@ export default class OrchestratorStop extends PromptCommand {
 
   static flags = {
     ...machineOutputFlags,
+    name: Flags.string({
+      char: 'n',
+      description: 'Name of the orchestrator session to stop (default: main)',
+    }),
     force: Flags.boolean({
       char: 'f',
       description: 'Skip confirmation',
@@ -37,10 +41,11 @@ export default class OrchestratorStop extends PromptCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(OrchestratorStop)
     const jsonMode = shouldOutputJson(flags)
+    const sessionName = buildOrchestratorSessionName(flags.name || 'main')
 
     // Check if orchestrator session exists
     const hostSessions = getHostTmuxSessionNames()
-    if (!hostSessions.includes(ORCHESTRATOR_SESSION_NAME)) {
+    if (!hostSessions.includes(sessionName)) {
       if (jsonMode) {
         outputErrorAsJson(
           'NOT_RUNNING',
@@ -75,7 +80,7 @@ export default class OrchestratorStop extends PromptCommand {
 
     // Kill the tmux session
     try {
-      execSync(`tmux kill-session -t "${ORCHESTRATOR_SESSION_NAME}"`, { stdio: 'pipe' })
+      execSync(`tmux kill-session -t "${sessionName}"`, { stdio: 'pipe' })
     } catch (error) {
       if (jsonMode) {
         outputErrorAsJson(
@@ -112,7 +117,7 @@ export default class OrchestratorStop extends PromptCommand {
 
     if (jsonMode) {
       outputSuccessAsJson({
-        sessionId: ORCHESTRATOR_SESSION_NAME,
+        sessionId: sessionName,
         status: 'stopped',
       }, createMetadata('orchestrator stop', flags as Record<string, unknown>))
       return


### PR DESCRIPTION
## Summary

- **Auto-detect shell** from `$SHELL` env var instead of prompting "Which shell do you use?"
- **Replace terminal/shell prompts** with a display mode prompt: "How do you want to view the orchestrator?" (New terminal tab / Current session / Background)
- **Auto-detect terminal app** from `$TERM_PROGRAM` only when "New terminal tab" is selected — fixes the AppleScript timeout when "tmux" was selected as terminal app
- **Add `--name` flag** to all orchestrator subcommands (`start`, `stop`, `attach`, `status`) for custom orchestrator naming (e.g. `prlt orchestrator start --name boss`)
- **Add `--foreground` flag** to `start` for attaching in the current terminal
- **Replace hardcoded `ORCHESTRATOR_SESSION_NAME`** constant with dynamic `buildOrchestratorSessionName()` function

## Test plan

- [ ] `prlt orchestrator start` — should ask display mode, NOT shell or terminal app
- [ ] `prlt orchestrator start --background` — should skip display mode prompt
- [ ] `prlt orchestrator start --foreground` — should attach in current terminal
- [ ] `prlt orchestrator start --name boss` — should create `prlt-orchestrator-boss` session
- [ ] `prlt orchestrator status --name boss` — should check the named session
- [ ] `prlt orchestrator stop --name boss` — should stop the named session
- [ ] `prlt orchestrator start --json` — verify JSON mode outputs display mode prompt config

🤖 Generated with [Claude Code](https://claude.com/claude-code)