### PR TITLE
TKT-1218: Remove aider executor support and add community-requested executor flow

### DIFF
--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -179,7 +179,7 @@ export default class OrchestratorStart extends PromptCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Executor type',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     'skip-permissions': Flags.boolean({
       description: 'Skip permission checks (shorthand for --permission-mode danger)',
@@ -362,8 +362,8 @@ export default class OrchestratorStart extends PromptCommand {
       const executorChoices = [
         { name: 'Claude Code', value: 'claude-code', command: 'prlt orchestrator start --executor claude-code --json' },
         { name: 'Codex', value: 'codex', command: 'prlt orchestrator start --executor codex --json' },
-        { name: 'Aider', value: 'aider', command: 'prlt orchestrator start --executor aider --json' },
         { name: 'Custom', value: 'custom', command: 'prlt orchestrator start --executor custom --json' },
+        { name: 'Request executor support...', value: 'request-support' },
       ]
       const executorMessage = 'Select executor:'
 
@@ -375,13 +375,17 @@ export default class OrchestratorStart extends PromptCommand {
         return
       }
 
-      const { executor } = await this.prompt<{ executor: ExecutorType }>([{
+      const { executor } = await this.prompt<{ executor: string }>([{
         type: 'list',
         name: 'executor',
         message: executorMessage,
         choices: executorChoices,
       }])
-      selectedExecutor = executor
+      if (executor === 'request-support') {
+        this.log('Request support for a new executor at: https://github.com/chrismcdermut/proletariat/issues')
+        return
+      }
+      selectedExecutor = executor as ExecutorType
     }
 
     // Validate Claude Code authentication for claude-code executor

--- a/apps/cli/src/commands/work/jira.ts
+++ b/apps/cli/src/commands/work/jira.ts
@@ -90,7 +90,7 @@ export default class WorkJira extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     display: Flags.string({
       char: 'd',

--- a/apps/cli/src/commands/work/linear.ts
+++ b/apps/cli/src/commands/work/linear.ts
@@ -79,7 +79,7 @@ export default class WorkLinear extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     display: Flags.string({
       char: 'd',

--- a/apps/cli/src/commands/work/review.ts
+++ b/apps/cli/src/commands/work/review.ts
@@ -57,7 +57,7 @@ export default class WorkReview extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     'run-on-host': Flags.boolean({
       description: 'Run on host even if devcontainer exists (bypasses sandbox)',

--- a/apps/cli/src/commands/work/revise.ts
+++ b/apps/cli/src/commands/work/revise.ts
@@ -63,7 +63,7 @@ export default class WorkRevise extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     force: Flags.boolean({
       char: 'f',

--- a/apps/cli/src/commands/work/spawn-all.ts
+++ b/apps/cli/src/commands/work/spawn-all.ts
@@ -33,7 +33,7 @@ export default class WorkSpawnAll extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
   }
 

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -122,7 +122,7 @@ export default class WorkSpawn extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     force: Flags.boolean({
       char: 'f',

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -217,7 +217,7 @@ export default class WorkStart extends PMOCommand {
     executor: Flags.string({
       char: 'e',
       description: 'Override executor',
-      options: ['claude-code', 'codex', 'aider', 'custom'],
+      options: ['claude-code', 'codex', 'custom'],
     }),
     action: Flags.string({
       char: 'A',

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -333,8 +333,6 @@ export function getExecutorCommand(executor: ExecutorType, prompt: string, skipP
       const codexResult = getCodexCommand(prompt, codexPermission, 'interactive')
       return { cmd: codexResult.cmd, args: codexResult.args }
     }
-    case 'aider':
-      return { cmd: 'aider', args: ['--message', prompt] }
     case 'custom':
       // Custom executor should be configured
       return { cmd: 'echo', args: ['Custom executor not configured'] }
@@ -363,7 +361,6 @@ export function getExecutorDisplayName(executor: ExecutorType): string {
   switch (executor) {
     case 'claude-code': return 'Claude Code'
     case 'codex': return 'Codex'
-    case 'aider': return 'Aider'
     case 'custom': return 'Custom'
     default: return 'Claude Code'
   }
@@ -376,7 +373,6 @@ export function getExecutorPackage(executor: ExecutorType): string | null {
   switch (executor) {
     case 'claude-code': return '@anthropic-ai/claude-code'
     case 'codex': return '@openai/codex'
-    case 'aider': return null  // aider is Python-based, installed via pip
     case 'custom': return null
     default: return '@anthropic-ai/claude-code'
   }

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -77,7 +77,6 @@ export type PermissionMode =
 export type ExecutorType =
   | 'claude-code'
   | 'codex'
-  | 'aider'
   | 'custom'
 
 // =============================================================================

--- a/apps/cli/test/unit/codex-runtime.test.ts
+++ b/apps/cli/test/unit/codex-runtime.test.ts
@@ -12,7 +12,7 @@ import type { ExecutionContext, ExecutorType } from '../../src/lib/execution/typ
  * TKT-1083: Finalize Codex behavior on Docker/VM runtimes
  *
  * Ensures that Docker and VM runners use the correct executor command
- * for all executor types (claude-code, codex, aider, custom) instead
+ * for all executor types (claude-code, codex, custom) instead
  * of hardcoding 'claude'.
  */
 describe('Codex Runtime Behavior (TKT-1083)', () => {
@@ -81,14 +81,6 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
       })
     })
 
-    describe('aider executor', () => {
-      it('should return aider command with --message flag', () => {
-        const result = getExecutorCommand('aider', testPrompt, true)
-        expect(result.cmd).to.equal('aider')
-        expect(result.args).to.deep.equal(['--message', testPrompt])
-      })
-    })
-
     describe('custom executor', () => {
       it('should return echo placeholder', () => {
         const result = getExecutorCommand('custom', testPrompt, true)
@@ -98,7 +90,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
 
     describe('all executors produce distinct commands', () => {
       it('should map each executor to a unique command binary', () => {
-        const executors: ExecutorType[] = ['claude-code', 'codex', 'aider']
+        const executors: ExecutorType[] = ['claude-code', 'codex']
         const commands = executors.map(e => getExecutorCommand(e, testPrompt).cmd)
 
         // Each executor should produce a different command
@@ -109,12 +101,6 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
       it('codex should use codex binary, not claude', () => {
         const result = getExecutorCommand('codex', testPrompt)
         expect(result.cmd).to.equal('codex')
-        expect(result.cmd).to.not.equal('claude')
-      })
-
-      it('aider should use aider binary, not claude', () => {
-        const result = getExecutorCommand('aider', testPrompt)
-        expect(result.cmd).to.equal('aider')
         expect(result.cmd).to.not.equal('claude')
       })
     })
@@ -129,12 +115,6 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
       const result = getExecutorCommand('codex', 'build the feature')
       expect(result.cmd).to.equal('codex')
       expect(result.args).to.deep.equal(['--yolo', 'build the feature'])
-    })
-
-    it('should use aider binary for aider executor (not hardcoded claude)', () => {
-      const result = getExecutorCommand('aider', 'fix the bug')
-      expect(result.cmd).to.equal('aider')
-      expect(result.args).to.deep.equal(['--message', 'fix the bug'])
     })
 
     it('should still use claude for claude-code executor in Docker', () => {
@@ -154,11 +134,6 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
       expect(result.args).to.deep.equal(['--yolo', 'implement on VM'])
     })
 
-    it('should use aider binary for aider executor on VM', () => {
-      const result = getExecutorCommand('aider', 'implement on VM')
-      expect(result.cmd).to.equal('aider')
-      expect(result.args[0]).to.equal('--message')
-    })
   })
 
   describe('Codex in devcontainer runtime', () => {
@@ -251,7 +226,7 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
      * Verifies that all four runtime environments now use the same
      * getExecutorCommand() function, ensuring consistent behavior.
      */
-    const executors: ExecutorType[] = ['claude-code', 'codex', 'aider', 'custom']
+    const executors: ExecutorType[] = ['claude-code', 'codex', 'custom']
 
     for (const executor of executors) {
       it(`should produce deterministic command for ${executor} executor`, () => {
@@ -266,7 +241,6 @@ describe('Codex Runtime Behavior (TKT-1083)', () => {
       const expectedBinaries: Record<string, string> = {
         'claude-code': 'claude',
         'codex': 'codex',
-        'aider': 'aider',
         'custom': 'echo',
       }
 

--- a/apps/cli/test/unit/codex-spawn-smoke.test.ts
+++ b/apps/cli/test/unit/codex-spawn-smoke.test.ts
@@ -214,14 +214,8 @@ describe('Codex Spawn Smoke Tests (TKT-1169)', () => {
       expect(claudeResult.args).to.include('--permission-mode')
     })
 
-    it('Codex changes should not affect Aider command generation', () => {
-      const aiderResult = getExecutorCommand('aider', 'test', true)
-      expect(aiderResult.cmd).to.equal('aider')
-      expect(aiderResult.args).to.include('--message')
-    })
-
     it('each executor should produce a unique command binary', () => {
-      const executors: ExecutorType[] = ['claude-code', 'codex', 'aider']
+      const executors: ExecutorType[] = ['claude-code', 'codex']
       const cmds = executors.map(e => getExecutorCommand(e, 'test').cmd)
       const unique = new Set(cmds)
       expect(unique.size).to.equal(executors.length)

--- a/apps/cli/test/unit/devcontainer.test.ts
+++ b/apps/cli/test/unit/devcontainer.test.ts
@@ -651,13 +651,6 @@ describe('Devcontainer', () => {
         expect(credentialMount).to.not.exist
       })
 
-      it('should NOT include claude-credentials mount for aider executor', () => {
-        const options = makeOptions({ executor: 'aider' })
-        const result = generateDevcontainerJson(options)
-
-        const credentialMount = result.mounts.find(m => m.includes('claude-credentials'))
-        expect(credentialMount).to.not.exist
-      })
     })
 
     describe('generateDockerfile', () => {

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -382,20 +382,6 @@ describe('Execution Utils', () => {
       })
     })
 
-    describe('aider executor', () => {
-      it('should return aider command with --message flag', () => {
-        const result = getExecutorCommand('aider', testPrompt)
-        expect(result.cmd).to.equal('aider')
-        expect(result.args).to.deep.equal(['--message', testPrompt])
-      })
-
-      it('should NOT include Claude-specific flags', () => {
-        const result = getExecutorCommand('aider', testPrompt, true)
-        expect(result.args).to.not.include('--dangerously-skip-permissions')
-        expect(result.args).to.not.include('-p')
-      })
-    })
-
     describe('custom executor', () => {
       it('should return echo fallback', () => {
         const result = getExecutorCommand('custom', testPrompt)
@@ -405,7 +391,7 @@ describe('Execution Utils', () => {
     })
 
     describe('all executor types', () => {
-      const executors: ExecutorType[] = ['claude-code', 'codex', 'aider', 'custom']
+      const executors: ExecutorType[] = ['claude-code', 'codex', 'custom']
 
       it('should return a cmd and args for every executor type', () => {
         for (const executor of executors) {
@@ -427,10 +413,6 @@ describe('Execution Utils', () => {
       expect(isClaudeExecutor('codex')).to.be.false
     })
 
-    it('should return false for aider', () => {
-      expect(isClaudeExecutor('aider')).to.be.false
-    })
-
     it('should return false for custom', () => {
       expect(isClaudeExecutor('custom')).to.be.false
     })
@@ -445,10 +427,6 @@ describe('Execution Utils', () => {
       expect(getExecutorDisplayName('codex')).to.equal('Codex')
     })
 
-    it('should return "Aider" for aider', () => {
-      expect(getExecutorDisplayName('aider')).to.equal('Aider')
-    })
-
     it('should return "Custom" for custom', () => {
       expect(getExecutorDisplayName('custom')).to.equal('Custom')
     })
@@ -461,10 +439,6 @@ describe('Execution Utils', () => {
 
     it('should return @openai/codex for codex', () => {
       expect(getExecutorPackage('codex')).to.equal('@openai/codex')
-    })
-
-    it('should return null for aider (Python-based)', () => {
-      expect(getExecutorPackage('aider')).to.be.null
     })
 
     it('should return null for custom', () => {

--- a/apps/cli/test/unit/execution-view.test.ts
+++ b/apps/cli/test/unit/execution-view.test.ts
@@ -164,7 +164,7 @@ describe('ExecutionView', () => {
     })
 
     it('returns different executor types', () => {
-      const executorTypes = ['claude-code', 'codex', 'aider', 'custom'] as const
+      const executorTypes = ['claude-code', 'codex', 'custom'] as const
 
       for (const executor of executorTypes) {
         storage.createExecution({
@@ -178,7 +178,7 @@ describe('ExecutionView', () => {
       }
 
       const executions = storage.listExecutions({ limit: 10 })
-      expect(executions).to.have.length(4)
+      expect(executions).to.have.length(3)
 
       for (const exec of executions) {
         expect(executorTypes).to.include(exec.executor)

--- a/specs/product/agents.md
+++ b/specs/product/agents.md
@@ -46,7 +46,7 @@ Agents are AI coding assistants that can be assigned to work on tickets. Each ag
 | id | string | auto | - | WORK-001 format |
 | ticket_id | ref | ✓ | - | Ticket being worked on |
 | agent_name | ref | ✓ | - | Agent doing the work |
-| executor | enum | | claude-code | claude-code, codex, aider |
+| executor | enum | | claude-code | claude-code, codex, custom |
 | environment | enum | | host | host, devcontainer, docker, vm |
 | display_mode | enum | | terminal | terminal, foreground, background, tmux |
 | sandboxed | boolean | | true | Whether permissions are restricted |

--- a/specs/product/work.md
+++ b/specs/product/work.md
@@ -82,7 +82,7 @@ When spawning multiple agents (`work spawn` or `work watch`):
 | id | string | auto | - | WORK-001 format |
 | ticket_id | ref | ✓ | - | Ticket being worked on |
 | agent_name | ref | ✓ | - | Agent doing the work |
-| executor | enum | | claude-code | claude-code, codex, aider |
+| executor | enum | | claude-code | claude-code, codex, custom |
 | mode | enum | | interactive | interactive, autonomous |
 | environment | enum | | host | host, devcontainer, docker, vm |
 | display_mode | enum | | terminal | terminal, foreground, background, tmux |
@@ -164,12 +164,6 @@ the constant and the smoke tests.
 |------|---------|
 | Safe | `claude <prompt>` |
 | Danger | `claude --permission-mode bypassPermissions --dangerously-skip-permissions --effort high <prompt>` |
-
-### Aider
-
-| Mode | Command |
-|------|---------|
-| All | `aider --message <prompt>` |
 
 ## Related Domains
 


### PR DESCRIPTION
## Summary

Resolves TKT-1218: Remove aider executor support and add community-requested executor flow

## Description

## Problem
Aider is listed as a supported executor but has never been set up or tested. It shouldn't ship as a supported option.

## Changes needed
1. Remove aider from executor types and runner config (17 files reference it)
2. Where aider was an option in CLI prompts/menus, consider adding a "Request executor support" option that links to a GitHub issue or discussion for community requests

## Key files
- `apps/cli/src/lib/execution/types.ts` - executor type definitions
- `apps/cli/src/lib/execution/runners.ts` - runner implementations  
- `apps/cli/src/commands/work/start.ts` - work start command
- `apps/cli/src/commands/work/spawn.ts` - work spawn command
- `apps/cli/src/commands/orchestrator/start.ts` - orchestrator
- Various test files

## Changes

- 7ddb7b3b feat(TKT-1218): remove aider executor support and add community request option

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
