### PR TITLE
release: bump @proletariat/cli version to 0.3.49

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary\n- bump @proletariat/cli version from 0.3.48 to 0.3.49\n\n## Notes\n- version-only release bump in apps/cli/package.json