### PR TITLE
TKT-1204: Multi-orchestrator themed naming and HQ-scoped discovery

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -10,6 +10,8 @@ import {
   shouldOutputJson,
   outputErrorAsJson,
   outputSuccessAsJson,
+  outputPromptAsJson,
+  buildPromptConfig,
   createMetadata,
 } from '../../lib/prompt-json.js'
 import { styles } from '../../lib/styles.js'
@@ -18,7 +20,12 @@ import { getWorkspaceInfo } from '../../lib/agents/commands.js'
 import { findHQRoot } from '../../lib/workspace.js'
 import { getHeadquartersNameFromPath } from '../../lib/machine-config.js'
 import { loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
-import { buildOrchestratorSessionName, findRunningOrchestratorSessions } from './start.js'
+import {
+  buildOrchestratorSessionName,
+  findRunningOrchestratorSessions,
+  findHQOrchestratorSessions,
+  extractOrchestratorNameFromSession,
+} from './start.js'
 
 /**
  * Detect the terminal emulator from environment variables.
@@ -97,15 +104,50 @@ export default class OrchestratorAttach extends PromptCommand {
     // Resolve session name: try HQ-scoped first, fall back to discovery
     let sessionName: string | undefined
     const hqPath = findHQRoot(process.cwd())
+
     if (hqPath) {
       const hqName = getHeadquartersNameFromPath(hqPath)
-      sessionName = buildOrchestratorSessionName(hqName, flags.name || 'main')
-      if (!hostSessions.includes(sessionName)) {
-        sessionName = undefined // Not running for this HQ
+
+      if (flags.name) {
+        // Explicit --name: look for that specific orchestrator
+        sessionName = buildOrchestratorSessionName(hqName, flags.name)
+        if (!hostSessions.includes(sessionName)) {
+          sessionName = undefined
+        }
+      } else {
+        // No --name: discover ALL orchestrators in this HQ
+        const hqSessions = findHQOrchestratorSessions(hostSessions, hqName)
+        if (hqSessions.length === 1) {
+          sessionName = hqSessions[0]
+        } else if (hqSessions.length > 1) {
+          const sessionChoices = hqSessions.map(s => ({
+            name: extractOrchestratorNameFromSession(s, hqName) || s,
+            value: s,
+            command: `prlt orchestrator attach --name "${extractOrchestratorNameFromSession(s, hqName) || s}" --json`,
+          }))
+          const selectMessage = 'Multiple orchestrator sessions found. Select one to attach:'
+
+          if (jsonMode) {
+            outputPromptAsJson(
+              buildPromptConfig('list', 'session', selectMessage, sessionChoices),
+              createMetadata('orchestrator attach', flags),
+            )
+            return
+          }
+
+          const { session } = await this.prompt<{ session: string }>([{
+            type: 'list',
+            name: 'session',
+            message: selectMessage,
+            choices: sessionChoices,
+          }])
+          sessionName = session
+        }
+        // If 0 found, fall through to global discovery below
       }
     }
 
-    // If not in HQ or session not found, discover running orchestrator sessions
+    // If not in HQ or session not found, discover running orchestrator sessions globally
     if (!sessionName) {
       const runningSessions = findRunningOrchestratorSessions(hostSessions)
       if (runningSessions.length === 0) {
@@ -126,16 +168,27 @@ export default class OrchestratorAttach extends PromptCommand {
         sessionName = runningSessions[0]
       } else {
         // Multiple sessions — let user pick
+        const sessionChoices = runningSessions.map(s => ({
+          name: s,
+          value: s,
+          command: `prlt orchestrator attach --name "${s}" --json`,
+        }))
+        const selectMessage = 'Multiple orchestrator sessions found. Select one to attach:'
+
+        if (jsonMode) {
+          outputPromptAsJson(
+            buildPromptConfig('list', 'session', selectMessage, sessionChoices),
+            createMetadata('orchestrator attach', flags),
+          )
+          return
+        }
+
         const { session } = await this.prompt<{ session: string }>([{
           type: 'list',
           name: 'session',
-          message: 'Multiple orchestrator sessions found. Select one to attach:',
-          choices: runningSessions.map(s => ({
-            name: s,
-            value: s,
-            command: `prlt orchestrator attach --name "${s}" --json`,
-          })),
-        }], jsonMode ? { flags, commandName: 'orchestrator attach' } : null)
+          message: selectMessage,
+          choices: sessionChoices,
+        }])
         sessionName = session
       }
     }

--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -34,11 +34,13 @@ import {
   detectShell,
   detectTerminalApp,
 } from '../../lib/execution/config.js'
+import { ensureBuiltinThemes } from '../../lib/themes.js'
+import { getActiveTheme, getAvailableThemeNames } from '../../lib/database/index.js'
 
 /**
  * Sanitize a name segment for use in tmux session names.
  */
-function sanitizeName(name: string): string {
+export function sanitizeName(name: string): string {
   return name
     .replace(/[^a-zA-Z0-9._-]/g, '-')
     .replace(/-+/g, '-')
@@ -62,6 +64,15 @@ export function buildOrchestratorSessionName(hqName: string, name: string = 'mai
  */
 export function findRunningOrchestratorSessions(hostSessions: string[]): string[] {
   return hostSessions.filter(s => s.startsWith('prlt-orchestrator-'))
+}
+
+/**
+ * Find orchestrator sessions scoped to a specific HQ workspace.
+ * Filters sessions by 'prlt-orchestrator-{sanitizedHqName}-' prefix.
+ */
+export function findHQOrchestratorSessions(hostSessions: string[], hqName: string): string[] {
+  const prefix = `prlt-orchestrator-${sanitizeName(hqName) || 'default'}-`
+  return hostSessions.filter(s => s.startsWith(prefix))
 }
 
 export function resolveOrchestratorName(name?: string): string {
@@ -226,20 +237,50 @@ export default class OrchestratorStart extends PromptCommand {
     )
 
     let orchestratorName = resolveOrchestratorName(flags.name)
-    if (!flags.name && !jsonMode) {
-      const availableNames = buildAvailableOrchestratorNames(reservedNames)
+    if (!flags.name) {
+      // Try theme-based names first
+      ensureBuiltinThemes(hqPath)
+      const activeTheme = getActiveTheme(hqPath)
+      let availableNames: string[]
+
+      if (activeTheme) {
+        const themeNames = getAvailableThemeNames(hqPath, activeTheme.id)
+        // Filter out names that are reserved by running orchestrators or agents
+        availableNames = themeNames
+          .filter(n => !reservedNames.has(n.toLowerCase()))
+          .slice(0, 8)
+      } else {
+        availableNames = []
+      }
+
+      // Fall back to buildAvailableOrchestratorNames if no theme names available
+      if (availableNames.length === 0) {
+        availableNames = buildAvailableOrchestratorNames(reservedNames)
+      }
+
+      const nameChoices = [
+        ...availableNames.map(name => ({
+          name,
+          value: name,
+          command: `prlt orchestrator start --name ${name} --json`,
+        })),
+        { name: 'Custom...', value: '__custom__' },
+      ]
+      const nameMessage = 'Select orchestrator name:'
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'selectedName', nameMessage, nameChoices),
+          createMetadata('orchestrator start', flags),
+        )
+        return
+      }
+
       const { selectedName } = await this.prompt<{ selectedName: string }>([{
         type: 'list',
         name: 'selectedName',
-        message: 'Select orchestrator name:',
-        choices: [
-          ...availableNames.map(name => ({
-            name,
-            value: name,
-            command: `prlt orchestrator start --name ${name} --json`,
-          })),
-          { name: 'Custom...', value: '__custom__' },
-        ],
+        message: nameMessage,
+        choices: nameChoices,
       }])
 
       if (selectedName === '__custom__') {
@@ -554,7 +595,7 @@ export default class OrchestratorStart extends PromptCommand {
           const executionStorage = new ExecutionStorage(db)
           executionStorage.createExecution({
             ticketId: 'ORCH',
-            agentName: 'orchestrator',
+            agentName: `orchestrator-${orchestratorName}`,
             executor: selectedExecutor,
             environment: 'host',
             displayMode,

--- a/apps/cli/src/commands/orchestrator/status.ts
+++ b/apps/cli/src/commands/orchestrator/status.ts
@@ -10,7 +10,12 @@ import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames, captureTmuxPane } from '../../lib/execution/session-utils.js'
 import { findHQRoot } from '../../lib/workspace.js'
 import { getHeadquartersNameFromPath } from '../../lib/machine-config.js'
-import { buildOrchestratorSessionName, findRunningOrchestratorSessions } from './start.js'
+import {
+  buildOrchestratorSessionName,
+  findRunningOrchestratorSessions,
+  findHQOrchestratorSessions,
+  extractOrchestratorNameFromSession,
+} from './start.js'
 
 export default class OrchestratorStatus extends PromptCommand {
   static description = 'Check if the orchestrator is running'
@@ -43,54 +48,91 @@ export default class OrchestratorStatus extends PromptCommand {
     const hostSessions = getHostTmuxSessionNames()
 
     // Resolve session name: try HQ-scoped first, fall back to discovery
-    let sessionName: string | undefined
     const hqPath = findHQRoot(process.cwd())
+
     if (hqPath) {
       const hqName = getHeadquartersNameFromPath(hqPath)
-      sessionName = buildOrchestratorSessionName(hqName, flags.name || 'main')
-    }
 
-    // If in HQ, check specifically for this HQ's session
-    if (sessionName) {
-      const isRunning = hostSessions.includes(sessionName)
+      if (flags.name) {
+        // Explicit --name: check that specific orchestrator
+        const sessionName = buildOrchestratorSessionName(hqName, flags.name)
+        const isRunning = hostSessions.includes(sessionName)
 
-      let recentOutput: string | null = null
-      if (isRunning && flags.peek) {
-        recentOutput = captureTmuxPane(sessionName, flags.lines)
+        let recentOutput: string | null = null
+        if (isRunning && flags.peek) {
+          recentOutput = captureTmuxPane(sessionName, flags.lines)
+        }
+
+        if (jsonMode) {
+          outputSuccessAsJson({
+            running: isRunning,
+            sessionId: isRunning ? sessionName : null,
+            name: flags.name,
+            ...(recentOutput !== null && { recentOutput }),
+          }, createMetadata('orchestrator status', flags as Record<string, unknown>))
+          return
+        }
+
+        this.log('')
+        if (isRunning) {
+          this.log(styles.success(`Orchestrator "${flags.name}" is running`))
+          this.log(styles.muted(`   Session: ${sessionName}`))
+          this.log(styles.muted(`   Attach: prlt orchestrator attach --name ${flags.name}`))
+
+          if (recentOutput) {
+            this.log('')
+            this.log(styles.header('Recent output:'))
+            this.log(styles.muted('─'.repeat(60)))
+            this.log(recentOutput)
+            this.log(styles.muted('─'.repeat(60)))
+          }
+        } else {
+          this.log(styles.muted(`Orchestrator "${flags.name}" is not running.`))
+          this.log(styles.muted('Start it with: prlt orchestrator start'))
+        }
+        this.log('')
+        return
       }
+
+      // No --name: show status for ALL orchestrators in this HQ
+      const hqSessions = findHQOrchestratorSessions(hostSessions, hqName)
 
       if (jsonMode) {
         outputSuccessAsJson({
-          running: isRunning,
-          sessionId: isRunning ? sessionName : null,
-          ...(recentOutput !== null && { recentOutput }),
+          running: hqSessions.length > 0,
+          sessions: hqSessions.map(s => ({
+            sessionId: s,
+            name: extractOrchestratorNameFromSession(s, hqName) || s,
+          })),
         }, createMetadata('orchestrator status', flags as Record<string, unknown>))
         return
       }
 
       this.log('')
-      if (isRunning) {
-        this.log(styles.success(`Orchestrator is running`))
-        this.log(styles.muted(`   Session: ${sessionName}`))
-        this.log(styles.muted(`   Attach: prlt orchestrator attach`))
-        this.log(styles.muted(`   Poke:   prlt session poke orchestrator "message"`))
-
-        if (recentOutput) {
-          this.log('')
-          this.log(styles.header('Recent output:'))
-          this.log(styles.muted('─'.repeat(60)))
-          this.log(recentOutput)
-          this.log(styles.muted('─'.repeat(60)))
-        }
+      if (hqSessions.length === 0) {
+        this.log(styles.muted('No orchestrator sessions running.'))
+        this.log(styles.muted('Start one with: prlt orchestrator start'))
       } else {
-        this.log(styles.muted('Orchestrator is not running.'))
-        this.log(styles.muted('Start it with: prlt orchestrator start'))
+        this.log(styles.success(`${hqSessions.length} orchestrator session(s) running:`))
+        for (const s of hqSessions) {
+          const name = extractOrchestratorNameFromSession(s, hqName) || s
+          this.log(styles.muted(`   ${name} (${s})`))
+          this.log(styles.muted(`     Attach: prlt orchestrator attach --name ${name}`))
+          if (flags.peek) {
+            const output = captureTmuxPane(s, flags.lines)
+            if (output) {
+              this.log(styles.muted('─'.repeat(60)))
+              this.log(output)
+              this.log(styles.muted('─'.repeat(60)))
+            }
+          }
+        }
       }
       this.log('')
       return
     }
 
-    // Not in HQ — discover all running orchestrator sessions
+    // Not in HQ — discover all running orchestrator sessions globally
     const runningSessions = findRunningOrchestratorSessions(hostSessions)
 
     if (jsonMode) {

--- a/apps/cli/src/commands/orchestrator/stop.ts
+++ b/apps/cli/src/commands/orchestrator/stop.ts
@@ -10,12 +10,19 @@ import {
   shouldOutputJson,
   outputErrorAsJson,
   outputSuccessAsJson,
+  outputPromptAsJson,
+  buildPromptConfig,
   createMetadata,
 } from '../../lib/prompt-json.js'
 import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
 import { ExecutionStorage } from '../../lib/execution/storage.js'
-import { buildOrchestratorSessionName, findRunningOrchestratorSessions } from './start.js'
+import {
+  buildOrchestratorSessionName,
+  findRunningOrchestratorSessions,
+  findHQOrchestratorSessions,
+  extractOrchestratorNameFromSession,
+} from './start.js'
 import { getHeadquartersNameFromPath } from '../../lib/machine-config.js'
 
 export default class OrchestratorStop extends PromptCommand {
@@ -46,16 +53,55 @@ export default class OrchestratorStop extends PromptCommand {
 
     // Resolve session name: try HQ-scoped first, fall back to discovery
     let sessionName: string | undefined
+    let orchestratorName: string | undefined
     const hqPath = findHQRoot(process.cwd())
+
     if (hqPath) {
       const hqName = getHeadquartersNameFromPath(hqPath)
-      sessionName = buildOrchestratorSessionName(hqName, flags.name || 'main')
-      if (!hostSessions.includes(sessionName)) {
-        sessionName = undefined
+
+      if (flags.name) {
+        // Explicit --name: look for that specific orchestrator
+        sessionName = buildOrchestratorSessionName(hqName, flags.name)
+        orchestratorName = flags.name
+        if (!hostSessions.includes(sessionName)) {
+          sessionName = undefined
+        }
+      } else {
+        // No --name: discover ALL orchestrators in this HQ
+        const hqSessions = findHQOrchestratorSessions(hostSessions, hqName)
+        if (hqSessions.length === 1) {
+          sessionName = hqSessions[0]
+          orchestratorName = extractOrchestratorNameFromSession(hqSessions[0], hqName) || undefined
+        } else if (hqSessions.length > 1) {
+          const sessionChoices = hqSessions.map(s => ({
+            name: extractOrchestratorNameFromSession(s, hqName) || s,
+            value: s,
+            command: `prlt orchestrator stop --name "${extractOrchestratorNameFromSession(s, hqName) || s}" --force --json`,
+          }))
+          const selectMessage = 'Multiple orchestrator sessions found. Select one to stop:'
+
+          if (jsonMode) {
+            outputPromptAsJson(
+              buildPromptConfig('list', 'session', selectMessage, sessionChoices),
+              createMetadata('orchestrator stop', flags),
+            )
+            return
+          }
+
+          const { session } = await this.prompt<{ session: string }>([{
+            type: 'list',
+            name: 'session',
+            message: selectMessage,
+            choices: sessionChoices,
+          }])
+          sessionName = session
+          orchestratorName = extractOrchestratorNameFromSession(session, hqName) || undefined
+        }
+        // If 0 found, fall through to global discovery below
       }
     }
 
-    // If not in HQ or session not found, discover running orchestrator sessions
+    // If not in HQ or session not found, discover running orchestrator sessions globally
     if (!sessionName) {
       const runningSessions = findRunningOrchestratorSessions(hostSessions)
       if (runningSessions.length === 0) {
@@ -75,16 +121,27 @@ export default class OrchestratorStop extends PromptCommand {
         sessionName = runningSessions[0]
       } else {
         // Multiple sessions — let user pick
+        const sessionChoices = runningSessions.map(s => ({
+          name: s,
+          value: s,
+          command: `prlt orchestrator stop --name "${s}" --force --json`,
+        }))
+        const selectMessage = 'Multiple orchestrator sessions found. Select one to stop:'
+
+        if (jsonMode) {
+          outputPromptAsJson(
+            buildPromptConfig('list', 'session', selectMessage, sessionChoices),
+            createMetadata('orchestrator stop', flags),
+          )
+          return
+        }
+
         const { session } = await this.prompt<{ session: string }>([{
           type: 'list',
           name: 'session',
-          message: 'Multiple orchestrator sessions found. Select one to stop:',
-          choices: runningSessions.map(s => ({
-            name: s,
-            value: s,
-            command: `prlt orchestrator stop --name "${s}" --force --json`,
-          })),
-        }], jsonMode ? { flags, commandName: 'orchestrator stop' } : null)
+          message: selectMessage,
+          choices: sessionChoices,
+        }])
         sessionName = session
       }
     }
@@ -134,10 +191,18 @@ export default class OrchestratorStop extends PromptCommand {
         try {
           db = new Database(dbPath)
           const executionStorage = new ExecutionStorage(db)
-          const running = executionStorage.listExecutions({ agentName: 'orchestrator', status: 'running' })
-          const starting = executionStorage.listExecutions({ agentName: 'orchestrator', status: 'starting' })
-          for (const exec of [...running, ...starting]) {
-            executionStorage.updateStatus(exec.id, 'stopped')
+          // Match new format: orchestrator-{name}
+          const agentNameToMatch = orchestratorName ? `orchestrator-${orchestratorName}` : undefined
+          const matchNames = agentNameToMatch ? [agentNameToMatch] : []
+          // Also match old format for backward compatibility
+          matchNames.push('orchestrator')
+
+          for (const matchName of matchNames) {
+            const running = executionStorage.listExecutions({ agentName: matchName, status: 'running' })
+            const starting = executionStorage.listExecutions({ agentName: matchName, status: 'starting' })
+            for (const exec of [...running, ...starting]) {
+              executionStorage.updateStatus(exec.id, 'stopped')
+            }
           }
         } catch {
           // Non-fatal


### PR DESCRIPTION
## Summary

Resolves TKT-1204: Multi-orchestrator themed naming and HQ-scoped discovery

## Description

## Context
Currently `prlt orchestrator start` generates boring names like 'main', 'main-2'. The attach command defaults to looking for 'main' only. The execution record hardcodes `agentName: 'orchestrator'` for all instances. This prevents running multiple named orchestrators in one HQ.

## Changes

### 1. `orchestrator/start.ts` — Theme-based name selection (lines 229-264)
- Replace `buildAvailableOrchestratorNames()` name generation with theme-based names
- Use `ensureBuiltinThemes(hqPath)` + `getActiveTheme(hqPath)` + `getAvailableThemeNames(hqPath, themeId)` from `lib/themes.ts` and `lib/database/index.ts` (same pattern as `commands/staff/add.ts`)
- Present theme names as a `list` prompt with up to 8 choices + "Custom..." option with `__custom__` sentinel
- Fall back to current `buildAvailableOrchestratorNames()` behavior if no active theme
- **Fix execution record** (line 557): Change `agentName: 'orchestrator'` → `agentName: 'orchestrator-{name}'` (e.g., `orchestrator-bezos`)
- Add new exported helper: `findHQOrchestratorSessions(hostSessions: string[], hqName: string): string[]` — filters sessions by `prlt-orchestrator-{sanitizedHqName}-` prefix

### 2. `orchestrator/attach.ts` — Multi-orchestrator discovery (lines 99-106)
- When `--name` is provided: look for that specific orchestrator (keep existing behavior)
- When `--name` is omitted: use new `findHQOrchestratorSessions()` to find ALL orchestrators in the current HQ
  - If 1 found: attach directly
  - If multiple: prompt user to select (show extracted orchestrator names via `extractOrchestratorNameFromSession()`, not raw session IDs)
  - If 0 found: fall through to existing global discovery code (lines 109-141)
- Import `sanitizeName`, `extractOrchestratorNameFromSession`, `findHQOrchestratorSessions` from `./start.js`

### 3. `orchestrator/stop.ts` — Same discovery pattern
- Replace `flags.name || 'main'` default with multi-orchestrator discovery using `findHQOrchestratorSessions()`
- Fix execution cleanup to match on `orchestrator-{name}` agentName format (with fallback for old `'orchestrator'` records)

### 4. `orchestrator/status.ts` — Same discovery pattern
- Replace `flags.name || 'main'` default with multi-orchestrator discovery
- Show status for all running orchestrators in the HQ when `--name` is omitted

## Reusable Functions (DO NOT rewrite these, import them)
- `ensureBuiltinThemes(hqPath)` from `../../lib/themes.js`
- `getActiveTheme(hqPath)`, `getAvailableThemeNames(hqPath, themeId)` from `../../lib/database/index.js`
- `extractOrchestratorNameFromSession(session, hqName)` already exported from `start.ts`
- `collectReservedOrchestratorNames()` already in `start.ts`
- `sanitizeName()` already in `start.ts`

## Backward Compatibility
- Old execution records with `agentName: 'orchestrator'` must still be matched via `|| exec.agentName === 'orchestrator'` fallback
- `--name main` still works explicitly
- IMPORTANT: Follow UX patterns in CLAUDE.md — use list prompts (not confirm), include JSON mode support for all new prompts

## Verification
- `cd apps/cli && pnpm build` must succeed
- `prlt orchestrator start` should show themed names from active theme
- `prlt orchestrator attach` (no --name) with multiple running should prompt to select

## Changes

- 7b4b7681 feat(TKT-1204): feat: multi-orchestrator themed naming and HQ-scoped discovery

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
