### PR TITLE
TKT-1216: Switch Statsig from server SDK to client SDK with public client key

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -21,6 +21,7 @@
     "@oclif/plugin-help": "^6",
     "@oclif/plugin-plugins": "^5",
     "@sentry/node": "^10.42.0",
+    "@statsig/js-client": "^3.32.0",
     "better-sqlite3": "^12.6.2",
     "chalk": "^4.1.2",
     "chokidar": "^5.0.0",
@@ -30,7 +31,6 @@
     "ink-select-input": "^6.0.0",
     "inquirer": "^8.2.5",
     "react": "^18.0.0",
-    "statsig-node": "^6.5.1",
     "string-width": "^8.1.1",
     "zod": "^4.3.6"
   },

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -1,7 +1,7 @@
 /**
  * Product Analytics (Statsig) & Event Tracking
  *
- * Provides anonymous usage analytics for the CLI using Statsig server SDK.
+ * Provides anonymous usage analytics for the CLI using Statsig client SDK.
  * All data is anonymous — identified by a machine UUID only, no PII is ever sent.
  *
  * Telemetry can be disabled via:
@@ -20,8 +20,8 @@ import * as path from 'node:path'
 import * as crypto from 'node:crypto'
 import { getMachineConfigDir, ensureMachineConfigDir } from '../machine-config.js'
 
-// Statsig server SDK key (placeholder — replace with real key in production)
-const STATSIG_SERVER_KEY = 'secret-placeholder'
+// Statsig client SDK key (public — safe to embed in open source repos)
+const STATSIG_CLIENT_KEY = 'client-kvxMxRhn9NFSmH8orl7e2W9nYTfWVS7Kjf7yRTdIecc'
 
 // Flush timeout — don't let analytics delay CLI exit
 const FLUSH_TIMEOUT_MS = 2000
@@ -43,24 +43,23 @@ interface TelemetryConfig {
 }
 
 /**
- * Minimal interface for the Statsig singleton methods we use.
- * Avoids importing the full Statsig type at the module level.
+ * Minimal interface for the Statsig client instance methods we use.
+ * Uses loose return types to avoid coupling to SDK internals.
  */
-interface StatsigClient {
+interface StatsigClientInstance {
+  initializeAsync(): Promise<unknown>
   logEvent(
-    user: { userID: string; custom?: Record<string, unknown> },
     eventName: string,
     value?: string | number | null,
-    metadata?: Record<string, unknown> | null,
+    metadata?: Record<string, string> | null,
   ): void
-  checkGate(user: { userID: string }, gateName: string): boolean
-  getConfig(user: { userID: string }, configName: string): { get<T>(key: string, defaultValue: T): T }
-  flush(timeout?: number): Promise<void>
-  shutdown(timeout?: number): void
+  checkGate(gateName: string): boolean
+  getDynamicConfig(configName: string): { get(key: string, defaultValue: unknown): unknown }
+  shutdown(): void
 }
 
 // Module-level state
-let statsigClient: StatsigClient | null = null
+let statsigClient: StatsigClientInstance | null = null
 let telemetryConfig: TelemetryConfig | null = null
 let cliVersion: string | null = null
 
@@ -215,16 +214,6 @@ export function getMachineId(): string {
 // ─── Statsig Client ──────────────────────────────────────────────────────────
 
 /**
- * Get the Statsig user object for the current machine.
- */
-function getStatsigUser(): { userID: string; custom?: Record<string, unknown> } {
-  return {
-    userID: getMachineId(),
-    ...(cliVersion ? { custom: { cli_version: cliVersion } } : {}),
-  }
-}
-
-/**
  * Initialize the Statsig SDK. Called from the init hook.
  * No-op if telemetry is disabled.
  */
@@ -236,19 +225,17 @@ export async function initAnalytics(version: string): Promise<void> {
   showTelemetryNotice()
 
   try {
-    const statsigModule = await import('statsig-node')
-    // statsig-node exports a CJS-style module; the Statsig singleton is on .default
-    const Statsig = statsigModule.default as unknown as StatsigClient & {
-      initialize(key: string, options?: { initTimeoutMs?: number }): Promise<unknown>
-    }
-    await Statsig.initialize(STATSIG_SERVER_KEY, {
-      initTimeoutMs: 3000,
-    })
-    statsigClient = Statsig
+    const { StatsigClient: StatsigClientClass } = await import('@statsig/js-client')
+    const client = new StatsigClientClass(
+      STATSIG_CLIENT_KEY,
+      { userID: getMachineId(), custom: { cli_version: version } },
+    )
+    await client.initializeAsync()
+    statsigClient = client
 
-    // Share Statsig module with feature-flags for synchronous gate checks
-    const { setStatsigModule } = await import('./feature-flags.js')
-    setStatsigModule(Statsig)
+    // Share Statsig client with feature-flags for synchronous gate checks
+    const { setStatsigClient } = await import('./feature-flags.js')
+    setStatsigClient(client)
   } catch {
     // If Statsig can't initialize, fail silently — analytics should never break the CLI
     statsigClient = null
@@ -268,11 +255,15 @@ export function trackEvent(eventName: string, value?: string | number | null, me
   if (!statsigClient || !isTelemetryEnabled()) return
 
   try {
-    const user = getStatsigUser()
-    statsigClient.logEvent(user, eventName, value, {
-      ...metadata,
-      cli_version: cliVersion,
-    })
+    // Convert metadata values to strings as required by the client SDK
+    const stringMetadata: Record<string, string> | null = metadata
+      ? Object.fromEntries(
+          Object.entries({ ...metadata, cli_version: cliVersion }).map(([k, v]) => [k, String(v)]),
+        )
+      : cliVersion
+        ? { cli_version: cliVersion }
+        : null
+    statsigClient.logEvent(eventName, value, stringMetadata)
   } catch {
     // Never let analytics errors affect the CLI
   }
@@ -372,10 +363,8 @@ export async function shutdownAnalytics(): Promise<void> {
   if (!statsigClient) return
 
   try {
-    await Promise.race([
-      statsigClient.flush(FLUSH_TIMEOUT_MS),
-      new Promise<void>((resolve) => setTimeout(resolve, FLUSH_TIMEOUT_MS)),
-    ])
+    // Give the client a moment to flush, but don't block the CLI
+    await new Promise<void>((resolve) => setTimeout(resolve, FLUSH_TIMEOUT_MS))
     statsigClient.shutdown()
   } catch {
     // Never let shutdown errors affect the CLI
@@ -383,8 +372,8 @@ export async function shutdownAnalytics(): Promise<void> {
     statsigClient = null
     // Clear feature-flags module reference
     try {
-      const { setStatsigModule } = await import('./feature-flags.js')
-      setStatsigModule(null)
+      const { setStatsigClient } = await import('./feature-flags.js')
+      setStatsigClient(null)
     } catch {
       // Ignore
     }

--- a/apps/cli/src/lib/telemetry/feature-flags.ts
+++ b/apps/cli/src/lib/telemetry/feature-flags.ts
@@ -13,25 +13,25 @@
  * If Statsig is unavailable or telemetry is disabled, all flags return false.
  */
 
-import { getMachineId, isTelemetryEnabled } from './analytics.js'
+import { isTelemetryEnabled } from './analytics.js'
 
 // Cache for flag values — populated on check, persists for the process lifetime
 const flagCache = new Map<string, boolean>()
 
-// Statsig module reference — set after dynamic import in initAnalytics
-let statsigModule: StatsigModule | null = null
+// Statsig client instance reference — set after initialization in initAnalytics
+let statsigClient: StatsigClientRef | null = null
 
-interface StatsigModule {
-  checkGate(user: { userID: string }, gateName: string): boolean
-  getConfig(user: { userID: string }, configName: string): { get<T>(key: string, defaultValue: T): T }
+interface StatsigClientRef {
+  checkGate(gateName: string): boolean
+  getDynamicConfig(configName: string): { get(key: string, defaultValue: unknown): unknown }
 }
 
 /**
- * Set the Statsig module reference (called from analytics.ts after init).
+ * Set the Statsig client reference (called from analytics.ts after init).
  * @internal
  */
-export function setStatsigModule(mod: StatsigModule | null): void {
-  statsigModule = mod
+export function setStatsigClient(client: StatsigClientRef | null): void {
+  statsigClient = client
 }
 
 /**
@@ -44,7 +44,7 @@ export function setStatsigModule(mod: StatsigModule | null): void {
  * @returns Whether the gate is enabled
  */
 export function isEnabled(gateName: string): boolean {
-  if (!isTelemetryEnabled() || !statsigModule) return false
+  if (!isTelemetryEnabled() || !statsigClient) return false
 
   // Return cached value if available
   if (flagCache.has(gateName)) {
@@ -52,8 +52,7 @@ export function isEnabled(gateName: string): boolean {
   }
 
   try {
-    const user = { userID: getMachineId() }
-    const result = statsigModule.checkGate(user, gateName)
+    const result = statsigClient.checkGate(gateName)
     flagCache.set(gateName, result)
     return result
   } catch {
@@ -75,11 +74,10 @@ export function isEnabled(gateName: string): boolean {
  * @returns The config value, or the default
  */
 export function getConfigValue<T>(configName: string, key: string, defaultValue: T): T {
-  if (!isTelemetryEnabled() || !statsigModule) return defaultValue
+  if (!isTelemetryEnabled() || !statsigClient) return defaultValue
 
   try {
-    const user = { userID: getMachineId() }
-    const config = statsigModule.getConfig(user, configName)
+    const config = statsigClient.getDynamicConfig(configName)
     return config.get(key, defaultValue) as T
   } catch {
     return defaultValue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@sentry/node':
         specifier: ^10.42.0
         version: 10.42.0
+      '@statsig/js-client':
+        specifier: ^3.32.0
+        version: 3.32.0
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -64,9 +67,6 @@ importers:
       react:
         specifier: ^18.0.0
         version: 18.3.1
-      statsig-node:
-        specifier: ^6.5.1
-        version: 6.5.1
       string-width:
         specifier: ^8.1.1
         version: 8.1.1
@@ -1517,6 +1517,12 @@ packages:
   '@smithy/uuid@1.1.0':
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
+
+  '@statsig/client-core@3.32.0':
+    resolution: {integrity: sha512-/cVPhFt4uvbhK9pI0ju8Ko4ZiJqc5paG9DoYZCtdy79ChA5LJ2gEo6L8qAvOfXQ9huYSSrwaFpv/29oJfXlEiw==}
+
+  '@statsig/js-client@3.32.0':
+    resolution: {integrity: sha512-TNsVTThSKRaRTb1bI5ZxL6lL63TukB2pcYcl4arWUt+8vdzZMlTRgRDFOxe3+vNj1HLSeF1NINWEflGSg7CDzQ==}
 
   '@stylistic/eslint-plugin@3.1.0':
     resolution: {integrity: sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==}
@@ -3131,9 +3137,6 @@ packages:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
 
-  ip3country@5.0.0:
-    resolution: {integrity: sha512-lcFLMFU4eO1Z7tIpbVFZkaZ5ltqpeaRx7L9NsAbA9uA7/O/rj3RF8+evE5gDitooaTTIqjdzZrenFO/OOxQ2ew==}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3583,15 +3586,6 @@ packages:
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -4239,10 +4233,6 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
-  statsig-node@6.5.1:
-    resolution: {integrity: sha512-/rKvMMN9SWTK8+b7MyRP1wOsStsKf55Mdj8O2ffV/bCQ/38bXYCC/GVd3gVvBSwVCibAnkTz2v1gpRJSIKsBIg==}
-    engines: {pnpm: never}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4354,9 +4344,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -4451,10 +4438,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ua-parser-js@1.0.41:
-    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
-    hasBin: true
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -4491,10 +4474,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -4511,12 +4490,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -6585,6 +6558,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@statsig/client-core@3.32.0': {}
+
+  '@statsig/js-client@3.32.0':
+    dependencies:
+      '@statsig/client-core': 3.32.0
+
   '@stylistic/eslint-plugin@3.1.0(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
@@ -8424,8 +8403,6 @@ snapshots:
 
   ip-address@10.0.1: {}
 
-  ip3country@5.0.0: {}
-
   ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
@@ -8832,10 +8809,6 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.3
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-releases@2.0.27: {}
 
@@ -9504,15 +9477,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  statsig-node@6.5.1:
-    dependencies:
-      ip3country: 5.0.0
-      node-fetch: 2.7.0
-      ua-parser-js: 1.0.41
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - encoding
-
   statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
@@ -9630,8 +9594,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tr46@0.0.3: {}
-
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9740,8 +9702,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ua-parser-js@1.0.41: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -9799,8 +9759,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
-
   v8-compile-cache-lib@3.0.1: {}
 
   validate-npm-package-license@3.0.4:
@@ -9815,13 +9773,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves TKT-1216: Switch Statsig from server SDK to client SDK with public client key

## Description

The current Statsig integration uses `statsig-node` (server SDK) which requires a secret key that can't be embedded in an open source repo. Switch to `@statsig/js-client` which uses a public client key.

## Changes needed
1. Uninstall `statsig-node`, install `@statsig/js-client`
2. Update `apps/cli/src/lib/telemetry/analytics.ts`:
   - Replace `secret-placeholder` with `client-kvxMxRhn9NFSmH8orl7e2W9nYTfWVS7Kjf7yRTdIecc`
   - Change from Statsig server singleton to `StatsigClient` instance from `@statsig/js-client`
   - Use `client.logEvent(eventName, value, metadata)` instead of `Statsig.logEvent(user, eventName, value, metadata)`
   - Use `client.checkGate(gateName)` instead of `Statsig.checkGate(user, gateName)` 
   - User is set at initialization: `new StatsigClient(clientKey, { userID: machineId })`
   - Use `client.initializeAsync()` instead of `Statsig.initialize()`
   - Use `client.shutdown()` for cleanup
3. Update `apps/cli/src/lib/telemetry/feature-flags.ts` to match new client API
4. Do NOT add session replay or web analytics plugins — this is a CLI, not a browser
5. Build and verify no TypeScript errors
6. Run existing telemetry tests and fix if needed

## Key info
- Client key (safe to embed): `client-kvxMxRhn9NFSmH8orl7e2W9nYTfWVS7Kjf7yRTdIecc`
- The client key is designed to be public — it's safe for open source repos
- Keep the same telemetry consent system, first-run notice, and command structure

## Changes

- 1f00a6ba feat(TKT-1216): switch Statsig from server SDK (statsig-node) to client SDK (@statsig/js-client) with public client key

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
