### PR TITLE
TKT-1166: Fix Codex spawn argument compatibility (--prompt is invalid)

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -208,9 +208,11 @@ export function getExecutorCommand(executor: ExecutorType, prompt: string, skipP
       return { cmd: 'claude', args: [prompt] }
     case 'codex':
       // Map danger mode to Codex-native autonomy mode.
+      // Codex CLI takes prompt as a positional argument: codex [OPTIONS] [PROMPT]
+      // --prompt is NOT a valid flag (TKT-1166)
       return skipPermissions
-        ? { cmd: 'codex', args: ['--yolo', '--prompt', prompt] }
-        : { cmd: 'codex', args: ['--prompt', prompt] }
+        ? { cmd: 'codex', args: ['--yolo', prompt] }
+        : { cmd: 'codex', args: [prompt] }
     case 'aider':
       return { cmd: 'aider', args: ['--message', prompt] }
     case 'custom':

--- a/apps/cli/test/unit/codex-runtime.test.ts
+++ b/apps/cli/test/unit/codex-runtime.test.ts
@@ -60,17 +60,17 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with --yolo and --prompt in danger mode', () => {
+      it('should return codex command with --yolo and positional prompt in danger mode', () => {
         const result = getExecutorCommand('codex', testPrompt, true)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
       })
 
       it('should map skipPermissions=false to non-yolo command', () => {
         const withSkip = getExecutorCommand('codex', testPrompt, true)
         const withoutSkip = getExecutorCommand('codex', testPrompt, false)
-        expect(withSkip.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
-        expect(withoutSkip.args).to.deep.equal(['--prompt', testPrompt])
+        expect(withSkip.args).to.deep.equal(['--yolo', testPrompt])
+        expect(withoutSkip.args).to.deep.equal([testPrompt])
       })
 
       it('should not include claude-specific flags', () => {
@@ -128,7 +128,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should use codex binary for codex executor (not hardcoded claude)', () => {
       const result = getExecutorCommand('codex', 'build the feature')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'build the feature'])
+      expect(result.args).to.deep.equal(['--yolo', 'build the feature'])
     })
 
     it('should use aider binary for aider executor (not hardcoded claude)', () => {
@@ -151,7 +151,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should use codex binary for codex executor on VM', () => {
       const result = getExecutorCommand('codex', 'implement on VM')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'implement on VM'])
+      expect(result.args).to.deep.equal(['--yolo', 'implement on VM'])
     })
 
     it('should use aider binary for aider executor on VM', () => {
@@ -205,7 +205,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should handle empty prompts', () => {
       const result = getExecutorCommand('codex', '')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', ''])
+      expect(result.args).to.deep.equal(['--yolo', ''])
     })
   })
 
@@ -226,6 +226,35 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
   })
 
   // buildTmuxScript tests removed - function was removed from runners.ts
+
+  describe('Regression: --prompt is not a valid Codex CLI flag (TKT-1166)', () => {
+    /**
+     * Codex CLI uses positional arguments for prompts: codex [OPTIONS] [PROMPT]
+     * The --prompt flag does NOT exist and causes:
+     *   error: unexpected argument '--prompt' found
+     *
+     * This regression test ensures we never reintroduce --prompt.
+     */
+    it('should NOT pass --prompt flag to codex (positional arg only)', () => {
+      const result = getExecutorCommand('codex', 'build the feature', true)
+      expect(result.args).to.not.include('--prompt')
+      // Prompt should be a positional argument (last element)
+      expect(result.args[result.args.length - 1]).to.equal('build the feature')
+    })
+
+    it('should NOT pass --prompt flag in safe mode either', () => {
+      const result = getExecutorCommand('codex', 'implement feature', false)
+      expect(result.args).to.not.include('--prompt')
+      expect(result.args).to.deep.equal(['implement feature'])
+    })
+
+    it('should use --yolo for danger mode (not --prompt)', () => {
+      const result = getExecutorCommand('codex', 'test prompt', true)
+      expect(result.args).to.include('--yolo')
+      expect(result.args).to.not.include('--prompt')
+      expect(result.args).to.deep.equal(['--yolo', 'test prompt'])
+    })
+  })
 
   describe('Executor consistency across runtimes', () => {
     /**

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -315,7 +315,7 @@ describe('Execution Utils', () => {
       ...overrides,
     })
 
-    it('should generate codex command with --yolo + --prompt in danger mode and no Claude-only flags', () => {
+    it('should generate codex command with --yolo + positional prompt in danger mode and no Claude-only flags', () => {
       const command = buildDevcontainerCommand(
         makeContext(),
         'codex',
@@ -327,7 +327,8 @@ describe('Execution Utils', () => {
       )
 
       expect(command).to.include('docker exec')
-      expect(command).to.include('codex --yolo --prompt "$(cat /workspace/repo/.prlt-prompt.txt)"')
+      expect(command).to.include('codex --yolo "$(cat /workspace/repo/.prlt-prompt.txt)"')
+      expect(command).to.not.include('--prompt')
       expect(command).to.not.include('--permission-mode bypassPermissions')
       expect(command).to.not.include('--dangerously-skip-permissions')
       expect(command).to.not.include(' -p ')
@@ -361,10 +362,10 @@ describe('Execution Utils', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with --yolo and --prompt when skipPermissions=true', () => {
+      it('should return codex command with --yolo and positional prompt when skipPermissions=true', () => {
         const result = getExecutorCommand('codex', testPrompt)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
       })
 
       it('should NOT include Claude-specific flags', () => {
@@ -377,8 +378,8 @@ describe('Execution Utils', () => {
       it('should apply Codex-native --yolo when skipPermissions=true', () => {
         const resultTrue = getExecutorCommand('codex', testPrompt, true)
         const resultFalse = getExecutorCommand('codex', testPrompt, false)
-        expect(resultTrue.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
-        expect(resultFalse.args).to.deep.equal(['--prompt', testPrompt])
+        expect(resultTrue.args).to.deep.equal(['--yolo', testPrompt])
+        expect(resultFalse.args).to.deep.equal([testPrompt])
       })
     })
 


### PR DESCRIPTION
## Summary

Resolves TKT-1166: Fix Codex spawn argument compatibility (--prompt is invalid)

## Description

## Problem
Codex spawn currently passes `--prompt`, which is rejected by installed Codex CLI (`codex-cli 0.106.0`).

Observed runtime error from session `TKT-1162-Implement-focal-altman`:
`error: unexpected argument '--prompt' found`

## Scope
- Update Codex command construction across runners to use supported argument shape
- Ensure host/devcontainer/docker/vm paths all use same fixed invocation
- Keep Claude and other executors unchanged

## Acceptance Criteria
1. `work start --executor codex` no longer errors with `unexpected argument --prompt`
2. All execution environments use the fixed Codex invocation
3. Unit tests updated to assert the new invocation contract
4. Add a regression test covering this exact failure mode


## Changes

- 1efb862b fix(TKT-1166): fix codex spawn: use positional prompt arg instead of invalid --prompt flag

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
