### PR TITLE
TKT-1205: Session poke orchestrator prefix matching for multi-orchestrator

### DIFF
--- a/apps/cli/src/commands/session/poke.ts
+++ b/apps/cli/src/commands/session/poke.ts
@@ -221,9 +221,34 @@ export default class SessionPoke extends PMOCommand {
       const activeExecutions = [...runningExecutions, ...startingExecutions]
 
       // Find matching execution by exact agent name or exact ticket ID
-      const match = activeExecutions.find(exec =>
+      let match = activeExecutions.find(exec =>
         exec.agentName === identifier || exec.ticketId === identifier,
       )
+
+      // Orchestrator prefix matching: when identifier is "orchestrator",
+      // find executions with agentName "orchestrator" or "orchestrator-*"
+      if (!match && identifier === 'orchestrator') {
+        const orchestratorMatches = activeExecutions.filter(exec =>
+          exec.agentName === 'orchestrator' || exec.agentName.startsWith('orchestrator-'),
+        )
+
+        if (orchestratorMatches.length === 1) {
+          match = orchestratorMatches[0]
+        } else if (orchestratorMatches.length > 1) {
+          const names = orchestratorMatches.map(e => e.agentName).join(', ')
+          if (jsonMode) {
+            outputErrorAsJson(
+              'MULTIPLE_ORCHESTRATORS',
+              `Multiple orchestrators running: ${names}. Specify one directly.`,
+              createMetadata('session poke', flags),
+            )
+          }
+          this.log('')
+          this.log(styles.error(`Multiple orchestrators running: ${names}. Specify one directly.`))
+          this.log('')
+          return null
+        }
+      }
 
       if (!match) {
         if (jsonMode) {


### PR DESCRIPTION
## Summary

Resolves TKT-1205: Session poke orchestrator prefix matching for multi-orchestrator

## Description

## Context
With multi-orchestrator support (TKT-1204), execution records now use `agentName: 'orchestrator-{name}'` instead of just `'orchestrator'`. The `prlt session poke orchestrator "msg"` shortcut needs to handle the new format.

## Changes

### `commands/session/poke.ts` — Orchestrator shortcut with prefix matching

In the session/execution resolution logic, add special handling when the identifier is `orchestrator`:

1. Find all active executions where `agentName` starts with `orchestrator-` OR equals `orchestrator` (backward compat)
2. If 1 match: poke it directly
3. If multiple: output error listing available orchestrator names (keep non-interactive for scriptability), e.g. "Multiple orchestrators running: orchestrator-bezos, orchestrator-gates. Specify one directly."
4. `prlt session poke orchestrator-bezos "msg"` → exact match on agentName (works with no changes needed)

## Important
- This is a SMALL change — just add orchestrator prefix matching to the execution resolution, don't restructure the whole command
- Keep the existing resolution logic for non-orchestrator identifiers unchanged
- Follow JSON mode patterns if adding any new prompts (see CLAUDE.md)

## Depends on
- TKT-1204 (which changes the agentName format in execution records)

## Verification
- `cd apps/cli && pnpm build` must succeed
- `prlt session poke orchestrator "test"` should find the running orchestrator
- `prlt session poke orchestrator-bezos "test"` should work for exact match

## Changes

- 642639cf feat(TKT-1205): add orchestrator prefix matching to session poke command

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
