### PR TITLE
TKT-1201: Orchestrator prompt should be role-specific, not generic ticket format

### DIFF
--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -448,6 +448,8 @@ export default class OrchestratorStart extends PromptCommand {
       actionPrompt,
       modifiesCode: false,
       hqPath,
+      isOrchestrator: true,
+      hqName,
     }
 
     // Build execution config

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -440,7 +440,56 @@ export function runExecutorPreflight(
   return { ok: true }
 }
 
+/**
+ * Build a role-specific prompt for orchestrator sessions.
+ * Unlike ticket workers, orchestrators are long-running managers that delegate work.
+ */
+function buildOrchestratorPrompt(context: ExecutionContext): string {
+  const hqName = context.hqName || 'workspace'
+  let prompt = `# Orchestrator: ${hqName}\n\n`
+  prompt += `You are the orchestrator for the **${hqName}** workspace using the prlt ecosystem.\n\n`
+
+  prompt += `## Your Role\n`
+  prompt += `- View and manage work using \`prlt\` CLI commands or MCP tools\n`
+  prompt += `- Delegate tasks to agents — do NOT implement work yourself\n`
+  prompt += `- Monitor agent progress, review completed work, and manage the board\n`
+  prompt += `- Spawn agents for Ready tickets, review PRs, merge completed work\n\n`
+
+  prompt += `## Available Tools\n`
+  prompt += `- Board: \`prlt board\`, \`prlt ticket list\`, \`prlt ticket show <id>\`, \`prlt work status\`\n`
+  prompt += `- Agents: \`prlt work start <ticket-id>\`, \`prlt session list\`, \`prlt session peek <session>\`, \`prlt session poke <session> "message"\`\n`
+  prompt += `- PRs: \`gh pr list\`, \`gh pr view\`, \`gh pr merge\`\n`
+  prompt += `- MCP: All prlt MCP tools are available\n\n`
+
+  // Load .orchestrator-context.md from HQ root if it exists
+  if (context.hqPath) {
+    const contextFilePath = path.join(context.hqPath, '.orchestrator-context.md')
+    if (fs.existsSync(contextFilePath)) {
+      try {
+        const contextContent = fs.readFileSync(contextFilePath, 'utf-8').trim()
+        if (contextContent) {
+          prompt += `## Workspace Context\n\n${contextContent}\n\n`
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+  }
+
+  // Include user's custom prompt or action content
+  if (context.actionPrompt) {
+    prompt += `## Instructions\n\n${context.actionPrompt}\n`
+  }
+
+  return prompt
+}
+
 function buildPrompt(context: ExecutionContext): string {
+  // Orchestrator sessions get a role-specific prompt instead of the generic ticket format
+  if (context.isOrchestrator) {
+    return buildOrchestratorPrompt(context)
+  }
+
   let prompt = ''
 
   // For revisions, lead with the PR feedback

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -177,6 +177,9 @@ export interface ExecutionContext {
   // PR feedback context (for work revise)
   prFeedback?: string // Formatted PR feedback markdown
   isRevision?: boolean // Whether this is a revision (addressing PR feedback)
+  // Orchestrator context
+  isOrchestrator?: boolean // Whether this is an orchestrator session (long-running manager, not a ticket worker)
+  hqName?: string // HQ workspace name (used in orchestrator prompt)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Resolves TKT-1201: Orchestrator prompt should be role-specific, not generic ticket format

## Description

## Problem

When the orchestrator is spawned, `buildPrompt()` in `runners.ts` generates a generic ticket prompt:

```
# Ticket: prlt
**Title:** Orchestrator
---
## When Complete
When you have completed the task, provide a summary of what you did.
---
**STOP:** After providing your final summary...
```

This is wrong. The orchestrator is NOT working on a ticket - it's a long-running manager that delegates work. The "STOP after summary" instruction is particularly harmful since it tells the orchestrator to finish and stop, when it should be continuously managing.

## Solution

The `buildPrompt()` function (or the orchestrator start command) needs a separate prompt path for orchestrator sessions. The orchestrator prompt should:

1. Explain the role: "You are an orchestrator for {hqName} using the prlt ecosystem"
2. Explain capabilities: "Use prlt to view work and delegate/manage via CLI or MCP"
3. Emphasize delegation: "You should NOT do work yourself, only delegate to agents"
4. NOT include "STOP" / "When Complete" / ticket format sections
5. Include the HQ name and any context from `.orchestrator-context.md` if it exists
6. Include the user's custom `--prompt` or `--action` content as additional instructions

## Key files
- `apps/cli/src/lib/execution/runners.ts` - `buildPrompt()` function (lines ~405-511)
- `apps/cli/src/commands/orchestrator/start.ts` - ExecutionContext creation (lines ~263-274)

## Approach
Either:
- Add a flag to ExecutionContext like `isOrchestrator: true` and branch in `buildPrompt()`
- Or build the orchestrator prompt directly in `start.ts` before passing it as `actionPrompt`, and add an `actionEndPrompt` that doesn't include STOP instructions

The orchestrator prompt template should look something like:
```
# Orchestrator: {hqName}

You are the orchestrator for the **{hqName}** workspace using the prlt ecosystem.

## Your Role
- View and manage work using `prlt` CLI commands or MCP tools
- Delegate tasks to agents - do NOT implement work yourself
- Monitor agent progress, review completed work, and manage the board
- Spawn agents for Ready tickets, review PRs, merge completed work

## Available Tools
- Board: `prlt board`, ticket CRUD, work status
- Agents: `prlt work start`, `prlt session list/peek/poke`
- PRs: `gh pr list/view/merge`
- MCP: All prlt MCP tools are available

{customPrompt}
```

## Changes

- 181f6b23 fix(TKT-1201): make orchestrator prompt role-specific instead of generic ticket format

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
