### PR TITLE
CI: fix detect-changes merge-base failure on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Fetch base branch
         if: github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }} --depth=1
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Classify changed paths
         id: classify
@@ -52,7 +52,13 @@ jobs:
           fi
 
           # Get the list of changed files relative to the PR base
-          MERGE_BASE=$(git merge-base origin/${{ github.base_ref }} HEAD)
+          MERGE_BASE=$(git merge-base origin/${{ github.base_ref }} HEAD || true)
+          if [[ -z "$MERGE_BASE" ]]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "scope=full" >> "$GITHUB_OUTPUT"
+            echo "reason=Full suite: unable to compute merge-base with origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
 
           if [[ -z "$CHANGED" ]]; then


### PR DESCRIPTION
## Summary
- Remove shallow base fetch in detect-changes (no --depth=1)
- Add safe fallback when git merge-base cannot be computed
- Fallback behavior: run full suite instead of failing pre-check

## Why
PR checks for #603 and #609 failed in detect-changes before build/unit started because merge-base exited non-zero under shallow/base-history edge cases (common after squash merges).

## Expected result
- detect-changes no longer hard-fails on merge-base calculation issues
- build/unit/e2e jobs run according to fallback scope instead of being skipped due to pre-check failure
