### PR TITLE
Set real Sentry DSN for crash reporting (TKT-1215)

### DIFF
--- a/apps/cli/src/lib/telemetry.ts
+++ b/apps/cli/src/lib/telemetry.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path'
 import { getMachineConfigDir, ensureMachineConfigDir } from './machine-config.js'
 
 // Sentry DSN — safe to embed, only allows sending events (not reading)
-const SENTRY_DSN = 'https://examplePublicKey@o0.ingest.sentry.io/0'
+const SENTRY_DSN = 'https://dfc8445d17ed9bb0c56f680ed28f72f8@o4510992964714496.ingest.us.sentry.io/4510992973037568'
 
 interface TelemetryConfig {
   enabled?: boolean


### PR DESCRIPTION
## Summary
- Replace placeholder Sentry DSN with real project DSN
- `sendDefaultPii` remains `false` — no IP addresses or PII collected
- One-line change in `apps/cli/src/lib/telemetry.ts`

## Test plan
- [x] DSN format is valid
- [x] `sendDefaultPii: false` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)