### PR TITLE
feat(TKT-1181): make work linear use DB config + direct issue lookup

### DIFF
--- a/apps/cli/src/commands/work/linear.ts
+++ b/apps/cli/src/commands/work/linear.ts
@@ -14,11 +14,13 @@ import {
 } from '../../lib/external-issues/types.js'
 import {
   listLinearIssues,
+  getLinearIssueByIdentifier,
   buildLinearIssueChoiceCommand,
   buildLinearTicketDescription,
   buildLinearMetadata,
   buildLinearSpawnContextMessage,
 } from '../../lib/external-issues/linear.js'
+import { getLinearApiKey, loadLinearConfig } from '../../lib/linear/index.js'
 
 function buildWorkStartArgs(options: {
   ticketId: string
@@ -155,6 +157,8 @@ export default class WorkLinear extends PMOCommand {
   async execute(): Promise<void> {
     const { flags } = await this.parse(WorkLinear)
     const jsonMode = shouldOutputJson(flags)
+    const db = this.storage.getDatabase()
+    const linearConfig = loadLinearConfig(db)
 
     const projectId = await this.requireProject({
       jsonMode: {
@@ -164,11 +168,13 @@ export default class WorkLinear extends PMOCommand {
       },
     })
 
-    const team = flags.team || process.env.PRLT_LINEAR_TEAM
+    const apiKey = getLinearApiKey(db) || undefined
+    const team = flags.team || linearConfig?.defaultTeamKey || process.env.PRLT_LINEAR_TEAM
 
     let issues: NormalizedIssueEnvelope[]
     try {
       issues = await listLinearIssues({
+        apiKey,
         team,
       }, { limit: flags.limit })
     } catch (error: unknown) {
@@ -184,11 +190,26 @@ export default class WorkLinear extends PMOCommand {
     }
 
     let selectedIssue = issues.find(issue => issue.source.externalKey === flags.issue)
-    if (!selectedIssue) {
-      if (flags.issue) {
-        return this.handleError('LINEAR_ISSUE_NOT_FOUND', `Linear issue "${flags.issue}" was not found.`, { jsonMode, commandName: 'work linear', flags })
+    if (!selectedIssue && flags.issue) {
+      try {
+        selectedIssue = await getLinearIssueByIdentifier({
+          apiKey,
+          team,
+        }, flags.issue) ?? undefined
+      } catch (error: unknown) {
+        if (error instanceof ExternalIssueAdapterError) {
+          return this.handleError(error.code, error.message, { jsonMode, commandName: 'work linear', flags })
+        }
+        const msg = error instanceof Error ? error.message : 'Failed to fetch Linear issue.'
+        return this.handleError('LINEAR_REQUEST_FAILED', msg, { jsonMode, commandName: 'work linear', flags })
       }
 
+      if (!selectedIssue) {
+        return this.handleError('LINEAR_ISSUE_NOT_FOUND', `Linear issue "${flags.issue}" was not found.`, { jsonMode, commandName: 'work linear', flags })
+      }
+    }
+
+    if (!selectedIssue) {
       const selectedKey = await this.selectFromList({
         message: 'Select Linear issue to spawn:',
         items: issues,
@@ -197,7 +218,10 @@ export default class WorkLinear extends PMOCommand {
           return `[${priority}] ${issue.source.externalKey} - ${issue.title}`
         },
         getValue: issue => issue.source.externalKey,
-        getCommand: issue => buildLinearIssueChoiceCommand(issue.source.externalKey, projectId),
+        getCommand: issue => {
+          const base = buildLinearIssueChoiceCommand(issue.source.externalKey, projectId)
+          return team ? `${base} --team ${team}` : base
+        },
         jsonMode: jsonMode ? { flags, commandName: 'work linear' } : null,
       })
 

--- a/apps/cli/src/lib/external-issues/linear.ts
+++ b/apps/cli/src/lib/external-issues/linear.ts
@@ -38,6 +38,28 @@ const LINEAR_ISSUES_QUERY = `
   }
 `
 
+const LINEAR_ISSUE_BY_IDENTIFIER_QUERY = `
+  query IssueForSpawn($id: String!) {
+    issue(id: $id) {
+      id
+      identifier
+      title
+      description
+      url
+      priority
+      labels {
+        nodes {
+          name
+        }
+      }
+      state {
+        name
+        type
+      }
+    }
+  }
+`
+
 interface LinearIssueLabel {
   name?: string
 }
@@ -228,6 +250,69 @@ export function buildLinearIssueChoiceCommand(issueIdentifier: string, projectId
     command += ` -P ${projectId}`
   }
   return command
+}
+
+/**
+ * Fetch a single Linear issue by identifier (for example, ENG-123) and normalize it.
+ */
+export async function getLinearIssueByIdentifier(
+  configInput: LinearAdapterConfig,
+  identifier: string,
+  options?: {
+    fetchImpl?: typeof fetch
+  },
+): Promise<NormalizedIssueEnvelope | null> {
+  const config = ensureLinearConfig(configInput)
+  const fetchImpl = options?.fetchImpl || fetch
+
+  const response = await fetchImpl(config.apiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: config.apiKey,
+    },
+    body: JSON.stringify({
+      query: LINEAR_ISSUE_BY_IDENTIFIER_QUERY,
+      variables: {
+        id: identifier,
+      },
+    }),
+  })
+
+  if (response.status === 401 || response.status === 403) {
+    throw new ExternalIssueAdapterError(
+      'AUTH_FAILED',
+      'Linear authentication failed. Verify your LINEAR_API_KEY token.',
+    )
+  }
+
+  if (!response.ok) {
+    throw new ExternalIssueAdapterError(
+      'REQUEST_FAILED',
+      `Linear request failed with status ${response.status}.`,
+    )
+  }
+
+  const payload = await response.json() as {
+    data?: { issue?: LinearIssueNode | null }
+    errors?: Array<{ message?: string }>
+  }
+
+  if (payload.errors && payload.errors.length > 0) {
+    const message = payload.errors[0]?.message || 'Unknown Linear API error.'
+    if (/auth|token|forbidden|unauthorized/i.test(message)) {
+      throw new ExternalIssueAdapterError('AUTH_FAILED', `Linear authentication failed: ${message}`)
+    }
+    // "not found" should be treated as null, not hard failure.
+    if (/not found/i.test(message)) {
+      return null
+    }
+    throw new ExternalIssueAdapterError('REQUEST_FAILED', `Linear API error: ${message}`)
+  }
+
+  const node = payload.data?.issue
+  if (!node) return null
+  return normalizeLinearIssueToEnvelope(node)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Make \ read Linear API key/default team from workspace DB config (saved by \{
  "type": "success",
  "prompt": null,
  "success": true,
  "result": {
    "authenticated": true,
    "organization": "Proletariat",
    "user": "chrismcdermut@gmail.com",
    "message": "Already authenticated. Use --force to re-authenticate."
  },
  "metadata": {
    "command": "linear auth",
    "flags": {
      "json": false,
      "machine": false,
      "check": false,
      "force": false,
      "disconnect": false
    },
    "timestamp": "2026-03-03T05:31:50.967Z"
  }
}) with env fallback
- Add direct lookup for \ so specific issue IDs are resolved even when outside list-limit results
- Include team in JSON prompt choice commands for deterministic non-interactive follow-up

## Why
- Current \ path only reads env vars and can fail despite successful \{
  "type": "success",
  "prompt": null,
  "success": true,
  "result": {
    "authenticated": true,
    "organization": "Proletariat",
    "user": "chrismcdermut@gmail.com",
    "message": "Already authenticated. Use --force to re-authenticate."
  },
  "metadata": {
    "command": "linear auth",
    "flags": {
      "json": false,
      "machine": false,
      "check": false,
      "force": false,
      "disconnect": false
    },
    "timestamp": "2026-03-03T05:31:51.680Z"
  }
}
- \ previously only matched against fetched list (limit-limited), causing false not-found errors

## Validation
- \ passes