### PR TITLE
TKT-1178: Support running orchestrator in Docker container

### DIFF
--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -22,9 +22,13 @@ import { getHeadquartersNameFromPath } from '../../lib/machine-config.js'
 import { loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
 import {
   buildOrchestratorSessionName,
+  buildOrchestratorContainerName,
   findRunningOrchestratorSessions,
   findHQOrchestratorSessions,
+  findHQOrchestratorContainers,
+  findRunningOrchestratorContainers,
   extractOrchestratorNameFromSession,
+  getOrchestratorContainerId,
 } from './start.js'
 
 /**
@@ -101,6 +105,10 @@ export default class OrchestratorAttach extends PromptCommand {
     const jsonMode = shouldOutputJson(flags)
     const hostSessions = getHostTmuxSessionNames()
 
+    // Track whether the resolved session is in a Docker container
+    let isDockerSession = false
+    let dockerContainerId: string | undefined
+
     // Resolve session name: try HQ-scoped first, fall back to discovery
     let sessionName: string | undefined
     const hqPath = findHQRoot(process.cwd())
@@ -109,21 +117,41 @@ export default class OrchestratorAttach extends PromptCommand {
       const hqName = getHeadquartersNameFromPath(hqPath)
 
       if (flags.name) {
-        // Explicit --name: look for that specific orchestrator
+        // Explicit --name: look for that specific orchestrator (host tmux first, then Docker)
         sessionName = buildOrchestratorSessionName(hqName, flags.name)
         if (!hostSessions.includes(sessionName)) {
-          sessionName = undefined
+          // Not found as host tmux session, check Docker
+          const containerName = buildOrchestratorContainerName(hqName, flags.name)
+          const containerId = getOrchestratorContainerId(containerName)
+          if (containerId) {
+            sessionName = containerName
+            isDockerSession = true
+            dockerContainerId = containerId
+          } else {
+            sessionName = undefined
+          }
         }
       } else {
-        // No --name: discover ALL orchestrators in this HQ
+        // No --name: discover ALL orchestrators in this HQ (host tmux + Docker)
         const hqSessions = findHQOrchestratorSessions(hostSessions, hqName)
-        if (hqSessions.length === 1) {
-          sessionName = hqSessions[0]
-        } else if (hqSessions.length > 1) {
-          const sessionChoices = hqSessions.map(s => ({
-            name: extractOrchestratorNameFromSession(s, hqName) || s,
-            value: s,
-            command: `prlt orchestrator attach --name "${extractOrchestratorNameFromSession(s, hqName) || s}" --json`,
+        const hqContainers = findHQOrchestratorContainers(hqName)
+
+        const allSessions = [
+          ...hqSessions.map(s => ({ name: extractOrchestratorNameFromSession(s, hqName) || s, value: s, isDocker: false })),
+          ...hqContainers.map(c => ({ name: extractOrchestratorNameFromSession(c, hqName) || c, value: c, isDocker: true })),
+        ]
+
+        if (allSessions.length === 1) {
+          sessionName = allSessions[0].value
+          isDockerSession = allSessions[0].isDocker
+          if (isDockerSession) {
+            dockerContainerId = getOrchestratorContainerId(sessionName) || undefined
+          }
+        } else if (allSessions.length > 1) {
+          const sessionChoices = allSessions.map(s => ({
+            name: `${s.name}${s.isDocker ? ' (Docker)' : ''}`,
+            value: s.value,
+            command: `prlt orchestrator attach --name "${s.name}" --json`,
           }))
           const selectMessage = 'Multiple orchestrator sessions found. Select one to attach:'
 
@@ -142,6 +170,11 @@ export default class OrchestratorAttach extends PromptCommand {
             choices: sessionChoices,
           }])
           sessionName = session
+          const matched = allSessions.find(s => s.value === session)
+          if (matched?.isDocker) {
+            isDockerSession = true
+            dockerContainerId = getOrchestratorContainerId(session) || undefined
+          }
         }
         // If 0 found, fall through to global discovery below
       }
@@ -150,7 +183,14 @@ export default class OrchestratorAttach extends PromptCommand {
     // If not in HQ or session not found, discover running orchestrator sessions globally
     if (!sessionName) {
       const runningSessions = findRunningOrchestratorSessions(hostSessions)
-      if (runningSessions.length === 0) {
+      const runningContainers = findRunningOrchestratorContainers()
+
+      const allSessions = [
+        ...runningSessions.map(s => ({ name: s, value: s, isDocker: false })),
+        ...runningContainers.map(c => ({ name: `${c} (Docker)`, value: c, isDocker: true })),
+      ]
+
+      if (allSessions.length === 0) {
         if (jsonMode) {
           outputErrorAsJson(
             'NOT_RUNNING',
@@ -164,14 +204,18 @@ export default class OrchestratorAttach extends PromptCommand {
         this.log(styles.muted('Start it with: prlt orchestrator start'))
         this.log('')
         return
-      } else if (runningSessions.length === 1) {
-        sessionName = runningSessions[0]
+      } else if (allSessions.length === 1) {
+        sessionName = allSessions[0].value
+        isDockerSession = allSessions[0].isDocker
+        if (isDockerSession) {
+          dockerContainerId = getOrchestratorContainerId(sessionName) || undefined
+        }
       } else {
         // Multiple sessions — let user pick
-        const sessionChoices = runningSessions.map(s => ({
-          name: s,
-          value: s,
-          command: `prlt orchestrator attach --name "${s}" --json`,
+        const sessionChoices = allSessions.map(s => ({
+          name: s.name,
+          value: s.value,
+          command: `prlt orchestrator attach --name "${s.value}" --json`,
         }))
         const selectMessage = 'Multiple orchestrator sessions found. Select one to attach:'
 
@@ -190,6 +234,11 @@ export default class OrchestratorAttach extends PromptCommand {
           choices: sessionChoices,
         }])
         sessionName = session
+        const matched = allSessions.find(s => s.value === session)
+        if (matched?.isDocker) {
+          isDockerSession = true
+          dockerContainerId = getOrchestratorContainerId(session) || undefined
+        }
       }
     }
 
@@ -200,6 +249,8 @@ export default class OrchestratorAttach extends PromptCommand {
     if (jsonMode) {
       outputSuccessAsJson({
         sessionId: sessionName,
+        containerId: dockerContainerId,
+        environment: isDockerSession ? 'docker' : 'host',
         status: 'attaching',
       }, createMetadata('orchestrator attach', flags as Record<string, unknown>))
       return
@@ -214,8 +265,30 @@ export default class OrchestratorAttach extends PromptCommand {
     }
 
     this.log('')
-    this.log(styles.info(`Attaching to orchestrator session: ${sessionName}`))
+    this.log(styles.info(`Attaching to orchestrator session: ${sessionName}${isDockerSession ? ' (Docker)' : ''}`))
 
+    // Docker-based orchestrator: attach via docker exec
+    if (isDockerSession && dockerContainerId) {
+      if (flags['new-tab']) {
+        const terminalApp = flags.terminal ?? detectTerminalApp()
+        if (!terminalApp) {
+          this.log(styles.warning('Could not detect terminal emulator for new tab.'))
+          this.log(styles.muted('Falling back to direct attach in current terminal.'))
+        } else {
+          await this.openDockerInNewTab(terminalApp, dockerContainerId, sessionName)
+          return
+        }
+      }
+      // Attach directly in current terminal
+      try {
+        execSync(`docker exec -it ${dockerContainerId} tmux attach -t "${sessionName}"`, { stdio: 'inherit' })
+      } catch {
+        this.error(`Failed to attach to Docker orchestrator session "${sessionName}"`)
+      }
+      return
+    }
+
+    // Host-based orchestrator: attach via tmux
     // Determine if we should use tmux control mode (-u -CC) for iTerm
     let useControlMode = false
     try {
@@ -349,6 +422,77 @@ exec $SHELL
       }
 
       this.log(styles.success('Opened new tab and attaching to orchestrator'))
+    } catch (error) {
+      this.error(`Failed to open terminal tab: ${error instanceof Error ? error.message : error}`)
+    }
+  }
+
+  private async openDockerInNewTab(terminalApp: string, containerId: string, sessionName: string): Promise<void> {
+    const title = 'Orchestrator (Docker)'
+    const baseDir = path.join(os.homedir(), '.proletariat', 'scripts')
+    fs.mkdirSync(baseDir, { recursive: true })
+    const scriptPath = path.join(baseDir, `attach-orch-docker-${Date.now()}.sh`)
+
+    const script = `#!/bin/bash
+echo -ne "\\033]0;${title}\\007"
+echo -ne "\\033]1;${title}\\007"
+echo "Attaching to Docker orchestrator: ${sessionName}"
+docker exec -it ${containerId} tmux attach -t "${sessionName}"
+rm -f "${scriptPath}"
+exec $SHELL
+`
+    fs.writeFileSync(scriptPath, script, { mode: 0o755 })
+
+    try {
+      switch (terminalApp) {
+        case 'iTerm':
+          execSync(`osascript -e '
+            tell application "iTerm"
+              activate
+              tell current window
+                set newTab to (create tab with default profile)
+                tell current session of newTab
+                  set name to "${title}"
+                  write text "${scriptPath}"
+                end tell
+              end tell
+            end tell
+          '`)
+          break
+
+        case 'Ghostty':
+          execSync(`osascript -e '
+            tell application "Ghostty"
+              activate
+            end tell
+            tell application "System Events"
+              tell process "Ghostty"
+                keystroke "t" using command down
+                delay 0.3
+                keystroke "${scriptPath}"
+                keystroke return
+              end tell
+            end tell
+          '`)
+          break
+
+        default:
+          execSync(`osascript -e '
+            tell application "Terminal"
+              activate
+              tell application "System Events"
+                tell process "Terminal"
+                  keystroke "t" using command down
+                end tell
+              end tell
+              delay 0.3
+              do script "${scriptPath}" in front window
+            end tell
+          '`)
+          break
+      }
+
+      this.log(styles.success('Opened new tab and attaching to Docker orchestrator'))
     } catch (error) {
       this.error(`Failed to open terminal tab: ${error instanceof Error ? error.message : error}`)
     }

--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
 import Database from 'better-sqlite3'
@@ -18,12 +19,18 @@ import { styles } from '../../lib/styles.js'
 import {
   OutputMode,
   DisplayMode,
+  ExecutionEnvironment,
   ExecutionContext,
   ExecutorType,
   PermissionMode,
   DEFAULT_EXECUTION_CONFIG,
 } from '../../lib/execution/types.js'
-import { runExecution, hostCredentialsExist } from '../../lib/execution/runners.js'
+import {
+  runExecution,
+  hostCredentialsExist,
+  isDockerRunning,
+  runOrchestratorInDocker,
+} from '../../lib/execution/runners.js'
 import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
 import { ExecutionStorage } from '../../lib/execution/storage.js'
 import { getWorkspaceInfo } from '../../lib/agents/commands.js'
@@ -73,6 +80,56 @@ export function findRunningOrchestratorSessions(hostSessions: string[]): string[
 export function findHQOrchestratorSessions(hostSessions: string[], hqName: string): string[] {
   const prefix = `prlt-orchestrator-${sanitizeName(hqName) || 'default'}-`
   return hostSessions.filter(s => s.startsWith(prefix))
+}
+
+/**
+ * Build Docker container name for an orchestrator instance.
+ * Format: 'prlt-orchestrator-{hqName}-{name}'
+ */
+export function buildOrchestratorContainerName(hqName: string, name: string = 'main'): string {
+  const safeHqName = sanitizeName(hqName) || 'default'
+  const safeName = sanitizeName(name) || 'main'
+  return `prlt-orchestrator-${safeHqName}-${safeName}`
+}
+
+/**
+ * Find running Docker-based orchestrator containers.
+ * Returns container names matching 'prlt-orchestrator-*'.
+ */
+export function findRunningOrchestratorContainers(): string[] {
+  try {
+    const output = execSync(
+      'docker ps --filter "name=prlt-orchestrator-" --format "{{.Names}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim()
+    if (!output) return []
+    return output.split('\n').filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Find Docker orchestrator containers scoped to a specific HQ workspace.
+ */
+export function findHQOrchestratorContainers(hqName: string): string[] {
+  const prefix = `prlt-orchestrator-${sanitizeName(hqName) || 'default'}-`
+  return findRunningOrchestratorContainers().filter(c => c.startsWith(prefix))
+}
+
+/**
+ * Get the Docker container ID for a running orchestrator container.
+ */
+export function getOrchestratorContainerId(containerName: string): string | null {
+  try {
+    const id = execSync(
+      `docker container inspect -f '{{.Id}}' ${containerName}`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim()
+    return id ? id.substring(0, 12) : null
+  } catch {
+    return null
+  }
 }
 
 export function resolveOrchestratorName(name?: string): string {
@@ -206,6 +263,16 @@ export default class OrchestratorStart extends PromptCommand {
       description: 'Attach to the tmux session in the current terminal (blocking)',
       default: false,
       exclusive: ['background'],
+    }),
+    docker: Flags.boolean({
+      description: 'Run orchestrator in a Docker container (sibling container pattern)',
+      default: false,
+      exclusive: ['run-on-host'],
+    }),
+    'run-on-host': Flags.boolean({
+      description: 'Run orchestrator on host (default behavior)',
+      default: false,
+      exclusive: ['docker'],
     }),
   }
 
@@ -388,20 +455,57 @@ export default class OrchestratorStart extends PromptCommand {
       selectedExecutor = executor as ExecutorType
     }
 
-    // Validate Claude Code authentication for claude-code executor
-    if (selectedExecutor === 'claude-code' && !hostCredentialsExist()) {
+    // Determine execution environment
+    let environment: ExecutionEnvironment = 'host'
+    if (flags.docker) {
+      environment = 'docker'
+    } else if (!flags['run-on-host'] && !jsonMode) {
+      // Interactive mode: if Docker is available, offer the choice
+      // (unless --run-on-host was explicitly set)
+      if (isDockerRunning()) {
+        const envChoices = [
+          { name: '💻 Host — run directly on this machine (default)', value: 'host', command: 'prlt orchestrator start --run-on-host --json' },
+          { name: '🐳 Docker — run in isolated container (sibling container pattern)', value: 'docker', command: 'prlt orchestrator start --docker --json' },
+        ]
+
+        const { selectedEnv } = await this.prompt<{ selectedEnv: string }>([{
+          type: 'list',
+          name: 'selectedEnv',
+          message: 'Where should the orchestrator run?',
+          choices: envChoices,
+        }])
+        environment = selectedEnv as ExecutionEnvironment
+      }
+    }
+
+    // Validate Docker is running if docker environment was selected
+    if (environment === 'docker' && !isDockerRunning()) {
+      const errorMsg = 'Docker is not running. Please start Docker Desktop and try again, or use --run-on-host.'
+      if (jsonMode) {
+        outputErrorAsJson('DOCKER_NOT_RUNNING', errorMsg, createMetadata('orchestrator start', flags))
+        return
+      }
+      this.error(errorMsg)
+    }
+
+    // Validate Claude Code authentication for host execution
+    // Docker uses OAuth credentials volume, so host auth check only applies to host mode
+    if (environment === 'host' && selectedExecutor === 'claude-code' && !hostCredentialsExist()) {
       const errorMsg = 'Claude Code authentication is not available. This usually happens when the macOS keychain is locked in SSH sessions.'
       const remediation = [
         '',
         'To fix this, choose one of the following:',
         '',
-        '1. Unlock the keychain:',
+        '1. Run orchestrator in Docker (uses OAuth, no keychain needed):',
+        '   prlt orchestrator start --docker',
+        '',
+        '2. Unlock the keychain:',
         '   security unlock-keychain',
         '',
-        '2. Set the ANTHROPIC_API_KEY environment variable:',
+        '3. Set the ANTHROPIC_API_KEY environment variable:',
         '   export ANTHROPIC_API_KEY=your-api-key',
         '',
-        '3. Login to Claude Code:',
+        '4. Login to Claude Code:',
         '   claude /login',
         '',
       ].join('\n')
@@ -574,6 +678,7 @@ export default class OrchestratorStart extends PromptCommand {
     if (!jsonMode) {
       this.log('')
       this.log(styles.muted(`   Starting orchestrator...`))
+      this.log(styles.muted(`   Environment: ${environment}`))
       this.log(styles.muted(`   Executor: ${selectedExecutor}`))
       this.log(styles.muted(`   Permission mode: ${permissionMode}`))
       this.log(styles.muted(`   Display mode: ${displayMode}`))
@@ -588,9 +693,17 @@ export default class OrchestratorStart extends PromptCommand {
     }
 
     // Launch orchestrator
-    const result = await runExecution('host', context, selectedExecutor, executionConfig, {
-      displayMode,
-    })
+    let result
+    if (environment === 'docker') {
+      result = await runOrchestratorInDocker(context, selectedExecutor, executionConfig, {
+        displayMode,
+        sessionName,
+      })
+    } else {
+      result = await runExecution('host', context, selectedExecutor, executionConfig, {
+        displayMode,
+      })
+    }
 
     if (result.success) {
       // Create execution record so `prlt session poke orchestrator "message"` works
@@ -601,10 +714,11 @@ export default class OrchestratorStart extends PromptCommand {
             ticketId: 'ORCH',
             agentName: `orchestrator-${orchestratorName}`,
             executor: selectedExecutor,
-            environment: 'host',
+            environment,
             displayMode,
             permissionMode,
             sessionId: result.sessionId || sessionName,
+            containerId: result.containerId,
           })
         } catch {
           // Non-fatal: poke won't work but orchestrator is running
@@ -614,6 +728,8 @@ export default class OrchestratorStart extends PromptCommand {
       if (jsonMode) {
         outputSuccessAsJson({
           sessionId: result.sessionId || sessionName,
+          containerId: result.containerId,
+          environment,
           executor: selectedExecutor,
           permissionMode,
           displayMode,
@@ -623,13 +739,19 @@ export default class OrchestratorStart extends PromptCommand {
       }
 
       if (displayMode === 'background') {
-        this.log(styles.success(`Orchestrator started in background`))
+        this.log(styles.success(`Orchestrator started in background${environment === 'docker' ? ' (Docker)' : ''}`))
         this.log(styles.muted(`   Session: ${result.sessionId || sessionName}`))
+        if (result.containerId) {
+          this.log(styles.muted(`   Container: ${result.containerId}`))
+        }
         this.log(styles.muted(`   Attach with: ${attachCommand}`))
       } else {
-        this.log(styles.success(`Orchestrator started`))
+        this.log(styles.success(`Orchestrator started${environment === 'docker' ? ' (Docker)' : ''}`))
         if (result.sessionId) {
           this.log(styles.muted(`   Session: ${result.sessionId}`))
+        }
+        if (result.containerId) {
+          this.log(styles.muted(`   Container: ${result.containerId}`))
         }
       }
     } else {

--- a/apps/cli/src/commands/orchestrator/status.ts
+++ b/apps/cli/src/commands/orchestrator/status.ts
@@ -10,11 +10,16 @@ import { styles } from '../../lib/styles.js'
 import { getHostTmuxSessionNames, captureTmuxPane } from '../../lib/execution/session-utils.js'
 import { findHQRoot } from '../../lib/workspace.js'
 import { getHeadquartersNameFromPath } from '../../lib/machine-config.js'
+import { execSync } from 'node:child_process'
 import {
   buildOrchestratorSessionName,
+  buildOrchestratorContainerName,
   findRunningOrchestratorSessions,
   findHQOrchestratorSessions,
+  findHQOrchestratorContainers,
+  findRunningOrchestratorContainers,
   extractOrchestratorNameFromSession,
+  getOrchestratorContainerId,
 } from './start.js'
 
 export default class OrchestratorStatus extends PromptCommand {
@@ -42,6 +47,20 @@ export default class OrchestratorStatus extends PromptCommand {
     }),
   }
 
+  /**
+   * Capture tmux pane from inside a Docker container.
+   */
+  private captureDockerTmuxPane(containerId: string, sessionName: string, lines: number): string | null {
+    try {
+      return execSync(
+        `docker exec ${containerId} tmux capture-pane -t "${sessionName}" -p -S -${lines}`,
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      ).trim() || null
+    } catch {
+      return null
+    }
+  }
+
   async run(): Promise<void> {
     const { flags } = await this.parse(OrchestratorStatus)
     const jsonMode = shouldOutputJson(flags)
@@ -54,19 +73,32 @@ export default class OrchestratorStatus extends PromptCommand {
       const hqName = getHeadquartersNameFromPath(hqPath)
 
       if (flags.name) {
-        // Explicit --name: check that specific orchestrator
+        // Explicit --name: check that specific orchestrator (host tmux + Docker)
         const sessionName = buildOrchestratorSessionName(hqName, flags.name)
-        const isRunning = hostSessions.includes(sessionName)
+        const isHostRunning = hostSessions.includes(sessionName)
+
+        const containerName = buildOrchestratorContainerName(hqName, flags.name)
+        const dockerContainerId = getOrchestratorContainerId(containerName)
+        const isDockerRunning = !!dockerContainerId
+
+        const isRunning = isHostRunning || isDockerRunning
+        const environment = isDockerRunning ? 'docker' : 'host'
 
         let recentOutput: string | null = null
         if (isRunning && flags.peek) {
-          recentOutput = captureTmuxPane(sessionName, flags.lines)
+          if (isDockerRunning && dockerContainerId) {
+            recentOutput = this.captureDockerTmuxPane(dockerContainerId, containerName, flags.lines)
+          } else {
+            recentOutput = captureTmuxPane(sessionName, flags.lines)
+          }
         }
 
         if (jsonMode) {
           outputSuccessAsJson({
             running: isRunning,
-            sessionId: isRunning ? sessionName : null,
+            sessionId: isRunning ? (isDockerRunning ? containerName : sessionName) : null,
+            containerId: dockerContainerId || null,
+            environment,
             name: flags.name,
             ...(recentOutput !== null && { recentOutput }),
           }, createMetadata('orchestrator status', flags as Record<string, unknown>))
@@ -75,8 +107,11 @@ export default class OrchestratorStatus extends PromptCommand {
 
         this.log('')
         if (isRunning) {
-          this.log(styles.success(`Orchestrator "${flags.name}" is running`))
-          this.log(styles.muted(`   Session: ${sessionName}`))
+          this.log(styles.success(`Orchestrator "${flags.name}" is running${isDockerRunning ? ' (Docker)' : ''}`))
+          this.log(styles.muted(`   Session: ${isDockerRunning ? containerName : sessionName}`))
+          if (dockerContainerId) {
+            this.log(styles.muted(`   Container: ${dockerContainerId}`))
+          }
           this.log(styles.muted(`   Attach: prlt orchestrator attach --name ${flags.name}`))
 
           if (recentOutput) {
@@ -94,32 +129,40 @@ export default class OrchestratorStatus extends PromptCommand {
         return
       }
 
-      // No --name: show status for ALL orchestrators in this HQ
+      // No --name: show status for ALL orchestrators in this HQ (host + Docker)
       const hqSessions = findHQOrchestratorSessions(hostSessions, hqName)
+      const hqContainers = findHQOrchestratorContainers(hqName)
+
+      const allSessions = [
+        ...hqSessions.map(s => ({ sessionId: s, name: extractOrchestratorNameFromSession(s, hqName) || s, environment: 'host' as const, containerId: null as string | null })),
+        ...hqContainers.map(c => ({ sessionId: c, name: extractOrchestratorNameFromSession(c, hqName) || c, environment: 'docker' as const, containerId: getOrchestratorContainerId(c) })),
+      ]
 
       if (jsonMode) {
         outputSuccessAsJson({
-          running: hqSessions.length > 0,
-          sessions: hqSessions.map(s => ({
-            sessionId: s,
-            name: extractOrchestratorNameFromSession(s, hqName) || s,
-          })),
+          running: allSessions.length > 0,
+          sessions: allSessions,
         }, createMetadata('orchestrator status', flags as Record<string, unknown>))
         return
       }
 
       this.log('')
-      if (hqSessions.length === 0) {
+      if (allSessions.length === 0) {
         this.log(styles.muted('No orchestrator sessions running.'))
         this.log(styles.muted('Start one with: prlt orchestrator start'))
       } else {
-        this.log(styles.success(`${hqSessions.length} orchestrator session(s) running:`))
-        for (const s of hqSessions) {
-          const name = extractOrchestratorNameFromSession(s, hqName) || s
-          this.log(styles.muted(`   ${name} (${s})`))
-          this.log(styles.muted(`     Attach: prlt orchestrator attach --name ${name}`))
+        this.log(styles.success(`${allSessions.length} orchestrator session(s) running:`))
+        for (const s of allSessions) {
+          const envLabel = s.environment === 'docker' ? ' (Docker)' : ''
+          this.log(styles.muted(`   ${s.name}${envLabel} (${s.sessionId})`))
+          this.log(styles.muted(`     Attach: prlt orchestrator attach --name ${s.name}`))
           if (flags.peek) {
-            const output = captureTmuxPane(s, flags.lines)
+            let output: string | null = null
+            if (s.environment === 'docker' && s.containerId) {
+              output = this.captureDockerTmuxPane(s.containerId, s.sessionId, flags.lines)
+            } else {
+              output = captureTmuxPane(s.sessionId, flags.lines)
+            }
             if (output) {
               this.log(styles.muted('─'.repeat(60)))
               this.log(output)
@@ -132,27 +175,34 @@ export default class OrchestratorStatus extends PromptCommand {
       return
     }
 
-    // Not in HQ — discover all running orchestrator sessions globally
+    // Not in HQ — discover all running orchestrator sessions globally (host + Docker)
     const runningSessions = findRunningOrchestratorSessions(hostSessions)
+    const runningContainers = findRunningOrchestratorContainers()
+
+    const allSessions = [
+      ...runningSessions.map(s => ({ name: s, environment: 'host' as const })),
+      ...runningContainers.map(c => ({ name: `${c} (Docker)`, environment: 'docker' as const })),
+    ]
 
     if (jsonMode) {
       outputSuccessAsJson({
-        running: runningSessions.length > 0,
-        sessions: runningSessions,
+        running: allSessions.length > 0,
+        sessions: allSessions,
       }, createMetadata('orchestrator status', flags as Record<string, unknown>))
       return
     }
 
     this.log('')
-    if (runningSessions.length === 0) {
+    if (allSessions.length === 0) {
       this.log(styles.muted('No orchestrator sessions running.'))
       this.log(styles.muted('Start one with: prlt orchestrator start'))
     } else {
-      this.log(styles.success(`${runningSessions.length} orchestrator session(s) running:`))
-      for (const s of runningSessions) {
-        this.log(styles.muted(`   ${s}`))
-        if (flags.peek) {
-          const output = captureTmuxPane(s, flags.lines)
+      this.log(styles.success(`${allSessions.length} orchestrator session(s) running:`))
+      for (const s of allSessions) {
+        this.log(styles.muted(`   ${s.name}`))
+        if (flags.peek && s.environment === 'host') {
+          // Can only peek at host sessions with captureTmuxPane
+          const output = captureTmuxPane(s.name, flags.lines)
           if (output) {
             this.log(styles.muted('─'.repeat(60)))
             this.log(output)

--- a/apps/cli/src/commands/orchestrator/stop.ts
+++ b/apps/cli/src/commands/orchestrator/stop.ts
@@ -19,9 +19,13 @@ import { getHostTmuxSessionNames } from '../../lib/execution/session-utils.js'
 import { ExecutionStorage } from '../../lib/execution/storage.js'
 import {
   buildOrchestratorSessionName,
+  buildOrchestratorContainerName,
   findRunningOrchestratorSessions,
   findHQOrchestratorSessions,
+  findHQOrchestratorContainers,
+  findRunningOrchestratorContainers,
   extractOrchestratorNameFromSession,
+  getOrchestratorContainerId,
 } from './start.js'
 import { getHeadquartersNameFromPath } from '../../lib/machine-config.js'
 
@@ -51,6 +55,9 @@ export default class OrchestratorStop extends PromptCommand {
     const jsonMode = shouldOutputJson(flags)
     const hostSessions = getHostTmuxSessionNames()
 
+    // Track whether the resolved session is in a Docker container
+    let isDockerSession = false
+
     // Resolve session name: try HQ-scoped first, fall back to discovery
     let sessionName: string | undefined
     let orchestratorName: string | undefined
@@ -60,23 +67,39 @@ export default class OrchestratorStop extends PromptCommand {
       const hqName = getHeadquartersNameFromPath(hqPath)
 
       if (flags.name) {
-        // Explicit --name: look for that specific orchestrator
+        // Explicit --name: look for that specific orchestrator (host tmux first, then Docker)
         sessionName = buildOrchestratorSessionName(hqName, flags.name)
         orchestratorName = flags.name
         if (!hostSessions.includes(sessionName)) {
-          sessionName = undefined
+          // Check Docker
+          const containerName = buildOrchestratorContainerName(hqName, flags.name)
+          const containerId = getOrchestratorContainerId(containerName)
+          if (containerId) {
+            sessionName = containerName
+            isDockerSession = true
+          } else {
+            sessionName = undefined
+          }
         }
       } else {
-        // No --name: discover ALL orchestrators in this HQ
+        // No --name: discover ALL orchestrators in this HQ (host + Docker)
         const hqSessions = findHQOrchestratorSessions(hostSessions, hqName)
-        if (hqSessions.length === 1) {
-          sessionName = hqSessions[0]
-          orchestratorName = extractOrchestratorNameFromSession(hqSessions[0], hqName) || undefined
-        } else if (hqSessions.length > 1) {
-          const sessionChoices = hqSessions.map(s => ({
-            name: extractOrchestratorNameFromSession(s, hqName) || s,
-            value: s,
-            command: `prlt orchestrator stop --name "${extractOrchestratorNameFromSession(s, hqName) || s}" --force --json`,
+        const hqContainers = findHQOrchestratorContainers(hqName)
+
+        const allSessions = [
+          ...hqSessions.map(s => ({ name: extractOrchestratorNameFromSession(s, hqName) || s, value: s, isDocker: false })),
+          ...hqContainers.map(c => ({ name: extractOrchestratorNameFromSession(c, hqName) || c, value: c, isDocker: true })),
+        ]
+
+        if (allSessions.length === 1) {
+          sessionName = allSessions[0].value
+          orchestratorName = allSessions[0].name
+          isDockerSession = allSessions[0].isDocker
+        } else if (allSessions.length > 1) {
+          const sessionChoices = allSessions.map(s => ({
+            name: `${s.name}${s.isDocker ? ' (Docker)' : ''}`,
+            value: s.value,
+            command: `prlt orchestrator stop --name "${s.name}" --force --json`,
           }))
           const selectMessage = 'Multiple orchestrator sessions found. Select one to stop:'
 
@@ -95,7 +118,9 @@ export default class OrchestratorStop extends PromptCommand {
             choices: sessionChoices,
           }])
           sessionName = session
-          orchestratorName = extractOrchestratorNameFromSession(session, hqName) || undefined
+          const matched = allSessions.find(s => s.value === session)
+          orchestratorName = matched?.name
+          isDockerSession = matched?.isDocker || false
         }
         // If 0 found, fall through to global discovery below
       }
@@ -104,7 +129,14 @@ export default class OrchestratorStop extends PromptCommand {
     // If not in HQ or session not found, discover running orchestrator sessions globally
     if (!sessionName) {
       const runningSessions = findRunningOrchestratorSessions(hostSessions)
-      if (runningSessions.length === 0) {
+      const runningContainers = findRunningOrchestratorContainers()
+
+      const allSessions = [
+        ...runningSessions.map(s => ({ name: s, value: s, isDocker: false })),
+        ...runningContainers.map(c => ({ name: `${c} (Docker)`, value: c, isDocker: true })),
+      ]
+
+      if (allSessions.length === 0) {
         if (jsonMode) {
           outputErrorAsJson(
             'NOT_RUNNING',
@@ -117,14 +149,15 @@ export default class OrchestratorStop extends PromptCommand {
         this.log(styles.muted('Orchestrator is not running.'))
         this.log('')
         return
-      } else if (runningSessions.length === 1) {
-        sessionName = runningSessions[0]
+      } else if (allSessions.length === 1) {
+        sessionName = allSessions[0].value
+        isDockerSession = allSessions[0].isDocker
       } else {
         // Multiple sessions — let user pick
-        const sessionChoices = runningSessions.map(s => ({
-          name: s,
-          value: s,
-          command: `prlt orchestrator stop --name "${s}" --force --json`,
+        const sessionChoices = allSessions.map(s => ({
+          name: s.name,
+          value: s.value,
+          command: `prlt orchestrator stop --name "${s.value}" --force --json`,
         }))
         const selectMessage = 'Multiple orchestrator sessions found. Select one to stop:'
 
@@ -143,6 +176,8 @@ export default class OrchestratorStop extends PromptCommand {
           choices: sessionChoices,
         }])
         sessionName = session
+        const matched = allSessions.find(s => s.value === session)
+        isDockerSession = matched?.isDocker || false
       }
     }
 
@@ -155,7 +190,7 @@ export default class OrchestratorStop extends PromptCommand {
       const { confirmed } = await this.prompt<{ confirmed: boolean }>([{
         type: 'list',
         name: 'confirmed',
-        message: `Stop the orchestrator (${sessionName})?`,
+        message: `Stop the orchestrator (${sessionName}${isDockerSession ? ' - Docker' : ''})?`,
         choices: [
           { name: 'Yes', value: true },
           { name: 'No', value: false },
@@ -168,9 +203,15 @@ export default class OrchestratorStop extends PromptCommand {
       }
     }
 
-    // Kill the tmux session
+    // Kill the session (Docker container or tmux session)
     try {
-      execSync(`tmux kill-session -t "${sessionName}"`, { stdio: 'pipe' })
+      if (isDockerSession) {
+        // Stop and remove the Docker container
+        execSync(`docker rm -f ${sessionName}`, { stdio: 'pipe' })
+      } else {
+        // Kill the host tmux session
+        execSync(`tmux kill-session -t "${sessionName}"`, { stdio: 'pipe' })
+      }
     } catch (error) {
       if (jsonMode) {
         outputErrorAsJson(

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -750,6 +750,109 @@ export function createDevcontainerConfig(options: DevcontainerOptions, config?: 
   fs.writeFileSync(setupScriptPath, setupScript, { mode: 0o755 })
 }
 
+// =============================================================================
+// Orchestrator Docker Support
+// =============================================================================
+
+export interface OrchestratorDockerOptions {
+  /** Orchestrator name (e.g., 'main') */
+  orchestratorName: string
+  /** HQ root directory path */
+  hqPath: string
+  /** Timezone for the container */
+  timezone?: string
+  /** prlt channel: "npm", "npm:dev", "gh", "mount", or version like "npm:1.2.3" */
+  prltChannel?: string
+  /** Executor type - determines which CLI tools to install */
+  executor?: ExecutorType
+  /** Git user.name for commit attribution */
+  gitUserName?: string
+  /** Git user.email for commit attribution */
+  gitUserEmail?: string
+}
+
+/**
+ * Generate a Dockerfile for the orchestrator container.
+ *
+ * The orchestrator container is designed for the sibling container pattern:
+ * - Docker socket is mounted from the host so the orchestrator can spawn
+ *   agent containers as siblings (not nested Docker-in-Docker)
+ * - HQ directory is mounted for workspace access
+ * - prlt CLI is installed for orchestration commands
+ * - No firewall needed since orchestrator needs to manage Docker
+ */
+export function generateOrchestratorDockerfile(options: OrchestratorDockerOptions): string {
+  const timezone = options.timezone || 'America/Los_Angeles'
+
+  return `FROM node:22
+
+# Ensure we run as root for apt-get and system setup
+USER root
+
+ARG TZ=${timezone}
+ENV TZ=\${TZ}
+
+# Install system dependencies (no iptables/ipset - orchestrator doesn't use firewall)
+RUN apt-get update && apt-get install -y \\
+    less git git-lfs procps sudo fzf zsh man-db unzip gnupg2 gh tmux \\
+    jq nano vim curl docker.io \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && git lfs install
+
+# Create workspace and claude directories
+RUN mkdir -p /workspace /hq /home/node/.claude \\
+    && chown -R node:node /workspace /hq /home/node/.claude
+
+# Add node user to docker group so it can use Docker socket
+RUN groupadd -f docker && usermod -aG docker node
+
+# Set up persistent bash history
+RUN mkdir -p /commandhistory \\
+    && touch /commandhistory/.bash_history \\
+    && chown -R node:node /commandhistory
+
+# Install git-delta for better diffs (architecture-aware)
+RUN ARCH=$(dpkg --print-architecture) && \\
+    curl -L "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_\${ARCH}.deb" -o /tmp/delta.deb && \\
+    dpkg -i /tmp/delta.deb && \\
+    rm /tmp/delta.deb
+
+# Install zsh with oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \\
+    && chsh -s /bin/zsh node
+
+# Configure npm global directory
+RUN mkdir -p /home/node/.npm-global/bin /home/node/.npm-global/lib \\
+    && chown -R node:node /home/node/.npm-global
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=/home/node/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
+
+# Install pnpm and executor CLI as node user
+USER node
+RUN npm install -g pnpm && npm install -g @anthropic-ai/claude-code${options.executor === 'codex' ? ' && npm install -g @openai/codex' : ''}
+USER root
+
+# Install prlt CLI
+ARG PRLT_REGISTRY=npm
+ARG PRLT_VERSION=latest
+RUN if [ "\${PRLT_REGISTRY}" = "npm" ] || [ "\${PRLT_REGISTRY}" = "gh" ]; then \\
+      echo "Installing @proletariat/cli@\${PRLT_VERSION} from npm..." && \\
+      npm install -g @proletariat/cli@\${PRLT_VERSION}; \\
+    else \\
+      echo "prlt will be mounted from host (mount mode)"; \\
+    fi
+
+# Set default editor
+ENV EDITOR=nano
+
+# Configure shell history
+ENV HISTFILE=/commandhistory/.bash_history
+
+USER node
+WORKDIR /hq
+`
+}
+
 /**
  * Check if agent has devcontainer configuration
  */

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -21,7 +21,8 @@ import {
   DEFAULT_EXECUTION_CONFIG,
 } from './types.js'
 import { getSetTitleCommands } from '../terminal.js'
-import { readDevcontainerJson } from './devcontainer.js'
+import { readDevcontainerJson, generateOrchestratorDockerfile } from './devcontainer.js'
+import type { OrchestratorDockerOptions } from './devcontainer.js'
 import { getCodexCommand, resolveCodexExecutionContext, validateCodexMode, CodexModeError } from './codex-adapter.js'
 
 // =============================================================================
@@ -2501,6 +2502,368 @@ export async function runDocker(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to start docker container',
+    }
+  }
+}
+
+// =============================================================================
+// Orchestrator Docker Runner (Sibling Container Pattern)
+// =============================================================================
+
+/**
+ * Run orchestrator in a Docker container using the sibling container pattern.
+ *
+ * Architecture:
+ * ```
+ * Host Docker daemon
+ * ├── orchestrator container (has /var/run/docker.sock mounted)
+ * ├── agent-1 container (spawned by orchestrator, sibling)
+ * ├── agent-2 container (spawned by orchestrator, sibling)
+ * ```
+ *
+ * The orchestrator container needs:
+ * - HQ directory mounted (proletariat-hq)
+ * - Docker socket mounted (/var/run/docker.sock) — so it can spawn agent containers as siblings
+ * - prlt CLI installed in the container
+ * - OAuth credentials for Claude Code (via Docker volume)
+ * - tmux for session persistence inside the container
+ */
+export async function runOrchestratorInDocker(
+  context: ExecutionContext,
+  executor: ExecutorType,
+  config: ExecutionConfig,
+  options?: { displayMode?: DisplayMode; sessionName?: string }
+): Promise<RunnerResult> {
+  const displayMode = options?.displayMode || 'background'
+  const hqPath = context.hqPath || context.worktreePath
+  const hqName = context.hqName || 'default'
+  const orchestratorName = context.agentName || 'main'
+
+  // Container name matches tmux session name for consistency
+  const containerName = `prlt-orchestrator-${(hqName).replace(/[^a-zA-Z0-9._-]/g, '-')}-${(orchestratorName).replace(/[^a-zA-Z0-9._-]/g, '-')}`
+  const imageName = `prlt-orchestrator-${(hqName).replace(/[^a-zA-Z0-9._-]/g, '-')}:latest`
+
+  try {
+    // Check Docker is running
+    if (!isDockerRunning()) {
+      return {
+        success: false,
+        error: 'Docker is not running. Please start Docker Desktop and try again.',
+      }
+    }
+
+    // Check if container already exists and is running
+    if (containerExists(containerName)) {
+      if (isContainerRunning(containerName)) {
+        return {
+          success: false,
+          error: `Orchestrator container "${containerName}" is already running. Use "prlt orchestrator attach" to reattach.`,
+        }
+      }
+      // Remove stopped container
+      try {
+        execSync(`docker rm -f ${containerName}`, { stdio: 'pipe' })
+      } catch {
+        // Ignore removal errors
+      }
+    }
+
+    // Generate Dockerfile
+    const orchestratorDockerOptions: OrchestratorDockerOptions = {
+      orchestratorName,
+      hqPath,
+      executor,
+    }
+    const dockerfileContent = generateOrchestratorDockerfile(orchestratorDockerOptions)
+
+    // Write Dockerfile to temp directory
+    const buildDir = path.join(hqPath, '.proletariat', 'orchestrator-docker')
+    fs.mkdirSync(buildDir, { recursive: true })
+    const dockerfilePath = path.join(buildDir, 'Dockerfile')
+    fs.writeFileSync(dockerfilePath, dockerfileContent)
+
+    // Build the image
+    const hostPrltVersion = getHostPrltVersion()
+    const buildArgs: Record<string, string> = {
+      PRLT_VERSION: hostPrltVersion || 'latest',
+    }
+    const buildArgFlags = Object.entries(buildArgs)
+      .map(([key, value]) => `--build-arg ${key}="${value}"`)
+      .join(' ')
+
+    console.debug(`[runners:orchestrator-docker] Building image: ${imageName}`)
+    try {
+      execSync(`docker build -t ${imageName} -f "${dockerfilePath}" ${buildArgFlags} "${buildDir}"`, { stdio: 'pipe' })
+    } catch (buildError) {
+      return {
+        success: false,
+        error: `Failed to build orchestrator Docker image: ${buildError instanceof Error ? buildError.message : buildError}`,
+      }
+    }
+
+    // Build mount flags for docker run
+    const mounts: string[] = [
+      // Mount HQ directory
+      `-v "${hqPath}:/hq:cached"`,
+      // Docker socket for sibling container pattern
+      `-v /var/run/docker.sock:/var/run/docker.sock`,
+      // Claude credentials volume (shared with agent containers)
+      ...(executor === 'claude-code' ? ['-v "claude-credentials:/home/node/.claude"'] : []),
+      // Persistent bash history
+      '-v "claude-bash-history:/commandhistory"',
+    ]
+
+    // Build environment variables
+    const envVars: string[] = [
+      `-e PRLT_HQ_PATH=/hq`,
+      `-e PRLT_AGENT_NAME="orchestrator-${orchestratorName}"`,
+      `-e PRLT_HOST_PATH="${hqPath}"`,
+      // Pass through GitHub tokens for agent spawning
+      ...(process.env.GITHUB_TOKEN ? [`-e GITHUB_TOKEN="${process.env.GITHUB_TOKEN}"`] : []),
+      ...(process.env.GH_TOKEN ? [`-e GH_TOKEN="${process.env.GH_TOKEN}"`] : []),
+      // Pass ANTHROPIC_API_KEY if available (for cases where OAuth is not set up)
+      ...(process.env.ANTHROPIC_API_KEY ? [`-e ANTHROPIC_API_KEY="${process.env.ANTHROPIC_API_KEY}"`] : []),
+    ]
+
+    // Create and start container
+    const createCmd = [
+      'docker run -d',
+      `--name ${containerName}`,
+      '--user node',
+      '-w /hq',
+      ...mounts,
+      ...envVars,
+      `--memory=${config.devcontainer.memory}`,
+      `--cpus=${config.devcontainer.cpus}`,
+      imageName,
+      'sleep infinity',  // Keep container running
+    ].join(' ')
+
+    console.debug(`[runners:orchestrator-docker] Creating container: ${createCmd}`)
+    execSync(createCmd, { stdio: 'pipe' })
+
+    const containerId = getContainerId(containerName)
+    if (!containerId) {
+      return {
+        success: false,
+        error: 'Failed to get container ID after creation',
+      }
+    }
+
+    // Fix Docker socket permissions inside the container
+    // The socket is owned by root on the host; we need the node user to access it
+    try {
+      execSync(`docker exec --user root ${containerId} chmod 666 /var/run/docker.sock`, { stdio: 'pipe' })
+    } catch {
+      console.debug('[runners:orchestrator-docker] Failed to fix Docker socket permissions (may already be accessible)')
+    }
+
+    // Copy Claude Code settings to container (for bypassing prompts)
+    if (executor === 'claude-code') {
+      try {
+        const hostClaudeJson = path.join(os.homedir(), '.claude.json')
+        let settings: Record<string, unknown> = {}
+
+        if (fs.existsSync(hostClaudeJson)) {
+          try {
+            settings = JSON.parse(fs.readFileSync(hostClaudeJson, 'utf-8'))
+          } catch {
+            // Use empty settings
+          }
+        }
+
+        if (config.permissionMode === 'danger') {
+          settings.bypassPermissionsModeAccepted = true
+        }
+        settings.numStartups = settings.numStartups || 1
+        settings.hasCompletedOnboarding = true
+        settings.theme = settings.theme || 'dark'
+        if (!settings.tipsHistory || typeof settings.tipsHistory !== 'object') {
+          settings.tipsHistory = {}
+        }
+        const tips = settings.tipsHistory as Record<string, number>
+        tips['new-user-warmup'] = tips['new-user-warmup'] || 1
+        settings.effortCalloutDismissed = true
+
+        if (!settings.projects || typeof settings.projects !== 'object') {
+          settings.projects = {}
+        }
+        const projects = settings.projects as Record<string, Record<string, unknown>>
+        for (const projectPath of ['/hq', '/']) {
+          if (!projects[projectPath]) projects[projectPath] = {}
+          projects[projectPath].hasTrustDialogAccepted = true
+          projects[projectPath].hasCompletedProjectOnboarding = true
+        }
+
+        execSync(
+          `docker exec -i ${containerId} bash -c 'cat > /home/node/.claude.json'`,
+          { input: JSON.stringify(settings), stdio: ['pipe', 'pipe', 'pipe'] }
+        )
+
+        const claudeSettings = JSON.stringify({ skipDangerousModePermissionPrompt: true })
+        execSync(
+          `docker exec -i ${containerId} bash -c 'mkdir -p /home/node/.claude && cat > /home/node/.claude/settings.json'`,
+          { input: claudeSettings, stdio: ['pipe', 'pipe', 'pipe'] }
+        )
+      } catch (error) {
+        console.debug('[runners:orchestrator-docker] Failed to copy Claude settings:', error)
+      }
+    }
+
+    // Build the prompt and write to temp file inside container
+    const prompt = buildPrompt(context)
+    const promptPath = `/tmp/orchestrator-prompt-${Date.now()}.txt`
+    try {
+      execSync(
+        `docker exec -i ${containerId} bash -c 'cat > ${promptPath}'`,
+        { input: prompt, stdio: ['pipe', 'pipe', 'pipe'] }
+      )
+    } catch {
+      return {
+        success: false,
+        error: 'Failed to write prompt to container',
+      }
+    }
+
+    // Build executor command
+    const skipPermissions = config.permissionMode === 'danger'
+    const permissionsFlag = skipPermissions ? '--dangerously-skip-permissions ' : ''
+    const effortFlag = skipPermissions ? '--effort high ' : ''
+    const executorCmd = executor === 'claude-code'
+      ? `claude ${permissionsFlag}${effortFlag}"$(cat ${promptPath})"`
+      : `claude ${permissionsFlag}${effortFlag}"$(cat ${promptPath})"`
+
+    // Build tmux session name (reuses the same name as host tmux for consistency)
+    const tmuxSessionName = options?.sessionName || containerName
+
+    // Create tmux session inside container with the executor command
+    const tmuxCmd = `tmux new-session -d -s "${tmuxSessionName}" -n "${tmuxSessionName}" bash -c '(unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT; cd /hq && ${executorCmd}); echo ""; echo "Orchestrator complete. Press Enter to close."; exec bash'`
+
+    try {
+      execSync(
+        `docker exec ${containerId} bash -c '${tmuxCmd.replace(/'/g, "'\\''")}'`,
+        { stdio: 'pipe' }
+      )
+    } catch (tmuxError) {
+      // Fallback: try simpler command without subshell
+      console.debug('[runners:orchestrator-docker] tmux creation failed, trying simpler approach:', tmuxError)
+      try {
+        // Write a script inside the container
+        const scriptContent = `#!/bin/bash
+cd /hq
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT
+${executor === 'claude-code' ? `claude ${permissionsFlag}${effortFlag}"$(cat ${promptPath})"` : `claude "$(cat ${promptPath})"`}
+echo ""
+echo "Orchestrator complete. Press Enter to close."
+exec bash
+`
+        execSync(
+          `docker exec -i ${containerId} bash -c 'cat > /tmp/orchestrator-start.sh && chmod +x /tmp/orchestrator-start.sh'`,
+          { input: scriptContent, stdio: ['pipe', 'pipe', 'pipe'] }
+        )
+        execSync(
+          `docker exec ${containerId} tmux new-session -d -s "${tmuxSessionName}" /tmp/orchestrator-start.sh`,
+          { stdio: 'pipe' }
+        )
+      } catch (fallbackError) {
+        return {
+          success: false,
+          error: `Failed to create tmux session in container: ${fallbackError instanceof Error ? fallbackError.message : fallbackError}`,
+        }
+      }
+    }
+
+    // Handle display mode
+    if (displayMode === 'foreground') {
+      // Attach to tmux inside the container in current terminal
+      try {
+        const child = spawn('docker', ['exec', '-it', containerId, 'tmux', 'attach', '-t', tmuxSessionName], {
+          stdio: 'inherit',
+        })
+        await new Promise<void>((resolve) => {
+          child.on('close', () => resolve())
+        })
+      } catch {
+        // User detached - that's fine
+      }
+    } else if (displayMode === 'terminal' && process.platform === 'darwin') {
+      // Open a new terminal tab that attaches to the container's tmux
+      const baseDir = path.join(hqPath, '.proletariat', 'scripts')
+      fs.mkdirSync(baseDir, { recursive: true })
+      const scriptPath = path.join(baseDir, `orch-docker-attach-${Date.now()}.sh`)
+      const scriptContent = `#!/bin/bash
+echo -ne "\\033]0;Orchestrator (Docker)\\007"
+echo -ne "\\033]1;Orchestrator (Docker)\\007"
+docker exec -it ${containerId} tmux attach -t "${tmuxSessionName}"
+rm -f "${scriptPath}"
+exec $SHELL
+`
+      fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 })
+
+      const terminalApp = config.terminal.app
+      try {
+        switch (terminalApp) {
+          case 'iTerm':
+            execSync(`osascript -e '
+              tell application "iTerm"
+                activate
+                tell current window
+                  set newTab to (create tab with default profile)
+                  tell current session of newTab
+                    set name to "Orchestrator (Docker)"
+                    write text "${scriptPath}"
+                  end tell
+                end tell
+              end tell
+            '`)
+            break
+
+          case 'Ghostty':
+            execSync(`osascript -e '
+              tell application "Ghostty"
+                activate
+              end tell
+              tell application "System Events"
+                tell process "Ghostty"
+                  keystroke "t" using command down
+                  delay 0.3
+                  keystroke "${scriptPath}"
+                  keystroke return
+                end tell
+              end tell
+            '`)
+            break
+
+          default:
+            execSync(`osascript -e '
+              tell application "Terminal"
+                activate
+                tell application "System Events"
+                  tell process "Terminal"
+                    keystroke "t" using command down
+                  end tell
+                end tell
+                delay 0.3
+                do script "${scriptPath}" in front window
+              end tell
+            '`)
+            break
+        }
+      } catch {
+        console.debug('[runners:orchestrator-docker] Failed to open terminal tab, running in background')
+      }
+    }
+    // 'background' display mode: container is already running, nothing more to do
+
+    return {
+      success: true,
+      containerId,
+      sessionId: tmuxSessionName,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to start orchestrator in Docker',
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `generateOrchestratorDockerfile()` and `runOrchestratorInDocker()` to support Docker-based orchestrator sessions
- Docker socket mount for sibling container spawning, HQ directory mount, Claude credentials volume
- Updates orchestrator attach/start/status/stop commands to discover both host tmux and Docker containers
- Supports all display modes (foreground, terminal, background)

Supersedes #579 (fine-thiel's implementation).

## Test plan
- [ ] Build passes (`pnpm build`)
- [ ] `prlt orchestrator start --docker` launches in container
- [ ] `prlt orchestrator attach` discovers Docker sessions
- [ ] `prlt orchestrator stop` cleans up Docker containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)