### PR TITLE
Bump version to 0.3.54

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.53",
+  "version": "0.3.54",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
Version bump to publish fixes to npm and brew.

Includes:
- #622: better-sqlite3 native binding error detection
- #623: Remove aider executor support  
- #624: Fix Claude Code auth detection for v2.x keychain

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>