### PR TITLE
TKT-1173: Stabilize e2e tests: investigate hangs/flakes and restore reliable CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,7 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [lts/*]
@@ -216,6 +217,7 @@ jobs:
       needs.detect-changes.outputs.run_tests == 'true' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [lts/*]
@@ -321,6 +323,7 @@ jobs:
       needs.detect-changes.outputs.run_tests == 'true' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [lts/*]

--- a/apps/cli/test/e2e/test-helpers.ts
+++ b/apps/cli/test/e2e/test-helpers.ts
@@ -34,6 +34,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ * Default timeout for execSync calls in milliseconds.
+ * This prevents indefinite hangs when a CLI command waits for interactive input.
+ * execSync blocks the Node.js event loop, so Mocha's own timeout cannot fire.
+ * A per-command timeout ensures the child process is killed and the test can proceed.
+ */
+const EXEC_TIMEOUT_MS = 30_000; // 30 seconds
+
+/**
  * Environment variables that could bypass test isolation.
  * These are explicitly cleared when running CLI commands to ensure
  * the CLI discovers the test database, not a real one.
@@ -644,6 +652,7 @@ export function exec(cmd: string): string {
     const result = execSync(`node ${binPath} ${cmd}`, {
       encoding: 'utf-8',
       cwd: process.cwd(),
+      timeout: EXEC_TIMEOUT_MS,
       env: {
         ...getIsolatedEnv(),
         // Force text output unless the command explicitly requests JSON via flags.
@@ -681,6 +690,7 @@ export function execWithFilter(cmd: string): string {
     const result = execSync(`node ${binPath} ${cmd} 2>&1`, {
       encoding: 'utf-8',
       cwd: process.cwd(),
+      timeout: EXEC_TIMEOUT_MS,
       env: {
         ...getIsolatedEnv(),
         ...(wantsJsonOutput(cmd) ? {} : { PRLT_FORCE_TEXT: '1' }),
@@ -722,6 +732,7 @@ export function execProduction(cmd: string): string {
     const result = execSync(`node ${binPath} ${cmd}`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: EXEC_TIMEOUT_MS,
       env,
       cwd: cliDir, // Run from CLI directory for proper module resolution
     });
@@ -744,6 +755,7 @@ export function execRaw(cmd: string): string {
     return execSync(`node ${binPath} ${cmd}`, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: EXEC_TIMEOUT_MS,
       env: {
         ...getIsolatedEnv(),
         ...(wantsJsonOutput(cmd) ? {} : { PRLT_FORCE_TEXT: '1' }),
@@ -765,6 +777,7 @@ export function execOrFail(cmd: string): string {
   return execSync(`${binPath} ${cmd}`, {
     encoding: 'utf-8',
     cwd: process.cwd(),
+    timeout: EXEC_TIMEOUT_MS,
     env: {
       ...getIsolatedEnv(),
       ...(wantsJsonOutput(cmd) ? {} : { PRLT_FORCE_TEXT: '1' }),
@@ -1016,6 +1029,7 @@ export function execAsHuman(cmd: string, env: NodeJS.ProcessEnv = {}): string {
     const result = execSync(`node ${binPath} ${cmd}`, {
       encoding: 'utf-8',
       cwd: process.cwd(),
+      timeout: EXEC_TIMEOUT_MS,
       env: baseEnv,
       maxBuffer: 10 * 1024 * 1024,
     });
@@ -1055,6 +1069,7 @@ export function execAsAgent(cmd: string, env: NodeJS.ProcessEnv = {}): string {
     const result = execSync(`node ${binPath} ${jsonCmd}`, {
       encoding: 'utf-8',
       cwd: process.cwd(),
+      timeout: EXEC_TIMEOUT_MS,
       env: baseEnv,
       maxBuffer: 10 * 1024 * 1024,
     });


### PR DESCRIPTION
## Summary

This PR adds CI job timeouts and per-command execution timeouts to prevent e2e tests from hanging indefinitely.

## Changes

- Added timeout-minutes to GitHub Actions workflow jobs (10/15/20 min limits)
- Added EXEC_TIMEOUT_MS (30s) to all execSync calls in test helpers

## Context

TKT-1173 originally identified multiple e2e test issues (hangs, flakes, assertion mismatches). However, TKT-1050 (#583) and TKT-1182 (#587) have already fixed most of these issues. This PR extracts the remaining valuable fix: timeout protection to prevent indefinite hangs in CI.

The timeout fix is still needed because:
- execSync blocks the Node.js event loop, so Mocha timeout cannot fire
- Per-command timeouts ensure hung processes are killed and tests can proceed
- CI job timeouts prevent GitHub Actions from running for hours

## Related
- Builds on fixes from TKT-1050 (#583) and TKT-1182 (#587)
- Part of TKT-1173 e2e stabilization effort

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>