### PR TITLE
fix(TKT-1203): add tmux -d flag to prevent multi-client attach lockups

### DIFF
--- a/apps/cli/src/commands/agent/shell.ts
+++ b/apps/cli/src/commands/agent/shell.ts
@@ -130,7 +130,7 @@ export default class Shell extends PMOCommand {
         const sessionName = existingSessions[0];
         this.log(colors.primary(`\nAttaching to session: ${sessionName}`));
         try {
-          execSync(`tmux attach-session -t "${sessionName}"`, { stdio: 'inherit' });
+          execSync(`tmux attach-session -d -t "${sessionName}"`, { stdio: 'inherit' });
         } catch {
           // User detached or session ended
           this.log(colors.textMuted('\nDetached from session.'));

--- a/apps/cli/src/commands/session/create.ts
+++ b/apps/cli/src/commands/session/create.ts
@@ -104,7 +104,7 @@ export default class SessionCreate extends PMOCommand {
     if (!flags.detach) {
       this.log(styles.info(`Attaching to session: ${sessionName}`))
       try {
-        execSync(`tmux attach -t "${sessionName}"`, { stdio: 'inherit' })
+        execSync(`tmux attach -d -t "${sessionName}"`, { stdio: 'inherit' })
       } catch {
         this.log(styles.muted(`Session "${sessionName}" is running in detached mode.`))
         this.log(styles.muted(`Attach with: tmux attach -t "${sessionName}"`))

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -755,7 +755,7 @@ export default class WorkStart extends PMOCommand {
 
         if (sessionAction === 'attach') {
           // Attach to existing session
-          execSync(`tmux attach -t "${existingSession.sessionName}"`, { stdio: 'inherit' })
+          execSync(`tmux attach -d -t "${existingSession.sessionName}"`, { stdio: 'inherit' })
           db.close()
           return
         }

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -91,9 +91,11 @@ export function buildTmuxAttachCommand(useControlMode: boolean, includeUnicodeFl
   const unicodeFlag = includeUnicodeFlag ? '-u ' : ''
   if (useControlMode) {
     // Always use -u with -CC for proper iTerm integration
-    return `tmux -u -CC attach`
+    // -d detaches other clients to prevent multi-attach lockups
+    return `tmux -u -CC attach -d`
   }
-  return `tmux ${unicodeFlag}attach`
+  // -d detaches other clients to prevent multi-attach lockups
+  return `tmux ${unicodeFlag}attach -d`
 }
 
 /**
@@ -736,7 +738,7 @@ exec $SHELL
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "tmux -u -CC attach -t \\"${sessionName}\\""
+                write text "tmux -u -CC attach -d -t \\"${sessionName}\\""
               end tell
             end tell
           end tell
@@ -749,7 +751,7 @@ exec $SHELL
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "tmux -u -CC attach -t \\"${sessionName}\\""
+                write text "tmux -u -CC attach -d -t \\"${sessionName}\\""
               end tell
             end tell
           end tell
@@ -2196,7 +2198,7 @@ exec bash
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -t \\"${sessionName}\\""
+                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -d -t \\"${sessionName}\\""
               end tell
             end tell
           end tell
@@ -2209,7 +2211,7 @@ exec bash
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -t \\"${sessionName}\\""
+                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -d -t \\"${sessionName}\\""
               end tell
             end tell
           end tell


### PR DESCRIPTION
## Summary
- Adds `-d` flag to all `tmux attach` commands across the CLI, which auto-detaches other clients when a new one attaches
- Prevents zombie control-mode clients that lock up sessions when switching between terminals (e.g. iTerm on Mac + Termius on phone)
- Affects: `buildTmuxAttachCommand()`, AppleScript iTerm/Docker attach blocks, and direct attach calls in `session/create`, `work/start`, `agent/shell`

## Test plan
- [ ] Attach to orchestrator from iTerm, then attach from another terminal — first session should auto-detach
- [ ] Attach from Termius (SSH), then attach from iTerm — Termius session should auto-detach
- [ ] Verify `prlt orchestrator attach` works with `-CC` mode in iTerm
- [ ] Verify `prlt session attach` works for both host and container sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)