### PR TITLE
TKT-1221: Detect stale Homebrew tap and print self-heal upgrade guidance

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -4,6 +4,7 @@ import { readMachineConfig } from '../lib/machine-config.js'
 import { findHQRoot } from '../lib/workspace.js'
 import { getCachedUpdateInfo, triggerBackgroundCheck } from '../lib/update-check.js'
 import { handleUpdatePrompt } from '../lib/update-prompt.js'
+import { checkTapStaleness, printStaleTapWarning } from '../lib/brew-tap-check.js'
 import { initSentry } from '../lib/telemetry.js'
 import { initAnalytics } from '../lib/telemetry/analytics.js'
 
@@ -73,6 +74,18 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
     const updateInfo = getCachedUpdateInfo(config.version)
     await handleUpdatePrompt(updateInfo)
     triggerBackgroundCheck(updateInfo.packageManager)
+
+    // ── Stale Homebrew tap check ───────────────────────────────────────
+    // For brew-managed installs, detect when the local tap is behind
+    // origin/main. A stale tap causes `brew upgrade` to silently no-op.
+    if (updateInfo.packageManager === 'brew') {
+      try {
+        const tapResult = checkTapStaleness()
+        await printStaleTapWarning(tapResult)
+      } catch {
+        // Never let tap-check errors break the CLI
+      }
+    }
   } catch {
     // Never let update-check errors break the CLI
   }

--- a/apps/cli/src/lib/brew-tap-check.ts
+++ b/apps/cli/src/lib/brew-tap-check.ts
@@ -1,0 +1,175 @@
+/**
+ * Homebrew Tap Staleness Detection
+ *
+ * Detects when the local Homebrew tap checkout for chrismcdermut/proletariat
+ * is behind origin/main. When stale, `brew upgrade prlt` silently does nothing
+ * because Homebrew doesn't see the new formula. This module surfaces that
+ * condition and provides copy-paste remediation commands.
+ *
+ * Only runs when the detected package manager is `brew`.
+ */
+
+import { execSync } from 'node:child_process'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TAP_NAME = 'chrismcdermut/proletariat'
+const TAP_REPO = 'chrismcdermut/homebrew-proletariat'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TapCheckResult {
+  /** Whether the tap is stale (local HEAD behind origin/main) */
+  isStale: boolean
+  /** Human-readable explanation (empty when healthy) */
+  message: string
+  /** Copy-paste remediation commands (empty when healthy) */
+  remediationCommands: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Tap path resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the local path of the Homebrew tap.
+ * Uses `brew --repository` which works on both Apple Silicon and Intel Macs.
+ * Returns null if the tap is not installed or brew is not available.
+ */
+export function getTapPath(): string | null {
+  try {
+    const tapPath = execSync(`brew --repository ${TAP_NAME}`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim()
+
+    if (!tapPath) return null
+    return tapPath
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Staleness check
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the local HEAD commit hash for the tap repo.
+ */
+function getLocalHead(tapPath: string): string | null {
+  try {
+    return execSync(`git -C "${tapPath}" rev-parse HEAD`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Get the remote HEAD commit hash for origin/main.
+ * Uses `git ls-remote` to avoid a full fetch.
+ */
+function getRemoteHead(tapPath: string): string | null {
+  try {
+    const output = execSync(
+      `git -C "${tapPath}" ls-remote origin refs/heads/main`,
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 10000,
+      },
+    ).trim()
+
+    // Output format: "<hash>\trefs/heads/main"
+    const hash = output.split('\t')[0]
+    return hash || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Build remediation commands for a stale tap.
+ */
+function buildRemediationCommands(): string[] {
+  return [
+    `brew tap --repair ${TAP_NAME}`,
+    `brew update`,
+    `brew upgrade ${TAP_NAME}/prlt`,
+  ]
+}
+
+/**
+ * Check whether the Homebrew tap is stale.
+ *
+ * A tap is considered stale when the local HEAD differs from origin/main.
+ * Returns a result with `isStale: false` in any non-error non-stale case
+ * (tap not installed, git unavailable, etc.) so the normal upgrade path
+ * is never disrupted.
+ */
+export function checkTapStaleness(tapPath?: string | null): TapCheckResult {
+  const healthy: TapCheckResult = {
+    isStale: false,
+    message: '',
+    remediationCommands: [],
+  }
+
+  const resolvedPath = tapPath ?? getTapPath()
+  if (!resolvedPath) return healthy
+
+  const localHead = getLocalHead(resolvedPath)
+  if (!localHead) return healthy
+
+  const remoteHead = getRemoteHead(resolvedPath)
+  if (!remoteHead) return healthy
+
+  if (localHead === remoteHead) return healthy
+
+  // Tap is stale
+  const commands = buildRemediationCommands()
+  return {
+    isStale: true,
+    message:
+      `Your Homebrew tap "${TAP_REPO}" is out of date.\n` +
+      'This can cause `brew upgrade prlt` to report "already installed" even when a newer version exists.\n' +
+      'Run the following commands to fix it:',
+    remediationCommands: commands,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+
+/**
+ * Print the stale tap warning with remediation commands.
+ * Returns true if a warning was printed.
+ */
+export async function printStaleTapWarning(
+  result: TapCheckResult,
+): Promise<boolean> {
+  if (!result.isStale) return false
+
+  const chalk = (await import('chalk')).default
+
+  console.log('')
+  console.log(chalk.yellow('Warning: Stale Homebrew tap detected'))
+  console.log('')
+  console.log(result.message)
+  console.log('')
+  for (const cmd of result.remediationCommands) {
+    console.log(`  ${chalk.cyan(cmd)}`)
+  }
+  console.log('')
+
+  return true
+}

--- a/apps/cli/src/lib/update-prompt.ts
+++ b/apps/cli/src/lib/update-prompt.ts
@@ -14,6 +14,7 @@
 import { execSync } from 'node:child_process'
 import type { UpdateInfo } from './update-check.js'
 import { dismissVersion } from './update-check.js'
+import { checkTapStaleness } from './brew-tap-check.js'
 
 // ---------------------------------------------------------------------------
 // Environment guards
@@ -115,10 +116,38 @@ export async function showUpdatePrompt(info: UpdateInfo): Promise<UpdateAction> 
 // ---------------------------------------------------------------------------
 
 /**
+ * For brew installs, repair a stale tap before running the upgrade.
+ * If the tap is healthy this is a no-op.
+ */
+function repairStaleTapIfNeeded(info: UpdateInfo): void {
+  if (info.packageManager !== 'brew') return
+
+  try {
+    const tapResult = checkTapStaleness()
+    if (!tapResult.isStale) return
+
+    console.log('Repairing stale Homebrew tap first...')
+    console.log('')
+    for (const cmd of tapResult.remediationCommands) {
+      // Skip the final upgrade command — we run it below as the main update
+      if (cmd.startsWith('brew upgrade')) continue
+      console.log(`Running: ${cmd}`)
+      execSync(cmd, { stdio: 'inherit', timeout: 60_000 })
+    }
+    console.log('')
+  } catch {
+    // Best-effort — continue with the upgrade anyway
+  }
+}
+
+/**
  * Execute the update command, then exit.
  * Runs synchronously so the user sees output in real time.
+ * For brew installs, repairs a stale tap first if needed.
  */
 function executeUpdate(info: UpdateInfo): never {
+  repairStaleTapIfNeeded(info)
+
   console.log('')
   console.log(`Running: ${info.updateCommand}`)
   console.log('')

--- a/apps/cli/test/unit/brew-tap-check.test.ts
+++ b/apps/cli/test/unit/brew-tap-check.test.ts
@@ -1,0 +1,122 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { execSync } from 'node:child_process'
+import {
+  checkTapStaleness,
+} from '../../src/lib/brew-tap-check.js'
+
+describe('Brew Tap Check', () => {
+  let testDir: string
+  let tapDir: string
+
+  beforeEach(() => {
+    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'brew-tap-test-')))
+    tapDir = path.join(testDir, 'tap-repo')
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  /**
+   * Create a bare git repo to act as the "remote" and a clone to act as the
+   * local tap checkout. Returns { localPath, remotePath }.
+   */
+  function createTapRepoWithRemote(): { localPath: string; remotePath: string } {
+    const remotePath = path.join(testDir, 'remote-repo')
+    const localPath = path.join(testDir, 'local-tap')
+
+    // Create a bare remote with main as default branch
+    fs.mkdirSync(remotePath, { recursive: true })
+    execSync('git init --bare --initial-branch=main', { cwd: remotePath, stdio: 'pipe' })
+
+    // Clone it as the local tap
+    execSync(`git clone "${remotePath}" "${localPath}"`, { stdio: 'pipe' })
+
+    // Configure git user for commits in the test repo
+    execSync('git config user.email "test@test.com" && git config user.name "Test"', { cwd: localPath, stdio: 'pipe' })
+
+    // Make an initial commit in the local clone and push it
+    const dummyFile = path.join(localPath, 'Formula', 'prlt.rb')
+    fs.mkdirSync(path.join(localPath, 'Formula'), { recursive: true })
+    fs.writeFileSync(dummyFile, 'class Prlt < Formula; end', 'utf-8')
+    execSync('git add -A && git commit -m "initial"', { cwd: localPath, stdio: 'pipe' })
+    execSync('git push origin main', { cwd: localPath, stdio: 'pipe' })
+
+    return { localPath, remotePath }
+  }
+
+  describe('checkTapStaleness', () => {
+    it('returns healthy when tapPath is null', () => {
+      const result = checkTapStaleness(null)
+      expect(result.isStale).to.be.false
+      expect(result.message).to.equal('')
+      expect(result.remediationCommands).to.have.lengthOf(0)
+    })
+
+    it('returns healthy when tapPath does not exist', () => {
+      const result = checkTapStaleness('/nonexistent/path')
+      expect(result.isStale).to.be.false
+    })
+
+    it('returns healthy when local HEAD matches remote HEAD', () => {
+      const { localPath } = createTapRepoWithRemote()
+      const result = checkTapStaleness(localPath)
+      expect(result.isStale).to.be.false
+      expect(result.message).to.equal('')
+      expect(result.remediationCommands).to.have.lengthOf(0)
+    })
+
+    it('returns stale when local HEAD is behind remote HEAD', () => {
+      const { localPath, remotePath } = createTapRepoWithRemote()
+
+      // Push a new commit to the remote (bypassing the local clone)
+      // Create a temporary clone, commit, and push
+      const tmpClone = path.join(testDir, 'tmp-clone')
+      execSync(`git clone "${remotePath}" "${tmpClone}"`, { stdio: 'pipe' })
+      execSync('git config user.email "test@test.com" && git config user.name "Test"', { cwd: tmpClone, stdio: 'pipe' })
+      const newFile = path.join(tmpClone, 'Formula', 'prlt.rb')
+      fs.writeFileSync(newFile, 'class Prlt < Formula; version "0.4.0"; end', 'utf-8')
+      execSync('git add -A && git commit -m "bump version"', { cwd: tmpClone, stdio: 'pipe' })
+      execSync('git push origin main', { cwd: tmpClone, stdio: 'pipe' })
+
+      // Now local tap is behind remote
+      const result = checkTapStaleness(localPath)
+      expect(result.isStale).to.be.true
+      expect(result.message).to.include('out of date')
+      expect(result.remediationCommands.length).to.be.greaterThan(0)
+      expect(result.remediationCommands.some(cmd => cmd.includes('brew'))).to.be.true
+    })
+
+    it('includes copy-paste remediation commands when stale', () => {
+      const { localPath, remotePath } = createTapRepoWithRemote()
+
+      // Push a new commit to the remote
+      const tmpClone = path.join(testDir, 'tmp-clone-2')
+      execSync(`git clone "${remotePath}" "${tmpClone}"`, { stdio: 'pipe' })
+      execSync('git config user.email "test@test.com" && git config user.name "Test"', { cwd: tmpClone, stdio: 'pipe' })
+      fs.writeFileSync(path.join(tmpClone, 'new-file'), 'data', 'utf-8')
+      execSync('git add -A && git commit -m "add file"', { cwd: tmpClone, stdio: 'pipe' })
+      execSync('git push origin main', { cwd: tmpClone, stdio: 'pipe' })
+
+      const result = checkTapStaleness(localPath)
+      expect(result.isStale).to.be.true
+
+      // Should include tap repair and upgrade commands
+      expect(result.remediationCommands).to.include('brew tap --repair chrismcdermut/proletariat')
+      expect(result.remediationCommands).to.include('brew update')
+      expect(result.remediationCommands).to.include('brew upgrade chrismcdermut/proletariat/prlt')
+    })
+
+    it('returns healthy when tapPath is not a git repo', () => {
+      // Create a plain directory (no git init)
+      fs.mkdirSync(tapDir, { recursive: true })
+      const result = checkTapStaleness(tapDir)
+      expect(result.isStale).to.be.false
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves TKT-1221: Detect stale Homebrew tap and print self-heal upgrade guidance

## Description

Problem: users can run `brew upgrade prlt` and still remain on an old version when the local tap checkout is stale.\n\nScope:\n- Add a doctor/update check that compares local tap head vs origin/main for `chrismcdermut/homebrew-proletariat`.\n- If stale, print exact remediation commands (fetch/reset tap, then brew upgrade).\n- Wire message into update UX so users are not blocked/confused.\n- Add tests/docs for the stale tap scenario.\n\nAcceptance Criteria:\n1) CLI detects stale tap condition and reports it clearly.\n2) CLI prints copy-paste fix commands.\n3) Normal upgrade path remains unchanged when tap is current.\n4) Tests cover stale and healthy tap cases.

## Changes

- 96c021e5 feat(TKT-1221): detect stale Homebrew tap and print self-heal upgrade guidance

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
