### PR TITLE
fix(TKT-1165): detect iTerm inside tmux via LC_TERMINAL fallback

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -35,7 +35,6 @@ export function detectTerminalApp(): string | null {
   }
 
   const termProgram = process.env.TERM_PROGRAM
-  if (!termProgram) return null
 
   switch (termProgram) {
     case 'iTerm.app':
@@ -46,9 +45,15 @@ export function detectTerminalApp(): string | null {
       return 'Terminal'
     case 'WezTerm':
       return 'WezTerm'
-    default:
-      return null
   }
+
+  // TERM_PROGRAM is overwritten to 'tmux' inside tmux sessions.
+  // Fall back to vars that persist through tmux to detect the outer terminal.
+  if (process.env.LC_TERMINAL === 'iTerm2' || process.env.ITERM_SESSION_ID) {
+    return 'iTerm'
+  }
+
+  return null
 }
 
 export default class OrchestratorAttach extends PromptCommand {


### PR DESCRIPTION
## Summary
- `detectTerminalApp()` only checked `TERM_PROGRAM`, which is `tmux` inside tmux sessions
- `prlt orchestrator attach` always runs from inside tmux, so iTerm was never detected
- Control mode (`-u -CC`) was never enabled, breaking scroll and text selection
- Fix: fall back to `LC_TERMINAL=iTerm2` and `ITERM_SESSION_ID` which persist through tmux

## Test plan
- [x] Build passes
- [ ] Run `prlt orchestrator attach` from inside orchestrator tmux - should now use `-u -CC`
- [ ] Verify scroll works in iTerm after attach