### PR TITLE
TKT-1180: Add external execution mapping store for provider-backed work

### DIFF
--- a/apps/cli/test/unit/external-execution-mapping-store.test.ts
+++ b/apps/cli/test/unit/external-execution-mapping-store.test.ts
@@ -77,4 +77,121 @@ describe('ExternalExecutionMappingStore', () => {
     expect(byExecution[0].provider).to.equal('jira')
     expect(byExecution[0].externalId).to.equal('10001')
   })
+
+  it('creates a new mapping with all fields populated', () => {
+    const now = new Date()
+    const mapping = store.upsertMapping({
+      provider: 'linear',
+      externalId: 'new-id-1',
+      externalKey: 'ENG-200',
+      canonicalUrl: 'https://linear.app/org/issue/ENG-200',
+      latestStateSnapshot: { status: 'Todo', priority: 'P1' },
+      executionId: 'WORK-CREATE01',
+      prUrl: 'https://github.com/org/repo/pull/5',
+      lastSyncedAt: now,
+      lastSpawnedAt: now,
+    })
+
+    expect(mapping.provider).to.equal('linear')
+    expect(mapping.externalId).to.equal('new-id-1')
+    expect(mapping.externalKey).to.equal('ENG-200')
+    expect(mapping.canonicalUrl).to.equal('https://linear.app/org/issue/ENG-200')
+    expect(mapping.latestStateSnapshot).to.deep.equal({ status: 'Todo', priority: 'P1' })
+    expect(mapping.executionIds).to.deep.equal(['WORK-CREATE01'])
+    expect(mapping.prUrls).to.deep.equal(['https://github.com/org/repo/pull/5'])
+    expect(mapping.lastSyncedAt).to.be.instanceOf(Date)
+    expect(mapping.lastSpawnedAt).to.be.instanceOf(Date)
+    expect(mapping.createdAt).to.be.instanceOf(Date)
+    expect(mapping.updatedAt).to.be.instanceOf(Date)
+  })
+
+  it('upsert updates snapshot and accumulates execution IDs and PR URLs', () => {
+    store.upsertMapping({
+      provider: 'jira',
+      externalId: '20001',
+      externalKey: 'PROJ-100',
+      latestStateSnapshot: { status: 'Open' },
+      executionId: 'WORK-EXEC01',
+      prUrl: 'https://github.com/org/repo/pull/10',
+    })
+
+    store.upsertMapping({
+      provider: 'jira',
+      externalId: '20001',
+      latestStateSnapshot: { status: 'In Review' },
+      executionId: 'WORK-EXEC02',
+      prUrl: 'https://github.com/org/repo/pull/11',
+    })
+
+    const mapping = store.getByExternalId('jira', '20001')!
+    expect(mapping.latestStateSnapshot).to.deep.equal({ status: 'In Review' })
+    expect(mapping.executionIds).to.include('WORK-EXEC01')
+    expect(mapping.executionIds).to.include('WORK-EXEC02')
+    expect(mapping.prUrls).to.include('https://github.com/org/repo/pull/10')
+    expect(mapping.prUrls).to.include('https://github.com/org/repo/pull/11')
+    expect(mapping.externalKey).to.equal('PROJ-100')
+  })
+
+  it('supports query by external key', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      externalId: 'lin-key-1',
+      externalKey: 'ENG-300',
+      canonicalUrl: 'https://linear.app/org/issue/ENG-300',
+    })
+
+    const byKey = store.getByExternalKey('linear', 'ENG-300')
+    expect(byKey).to.not.equal(null)
+    expect(byKey!.externalId).to.equal('lin-key-1')
+    expect(byKey!.provider).to.equal('linear')
+  })
+
+  it('returns null for non-existent external ref', () => {
+    const result = store.getByExternalId('linear', 'does-not-exist')
+    expect(result).to.equal(null)
+  })
+
+  it('returns empty array for non-existent execution ID', () => {
+    const result = store.findByExecutionId('WORK-NONEXIST')
+    expect(result).to.deep.equal([])
+  })
+
+  it('keeps separate mappings for different providers with the same external_id', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      externalId: 'shared-id',
+      externalKey: 'ENG-400',
+      executionId: 'WORK-LIN01',
+    })
+
+    store.upsertMapping({
+      provider: 'jira',
+      externalId: 'shared-id',
+      externalKey: 'PROJ-400',
+      executionId: 'WORK-JIRA01',
+    })
+
+    const linear = store.getByExternalId('linear', 'shared-id')
+    const jira = store.getByExternalId('jira', 'shared-id')
+    expect(linear).to.not.equal(null)
+    expect(jira).to.not.equal(null)
+    expect(linear!.externalKey).to.equal('ENG-400')
+    expect(jira!.externalKey).to.equal('PROJ-400')
+    expect(linear!.executionIds).to.deep.equal(['WORK-LIN01'])
+    expect(jira!.executionIds).to.deep.equal(['WORK-JIRA01'])
+  })
+
+  it('upsert without executionId or prUrl only updates the map row', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      externalId: 'lin-noexec',
+      externalKey: 'ENG-500',
+      latestStateSnapshot: { status: 'Backlog' },
+    })
+
+    const mapping = store.getByExternalId('linear', 'lin-noexec')!
+    expect(mapping.executionIds).to.deep.equal([])
+    expect(mapping.prUrls).to.deep.equal([])
+    expect(mapping.externalKey).to.equal('ENG-500')
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "apps/cli": {
       "name": "@proletariat/cli",
-      "version": "0.3.46",
+      "version": "0.3.52",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

Resolves TKT-1180: Add external execution mapping store for provider-backed work

## Description

## Goal
Store provider-agnostic execution metadata keyed by external issue refs so orchestration does not require full PMO mirroring.

## Scope
- Add storage model for external work refs:
  - provider (`linear|jira|asana|monday|pmo`)
  - external key/id
  - canonical URL
  - latest synced state snapshot
  - linked execution IDs / PR URLs
  - sync timestamps
- Add read/write APIs used by `work spawn`, provider adapters, and sync commands.
- Ensure idempotent upserts for repeated imports/spawns.

## Out of Scope
- Full bidirectional sync behavior for every provider.

## Acceptance Criteria
- Schema supports unique key `(provider, external_id)`.
- Spawning from same external issue updates existing mapping record (no duplicates).
- Mapping record can be queried by external ref and by execution ID.
- Linear/Jira adapters can persist and read mapping without PMO ticket dependency.
- Unit tests cover create/upsert/query behavior.


## Changes

- deb4ef7e chore(TKT-1180): expand unit tests for external execution mapping store create/upsert/query coverage

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
