### PR TITLE
chore(release): bump CLI to 0.3.52

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.51",
+  "version": "0.3.52",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary\n- bump @proletariat/cli version to 0.3.52\n\n## Notes\n- version-only release bump for latest merged changes