### PR TITLE
TKT-1174: Bump npm CLI version to 0.3.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.48] - 2026-03-02
+
+### Changed
+- TKT-1174: Version bump and maintenance release
+
 ## [0.3.27] - 2026-02-10
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Resolves TKT-1174: Bump npm CLI version to 0.3.48

## Description

## Goal
Bump @proletariat/cli package version for next npm release.

## Scope
- Update `apps/cli/package.json` version from `0.3.47` to `0.3.48`
- Update lockfile/changelog/docs if required by repo conventions
- Open PR with release bump only (no functional code changes)

## Acceptance Criteria
1. Version is updated to `0.3.48`
2. PR is open and clearly labeled as release bump
3. CI is green or in-progress with no unrelated code changes


## Changes

- cb00f216 release(TKT-1174): bump @proletariat/cli version to 0.3.48

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
