### PR TITLE
TKT-1162: Add caffeinate namespace (start/stop/status)

### DIFF
--- a/apps/cli/src/commands/caffeinate/index.ts
+++ b/apps/cli/src/commands/caffeinate/index.ts
@@ -1,0 +1,76 @@
+import { Command } from '@oclif/core'
+import { styles } from '../../lib/styles.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { FlagResolver } from '../../lib/flags/index.js'
+import { isMacOS } from '../../lib/caffeinate.js'
+
+export default class Caffeinate extends Command {
+  static description = 'Manage caffeinate to keep macOS awake'
+
+  static examples = [
+    '<%= config.bin %> caffeinate',
+    '<%= config.bin %> caffeinate start',
+    '<%= config.bin %> caffeinate status',
+    '<%= config.bin %> caffeinate stop',
+    '<%= config.bin %> caffeinate start --duration 3600',
+    '<%= config.bin %> caffeinate start --display',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Caffeinate)
+    const jsonMode = shouldOutputJson(flags)
+
+    if (!isMacOS()) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          type: 'error',
+          error: { code: 'UNSUPPORTED_PLATFORM', message: `caffeinate is only supported on macOS (current platform: ${process.platform})` },
+        }, null, 2))
+        this.exit(1)
+      }
+      this.error(`caffeinate is only supported on macOS (current platform: ${process.platform})`)
+    }
+
+    const menuChoices = [
+      { name: 'Check caffeinate status', value: 'status', command: 'prlt caffeinate status --json' },
+      { name: 'Start caffeinate', value: 'start', command: 'prlt caffeinate start --json' },
+      { name: 'Stop caffeinate', value: 'stop', command: 'prlt caffeinate stop --json' },
+      { name: 'Exit', value: 'exit', command: 'prlt caffeinate --exit' },
+    ]
+
+    const resolver = new FlagResolver<{ action?: string; machine?: boolean; json?: boolean }>({
+      commandName: 'caffeinate',
+      baseCommand: 'prlt caffeinate',
+      jsonMode,
+      flags,
+    })
+
+    resolver.addPrompt({
+      flagName: 'action',
+      type: 'list',
+      message: 'What would you like to do?',
+      choices: () => menuChoices,
+      skipAutoCommand: true,
+    })
+
+    if (!jsonMode) {
+      this.log('')
+      this.log(styles.header('Caffeinate'))
+      this.log('')
+    }
+
+    const resolved = await resolver.resolve()
+    const action = resolved.action
+
+    if (!action || action === 'exit') {
+      return
+    }
+
+    await this.config.runCommand(`caffeinate:${action}`, [])
+  }
+}

--- a/apps/cli/src/commands/caffeinate/start.ts
+++ b/apps/cli/src/commands/caffeinate/start.ts
@@ -1,0 +1,93 @@
+import { Command, Flags } from '@oclif/core'
+import { styles } from '../../lib/styles.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { isMacOS, startCaffeinate, getStatus } from '../../lib/caffeinate.js'
+
+export default class CaffeinateStart extends Command {
+  static description = 'Start caffeinate to prevent macOS from sleeping'
+
+  static examples = [
+    '<%= config.bin %> caffeinate start',
+    '<%= config.bin %> caffeinate start --duration 3600',
+    '<%= config.bin %> caffeinate start --display',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    duration: Flags.integer({
+      char: 't',
+      description: 'Duration in seconds (default: indefinite)',
+    }),
+    display: Flags.boolean({
+      char: 'd',
+      description: 'Prevent display from sleeping (adds -d flag)',
+      default: false,
+    }),
+    idle: Flags.boolean({
+      char: 'i',
+      description: 'Prevent idle sleep (adds -i flag)',
+      default: false,
+    }),
+    system: Flags.boolean({
+      char: 's',
+      description: 'Prevent system sleep (adds -s flag)',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(CaffeinateStart)
+    const jsonMode = shouldOutputJson(flags)
+
+    if (!isMacOS()) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          type: 'error',
+          error: { code: 'UNSUPPORTED_PLATFORM', message: `caffeinate is only supported on macOS (current platform: ${process.platform})` },
+        }, null, 2))
+        this.exit(1)
+      }
+      this.error(`caffeinate is only supported on macOS (current platform: ${process.platform})`)
+    }
+
+    // Build caffeinate flags
+    const caffeinateFlags: string[] = []
+    if (flags.display) caffeinateFlags.push('-d')
+    if (flags.idle) caffeinateFlags.push('-i')
+    if (flags.system) caffeinateFlags.push('-s')
+
+    // Check if already running (idempotent)
+    const { running, state: existingState } = getStatus()
+    if (running && existingState) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          type: 'success',
+          result: { ...existingState, status: 'already_running' },
+        }, null, 2))
+        return
+      }
+      this.log(`\n${styles.warning('caffeinate is already running')} ${styles.muted(`(PID: ${existingState.pid})`)}\n`)
+      return
+    }
+
+    const state = startCaffeinate(caffeinateFlags, flags.duration)
+
+    if (jsonMode) {
+      this.log(JSON.stringify({
+        type: 'success',
+        result: { ...state, status: 'started' },
+      }, null, 2))
+      return
+    }
+
+    this.log(`\n${styles.success('caffeinate started')} ${styles.muted(`(PID: ${state.pid})`)}`)
+    if (state.duration) {
+      this.log(styles.muted(`  Duration: ${state.duration}s`))
+    }
+    if (state.flags.length > 0) {
+      this.log(styles.muted(`  Flags: ${state.flags.join(' ')}`))
+    }
+    this.log('')
+  }
+}

--- a/apps/cli/src/commands/caffeinate/status.ts
+++ b/apps/cli/src/commands/caffeinate/status.ts
@@ -1,0 +1,63 @@
+import { Command } from '@oclif/core'
+import { styles } from '../../lib/styles.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { isMacOS, getStatus } from '../../lib/caffeinate.js'
+
+export default class CaffeinateStatus extends Command {
+  static description = 'Check if caffeinate is running'
+
+  static examples = [
+    '<%= config.bin %> caffeinate status',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(CaffeinateStatus)
+    const jsonMode = shouldOutputJson(flags)
+
+    if (!isMacOS()) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          type: 'error',
+          error: { code: 'UNSUPPORTED_PLATFORM', message: `caffeinate is only supported on macOS (current platform: ${process.platform})` },
+        }, null, 2))
+        this.exit(1)
+      }
+      this.error(`caffeinate is only supported on macOS (current platform: ${process.platform})`)
+    }
+
+    const { running, state } = getStatus()
+
+    if (jsonMode) {
+      this.log(JSON.stringify({
+        type: 'success',
+        result: {
+          running,
+          ...(state ? { pid: state.pid, startedAt: state.startedAt, flags: state.flags, duration: state.duration ?? null } : {}),
+        },
+      }, null, 2))
+      return
+    }
+
+    this.log(`\n${styles.header('Caffeinate Status')}`)
+    this.log('─'.repeat(40))
+
+    if (running && state) {
+      this.log(`${styles.success('Running')} ${styles.muted(`(PID: ${state.pid})`)}`)
+      this.log(styles.muted(`  Started: ${state.startedAt}`))
+      if (state.flags.length > 0) {
+        this.log(styles.muted(`  Flags:   ${state.flags.join(' ')}`))
+      }
+      if (state.duration) {
+        this.log(styles.muted(`  Duration: ${state.duration}s`))
+      }
+    } else {
+      this.log(styles.muted('Not running'))
+    }
+    this.log('')
+  }
+}

--- a/apps/cli/src/commands/caffeinate/stop.ts
+++ b/apps/cli/src/commands/caffeinate/stop.ts
@@ -1,0 +1,54 @@
+import { Command } from '@oclif/core'
+import { styles } from '../../lib/styles.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { isMacOS, stopCaffeinate, getStatus } from '../../lib/caffeinate.js'
+
+export default class CaffeinateStop extends Command {
+  static description = 'Stop the managed caffeinate process'
+
+  static examples = [
+    '<%= config.bin %> caffeinate stop',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(CaffeinateStop)
+    const jsonMode = shouldOutputJson(flags)
+
+    if (!isMacOS()) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          type: 'error',
+          error: { code: 'UNSUPPORTED_PLATFORM', message: `caffeinate is only supported on macOS (current platform: ${process.platform})` },
+        }, null, 2))
+        this.exit(1)
+      }
+      this.error(`caffeinate is only supported on macOS (current platform: ${process.platform})`)
+    }
+
+    // Get current state for reporting
+    const { state } = getStatus()
+    const stopped = stopCaffeinate()
+
+    if (jsonMode) {
+      this.log(JSON.stringify({
+        type: 'success',
+        result: {
+          stopped,
+          pid: state?.pid ?? null,
+        },
+      }, null, 2))
+      return
+    }
+
+    if (stopped) {
+      this.log(`\n${styles.success('caffeinate stopped')} ${styles.muted(`(PID: ${state?.pid})`)}\n`)
+    } else {
+      this.log(`\n${styles.muted('caffeinate is not running')}\n`)
+    }
+  }
+}

--- a/apps/cli/src/lib/caffeinate.ts
+++ b/apps/cli/src/lib/caffeinate.ts
@@ -1,0 +1,172 @@
+/**
+ * Caffeinate management for macOS
+ *
+ * Manages a background `caffeinate` process to prevent macOS from sleeping.
+ * PID state is stored in a runtime file for reliable stop/status operations.
+ */
+
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { spawn } from 'node:child_process'
+
+const RUNTIME_DIR = path.join(os.tmpdir(), 'prlt')
+const PID_FILE = path.join(RUNTIME_DIR, 'caffeinate.pid')
+
+export interface CaffeinateState {
+  pid: number
+  startedAt: string
+  flags: string[]
+  duration?: number
+}
+
+/**
+ * Ensure the platform is macOS. Throws a descriptive error on other platforms.
+ */
+export function assertMacOS(): void {
+  if (process.platform !== 'darwin') {
+    throw new Error(`caffeinate is only supported on macOS (current platform: ${process.platform})`)
+  }
+}
+
+/**
+ * Check whether the platform is macOS.
+ */
+export function isMacOS(): boolean {
+  return process.platform === 'darwin'
+}
+
+/**
+ * Read the stored caffeinate state from the PID file.
+ * Returns null if no state exists or the file is invalid.
+ */
+export function readState(): CaffeinateState | null {
+  try {
+    const data = fs.readFileSync(PID_FILE, 'utf-8')
+    return JSON.parse(data) as CaffeinateState
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write caffeinate state to the PID file.
+ */
+export function writeState(state: CaffeinateState): void {
+  fs.mkdirSync(RUNTIME_DIR, { recursive: true })
+  fs.writeFileSync(PID_FILE, JSON.stringify(state, null, 2))
+}
+
+/**
+ * Remove the PID file.
+ */
+export function clearState(): void {
+  try {
+    fs.unlinkSync(PID_FILE)
+  } catch {
+    // File may not exist - that's fine
+  }
+}
+
+/**
+ * Check whether a process with the given PID is still running.
+ */
+export function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Get the status of the managed caffeinate process.
+ * Cleans up stale state if the process is no longer running.
+ */
+export function getStatus(): { running: boolean; state: CaffeinateState | null } {
+  const state = readState()
+  if (!state) {
+    return { running: false, state: null }
+  }
+
+  if (!isProcessRunning(state.pid)) {
+    // Process died externally - clean up stale PID file
+    clearState()
+    return { running: false, state: null }
+  }
+
+  return { running: true, state }
+}
+
+/**
+ * Start a background caffeinate process.
+ *
+ * @param flags - Additional flags to pass to caffeinate (e.g. ['-d', '-i'])
+ * @param duration - Optional duration in seconds (passed as -t flag)
+ * @returns The state of the started process
+ * @throws If already running (idempotent guard) or on non-macOS
+ */
+export function startCaffeinate(flags: string[] = [], duration?: number): CaffeinateState {
+  assertMacOS()
+
+  // Idempotent: if already running, return existing state
+  const { running, state: existingState } = getStatus()
+  if (running && existingState) {
+    return existingState
+  }
+
+  const args = [...flags]
+  if (duration !== undefined && duration > 0) {
+    args.push('-t', String(duration))
+  }
+
+  const child = spawn('caffeinate', args, {
+    detached: true,
+    stdio: 'ignore',
+  })
+
+  child.unref()
+
+  if (!child.pid) {
+    throw new Error('Failed to start caffeinate process')
+  }
+
+  const state: CaffeinateState = {
+    pid: child.pid,
+    startedAt: new Date().toISOString(),
+    flags: args,
+    ...(duration !== undefined && duration > 0 ? { duration } : {}),
+  }
+
+  writeState(state)
+  return state
+}
+
+/**
+ * Stop the managed caffeinate process.
+ *
+ * @returns true if a process was stopped, false if nothing was running
+ */
+export function stopCaffeinate(): boolean {
+  const { running, state } = getStatus()
+  if (!running || !state) {
+    clearState() // Clean up any stale file
+    return false
+  }
+
+  try {
+    process.kill(state.pid, 'SIGTERM')
+  } catch {
+    // Process may have already exited
+  }
+
+  clearState()
+  return true
+}
+
+// Exported for testing
+export const _internals = {
+  RUNTIME_DIR,
+  PID_FILE,
+}

--- a/apps/cli/test/unit/caffeinate.test.ts
+++ b/apps/cli/test/unit/caffeinate.test.ts
@@ -1,0 +1,204 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import {
+  assertMacOS,
+  isMacOS,
+  readState,
+  writeState,
+  clearState,
+  isProcessRunning,
+  getStatus,
+  startCaffeinate,
+  stopCaffeinate,
+  _internals,
+  type CaffeinateState,
+} from '../../src/lib/caffeinate.js'
+
+const IS_MACOS = process.platform === 'darwin'
+
+describe('caffeinate', () => {
+  let originalPidFile: string
+  let originalRuntimeDir: string
+  let tmpDir: string
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-caffeinate-test-'))
+    originalPidFile = _internals.PID_FILE
+    originalRuntimeDir = _internals.RUNTIME_DIR
+    ;(_internals as { PID_FILE: string }).PID_FILE = path.join(tmpDir, 'caffeinate.pid')
+    ;(_internals as { RUNTIME_DIR: string }).RUNTIME_DIR = tmpDir
+  })
+
+  afterEach(() => {
+    try {
+      fs.unlinkSync(_internals.PID_FILE)
+    } catch {
+      // fine
+    }
+  })
+
+  after(() => {
+    ;(_internals as { PID_FILE: string }).PID_FILE = originalPidFile
+    ;(_internals as { RUNTIME_DIR: string }).RUNTIME_DIR = originalRuntimeDir
+    try {
+      fs.rmSync(tmpDir, { recursive: true })
+    } catch {
+      // fine
+    }
+  })
+
+  describe('isMacOS', () => {
+    it('returns a boolean', () => {
+      expect(isMacOS()).to.be.a('boolean')
+    })
+
+    it('matches process.platform', () => {
+      expect(isMacOS()).to.equal(process.platform === 'darwin')
+    })
+  })
+
+  describe('assertMacOS', () => {
+    if (IS_MACOS) {
+      it('does not throw on macOS', () => {
+        expect(() => assertMacOS()).not.to.throw()
+      })
+    } else {
+      it('throws on non-macOS platforms', () => {
+        expect(() => assertMacOS()).to.throw(/only supported on macOS/)
+      })
+    }
+  })
+
+  describe('readState / writeState / clearState', () => {
+    it('returns null when no PID file exists', () => {
+      expect(readState()).to.be.null
+    })
+
+    it('writes and reads state correctly', () => {
+      const state: CaffeinateState = {
+        pid: 12345,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        flags: ['-d', '-i'],
+        duration: 3600,
+      }
+      writeState(state)
+      const read = readState()
+      expect(read).to.deep.equal(state)
+    })
+
+    it('clearState removes the PID file', () => {
+      const state: CaffeinateState = {
+        pid: 12345,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        flags: [],
+      }
+      writeState(state)
+      expect(readState()).not.to.be.null
+      clearState()
+      expect(readState()).to.be.null
+    })
+
+    it('clearState does not throw if file does not exist', () => {
+      expect(() => clearState()).not.to.throw()
+    })
+  })
+
+  describe('isProcessRunning', () => {
+    it('returns true for the current process PID', () => {
+      expect(isProcessRunning(process.pid)).to.be.true
+    })
+
+    it('returns false for a non-existent PID', () => {
+      expect(isProcessRunning(999999999)).to.be.false
+    })
+  })
+
+  describe('getStatus', () => {
+    it('returns not running when no state exists', () => {
+      const { running, state } = getStatus()
+      expect(running).to.be.false
+      expect(state).to.be.null
+    })
+
+    it('returns running for a live process', () => {
+      const testState: CaffeinateState = {
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+        flags: [],
+      }
+      writeState(testState)
+
+      const { running, state } = getStatus()
+      expect(running).to.be.true
+      expect(state).to.not.be.null
+      expect(state!.pid).to.equal(process.pid)
+    })
+
+    it('cleans up stale state for dead processes', () => {
+      const testState: CaffeinateState = {
+        pid: 999999999,
+        startedAt: new Date().toISOString(),
+        flags: [],
+      }
+      writeState(testState)
+
+      const { running, state } = getStatus()
+      expect(running).to.be.false
+      expect(state).to.be.null
+      expect(readState()).to.be.null
+    })
+  })
+
+  if (IS_MACOS) {
+    describe('startCaffeinate (macOS)', () => {
+      afterEach(() => {
+        // Always clean up any spawned caffeinate
+        stopCaffeinate()
+      })
+
+      it('starts caffeinate and returns state', () => {
+        const state = startCaffeinate(['-i'], 5)
+        expect(state.pid).to.be.a('number')
+        expect(state.pid).to.be.greaterThan(0)
+        expect(state.startedAt).to.be.a('string')
+        expect(state.flags).to.include('-t')
+        expect(state.duration).to.equal(5)
+      })
+
+      it('is idempotent - returns existing state if already running', () => {
+        const state1 = startCaffeinate()
+        const state2 = startCaffeinate()
+        expect(state1.pid).to.equal(state2.pid)
+      })
+    })
+
+    describe('stopCaffeinate (macOS)', () => {
+      it('returns false when nothing is running', () => {
+        expect(stopCaffeinate()).to.be.false
+      })
+
+      it('stops a running process and returns true', () => {
+        startCaffeinate()
+        const stopped = stopCaffeinate()
+        expect(stopped).to.be.true
+
+        const { running } = getStatus()
+        expect(running).to.be.false
+      })
+    })
+  } else {
+    describe('startCaffeinate (non-macOS)', () => {
+      it('throws on non-macOS', () => {
+        expect(() => startCaffeinate()).to.throw(/only supported on macOS/)
+      })
+    })
+
+    describe('stopCaffeinate (non-macOS)', () => {
+      it('returns false when nothing is running', () => {
+        expect(stopCaffeinate()).to.be.false
+      })
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Resolves TKT-1162: Add caffeinate namespace (start/stop/status)

## Description

## Goal
Add a first-class PRLT namespace for keeping macOS awake via caffeinate.

## Scope
- Add `prlt caffeinate` command group
- Implement:
  - `prlt caffeinate start` (optional duration/flags)
  - `prlt caffeinate stop`
  - `prlt caffeinate status`
- Store PID state in a stable runtime file so stop/status are reliable
- macOS-only guard with clear error on unsupported platforms

## Acceptance Criteria
1. `prlt caffeinate start` starts background caffeinate and returns PID
2. `prlt caffeinate status` reports running/not-running accurately
3. `prlt caffeinate stop` stops managed process cleanly
4. Re-running start is idempotent (does not spawn duplicates)
5. Unit tests cover happy paths + unsupported-platform error
6. CLI help/docs include examples

## Changes

- 65314300 feat(TKT-1162): add caffeinate namespace with start/stop/status commands

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
