### PR TITLE
fix: keep execution/session list in sync with actual tmux state

### DIFF
--- a/apps/cli/src/commands/execution/list.ts
+++ b/apps/cli/src/commands/execution/list.ts
@@ -60,6 +60,10 @@ export default class ExecutionList extends PMOCommand {
     const executionStorage = new ExecutionStorage(db)
 
     try {
+      // Keep execution status truthful: mark missing tmux/container sessions as stopped
+      // before listing so "running" only reflects actually active work.
+      executionStorage.cleanupStaleExecutions()
+
       const executions = executionStorage.listExecutions({
         status: flags.status as ExecutionStatus | undefined,
         agentName: flags.agent,

--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -73,6 +73,9 @@ export default class SessionList extends PMOCommand {
       const startingExecutions = executionStorage?.listExecutions({ status: 'starting' }) || []
       const activeExecutions = [...runningExecutions, ...startingExecutions]
 
+      // Refresh execution state so dead sessions aren't reported as running.
+      executionStorage?.cleanupStaleExecutions()
+
       // Get list of actual tmux sessions for verification
       const hostTmuxSessions = getHostTmuxSessionNames()
       const containerTmuxSessions = getContainerTmuxSessionMap()
@@ -135,15 +138,14 @@ export default class SessionList extends PMOCommand {
           }
         }
 
-        // Always include sessions from DB that have a sessionId.
-        // When tmux verification fails (e.g., Docker/tmux not accessible from MCP context),
-        // show the session with the DB status instead of silently dropping it.
-        if (actualSessionId) {
+        // Only include active sessions by default.
+        // Use --all to include stale DB records (exists=false).
+        if (actualSessionId && (exists || flags.all)) {
           sessions.push({
             sessionId: actualSessionId,
             ticketId: exec.ticketId,
             agentName: exec.agentName,
-            status: exists ? exec.status : (flags.all ? 'stale' : exec.status),
+            status: exists ? exec.status : 'stale',
             environment: isContainer ? 'container' : 'host',
             containerId,
             exists,


### PR DESCRIPTION
## Summary
- run stale execution cleanup before 
- run stale cleanup before 
- only show non-existent DB session records in  when  is used

## Why
Host tmux sessions can exit while DB records remain marked running. This caused ghost running work in list commands.

## Validation
- pnpm --filter @proletariat/cli build
- local verification against HQ DB: stale running records were converted to stopped and removed from default session list output
