### PR TITLE
TKT-1207: Graceful ctrl+c handling across CLI commands

### DIFF
--- a/apps/cli/bin/run.js
+++ b/apps/cli/bin/run.js
@@ -9,21 +9,31 @@ if (args.length === 1 && args[0] === '-v') {
   process.argv[2] = '--version'
 }
 
-// Handle process termination gracefully
-process.on('SIGINT', () => {
-  console.log('\n'); // Add newline for clean exit
-  process.exit(0);
-});
-
-process.on('SIGTERM', () => {
-  process.exit(0);
-});
+// Install centralized signal handlers for graceful Ctrl+C shutdown.
+// This replaces the old per-handler approach and ensures:
+// - Cleanup callbacks run in order
+// - Tracked child processes are killed
+// - Exit code 130 (standard Unix SIGINT convention)
+// - No stack traces from ERR_USE_AFTER_CLOSE
+import {installSignalHandlers, isExiting} from '../dist/lib/signal-handler.js'
+installSignalHandlers()
 
 try {
   await execute({dir: import.meta.url});
 } catch (error) {
-  // Handle any unhandled errors
-  if (error.code !== 'EEXIT') {
+  if (error.code === 'EEXIT') {
+    // Normal oclif exit - ignore
+  } else if (isExiting()) {
+    // SIGINT triggered during command execution - exit silently with 130
+    process.exit(130);
+  } else if (
+    error.code === 'ERR_USE_AFTER_CLOSE' ||
+    (error.message && error.message.includes('ERR_USE_AFTER_CLOSE')) ||
+    (error.message && error.message.includes('readline was closed'))
+  ) {
+    // Readline/inquirer closed by SIGINT - exit silently
+    process.exit(130);
+  } else {
     console.error(error);
     process.exit(1);
   }

--- a/apps/cli/src/commands/agent/shell.ts
+++ b/apps/cli/src/commands/agent/shell.ts
@@ -18,6 +18,7 @@ import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import {
   shouldOutputJson,
 } from '../../lib/prompt-json.js';
+import { trackChildProcess } from '../../lib/signal-handler.js';
 
 export default class Shell extends PMOCommand {
   static description = 'Open an interactive shell in an agent workspace';
@@ -292,6 +293,8 @@ export default class Shell extends PMOCommand {
         stdio: 'inherit'
       });
 
+      trackChildProcess(child);
+
       await new Promise<void>((resolve, reject) => {
         child.on('close', (code) => {
           if (code === 0) {
@@ -359,6 +362,8 @@ exec bash
         stdio: 'inherit',
         cwd: agentDir,
       });
+
+      trackChildProcess(child);
 
       await new Promise<void>((resolve, reject) => {
         child.on('close', (code) => {

--- a/apps/cli/src/commands/docker/logs.ts
+++ b/apps/cli/src/commands/docker/logs.ts
@@ -9,6 +9,7 @@ import { isDockerRunning } from '../../lib/execution/runners.js'
 import { resolveContainerId } from '../../lib/docker/resolve.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { trackChildProcess } from '../../lib/signal-handler.js'
 
 export default class DockerLogs extends Command {
   static description = 'View logs from a container (by execution ID, agent name, or container ID)'
@@ -107,10 +108,12 @@ export default class DockerLogs extends Command {
       db.close()
 
       if (flags.follow) {
-        // Stream logs
+        // Stream logs - track for cleanup on Ctrl+C
         const proc = spawn('docker', dockerArgs, {
           stdio: 'inherit',
         })
+
+        trackChildProcess(proc)
 
         proc.on('error', (err) => {
           this.error(`Failed to get logs: ${err.message}`)

--- a/apps/cli/src/commands/docker/shell.ts
+++ b/apps/cli/src/commands/docker/shell.ts
@@ -9,6 +9,7 @@ import { isDockerRunning } from '../../lib/execution/runners.js'
 import { resolveContainerId, isContainerRunning } from '../../lib/docker/resolve.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { trackChildProcess } from '../../lib/signal-handler.js'
 
 export default class DockerShell extends Command {
   static description = 'Open a shell in a running container (by execution ID, agent name, or container ID)'
@@ -109,10 +110,12 @@ export default class DockerShell extends Command {
 
       dockerArgs.push(result.containerId, flags.shell)
 
-      // Spawn interactive shell
+      // Spawn interactive shell - track for cleanup on Ctrl+C
       const proc = spawn('docker', dockerArgs, {
         stdio: 'inherit',
       })
+
+      trackChildProcess(proc)
 
       proc.on('error', (err) => {
         this.error(`Failed to open shell: ${err.message}`)

--- a/apps/cli/src/commands/execution/logs.ts
+++ b/apps/cli/src/commands/execution/logs.ts
@@ -12,6 +12,7 @@ import {
   createMetadata,
   shouldOutputJson,
 } from '../../lib/prompt-json.js'
+import { trackChildProcess } from '../../lib/signal-handler.js'
 
 export default class ExecutionLogs extends PMOCommand {
   static description = 'View execution logs'
@@ -148,11 +149,8 @@ export default class ExecutionLogs extends PMOCommand {
           stdio: 'inherit',
         })
 
-        // Handle Ctrl+C
-        process.on('SIGINT', () => {
-          tailProcess.kill()
-          process.exit(0)
-        })
+        // Track for automatic cleanup on Ctrl+C
+        trackChildProcess(tailProcess)
 
         await new Promise((resolve) => {
           tailProcess.on('close', resolve)

--- a/apps/cli/src/commands/gh/login.ts
+++ b/apps/cli/src/commands/gh/login.ts
@@ -10,6 +10,7 @@ import {
   createMetadata,
 } from '../../lib/prompt-json.js';
 import { machineOutputFlags } from '../../lib/pmo/index.js';
+import { trackChildProcess } from '../../lib/signal-handler.js';
 
 export default class GHLogin extends Command {
   static description = 'Login to GitHub CLI for PR workflow';
@@ -78,11 +79,13 @@ export default class GHLogin extends Command {
 
     this.log(styles.muted('Starting GitHub authentication...\n'));
 
-    // Run gh auth login interactively
+    // Run gh auth login interactively - track for cleanup on Ctrl+C
     const child = spawn('gh', ['auth', 'login'], {
       stdio: 'inherit',
       shell: true,
     });
+
+    trackChildProcess(child);
 
     await new Promise<void>((resolve, reject) => {
       child.on('close', (code) => {

--- a/apps/cli/src/commands/session/health.ts
+++ b/apps/cli/src/commands/session/health.ts
@@ -16,6 +16,7 @@ import {
 } from '../../lib/execution/session-utils.js'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { visualPadEnd } from '../../lib/string-utils.js'
+import { onShutdown } from '../../lib/signal-handler.js'
 import {
   shouldOutputJson,
   outputSuccessAsJson,
@@ -550,16 +551,11 @@ export default class SessionHealth extends PMOCommand {
         }
       }, intervalMs)
 
-      // Handle graceful shutdown
-      const cleanup = () => {
+      // Register cleanup via centralized signal handler
+      onShutdown(() => {
         clearInterval(timer)
-        this.log('')
-        this.log(styles.muted('Watchdog stopped.'))
         resolve()
-      }
-
-      process.on('SIGINT', cleanup)
-      process.on('SIGTERM', cleanup)
+      })
     })
   }
 }

--- a/apps/cli/src/commands/work/watch.ts
+++ b/apps/cli/src/commands/work/watch.ts
@@ -21,6 +21,7 @@ import {
   createMetadata,
 } from '../../lib/prompt-json.js'
 import { FlagResolver } from '../../lib/flags/index.js'
+import { onShutdown } from '../../lib/signal-handler.js'
 
 export default class WorkWatch extends PMOCommand {
   static description = 'Watch a column and auto-spawn agents for new tickets'
@@ -128,17 +129,11 @@ export default class WorkWatch extends PMOCommand {
     const db = new Database(dbPath)
     const executionStorage = new ExecutionStorage(db)
 
-    // Handle graceful shutdown
-    const cleanup = async () => {
+    // Register graceful shutdown via centralized signal handler
+    onShutdown(() => {
       this.isRunning = false
-      this.log('')
-      this.log(styles.muted('Stopping watch...'))
       db.close()
-      process.exit(0)
-    }
-
-    process.on('SIGINT', cleanup)
-    process.on('SIGTERM', cleanup)
+    })
 
     try {
       // Get board columns for selection

--- a/apps/cli/src/lib/flags/resolver.ts
+++ b/apps/cli/src/lib/flags/resolver.ts
@@ -48,6 +48,7 @@ import {
   PromptConfig,
 } from '../prompt-json.js';
 import { multiLineInput } from '../multiline-input.js';
+import { withSignalSafePrompt } from '../signal-handler.js';
 
 /**
  * Context available during prompt resolution
@@ -444,8 +445,8 @@ export class FlagResolver<TFlags extends Record<string, unknown> = Record<string
       };
     }
 
-    // Prompt and return value
-    const answers = await inquirer.prompt([question]);
+    // Prompt and return value (with signal-safe wrapper)
+    const answers = await withSignalSafePrompt(() => inquirer.prompt([question]));
     return answers[prompt.flagName];
   }
 

--- a/apps/cli/src/lib/pmo/base-command.ts
+++ b/apps/cli/src/lib/pmo/base-command.ts
@@ -11,6 +11,7 @@ import {
   createMetadata,
   type JsonFlags,
 } from '../prompt-json.js';
+import { withSignalSafePrompt } from '../signal-handler.js';
 
 /**
  * Base flags for JSON/agent mode support
@@ -229,15 +230,17 @@ export abstract class PMOCommand extends PromptCommand {
     }
 
     // Interactive mode - prompt for selection
-    const { selectedProjectId } = await inquirer.prompt([{
-      type: 'list',
-      name: 'selectedProjectId',
-      message: 'Select project:',
-      choices: sortedProjects.map(p => ({
-        name: `${p.name} (${p.id})`,
-        value: p.id,
-      })),
-    }]);
+    const { selectedProjectId } = await withSignalSafePrompt(() =>
+      inquirer.prompt([{
+        type: 'list',
+        name: 'selectedProjectId',
+        message: 'Select project:',
+        choices: sortedProjects.map(p => ({
+          name: `${p.name} (${p.id})`,
+          value: p.id,
+        })),
+      }])
+    );
 
     return selectedProjectId;
   }
@@ -343,12 +346,14 @@ export abstract class PMOCommand extends PromptCommand {
       );
     }
 
-    const { selection } = await inquirer.prompt([{
-      type: 'list',
-      name: 'selection',
-      message,
-      choices: interactiveChoices,
-    }]);
+    const { selection } = await withSignalSafePrompt(() =>
+      inquirer.prompt([{
+        type: 'list',
+        name: 'selection',
+        message,
+        choices: interactiveChoices,
+      }])
+    );
 
     if (selection === '__cancel__' || selection === '__separator__') {
       return null;
@@ -412,13 +417,15 @@ export abstract class PMOCommand extends PromptCommand {
     }
 
     // Interactive mode
-    const { value } = await inquirer.prompt([{
-      type: 'input',
-      name: 'value',
-      message,
-      default: defaultValue,
-      validate,
-    }]);
+    const { value } = await withSignalSafePrompt(() =>
+      inquirer.prompt([{
+        type: 'input',
+        name: 'value',
+        message,
+        default: defaultValue,
+        validate,
+      }])
+    );
 
     return value;
   }

--- a/apps/cli/src/lib/pmo/watcher.ts
+++ b/apps/cli/src/lib/pmo/watcher.ts
@@ -16,6 +16,7 @@ import * as crypto from 'node:crypto';
 import { watch, FSWatcher } from 'chokidar';
 import { SQLiteStorage } from './storage-sqlite.js';
 import { parseBoard } from './markdown.js';
+import { onShutdown } from '../signal-handler.js';
 
 export interface WatcherOptions {
   /** Debounce delay in milliseconds (default: 500) */
@@ -257,7 +258,7 @@ export function startWatcher(
 
 /**
  * Run watcher as a foreground process (for CLI command)
- * Handles SIGINT/SIGTERM for graceful shutdown
+ * Uses centralized signal handler for graceful shutdown
  */
 export async function runWatcherForeground(
   pmoPath: string,
@@ -266,14 +267,10 @@ export async function runWatcherForeground(
 ): Promise<void> {
   const watcher = startWatcher(pmoPath, storageType, options);
 
-  // Handle graceful shutdown
-  const shutdown = async () => {
+  // Register cleanup via centralized signal handler
+  onShutdown(async () => {
     await watcher.stop();
-    process.exit(0);
-  };
-
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  });
 
   // Keep process alive
   await new Promise(() => {

--- a/apps/cli/src/lib/prompt-command.ts
+++ b/apps/cli/src/lib/prompt-command.ts
@@ -9,6 +9,7 @@ import {
   type JsonFlags,
 } from './prompt-json.js';
 import { isPlainOutput, plainText } from './styles.js';
+import { withSignalSafePrompt } from './signal-handler.js';
 
 /**
  * Lightweight base command with prompt() method for JSON mode support.
@@ -169,7 +170,9 @@ export abstract class PromptCommand extends Command {
       return {} as T;
     }
 
-    // Interactive mode: just call inquirer
-    return inquirer.prompt(questions as Parameters<typeof inquirer.prompt>[0]) as Promise<T>;
+    // Interactive mode: call inquirer with signal-safe wrapper
+    return withSignalSafePrompt(() =>
+      inquirer.prompt(questions as Parameters<typeof inquirer.prompt>[0]) as Promise<T>
+    );
   }
 }

--- a/apps/cli/src/lib/signal-handler.ts
+++ b/apps/cli/src/lib/signal-handler.ts
@@ -1,0 +1,172 @@
+/**
+ * Centralized signal handler for graceful CLI shutdown
+ *
+ * Manages SIGINT (Ctrl+C) and SIGTERM handling across the CLI:
+ * - Runs registered cleanup callbacks in LIFO order
+ * - Kills tracked child processes
+ * - Exits with code 130 (standard Unix SIGINT convention)
+ * - Prevents ERR_USE_AFTER_CLOSE from dangling inquirer prompts
+ *
+ * Usage:
+ * ```typescript
+ * import { onShutdown, trackChildProcess } from '../lib/signal-handler.js'
+ *
+ * // Register cleanup (returns unregister function)
+ * const unregister = onShutdown(async () => {
+ *   db.close()
+ * })
+ *
+ * // Track a child process for automatic cleanup
+ * trackChildProcess(childProc)
+ * ```
+ */
+
+import type { ChildProcess } from 'node:child_process'
+
+/** Cleanup callback - should be fast and not throw */
+type CleanupFn = () => void | Promise<void>
+
+const cleanupCallbacks: CleanupFn[] = []
+const trackedProcesses = new Set<ChildProcess>()
+let isShuttingDown = false
+let installed = false
+
+/**
+ * Run all cleanup callbacks and exit.
+ * Called on SIGINT or SIGTERM.
+ */
+async function shutdown(): Promise<void> {
+  if (isShuttingDown) return
+  isShuttingDown = true
+
+  // Kill tracked child processes first
+  for (const child of trackedProcesses) {
+    try {
+      if (child.pid && !child.killed) {
+        child.kill('SIGTERM')
+      }
+    } catch {
+      // Process may have already exited
+    }
+  }
+  trackedProcesses.clear()
+
+  // Run cleanup callbacks in LIFO order (most recent first)
+  const callbacks = [...cleanupCallbacks].reverse()
+  for (const cb of callbacks) {
+    try {
+      await cb()
+    } catch {
+      // Swallow errors during cleanup
+    }
+  }
+  cleanupCallbacks.length = 0
+
+  // Exit with 130 = 128 + 2 (SIGINT)
+  process.exit(130)
+}
+
+/**
+ * Install global signal handlers. Called once at CLI startup.
+ * Safe to call multiple times (idempotent).
+ */
+export function installSignalHandlers(): void {
+  if (installed) return
+  installed = true
+
+  process.on('SIGINT', () => {
+    // Write a newline to avoid dangling prompt characters
+    if (process.stdout.isTTY) {
+      process.stdout.write('\n')
+    }
+    void shutdown()
+  })
+
+  process.on('SIGTERM', () => {
+    void shutdown()
+  })
+}
+
+/**
+ * Register a cleanup callback to run on shutdown.
+ * Callbacks run in LIFO order (most recently registered runs first).
+ *
+ * @returns Unregister function to remove the callback
+ */
+export function onShutdown(fn: CleanupFn): () => void {
+  cleanupCallbacks.push(fn)
+  return () => {
+    const idx = cleanupCallbacks.indexOf(fn)
+    if (idx !== -1) {
+      cleanupCallbacks.splice(idx, 1)
+    }
+  }
+}
+
+/**
+ * Track a child process for automatic cleanup on shutdown.
+ * The process will receive SIGTERM when the CLI exits.
+ *
+ * Automatically removes itself from tracking when it exits.
+ */
+export function trackChildProcess(child: ChildProcess): void {
+  trackedProcesses.add(child)
+  child.on('exit', () => {
+    trackedProcesses.delete(child)
+  })
+  child.on('error', () => {
+    trackedProcesses.delete(child)
+  })
+}
+
+/**
+ * Check if the process is currently shutting down.
+ * Useful for avoiding work after SIGINT.
+ */
+export function isExiting(): boolean {
+  return isShuttingDown
+}
+
+/**
+ * Wrap an inquirer prompt call to handle SIGINT gracefully.
+ * On SIGINT during a prompt, triggers the shutdown sequence
+ * instead of letting inquirer throw ERR_USE_AFTER_CLOSE.
+ *
+ * @param promptFn - Function that calls inquirer.prompt()
+ * @returns The prompt result
+ */
+export async function withSignalSafePrompt<T>(promptFn: () => Promise<T>): Promise<T> {
+  if (isShuttingDown) {
+    // If already shutting down, just exit
+    process.exit(130)
+  }
+
+  try {
+    return await promptFn()
+  } catch (error: unknown) {
+    // Check if this is a prompt close error from SIGINT
+    if (isShuttingDown) {
+      // We're already in shutdown, just wait for it
+      await new Promise(() => {
+        // Never resolves - shutdown() will call process.exit
+      })
+      // Unreachable, but satisfies TypeScript
+      throw error
+    }
+
+    // Check for readline/inquirer close errors that indicate SIGINT
+    const message = error instanceof Error ? error.message : String(error)
+    if (
+      message.includes('ERR_USE_AFTER_CLOSE') ||
+      message.includes('readline was closed')
+    ) {
+      // Inquirer's readline was closed by SIGINT - trigger clean shutdown
+      void shutdown()
+      await new Promise(() => {})
+      throw error // Unreachable
+    }
+
+    // Re-throw other errors normally
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary

Resolves TKT-1207: Graceful ctrl+c handling across CLI commands

## Description

## Problem
CLI commands don't handle ctrl+c (SIGINT) gracefully. When a user presses ctrl+c during an interactive prompt or long-running operation, the CLI should exit cleanly without stack traces or orphaned processes.

## Requirements
- Catch SIGINT globally and exit with code 130 (standard Unix convention)
- Clean up any active inquirer prompts without ERR_USE_AFTER_CLOSE errors
- Kill any spawned child processes (tmux sessions, docker exec, etc.)
- Don't leave orphaned tmux sessions when ctrl+c during `work start`
- Show no stack trace - just silently exit or show a brief "Cancelled." message

## Investigation needed
- Audit current SIGINT handling across commands
- Check if oclif has built-in signal handling we should leverage
- Look at how inquirer prompts behave on SIGINT (this may be causing the ERR_USE_AFTER_CLOSE errors in e2e tests too)

## Changes

- 4e76ac2f fix(TKT-1207): add centralized signal handler for graceful ctrl+c across CLI commands

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
