### PR TITLE
TKT-1219: Fix Claude Code auth detection for v2.x (keychain-based credentials)

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -195,9 +195,10 @@ export function getDockerCredentialInfo(): { expiresAt: Date; subscriptionType?:
 
 /**
  * Check if Claude Code authentication is available on the host system.
- * Returns true if either:
- * 1. OAuth credentials exist in ~/.claude/.credentials.json, OR
- * 2. ANTHROPIC_API_KEY environment variable is set
+ * Returns true if any of:
+ * 1. ANTHROPIC_API_KEY environment variable is set
+ * 2. OAuth credentials exist in ~/.claude/.credentials.json (Claude Code 1.x)
+ * 3. OAuth credentials exist in macOS keychain (Claude Code 2.x)
  *
  * This is used to validate auth before spawning host sessions (e.g., orchestrator)
  * to avoid creating stuck sessions when the keychain is locked (SSH contexts).
@@ -208,27 +209,42 @@ export function hostCredentialsExist(): boolean {
     return true
   }
 
-  // Check for OAuth credentials in ~/.claude/.credentials.json
+  // Check for OAuth credentials in ~/.claude/.credentials.json (Claude Code 1.x)
   try {
     const homeDir = process.env.HOME || os.homedir()
     const credPath = path.join(homeDir, '.claude', '.credentials.json')
-    if (!fs.existsSync(credPath)) {
-      return false
+    if (fs.existsSync(credPath)) {
+      const credData = fs.readFileSync(credPath, 'utf-8')
+      const creds = JSON.parse(credData)
+
+      // Check if OAuth credentials exist (similar to Docker check)
+      // Don't check expiration - Claude Code handles token refresh internally
+      if (creds.claudeAiOauth?.accessToken) {
+        return true
+      }
     }
-
-    const credData = fs.readFileSync(credPath, 'utf-8')
-    const creds = JSON.parse(credData)
-
-    // Check if OAuth credentials exist (similar to Docker check)
-    // Don't check expiration - Claude Code handles token refresh internally
-    if (creds.claudeAiOauth?.accessToken) {
-      return true
-    }
-
-    return false
   } catch {
-    return false
+    // Fall through to keychain check
   }
+
+  // Check for Claude Code 2.x keychain-based auth (macOS)
+  // Claude Code 2.x stores OAuth tokens in the macOS keychain under service
+  // "Claude Code-credentials". If the keychain is locked (e.g., SSH sessions),
+  // this check will fail, which is the desired behavior — we want to surface
+  // the error early rather than create stuck sessions.
+  if (process.platform === 'darwin') {
+    try {
+      execSync('security find-generic-password -s "Claude Code-credentials" 2>/dev/null', {
+        stdio: 'pipe',
+        timeout: 5000,
+      })
+      return true
+    } catch {
+      // Keychain entry not found or keychain is locked
+    }
+  }
+
+  return false
 }
 
 /**

--- a/apps/cli/test/unit/host-credentials.test.ts
+++ b/apps/cli/test/unit/host-credentials.test.ts
@@ -1,12 +1,33 @@
 import { expect } from 'chai'
+import { execSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { hostCredentialsExist } from '../../src/lib/execution/runners.js'
 
+/**
+ * Check if macOS keychain has Claude Code 2.x credentials.
+ * Used to adjust test expectations on machines with keychain-based auth.
+ * Must be called with the real HOME to work correctly.
+ */
+function hasKeychainCredentials(): boolean {
+  if (process.platform !== 'darwin') return false
+  try {
+    execSync('security find-generic-password -s "Claude Code-credentials" 2>/dev/null', {
+      stdio: 'pipe',
+      timeout: 5000,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
 describe('Host Credentials Check', () => {
   let originalEnv: NodeJS.ProcessEnv
   let tempHome: string
+  // Check keychain before any beforeEach modifies HOME
+  const keychainAvailable = hasKeychainCredentials()
 
   function credentialsPath(): string {
     return path.join(tempHome, '.claude', '.credentials.json')
@@ -48,7 +69,11 @@ describe('Host Credentials Check', () => {
       expect(hostCredentialsExist()).to.be.true
     })
 
-    it('returns false when credentials file does not exist', () => {
+    it('returns false when no credentials are available', function (this: Mocha.Context) {
+      // On macOS with Claude Code 2.x keychain credentials, the function
+      // correctly returns true via the keychain check. However, setting HOME
+      // to a temp dir (as beforeEach does) prevents the security command from
+      // finding the login keychain, so this test still works.
       expect(hostCredentialsExist()).to.be.false
     })
 
@@ -66,5 +91,20 @@ describe('Host Credentials Check', () => {
       process.env.ANTHROPIC_API_KEY = 'test-api-key'
       expect(hostCredentialsExist()).to.be.true
     })
+
+    if (process.platform === 'darwin') {
+      it('returns true when Claude Code 2.x keychain credentials exist', function (this: Mocha.Context) {
+        // This test verifies the keychain detection path on macOS.
+        // It will only pass on machines with Claude Code 2.x auth configured.
+        if (!keychainAvailable) {
+          this.skip()
+        }
+
+        // Restore the real HOME so the security command can find the login keychain
+        process.env.HOME = originalEnv.HOME
+        // No ANTHROPIC_API_KEY, no credentials file in real home — keychain should be detected
+        expect(hostCredentialsExist()).to.be.true
+      })
+    }
   })
 })


### PR DESCRIPTION
## Summary

Resolves TKT-1219: Fix Claude Code auth detection for v2.x (keychain-based credentials)

## Description

## Problem
`hostCredentialsExist()` in `runners.ts` checks for `~/.claude/.credentials.json` with `claudeAiOauth.accessToken`, but Claude Code 2.x stores OAuth tokens in the macOS keychain, not a file. The credentials file no longer exists, so the check always returns false and blocks orchestrator start with "Claude Code authentication is not available."

## Solution
Update `hostCredentialsExist()` to detect Claude Code 2.x auth. Options:
- Run `claude --print-auth-status` or similar quick probe
- Check macOS keychain via `security find-generic-password`
- Just run `claude -p 'hi' --max-turns 1` with a short timeout as a smoke test
- Or simplest: skip the pre-check entirely and let Claude Code handle its own auth errors at runtime

## Key Files
- `apps/cli/src/lib/execution/runners.ts:166` - `hostCredentialsExist()` function
- `apps/cli/src/commands/orchestrator/start.ts:304` - where the check is called

## Changes

- 79fe8edd fix(TKT-1219): fix: detect Claude Code 2.x keychain-based auth in hostCredentialsExist()

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
