### PR TITLE
TKT-1190: Codex launch validation

### DIFF
--- a/apps/cli/src/lib/execution/codex-adapter.ts
+++ b/apps/cli/src/lib/execution/codex-adapter.ts
@@ -20,10 +20,10 @@
  *
  * | Permission | Context       | Supported | Notes                                    |
  * |------------|---------------|-----------|------------------------------------------|
- * | danger     | interactive   | Yes       | `codex --yolo --prompt "..."`            |
- * | danger     | background    | Yes       | `codex --yolo --prompt "..."`            |
- * | danger     | non-tty       | Yes       | `codex --yolo --prompt "..."`            |
- * | safe       | interactive   | Yes       | `codex --prompt "..."` (user can approve)|
+ * | danger     | interactive   | Yes       | `codex --yolo "..."`                     |
+ * | danger     | background    | Yes       | `codex --yolo "..."`                     |
+ * | danger     | non-tty       | Yes       | `codex --yolo "..."`                     |
+ * | safe       | interactive   | Yes       | `codex "..."` (user can approve)         |
  * | safe       | background    | No        | Cannot prompt for approval in background |
  * | safe       | non-tty       | No        | Cannot prompt for approval without TTY   |
  */
@@ -183,7 +183,8 @@ export function getCodexCommand(
     args.push('--yolo')
   }
 
-  args.push('--prompt', prompt)
+  // Codex CLI expects the initial prompt as a positional argument.
+  args.push(prompt)
 
   return {
     cmd: 'codex',

--- a/apps/cli/test/unit/codex-adapter.test.ts
+++ b/apps/cli/test/unit/codex-adapter.test.ts
@@ -118,34 +118,34 @@ describe('Codex Runtime Adapter (TKT-1167)', () => {
 
   describe('getCodexCommand', () => {
     describe('danger mode', () => {
-      it('should return codex --yolo --prompt for danger + interactive', () => {
+      it('should return codex --yolo <prompt> for danger + interactive', () => {
         const result = getCodexCommand(testPrompt, 'danger', 'interactive')
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
         expect(result.yolo).to.be.true
         expect(result.executionContext).to.equal('interactive')
       })
 
-      it('should return codex --yolo --prompt for danger + background', () => {
+      it('should return codex --yolo <prompt> for danger + background', () => {
         const result = getCodexCommand(testPrompt, 'danger', 'background')
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
         expect(result.yolo).to.be.true
       })
 
-      it('should return codex --yolo --prompt for danger + non-tty', () => {
+      it('should return codex --yolo <prompt> for danger + non-tty', () => {
         const result = getCodexCommand(testPrompt, 'danger', 'non-tty')
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
         expect(result.yolo).to.be.true
       })
     })
 
     describe('safe mode', () => {
-      it('should return codex --prompt (no --yolo) for safe + interactive', () => {
+      it('should return codex <prompt> (no --yolo) for safe + interactive', () => {
         const result = getCodexCommand(testPrompt, 'safe', 'interactive')
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--prompt', testPrompt])
+        expect(result.args).to.deep.equal([testPrompt])
         expect(result.yolo).to.be.false
         expect(result.executionContext).to.equal('interactive')
       })
@@ -210,7 +210,7 @@ describe('Codex Runtime Adapter (TKT-1167)', () => {
       it('should handle empty prompts', () => {
         const result = getCodexCommand('', 'danger', 'interactive')
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', ''])
+        expect(result.args).to.deep.equal(['--yolo', ''])
       })
     })
   })

--- a/apps/cli/test/unit/codex-runtime.test.ts
+++ b/apps/cli/test/unit/codex-runtime.test.ts
@@ -60,17 +60,17 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with --yolo and --prompt in danger mode', () => {
+      it('should return codex command with --yolo and positional prompt in danger mode', () => {
         const result = getExecutorCommand('codex', testPrompt, true)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
       })
 
-      it('should map skipPermissions=false to safe command (--prompt only)', () => {
+      it('should map skipPermissions=false to safe command (prompt only)', () => {
         const withSkip = getExecutorCommand('codex', testPrompt, true)
         const withoutSkip = getExecutorCommand('codex', testPrompt, false)
-        expect(withSkip.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
-        expect(withoutSkip.args).to.deep.equal(['--prompt', testPrompt])
+        expect(withSkip.args).to.deep.equal(['--yolo', testPrompt])
+        expect(withoutSkip.args).to.deep.equal([testPrompt])
       })
 
       it('should not include claude-specific flags', () => {
@@ -128,7 +128,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should use codex binary for codex executor (not hardcoded claude)', () => {
       const result = getExecutorCommand('codex', 'build the feature')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'build the feature'])
+      expect(result.args).to.deep.equal(['--yolo', 'build the feature'])
     })
 
     it('should use aider binary for aider executor (not hardcoded claude)', () => {
@@ -151,7 +151,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should use codex binary for codex executor on VM', () => {
       const result = getExecutorCommand('codex', 'implement on VM')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'implement on VM'])
+      expect(result.args).to.deep.equal(['--yolo', 'implement on VM'])
     })
 
     it('should use aider binary for aider executor on VM', () => {
@@ -205,7 +205,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
     it('should handle empty prompts', () => {
       const result = getExecutorCommand('codex', '')
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', ''])
+      expect(result.args).to.deep.equal(['--yolo', ''])
     })
   })
 
@@ -228,23 +228,21 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
   // buildTmuxScript tests removed - function was removed from runners.ts
 
   describe('Codex CLI flag contract', () => {
-    it('should pass prompt via --prompt flag in danger mode', () => {
+    it('should pass prompt as positional argument in danger mode', () => {
       const result = getExecutorCommand('codex', 'build the feature', true)
-      expect(result.args).to.include('--prompt')
       expect(result.args).to.include('--yolo')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'build the feature'])
+      expect(result.args).to.deep.equal(['--yolo', 'build the feature'])
     })
 
-    it('should pass prompt via --prompt flag in safe mode', () => {
+    it('should pass prompt as positional argument in safe mode', () => {
       const result = getExecutorCommand('codex', 'implement feature', false)
-      expect(result.args).to.include('--prompt')
-      expect(result.args).to.deep.equal(['--prompt', 'implement feature'])
+      expect(result.args).to.deep.equal(['implement feature'])
     })
 
     it('should use --yolo for danger mode', () => {
       const result = getExecutorCommand('codex', 'test prompt', true)
       expect(result.args).to.include('--yolo')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', 'test prompt'])
+      expect(result.args).to.deep.equal(['--yolo', 'test prompt'])
     })
   })
 

--- a/apps/cli/test/unit/codex-spawn-smoke.test.ts
+++ b/apps/cli/test/unit/codex-spawn-smoke.test.ts
@@ -7,7 +7,7 @@ import {
 import type { ExecutionContext, ExecutorType, PermissionMode } from '../../src/lib/execution/types.js'
 
 // Codex CLI supported flags — maintained here for contract testing
-const CODEX_SUPPORTED_FLAGS = ['--yolo', '--prompt'] as const
+const CODEX_SUPPORTED_FLAGS = ['--yolo'] as const
 
 /**
  * Codex Spawn Smoke Tests (TKT-1169)
@@ -17,7 +17,7 @@ const CODEX_SUPPORTED_FLAGS = ['--yolo', '--prompt'] as const
  * to these tests — CI will fail otherwise.
  *
  * Contract:
- *   - Prompt is passed via --prompt flag
+ *   - Prompt is passed as a positional argument
  *   - Autonomous mode uses --yolo
  *   - Only flags in CODEX_SUPPORTED_FLAGS are allowed
  */
@@ -44,10 +44,6 @@ describe('Codex Spawn Smoke Tests (TKT-1169)', () => {
 
     it('should include --yolo in supported flags', () => {
       expect(CODEX_SUPPORTED_FLAGS).to.include('--yolo')
-    })
-
-    it('should include --prompt in supported flags', () => {
-      expect(CODEX_SUPPORTED_FLAGS).to.include('--prompt')
     })
 
     it('should only use supported flags in danger mode command', () => {
@@ -90,18 +86,18 @@ describe('Codex Spawn Smoke Tests (TKT-1169)', () => {
       expect(result.cmd).to.equal('codex')
     })
 
-    it('danger mode: should produce codex --yolo --prompt <prompt>', () => {
+    it('danger mode: should produce codex --yolo <prompt>', () => {
       const prompt = 'implement the feature'
       const result = getExecutorCommand('codex', prompt, true)
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', prompt])
+      expect(result.args).to.deep.equal(['--yolo', prompt])
     })
 
-    it('safe mode: should produce codex --prompt <prompt>', () => {
+    it('safe mode: should produce codex <prompt>', () => {
       const prompt = 'implement the feature'
       const result = getExecutorCommand('codex', prompt, false)
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--prompt', prompt])
+      expect(result.args).to.deep.equal([prompt])
     })
 
     it('should not contain any Claude-specific flags', () => {
@@ -140,7 +136,7 @@ describe('Codex Spawn Smoke Tests (TKT-1169)', () => {
       )
 
       expect(command).to.include('docker exec')
-      expect(command).to.include('codex --yolo --prompt')
+      expect(command).to.include('codex --yolo ')
       expect(command).to.not.include('--permission-mode')
       expect(command).to.not.include('--dangerously-skip-permissions')
     })
@@ -189,7 +185,7 @@ describe('Codex Spawn Smoke Tests (TKT-1169)', () => {
     it('should handle empty prompt', () => {
       const result = getExecutorCommand('codex', '', true)
       expect(result.cmd).to.equal('codex')
-      expect(result.args).to.deep.equal(['--yolo', '--prompt', ''])
+      expect(result.args).to.deep.equal(['--yolo', ''])
     })
 
     it('should handle prompt with special characters', () => {

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -315,7 +315,7 @@ describe('Execution Utils', () => {
       ...overrides,
     })
 
-    it('should generate codex command with --yolo + --prompt in danger mode and no Claude-only flags', () => {
+    it('should generate codex command with --yolo + positional prompt in danger mode and no Claude-only flags', () => {
       const command = buildDevcontainerCommand(
         makeContext(),
         'codex',
@@ -327,7 +327,7 @@ describe('Execution Utils', () => {
       )
 
       expect(command).to.include('docker exec')
-      expect(command).to.include('codex --yolo --prompt "$(cat /workspace/repo/.prlt-prompt.txt)"')
+      expect(command).to.include('codex --yolo "$(cat /workspace/repo/.prlt-prompt.txt)"')
       expect(command).to.not.include('--permission-mode bypassPermissions')
       expect(command).to.not.include('--dangerously-skip-permissions')
       expect(command).to.not.include(' -p ')
@@ -361,10 +361,10 @@ describe('Execution Utils', () => {
     })
 
     describe('codex executor', () => {
-      it('should return codex command with --yolo and --prompt when skipPermissions=true', () => {
+      it('should return codex command with --yolo and positional prompt when skipPermissions=true', () => {
         const result = getExecutorCommand('codex', testPrompt)
         expect(result.cmd).to.equal('codex')
-        expect(result.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
+        expect(result.args).to.deep.equal(['--yolo', testPrompt])
       })
 
       it('should NOT include Claude-specific flags', () => {
@@ -377,8 +377,8 @@ describe('Execution Utils', () => {
       it('should apply Codex-native --yolo when skipPermissions=true', () => {
         const resultTrue = getExecutorCommand('codex', testPrompt, true)
         const resultFalse = getExecutorCommand('codex', testPrompt, false)
-        expect(resultTrue.args).to.deep.equal(['--yolo', '--prompt', testPrompt])
-        expect(resultFalse.args).to.deep.equal(['--prompt', testPrompt])
+        expect(resultTrue.args).to.deep.equal(['--yolo', testPrompt])
+        expect(resultFalse.args).to.deep.equal([testPrompt])
       })
     })
 


### PR DESCRIPTION
## Summary

Resolves TKT-1190: Codex launch validation

## Description

Temporary validation ticket for codex prompt arg fix

## Changes

- df508b10 fix(codex): pass prompt as positional argument

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
