### PR TITLE
TKT-1172: Split CI tests by touched paths (run only affected suites)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }} --depth=1
+
       - name: Classify changed paths
         id: classify
         shell: bash
@@ -49,7 +53,7 @@ jobs:
 
           # Get the list of changed files relative to the PR base
           MERGE_BASE=$(git merge-base origin/${{ github.base_ref }} HEAD)
-          CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD)
+          CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
 
           if [[ -z "$CHANGED" ]]; then
             echo "run_tests=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Resolves TKT-1172: Split CI tests by touched paths (run only affected suites)

## Description

## Problem
CI currently runs full unit + full e2e for every PR, which is slow and obscures hangs/failures.

## Scope
- Add a change-detection job to classify touched files
- Gate test jobs by path categories (for example: execution, commands/work, mcp, docs-only)
- Run only affected unit/e2e subsets when possible
- Keep a fallback full run trigger for high-risk/core changes

## Acceptance Criteria
1. Docs-only PRs skip heavy test suites
2. Scoped code changes run scoped unit/e2e suites
3. Core/runtime changes still run full suite
4. Workflow emits clear summary of why each suite ran/skipped
5. Existing branch protections remain satisfied


## Changes

- 422b1b12 ci(TKT-1172): add explicit base branch fetch for reliable PR diff
- 0d1fcf1b ci(TKT-1172): add change-detection to CI workflow for path-scoped test runs

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
