### PR TITLE
TKT-1176: Scope unit tests by changed paths (match e2e scoping from TKT-1172)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ on:
 
 # Change-detection scoping:
 # - docs-only PRs skip all test suites entirely
-# - Scoped source changes (pmo, execution) run only affected e2e subsets + full unit tests
+# - Scoped source changes (pmo, execution) run only affected unit + e2e subsets
 # - Core/runtime changes (database, shared lib, config files) trigger the full suite
 # - push to main and workflow_dispatch always run the full suite
 # - The ci-status job serves as a single required check for branch protection
@@ -276,11 +276,42 @@ jobs:
         run: pnpm -r build
 
       - name: Run unit tests
-        run: pnpm --filter @proletariat/cli test:unit
+        working-directory: apps/cli
+        run: |
+          SCOPE="${{ needs.detect-changes.outputs.scope }}"
+          echo "Unit test scope: $SCOPE"
+
+          case "$SCOPE" in
+            full)
+              echo "Running full unit test suite"
+              pnpm test:unit
+              ;;
+            pmo)
+              echo "Running PMO-scoped unit tests"
+              npx mocha --forbid-only "test/unit/pmo-*.test.ts"
+              ;;
+            execution)
+              echo "Running execution-scoped unit tests"
+              npx mocha --forbid-only \
+                "test/unit/execution-*.test.ts" \
+                "test/unit/agent-*.test.ts" \
+                "test/unit/session-*.test.ts" \
+                "test/unit/spawner*.test.ts" \
+                "test/unit/codex-*.test.ts"
+              ;;
+            *)
+              echo "Running full unit test suite (unrecognized scope: $SCOPE)"
+              pnpm test:unit
+              ;;
+          esac
 
       # TKT-1169: Codex spawn smoke tests run as a dedicated step so failures
       # are immediately visible. Any Codex command contract change will fail here.
+      # Only runs for execution or full scope since codex is in the execution domain.
       - name: Codex spawn smoke checks
+        if: |
+          needs.detect-changes.outputs.scope == 'full' ||
+          needs.detect-changes.outputs.scope == 'execution'
         run: pnpm --filter @proletariat/cli mocha --forbid-only "test/unit/codex-spawn-smoke.test.ts"
 
   e2e-tests:


### PR DESCRIPTION
## Summary

Resolves TKT-1176: Scope unit tests by changed paths (match e2e scoping from TKT-1172)

## Description

## Problem
TKT-1172 added path-based scoping for e2e tests but unit tests still run the full suite regardless of scope. This is inconsistent and wastes CI time as the test count grows (currently 1114 and increasing).

## Fix
Extend the e2e scoping pattern to unit tests in `.github/workflows/test.yml`:

- **docs/scripts scope**: already skips all tests (no change needed)
- **pmo scope**: run only `test/unit/pmo-*.test.ts` and related PMO unit tests
- **execution scope**: run only `test/unit/execution-*.test.ts`, `test/unit/agent-*.test.ts`, `test/unit/session-*.test.ts`, `test/unit/spawner*.test.ts`, `test/unit/codex-*.test.ts`
- **full scope**: run all unit tests (no change)

The `detect-changes` job already emits the scope - just add a `case` block in the unit-tests step matching the pattern used in e2e-tests.

## Files to change
- `.github/workflows/test.yml` - add scope-based unit test selection in the unit-tests job

## Changes

- 0cb746f9 ci(TKT-1176): scope unit tests by changed paths matching e2e scoping pattern

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
