### PR TITLE
TKT-1171: Bug: session poke doesn't work for Docker/devcontainer agents

### DIFF
--- a/apps/cli/src/commands/session/poke.ts
+++ b/apps/cli/src/commands/session/poke.ts
@@ -254,7 +254,7 @@ export default class SessionPoke extends PMOCommand {
     jsonMode: boolean,
     flags: Record<string, unknown>,
   ): ResolvedSession | null {
-    const isContainer = exec.environment === 'devcontainer'
+    const isContainer = !!exec.containerId
     let actualSessionId = exec.sessionId
     let containerId = isContainer ? exec.containerId : undefined
 

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -39,6 +39,7 @@ describe('Session Commands E2E Tests', () => {
     sessionId: string;
     status?: string;
     environment?: string;
+    containerId?: string;
   }>): void {
     const db = new Database(dbPath);
     try {
@@ -59,8 +60,8 @@ describe('Session Commands E2E Tests', () => {
 
         // Create execution record
         db.prepare(`
-          INSERT INTO agent_work (id, ticket_id, agent_name, executor, environment, status, session_id, started_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+          INSERT INTO agent_work (id, ticket_id, agent_name, executor, environment, status, session_id, container_id, started_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
         `).run(
           rec.id,
           rec.ticketId,
@@ -69,6 +70,7 @@ describe('Session Commands E2E Tests', () => {
           rec.environment || 'host',
           rec.status || 'running',
           rec.sessionId,
+          rec.containerId || null,
         );
       }
 
@@ -637,6 +639,49 @@ describe('Session Commands E2E Tests', () => {
       expect(json).to.not.be.null;
       expect(json!.error).to.exist;
       expect(json!.error.code).to.equal('NO_ACTIVE_EXECUTION');
+    });
+
+    it('should resolve docker container agent by name and attempt docker exec (not host tmux)', () => {
+      seedExecutionRecords([{
+        id: 'exec-poke-docker-001',
+        ticketId: 'TKT-800',
+        ticketTitle: 'Docker poke test',
+        agentName: 'docker-agent',
+        sessionId: 'TKT-800-implement-docker-agent',
+        status: 'running',
+        environment: 'docker',
+        containerId: 'abc123def456',
+      }]);
+
+      const output = execProduction('session poke docker-agent "test message" --json');
+      const json = extractJson<{ error: { code: string; message: string } }>(output);
+
+      expect(json).to.not.be.null;
+      expect(json!.error).to.exist;
+      // Should fail at docker exec level (SEND_FAILED or CONTAINER_NOT_RUNNING),
+      // NOT at SESSION_NOT_FOUND from host tmux lookup — proving we took the container path
+      expect(['SEND_FAILED', 'CONTAINER_NOT_RUNNING']).to.include(json!.error.code);
+    });
+
+    it('should resolve devcontainer agent by name and attempt docker exec', () => {
+      seedExecutionRecords([{
+        id: 'exec-poke-devcontainer-001',
+        ticketId: 'TKT-801',
+        ticketTitle: 'Devcontainer poke test',
+        agentName: 'devcontainer-agent',
+        sessionId: 'TKT-801-implement-devcontainer-agent',
+        status: 'running',
+        environment: 'devcontainer',
+        containerId: 'def456abc789',
+      }]);
+
+      const output = execProduction('session poke devcontainer-agent "test message" --json');
+      const json = extractJson<{ error: { code: string; message: string } }>(output);
+
+      expect(json).to.not.be.null;
+      expect(json!.error).to.exist;
+      // Should fail at docker exec level, NOT at host tmux lookup
+      expect(['SEND_FAILED', 'CONTAINER_NOT_RUNNING']).to.include(json!.error.code);
     });
 
     it('should include poke choice in session menu with correct command', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-1171: Bug: session poke doesn't work for Docker/devcontainer agents

## Description

## Problem
`prlt session poke <agent> "message"` returns `SESSION_NOT_FOUND` for agents running in Docker containers. It only finds host tmux sessions, not sessions inside devcontainers.

Also, when using raw `tmux send-keys` to poke agents, the text is typed into the prompt but not submitted - a separate Enter keystroke is needed. The poke command should handle this atomically.

## Repro
```bash
# Agent running in Docker with active tmux session inside container
prlt session poke calm-ellison "do something"
# → Error: Could not find tmux session for agent "calm-ellison"
```

The workaround is `docker exec <container> tmux send-keys -t 0 "message" Enter` which works fine but requires knowing the container name.

## Fix
1. `session poke` needs to check for devcontainer-based executions in the DB. If the agent has a `containerId`, run `docker exec <containerId> tmux send-keys` instead of looking for a host tmux session. The execution DB already has `containerId` and `environment` fields - same lookup pattern used by `session attach`.

2. Ensure poke always sends the message text AND Enter as one atomic operation, so the message is actually submitted to the Claude Code prompt - not just typed in.

## Changes

- 3405ce23 fix(TKT-1171): fix session poke to use containerId check instead of environment check for Docker agents

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
