### PR TITLE
TKT-1226: Convert 12 integration e2e test files to in-process invocation

### DIFF
--- a/apps/cli/test/e2e/branch-commands.test.ts
+++ b/apps/cli/test/e2e/branch-commands.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import Database from 'better-sqlite3';
 import {
-  exec,
+  execInProcess,
   createTestEnvironment,
   cleanupTestEnvironment,
   setupProductionSchema,
@@ -66,37 +66,37 @@ describe('Branch Commands E2E Tests', () => {
   });
 
   describe('prlt branch list', () => {
-    it('should list branches', () => {
-      const output = exec('branch list');
+    it('should list branches', async () => {
+      const output = await execInProcess('branch list');
 
       expect(output).to.contain('Branches');
       // Should show main/master branch
       expect(output.toLowerCase()).to.match(/main|master/);
     });
 
-    it('should show current branch marker', () => {
-      const output = exec('branch list');
+    it('should show current branch marker', async () => {
+      const output = await execInProcess('branch list');
 
       // Current branch should be indicated
       expect(output).to.match(/\*|current/i);
     });
 
-    it('should list conventional branches with type info', () => {
+    it('should list conventional branches with type info', async () => {
       // Create a conventional branch
       execSync('git checkout -b feat/chris/add-login', { stdio: 'pipe' });
 
-      const output = exec('branch list');
+      const output = await execInProcess('branch list');
 
       expect(output).to.contain('feat/chris/add-login');
       expect(output).to.contain('feat');
     });
 
-    it('should list ticket-first branches', () => {
+    it('should list ticket-first branches', async () => {
       // Create a ticket-first branch
       execSync('git checkout -b TKT-001/feat/chris/altman/add-auth', { stdio: 'pipe' });
 
       // Use JSON format to avoid table truncation
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       const branch = branches.find((b: { name: string; ticketId?: string }) => b.name === 'TKT-001/feat/chris/altman/add-auth');
@@ -104,16 +104,16 @@ describe('Branch Commands E2E Tests', () => {
       expect(branch!.ticketId).to.equal('TKT-001');
     });
 
-    it('should support compact format', () => {
+    it('should support compact format', async () => {
       execSync('git checkout -b feat/test/compact-test', { stdio: 'pipe' });
 
-      const output = exec('branch list --format compact');
+      const output = await execInProcess('branch list --format compact');
 
       expect(output).to.contain('feat/test/compact-test');
     });
 
-    it('should support JSON format', () => {
-      const output = exec('branch list --format json');
+    it('should support JSON format', async () => {
+      const output = await execInProcess('branch list --format json');
 
       // Should be valid JSON
       const parsed = JSON.parse(output);
@@ -123,67 +123,67 @@ describe('Branch Commands E2E Tests', () => {
       expect(parsed[0]).to.have.property('current');
     });
 
-    it('should filter by type', () => {
+    it('should filter by type', async () => {
       // Create branches of different types
       execSync('git checkout -b feat/test/feature-one', { stdio: 'pipe' });
       execSync('git checkout -b fix/test/bug-fix', { stdio: 'pipe' });
       execSync('git checkout -b docs/test/add-docs', { stdio: 'pipe' });
 
-      const output = exec('branch list --type feat');
+      const output = await execInProcess('branch list --type feat');
 
       expect(output).to.contain('feat/test/feature-one');
       expect(output).not.to.contain('fix/test/bug-fix');
       expect(output).not.to.contain('docs/test/add-docs');
     });
 
-    it('should show no branches message when filtered type has none', () => {
-      const output = exec('branch list --type sec');
+    it('should show no branches message when filtered type has none', async () => {
+      const output = await execInProcess('branch list --type sec');
 
       expect(output.toLowerCase()).to.contain('no');
     });
   });
 
   describe('prlt branch validate', () => {
-    it('should validate correct conventional branch name', () => {
-      const output = exec('branch validate feat/chris/add-login');
+    it('should validate correct conventional branch name', async () => {
+      const output = await execInProcess('branch validate feat/chris/add-login');
 
       expect(output.toLowerCase()).to.contain('valid');
     });
 
-    it('should validate ticket-first branch name', () => {
-      const output = exec('branch validate TKT-001/feat/chris/altman/add-auth');
+    it('should validate ticket-first branch name', async () => {
+      const output = await execInProcess('branch validate TKT-001/feat/chris/altman/add-auth');
 
       expect(output.toLowerCase()).to.contain('valid');
     });
 
-    it('should validate minimal branch name', () => {
-      const output = exec('branch validate feat/add-feature');
+    it('should validate minimal branch name', async () => {
+      const output = await execInProcess('branch validate feat/add-feature');
 
       expect(output.toLowerCase()).to.contain('valid');
     });
 
-    it('should reject invalid branch type', () => {
-      const output = exec('branch validate invalid/chris/test');
+    it('should reject invalid branch type', async () => {
+      const output = await execInProcess('branch validate invalid/chris/test');
 
       expect(output.toLowerCase()).to.contain('invalid');
     });
 
-    it('should reject non-kebab-case description', () => {
-      const output = exec('branch validate feat/chris/AddLogin');
+    it('should reject non-kebab-case description', async () => {
+      const output = await execInProcess('branch validate feat/chris/AddLogin');
 
       expect(output.toLowerCase()).to.match(/invalid|kebab/i);
     });
 
-    it('should show parsed parts for valid branch', () => {
-      const output = exec('branch validate TKT-054/chore/chris/altman/update-naming');
+    it('should show parsed parts for valid branch', async () => {
+      const output = await execInProcess('branch validate TKT-054/chore/chris/altman/update-naming');
 
       expect(output).to.contain('TKT-054');
       expect(output).to.contain('chore');
       expect(output).to.contain('chris');
     });
 
-    it('should validate branch with ticket ID', () => {
-      const output = exec('branch validate TKT-123/fix/john/bug-fix');
+    it('should validate branch with ticket ID', async () => {
+      const output = await execInProcess('branch validate TKT-123/fix/john/bug-fix');
 
       expect(output.toLowerCase()).to.contain('valid');
       expect(output).to.contain('TKT-123');
@@ -191,8 +191,8 @@ describe('Branch Commands E2E Tests', () => {
   });
 
   describe('prlt branch create', () => {
-    it('should create branch with type and description flags', () => {
-      const output = exec('branch create -t feat -d add-user-auth');
+    it('should create branch with type and description flags', async () => {
+      const output = await execInProcess('branch create -t feat -d add-user-auth');
 
       expect(output).to.contain('Creating branch');
 
@@ -201,8 +201,8 @@ describe('Branch Commands E2E Tests', () => {
       expect(branches).to.match(/feat\/.*add-user-auth/);
     });
 
-    it('should create branch with owner flag', () => {
-      const output = exec('branch create -t fix -c chris -d fix-login-bug');
+    it('should create branch with owner flag', async () => {
+      const output = await execInProcess('branch create -t fix -c chris -d fix-login-bug');
 
       expect(output).to.contain('Creating branch');
 
@@ -210,17 +210,17 @@ describe('Branch Commands E2E Tests', () => {
       expect(branches).to.contain('fix/chris/fix-login-bug');
     });
 
-    it('should create branch with ticket flag', () => {
+    it('should create branch with ticket flag', async () => {
       // Need PMO context for ticket lookup, so test direct name instead
-      const output = exec('branch create TKT-001/feat/test/add-feature');
+      const output = await execInProcess('branch create TKT-001/feat/test/add-feature');
 
       // Branch may or may not be created depending on prompt answer
       // Just verify command ran without crash
       expect(output).to.be.a('string');
     });
 
-    it('should create branch with empty commit flag', () => {
-      const output = exec('branch create -t chore -d setup-ci -e');
+    it('should create branch with empty commit flag', async () => {
+      const output = await execInProcess('branch create -t chore -d setup-ci -e');
 
       // Check that branch was created
       expect(output).to.contain('Creating branch');
@@ -233,30 +233,30 @@ describe('Branch Commands E2E Tests', () => {
       // the prompt may be skipped. Just verify the branch was created successfully.
     });
 
-    it('should reject existing branch name', () => {
+    it('should reject existing branch name', async () => {
       // Create a branch first
       execSync('git checkout -b feat/existing-branch', { stdio: 'pipe' });
       execSync('git checkout -', { stdio: 'pipe' });
 
-      const output = exec('branch create feat/existing-branch');
+      const output = await execInProcess('branch create feat/existing-branch');
 
       expect(output.toLowerCase()).to.contain('already exists');
     });
 
-    it('should create branch from origin/main with flag', () => {
+    it('should create branch from origin/main with flag', async () => {
       // Create a fake origin for testing
       execSync('git remote add origin .', { stdio: 'pipe' });
 
-      const output = exec('branch create -t feat -d from-origin -o');
+      const output = await execInProcess('branch create -t feat -d from-origin -o');
 
       // Should attempt to fetch (may warn about no origin/main)
       expect(output).to.be.a('string');
     });
 
-    it('should support no-switch flag', () => {
+    it('should support no-switch flag', async () => {
       const currentBranch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
 
-      exec('branch create -t docs -d readme-update --no-switch');
+      await execInProcess('branch create -t docs -d readme-update --no-switch');
 
       // Should still be on original branch
       const afterBranch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
@@ -267,15 +267,15 @@ describe('Branch Commands E2E Tests', () => {
       expect(branches).to.match(/docs\/.*readme-update/);
     });
 
-    it('should validate branch type option', () => {
-      const output = exec('branch create -t invalid-type -d test');
+    it('should validate branch type option', async () => {
+      const output = await execInProcess('branch create -t invalid-type -d test');
 
       expect(output.toLowerCase()).to.match(/invalid|error|unknown/i);
     });
 
-    it('should handle kebab-case conversion for description', () => {
+    it('should handle kebab-case conversion for description', async () => {
       // Note: Interactive mode would auto-convert, but flag mode requires kebab-case
-      const output = exec('branch create -t feat -d "test branch"');
+      const output = await execInProcess('branch create -t feat -d "test branch"');
 
       // Should either work or error about format
       expect(output).to.be.a('string');
@@ -283,14 +283,14 @@ describe('Branch Commands E2E Tests', () => {
   });
 
   describe('Branch naming conventions', () => {
-    it('should recognize all conventional commit types', () => {
+    it('should recognize all conventional commit types', async () => {
       const types = ['feat', 'fix', 'docs', 'test', 'chore', 'perf', 'ci', 'build', 'rfct'];
 
       for (const type of types) {
         execSync(`git checkout -b ${type}/test/type-${type}`, { stdio: 'pipe' });
       }
 
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       for (const type of types) {
@@ -300,14 +300,14 @@ describe('Branch Commands E2E Tests', () => {
       }
     });
 
-    it('should recognize extended types', () => {
+    it('should recognize extended types', async () => {
       const types = ['sec', 'db', 'rel'];
 
       for (const type of types) {
         execSync(`git checkout -b ${type}/test/ext-${type}`, { stdio: 'pipe' });
       }
 
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       for (const type of types) {
@@ -317,14 +317,14 @@ describe('Branch Commands E2E Tests', () => {
       }
     });
 
-    it('should recognize founder types', () => {
+    it('should recognize founder types', async () => {
       const types = ['ship', 'grow', 'cx', 'strat', 'ops'];
 
       for (const type of types) {
         execSync(`git checkout -b ${type}/test/founder-${type}`, { stdio: 'pipe' });
       }
 
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       for (const type of types) {
@@ -334,10 +334,10 @@ describe('Branch Commands E2E Tests', () => {
       }
     });
 
-    it('should parse ticket ID from branch name', () => {
+    it('should parse ticket ID from branch name', async () => {
       execSync('git checkout -b TKT-123/feat/chris/add-feature', { stdio: 'pipe' });
 
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       const branch = branches.find((b: BranchInfo) => b.name.startsWith('TKT-123'));
@@ -347,10 +347,10 @@ describe('Branch Commands E2E Tests', () => {
       expect(branch.owner).to.equal('chris');
     });
 
-    it('should parse owner from branch name', () => {
+    it('should parse owner from branch name', async () => {
       execSync('git checkout -b fix/john-doe/bug-fix', { stdio: 'pipe' });
 
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       const branch = branches.find((b: BranchInfo) => b.name === 'fix/john-doe/bug-fix');
@@ -358,10 +358,10 @@ describe('Branch Commands E2E Tests', () => {
       expect(branch.owner).to.equal('john-doe');
     });
 
-    it('should parse agent from ticket-first branch', () => {
+    it('should parse agent from ticket-first branch', async () => {
       execSync('git checkout -b TKT-001/feat/chris/altman/implement', { stdio: 'pipe' });
 
-      const output = exec('branch list --format json');
+      const output = await execInProcess('branch list --format json');
       const branches = JSON.parse(output);
 
       const branch = branches.find((b: BranchInfo) => b.name.startsWith('TKT-001'));
@@ -371,37 +371,37 @@ describe('Branch Commands E2E Tests', () => {
   });
 
   describe('prlt branch where', () => {
-    it('should find branch in main worktree by exact name', () => {
+    it('should find branch in main worktree by exact name', async () => {
       // Create a branch and stay on it (branch where finds checked-out branches in worktrees)
       execSync('git checkout -b feat/test/find-me', { stdio: 'pipe' });
 
-      const output = exec('branch where feat/test/find-me');
+      const output = await execInProcess('branch where feat/test/find-me');
 
       expect(output).to.contain('feat/test/find-me');
       expect(output).to.contain('Path:');
     });
 
-    it('should find branch by partial match', () => {
+    it('should find branch by partial match', async () => {
       execSync('git checkout -b feat/test/unique-branch-name', { stdio: 'pipe' });
 
-      const output = exec('branch where unique-branch');
+      const output = await execInProcess('branch where unique-branch');
 
       expect(output).to.contain('unique-branch-name');
     });
 
-    it('should find branch by ticket ID prefix', () => {
+    it('should find branch by ticket ID prefix', async () => {
       execSync('git checkout -b TKT-999/feat/test/ticket-feature', { stdio: 'pipe' });
 
-      const output = exec('branch where TKT-999');
+      const output = await execInProcess('branch where TKT-999');
 
       expect(output).to.contain('TKT-999');
       expect(output).to.contain('ticket-feature');
     });
 
-    it('should output JSON format when --json flag is used', () => {
+    it('should output JSON format when --json flag is used', async () => {
       execSync('git checkout -b feat/test/json-test', { stdio: 'pipe' });
 
-      const output = exec('branch where json-test --json');
+      const output = await execInProcess('branch where json-test --json');
 
       // Should be valid JSON
       const parsed = JSON.parse(output);
@@ -414,14 +414,14 @@ describe('Branch Commands E2E Tests', () => {
       expect(parsed.matches[0]).to.have.property('branch');
     });
 
-    it('should return not found for non-existent branch', () => {
-      const output = exec('branch where non-existent-branch-xyz');
+    it('should return not found for non-existent branch', async () => {
+      const output = await execInProcess('branch where non-existent-branch-xyz');
 
       expect(output.toLowerCase()).to.contain('no worktree found');
     });
 
-    it('should return JSON with found=false for non-existent branch', () => {
-      const output = exec('branch where non-existent-xyz --json');
+    it('should return JSON with found=false for non-existent branch', async () => {
+      const output = await execInProcess('branch where non-existent-xyz --json');
 
       const parsed = JSON.parse(output);
       expect(parsed).to.have.property('found', false);
@@ -430,20 +430,20 @@ describe('Branch Commands E2E Tests', () => {
       expect(parsed.matches.length).to.equal(0);
     });
 
-    it('should be case-insensitive when searching', () => {
+    it('should be case-insensitive when searching', async () => {
       execSync('git checkout -b feat/test/CaseSensitive', { stdio: 'pipe' });
 
-      const output = exec('branch where casesensitive');
+      const output = await execInProcess('branch where casesensitive');
 
       expect(output).to.contain('CaseSensitive');
     });
 
-    it('should find matching branch in current worktree', () => {
+    it('should find matching branch in current worktree', async () => {
       // branch where searches worktrees, not all branches
       // Only the currently checked-out branch in the main worktree will be found
       execSync('git checkout -b fix/test/multi-three', { stdio: 'pipe' });
 
-      const output = exec('branch where multi --json');
+      const output = await execInProcess('branch where multi --json');
       const parsed = JSON.parse(output);
 
       expect(parsed.found).to.equal(true);

--- a/apps/cli/test/e2e/branch-json-mode.test.ts
+++ b/apps/cli/test/e2e/branch-json-mode.test.ts
@@ -9,7 +9,7 @@ import {
   cleanupTestEnvironment,
   createHQConfig,
   createPMODirectories,
-  execProduction,
+  execInProcess,
   filterOutput,
   findChoice as sharedFindChoice,
   execChoice as sharedExecChoice,
@@ -19,9 +19,9 @@ import {
 import { initializePMOTables } from '../../src/lib/pmo/storage/base.js';
 import { CREATE_TABLES_SQL } from '../../src/lib/database/index.js';
 
-// Local exec wrapper that uses execProduction with filtering
-const exec = (cmd: string): string => {
-  const output = execProduction(cmd);
+// Local exec wrapper that uses execInProcess with filtering
+const exec = async (cmd: string): Promise<string> => {
+  const output = await execInProcess(cmd);
   return filterOutput(output);
 };
 
@@ -107,8 +107,8 @@ describe('Branch Commands JSON Mode', () => {
   }
 
   describe('branch (main menu) --machine', () => {
-    it('should output valid JSON with prompt schema', () => {
-      const output = exec('branch --machine');
+    it('should output valid JSON with prompt schema', async () => {
+      const output = await exec('branch --machine');
       const json = extractJson<{
         prompt: { type: string; name: string; message: string; choices: Array<{ name: string; value: string }> };
         metadata: { command: string; flags: Record<string, unknown> };
@@ -122,16 +122,16 @@ describe('Branch Commands JSON Mode', () => {
       expect(json.metadata.flags.machine).to.equal(true);
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('branch -m');
+    it('should work with -m shorthand', async () => {
+      const output = await exec('branch -m');
       const json = extractJson<{ prompt: { type: string }; metadata: { flags: { machine: boolean } } }>(output);
 
       expect(json.prompt).to.exist;
       expect(json.metadata.flags.machine).to.equal(true);
     });
 
-    it('should include command field in all choices', () => {
-      const output = exec('branch --machine');
+    it('should include command field in all choices', async () => {
+      const output = await exec('branch --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ name: string; value: string; command?: string }> };
       }>(output);
@@ -144,8 +144,8 @@ describe('Branch Commands JSON Mode', () => {
       }
     });
 
-    it('should have all standard menu choices', () => {
-      const output = exec('branch --machine');
+    it('should have all standard menu choices', async () => {
+      const output = await exec('branch --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ name: string; value: string }> };
       }>(output);
@@ -159,8 +159,8 @@ describe('Branch Commands JSON Mode', () => {
   });
 
   describe('branch list --format json', () => {
-    it('should output valid JSON array with --format json flag', () => {
-      const output = exec('branch list --format json');
+    it('should output valid JSON array with --format json flag', async () => {
+      const output = await exec('branch list --format json');
       const json = extractJson<Array<{ name: string; current?: boolean }>>(output);
 
       expect(json).to.be.an('array');
@@ -170,8 +170,8 @@ describe('Branch Commands JSON Mode', () => {
       }
     });
 
-    it('should work with -f json shorthand', () => {
-      const output = exec('branch list -f json');
+    it('should work with -f json shorthand', async () => {
+      const output = await exec('branch list -f json');
       const json = extractJson<Array<{ name: string }>>(output);
 
       expect(json).to.be.an('array');
@@ -179,8 +179,8 @@ describe('Branch Commands JSON Mode', () => {
   });
 
   describe('branch create --machine', () => {
-    it('should output prompt JSON for mode selection', () => {
-      const output = exec('branch create --machine');
+    it('should output prompt JSON for mode selection', async () => {
+      const output = await exec('branch create --machine');
       const json = extractJson<{
         prompt: { type: string; name: string; message: string; choices: Array<{ name: string; value: string }> };
         metadata: { command: string; flags: Record<string, unknown> };
@@ -192,16 +192,16 @@ describe('Branch Commands JSON Mode', () => {
       expect(json.metadata.flags.machine).to.equal(true);
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('branch create -m');
+    it('should work with -m shorthand', async () => {
+      const output = await exec('branch create -m');
       const json = extractJson<{ prompt: { type: string }; metadata: { flags: { machine: boolean } } }>(output);
 
       expect(json.prompt).to.exist;
       expect(json.metadata.flags.machine).to.equal(true);
     });
 
-    it('should include command hints in choices', () => {
-      const output = exec('branch create --machine');
+    it('should include command hints in choices', async () => {
+      const output = await exec('branch create --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ name: string; command?: string }> };
       }>(output);
@@ -214,8 +214,8 @@ describe('Branch Commands JSON Mode', () => {
       }
     });
 
-    it('should create branch when type and description flags provided', () => {
-      const output = exec('branch create -t feat -d test-feature --force');
+    it('should create branch when type and description flags provided', async () => {
+      const output = await exec('branch create -t feat -d test-feature --force');
 
       // Should either succeed or fail with meaningful error
       expect(output).to.be.a('string');
@@ -228,24 +228,24 @@ describe('Branch Commands JSON Mode', () => {
   });
 
   describe('branch validate --machine', () => {
-    it('should validate current branch', () => {
-      const output = exec('branch validate');
+    it('should validate current branch', async () => {
+      const output = await exec('branch validate');
 
       // Should output validation result
       expect(output).to.be.a('string');
       expect(output.toLowerCase()).to.match(/valid|invalid|branch/);
     });
 
-    it('should validate provided branch name', () => {
-      const output = exec('branch validate feat/chris/add-auth');
+    it('should validate provided branch name', async () => {
+      const output = await exec('branch validate feat/chris/add-auth');
 
       // In non-TTY mode, output is JSON: { "branch": "...", "valid": true, "parts": { "type": "feat", ... } }
       expect(output).to.include('"valid"');
       expect(output).to.include('feat');
     });
 
-    it('should report invalid branch format', () => {
-      const output = exec('branch validate invalid-branch-name');
+    it('should report invalid branch format', async () => {
+      const output = await exec('branch validate invalid-branch-name');
 
       expect(output.toLowerCase()).to.include('invalid');
     });
@@ -271,8 +271,8 @@ describe('Branch Commands JSON Mode', () => {
     }
 
     // Local agentExec that uses the local exec function with extractJson
-    function agentExec(cmd: string): AgentPrompt {
-      const output = exec(cmd);
+    async function agentExec(cmd: string): Promise<AgentPrompt> {
+      const output = await exec(cmd);
       return extractJson<AgentPrompt>(output);
     }
 
@@ -280,9 +280,9 @@ describe('Branch Commands JSON Mode', () => {
     const execChoice = sharedExecChoice;
 
     describe('branch menu navigation', () => {
-      it('should navigate from branch menu to branch create', () => {
+      it('should navigate from branch menu to branch create', async () => {
         // Agent Step 1: Get main menu
-        const step1 = agentExec('branch --machine');
+        const step1 = await agentExec('branch --machine');
         expect(step1.prompt.type).to.equal('list');
 
         // Find create choice
@@ -291,14 +291,14 @@ describe('Branch Commands JSON Mode', () => {
         expect(createChoice!.command).to.include('branch create');
 
         // Agent Step 2: Navigate to create
-        const step2 = agentExec(execChoice(createChoice!));
+        const step2 = await agentExec(execChoice(createChoice!));
         expect(step2.prompt.type).to.equal('list');
         expect(step2.prompt.choices).to.be.an('array');
       });
 
-      it('should navigate from branch menu to branch list', () => {
+      it('should navigate from branch menu to branch list', async () => {
         // Agent Step 1: Get main menu
-        const step1 = agentExec('branch --machine');
+        const step1 = await agentExec('branch --machine');
         expect(step1.prompt.type).to.equal('list');
 
         // Find list choice
@@ -307,9 +307,9 @@ describe('Branch Commands JSON Mode', () => {
         expect(listChoice!.command).to.include('branch list');
       });
 
-      it('should navigate from branch menu to branch validate', () => {
+      it('should navigate from branch menu to branch validate', async () => {
         // Agent Step 1: Get main menu
-        const step1 = agentExec('branch --machine');
+        const step1 = await agentExec('branch --machine');
         expect(step1.prompt.type).to.equal('list');
 
         // Find validate choice
@@ -325,9 +325,9 @@ describe('Branch Commands JSON Mode', () => {
         createTestTicket('TKT-001', 'Test ticket for branch creation');
       });
 
-      it('should complete flow: select mode → create with flags', () => {
+      it('should complete flow: select mode → create with flags', async () => {
         // Agent Step 1: Get mode selection
-        const step1 = agentExec('branch create --machine');
+        const step1 = await agentExec('branch create --machine');
         expect(step1.prompt.type).to.equal('list');
         expect(step1.prompt.choices).to.be.an('array');
 
@@ -345,16 +345,16 @@ describe('Branch Commands JSON Mode', () => {
         }
       });
 
-      it('should complete flow with all flags provided directly (custom)', () => {
-        const result = exec('branch create -t feat -d agent-test-branch --force');
+      it('should complete flow with all flags provided directly (custom)', async () => {
+        const result = await exec('branch create -t feat -d agent-test-branch --force');
 
         // Should create branch or indicate it exists
         expect(result).to.be.a('string');
       });
 
-      it('should complete flow with ticket flag provided directly', () => {
+      it('should complete flow with ticket flag provided directly', async () => {
         // Use the test ticket
-        const result = exec('branch create -T TKT-001 --force');
+        const result = await exec('branch create -T TKT-001 --force');
 
         // Should attempt to create branch from ticket
         expect(result).to.be.a('string');
@@ -362,9 +362,9 @@ describe('Branch Commands JSON Mode', () => {
     });
 
     describe('branch list - agent data retrieval', () => {
-      it('should return all branches as JSON array for agent processing', () => {
+      it('should return all branches as JSON array for agent processing', async () => {
         // Use --format json since branch list uses that flag instead of --machine
-        const output = exec('branch list --format json');
+        const output = await exec('branch list --format json');
         const branches = extractJson<Array<{ name: string; current?: boolean }>>(output);
 
         expect(branches).to.be.an('array');
@@ -375,9 +375,9 @@ describe('Branch Commands JSON Mode', () => {
         }
       });
 
-      it('should identify current branch', () => {
+      it('should identify current branch', async () => {
         // Use --format json since branch list uses that flag instead of --machine
-        const output = exec('branch list --format json');
+        const output = await exec('branch list --format json');
         const branches = extractJson<Array<{ name: string; current?: boolean }>>(output);
 
         // At least one branch should be current
@@ -389,20 +389,20 @@ describe('Branch Commands JSON Mode', () => {
     });
 
     describe('backward compatibility: --json flag flows', () => {
-      it('should complete menu flow with --json flag (legacy)', () => {
-        const step1 = agentExec('branch --json');
+      it('should complete menu flow with --json flag (legacy)', async () => {
+        const step1 = await agentExec('branch --json');
         expect(step1.prompt.type).to.equal('list');
         expect(step1.prompt.choices).to.be.an('array');
       });
 
-      it('should complete create flow with --json flag (legacy)', () => {
-        const step1 = agentExec('branch create --json');
+      it('should complete create flow with --json flag (legacy)', async () => {
+        const step1 = await agentExec('branch create --json');
         expect(step1.prompt.type).to.equal('list');
         expect(step1.prompt.choices).to.be.an('array');
       });
 
-      it('should complete list flow with --format json (legacy)', () => {
-        const output = exec('branch list --format json');
+      it('should complete list flow with --format json (legacy)', async () => {
+        const output = await exec('branch list --format json');
         const branches = extractJson<Array<{ name: string }>>(output);
 
         expect(branches).to.be.an('array');
@@ -411,8 +411,8 @@ describe('Branch Commands JSON Mode', () => {
   });
 
   describe('Flag accumulation in choices', () => {
-    it('branch menu choices should have commands for navigation', () => {
-      const output = exec('branch --machine');
+    it('branch menu choices should have commands for navigation', async () => {
+      const output = await exec('branch --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ name: string; command?: string }> };
       }>(output);
@@ -426,8 +426,8 @@ describe('Branch Commands JSON Mode', () => {
       }
     });
 
-    it('branch create mode choices should include --json', () => {
-      const output = exec('branch create --machine');
+    it('branch create mode choices should include --json', async () => {
+      const output = await exec('branch create --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ command?: string }> };
       }>(output);
@@ -466,9 +466,9 @@ describe('Branch Commands - JSON Mode Compatibility', () => {
     cleanupTestEnvironment(env);
   });
 
-  it('--json and --machine should be interchangeable', () => {
-    const jsonOutput = exec('branch --json');
-    const machineOutput = exec('branch --machine');
+  it('--json and --machine should be interchangeable', async () => {
+    const jsonOutput = await exec('branch --json');
+    const machineOutput = await exec('branch --machine');
 
     const jsonResult = extractJson<{ prompt: { type: string; choices: Array<{ value: string }> } }>(jsonOutput);
     const machineResult = extractJson<{ prompt: { type: string; choices: Array<{ value: string }> } }>(machineOutput);
@@ -482,9 +482,9 @@ describe('Branch Commands - JSON Mode Compatibility', () => {
     expect(machineValues).to.deep.equal(jsonValues);
   });
 
-  it('branch create --json should match --machine', () => {
-    const jsonOutput = exec('branch create --json');
-    const machineOutput = exec('branch create --machine');
+  it('branch create --json should match --machine', async () => {
+    const jsonOutput = await exec('branch create --json');
+    const machineOutput = await exec('branch create --machine');
 
     const jsonResult = extractJson<{ prompt: { type: string; choices: Array<unknown> } }>(jsonOutput);
     const machineResult = extractJson<{ prompt: { type: string; choices: Array<unknown> } }>(machineOutput);

--- a/apps/cli/test/e2e/docker-commands.test.ts
+++ b/apps/cli/test/e2e/docker-commands.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import Database from 'better-sqlite3'
-import { execProduction as exec } from './test-helpers.js'
+import { execInProcess } from './test-helpers.js'
 
 /** Database row type for agent_work queries */
 interface AgentWorkRow {
@@ -74,24 +74,24 @@ describe('Docker Commands E2E Tests', () => {
    * Note: docker status doesn't need a workspace, just checks Docker daemon
    */
   describe('prlt docker status', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker status --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker status --help')
 
       expect(output).to.contain('Check if Docker daemon is running')
       expect(output).to.contain('USAGE')
     })
 
-    it('should report Docker status', () => {
-      const output = exec('docker status')
+    it('should report Docker status', async () => {
+      const output = await execInProcess('docker status')
 
       // docker status outputs JSON in non-TTY (piped) environments
       const hasStatus = output.includes('"running"') || output.includes('Docker Status')
       expect(hasStatus).to.be.true
     })
 
-    it('should indicate when Docker is not available', () => {
+    it('should indicate when Docker is not available', async () => {
       // In test environment, Docker is typically not running
-      const output = exec('docker status')
+      const output = await execInProcess('docker status')
 
       // If Docker isn't running, should show appropriate message
       if (output.includes('Not Running')) {
@@ -104,8 +104,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker list
    */
   describe('prlt docker list', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker list --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker list --help')
 
       expect(output).to.contain('Show Docker containers from agent_work table')
       expect(output).to.contain('--all')
@@ -113,22 +113,22 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --all flag without unknown flag error', () => {
-      const output = exec('docker list --all --help')
+    it('should accept --all flag without unknown flag error', async () => {
+      const output = await execInProcess('docker list --all --help')
 
       expect(output).to.not.contain('Unknown flag')
       expect(output).to.not.contain('Unexpected argument')
     })
 
-    it('should accept --running flag without unknown flag error', () => {
-      const output = exec('docker list --running --help')
+    it('should accept --running flag without unknown flag error', async () => {
+      const output = await execInProcess('docker list --running --help')
 
       expect(output).to.not.contain('Unknown flag')
       expect(output).to.not.contain('Unexpected argument')
     })
 
-    it('should handle missing workspace gracefully', () => {
-      const output = exec('docker list')
+    it('should handle missing workspace gracefully', async () => {
+      const output = await execInProcess('docker list')
 
       const validOutput =
         output.includes('Not in a workspace') ||
@@ -143,8 +143,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker clean
    */
   describe('prlt docker clean', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker clean --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker clean --help')
 
       expect(output).to.contain('Remove orphaned containers')
       expect(output).to.contain('--force')
@@ -153,34 +153,34 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --dry-run flag without unknown flag error', () => {
-      const output = exec('docker clean --dry-run --help')
+    it('should accept --dry-run flag without unknown flag error', async () => {
+      const output = await execInProcess('docker clean --dry-run --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --all flag without unknown flag error', () => {
-      const output = exec('docker clean --all --help')
+    it('should accept --all flag without unknown flag error', async () => {
+      const output = await execInProcess('docker clean --all --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --force flag without unknown flag error', () => {
-      const output = exec('docker clean --force --help')
+    it('should accept --force flag without unknown flag error', async () => {
+      const output = await execInProcess('docker clean --force --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should handle missing workspace gracefully', () => {
-      const output = exec('docker clean --force')
+    it('should handle missing workspace gracefully', async () => {
+      const output = await execInProcess('docker clean --force')
 
       expect(hasDockerOrWorkspaceError(output) ||
         output.includes('No orphaned containers') ||
         output.includes('Removed')).to.be.true
     })
 
-    it('should accept --machine flag for JSON mode support', () => {
-      const output = exec('docker clean --machine --help')
+    it('should accept --machine flag for JSON mode support', async () => {
+      const output = await execInProcess('docker clean --machine --help')
 
       expect(output).to.contain('--machine')
       expect(output).to.contain('JSON')
@@ -191,8 +191,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker logs
    */
   describe('prlt docker logs', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker logs --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker logs --help')
 
       expect(output).to.contain('View logs from a container')
       expect(output).to.contain('--follow')
@@ -200,20 +200,20 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --follow flag without unknown flag error', () => {
-      const output = exec('docker logs --follow --help')
+    it('should accept --follow flag without unknown flag error', async () => {
+      const output = await execInProcess('docker logs --follow --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --tail flag without unknown flag error', () => {
-      const output = exec('docker logs --tail 50 --help')
+    it('should accept --tail flag without unknown flag error', async () => {
+      const output = await execInProcess('docker logs --tail 50 --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should require a target argument', () => {
-      const output = exec('docker logs')
+    it('should require a target argument', async () => {
+      const output = await execInProcess('docker logs')
 
       const validOutput =
         output.includes('Missing required arg') ||
@@ -222,8 +222,8 @@ describe('Docker Commands E2E Tests', () => {
       expect(validOutput).to.be.true
     })
 
-    it('should accept execution ID format', () => {
-      const output = exec('docker logs WORK-001')
+    it('should accept execution ID format', async () => {
+      const output = await execInProcess('docker logs WORK-001')
 
       // Should process the command (may fail due to no Docker or no execution)
       expect(
@@ -238,8 +238,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker stop
    */
   describe('prlt docker stop', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker stop --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker stop --help')
 
       expect(output).to.contain('Stop a running container')
       expect(output).to.contain('--force')
@@ -247,20 +247,20 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --force flag without unknown flag error', () => {
-      const output = exec('docker stop --force --help')
+    it('should accept --force flag without unknown flag error', async () => {
+      const output = await execInProcess('docker stop --force --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --time flag without unknown flag error', () => {
-      const output = exec('docker stop --time 30 --help')
+    it('should accept --time flag without unknown flag error', async () => {
+      const output = await execInProcess('docker stop --time 30 --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should require a target argument', () => {
-      const output = exec('docker stop')
+    it('should require a target argument', async () => {
+      const output = await execInProcess('docker stop')
 
       const validOutput =
         output.includes('Missing required arg') ||
@@ -269,8 +269,8 @@ describe('Docker Commands E2E Tests', () => {
       expect(validOutput).to.be.true
     })
 
-    it('should accept --machine flag for JSON mode support', () => {
-      const output = exec('docker stop --machine --help')
+    it('should accept --machine flag for JSON mode support', async () => {
+      const output = await execInProcess('docker stop --machine --help')
 
       expect(output).to.contain('--machine')
       expect(output).to.contain('JSON')
@@ -281,8 +281,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker shell
    */
   describe('prlt docker shell', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker shell --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker shell --help')
 
       expect(output).to.contain('Open a shell in a running container')
       expect(output).to.contain('--shell')
@@ -290,20 +290,20 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --shell flag without unknown flag error', () => {
-      const output = exec('docker shell --shell /bin/bash --help')
+    it('should accept --shell flag without unknown flag error', async () => {
+      const output = await execInProcess('docker shell --shell /bin/bash --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --user flag without unknown flag error', () => {
-      const output = exec('docker shell --user root --help')
+    it('should accept --user flag without unknown flag error', async () => {
+      const output = await execInProcess('docker shell --user root --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should require a target argument', () => {
-      const output = exec('docker shell')
+    it('should require a target argument', async () => {
+      const output = await execInProcess('docker shell')
 
       const validOutput =
         output.includes('Missing required arg') ||
@@ -317,8 +317,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker restart
    */
   describe('prlt docker restart', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker restart --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker restart --help')
 
       expect(output).to.contain('Restart a container')
       expect(output).to.contain('--force')
@@ -326,14 +326,14 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --force flag without unknown flag error', () => {
-      const output = exec('docker restart --force --help')
+    it('should accept --force flag without unknown flag error', async () => {
+      const output = await execInProcess('docker restart --force --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should require a target argument', () => {
-      const output = exec('docker restart')
+    it('should require a target argument', async () => {
+      const output = await execInProcess('docker restart')
 
       const validOutput =
         output.includes('Missing required arg') ||
@@ -342,8 +342,8 @@ describe('Docker Commands E2E Tests', () => {
       expect(validOutput).to.be.true
     })
 
-    it('should accept --machine flag for JSON mode support', () => {
-      const output = exec('docker restart --machine --help')
+    it('should accept --machine flag for JSON mode support', async () => {
+      const output = await execInProcess('docker restart --machine --help')
 
       expect(output).to.contain('--machine')
       expect(output).to.contain('JSON')
@@ -354,15 +354,15 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker start
    */
   describe('prlt docker start', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker start --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker start --help')
 
       expect(output).to.contain('Start a stopped container')
       expect(output).to.contain('USAGE')
     })
 
-    it('should require a target argument', () => {
-      const output = exec('docker start')
+    it('should require a target argument', async () => {
+      const output = await execInProcess('docker start')
 
       const validOutput =
         output.includes('Missing required arg') ||
@@ -371,8 +371,8 @@ describe('Docker Commands E2E Tests', () => {
       expect(validOutput).to.be.true
     })
 
-    it('should accept execution ID format', () => {
-      const output = exec('docker start WORK-001')
+    it('should accept execution ID format', async () => {
+      const output = await execInProcess('docker start WORK-001')
 
       expect(
         hasDockerOrWorkspaceError(output) ||
@@ -389,15 +389,15 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker sync
    */
   describe('prlt docker sync', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker sync --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker sync --help')
 
       expect(output).to.contain('Sync container status from Docker into the database')
       expect(output).to.contain('USAGE')
     })
 
-    it('should handle missing workspace gracefully', () => {
-      const output = exec('docker sync')
+    it('should handle missing workspace gracefully', async () => {
+      const output = await execInProcess('docker sync')
 
       expect(
         hasDockerOrWorkspaceError(output) ||
@@ -411,8 +411,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker prune
    */
   describe('prlt docker prune', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker prune --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker prune --help')
 
       expect(output).to.contain('Remove unused Docker resources')
       expect(output).to.contain('--force')
@@ -422,26 +422,26 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('USAGE')
     })
 
-    it('should accept --dry-run flag without unknown flag error', () => {
-      const output = exec('docker prune --dry-run --help')
+    it('should accept --dry-run flag without unknown flag error', async () => {
+      const output = await execInProcess('docker prune --dry-run --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --all flag without unknown flag error', () => {
-      const output = exec('docker prune --all --help')
+    it('should accept --all flag without unknown flag error', async () => {
+      const output = await execInProcess('docker prune --all --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should accept --volumes flag without unknown flag error', () => {
-      const output = exec('docker prune --volumes --help')
+    it('should accept --volumes flag without unknown flag error', async () => {
+      const output = await execInProcess('docker prune --volumes --help')
 
       expect(output).to.not.contain('Unknown flag')
     })
 
-    it('should handle Docker not running gracefully', () => {
-      const output = exec('docker prune --force')
+    it('should handle Docker not running gracefully', async () => {
+      const output = await execInProcess('docker prune --force')
 
       expect(
         hasDockerOrWorkspaceError(output) ||
@@ -450,8 +450,8 @@ describe('Docker Commands E2E Tests', () => {
       ).to.be.true
     })
 
-    it('should accept --machine flag for JSON mode support', () => {
-      const output = exec('docker prune --machine --help')
+    it('should accept --machine flag for JSON mode support', async () => {
+      const output = await execInProcess('docker prune --machine --help')
 
       expect(output).to.contain('--machine')
       expect(output).to.contain('JSON')
@@ -462,8 +462,8 @@ describe('Docker Commands E2E Tests', () => {
    * prlt docker (main menu)
    */
   describe('prlt docker', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('docker --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('docker --help')
 
       expect(output).to.contain('Manage Docker containers')
       expect(output).to.contain('clean')
@@ -471,8 +471,8 @@ describe('Docker Commands E2E Tests', () => {
       expect(output).to.contain('COMMANDS')
     })
 
-    it('should list available subcommands in examples', () => {
-      const output = exec('docker --help')
+    it('should list available subcommands in examples', async () => {
+      const output = await execInProcess('docker --help')
 
       expect(output).to.contain('prlt docker status')
       expect(output).to.contain('prlt docker list')
@@ -510,8 +510,8 @@ describe('Docker Commands E2E Tests', () => {
       }
     }
 
-    it('prlt docker --json should output action menu as JSON', () => {
-      const output = exec('docker --json')
+    it('prlt docker --json should output action menu as JSON', async () => {
+      const output = await execInProcess('docker --json')
       const json = tryParsePromptJson(output)
 
       if (!json) {
@@ -536,8 +536,8 @@ describe('Docker Commands E2E Tests', () => {
       expect(json.metadata.command).to.equal('docker')
     })
 
-    it('prlt docker clean --json should output confirm prompt or error', () => {
-      const output = exec('docker clean --json')
+    it('prlt docker clean --json should output confirm prompt or error', async () => {
+      const output = await execInProcess('docker clean --json')
       const json = tryParsePromptJson(output)
 
       if (json) {
@@ -552,8 +552,8 @@ describe('Docker Commands E2E Tests', () => {
       }
     })
 
-    it('prlt docker prune --json should output confirm prompt or error', () => {
-      const output = exec('docker prune --json')
+    it('prlt docker prune --json should output confirm prompt or error', async () => {
+      const output = await execInProcess('docker prune --json')
       const json = tryParsePromptJson(output)
 
       if (json) {
@@ -567,8 +567,8 @@ describe('Docker Commands E2E Tests', () => {
       }
     })
 
-    it('prlt docker stop <target> --json should output confirm prompt or error', () => {
-      const output = exec('docker stop test-container --json')
+    it('prlt docker stop <target> --json should output confirm prompt or error', async () => {
+      const output = await execInProcess('docker stop test-container --json')
       const json = tryParsePromptJson(output)
 
       if (json) {
@@ -582,8 +582,8 @@ describe('Docker Commands E2E Tests', () => {
       }
     })
 
-    it('prlt docker restart <target> --json should output confirm prompt or error', () => {
-      const output = exec('docker restart test-container --json')
+    it('prlt docker restart <target> --json should output confirm prompt or error', async () => {
+      const output = await execInProcess('docker restart test-container --json')
       const json = tryParsePromptJson(output)
 
       if (json) {
@@ -597,8 +597,8 @@ describe('Docker Commands E2E Tests', () => {
       }
     })
 
-    it('--force flag should skip confirmation prompt in JSON mode', () => {
-      const output = exec('docker clean --force --json')
+    it('--force flag should skip confirmation prompt in JSON mode', async () => {
+      const output = await execInProcess('docker clean --force --json')
 
       // Should NOT have a prompt JSON when --force is used
       const jsonMatch = output.match(/\{"prompt"/)
@@ -742,8 +742,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   /**
    * Execute command and parse JSON response. Returns null if Docker/workspace error.
    */
-  function agentExec(cmd: string): AgentPrompt | null {
-    const output = exec(cmd)
+  async function agentExec(cmd: string): Promise<AgentPrompt | null> {
+    const output = await execInProcess(cmd)
     if (hasDockerOrWorkspaceError(output)) {
       return null
     }
@@ -786,8 +786,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker index menu - prompt schema', () => {
-    it('should output a list prompt with name "action"', () => {
-      const result = agentExec('docker --machine')
+    it('should output a list prompt with name "action"', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -796,8 +796,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.prompt.message).to.include('What would you like to do')
     })
 
-    it('should include metadata with command and flags', () => {
-      const result = agentExec('docker --machine')
+    it('should include metadata with command and flags', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -807,8 +807,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.flags.machine).to.equal(true)
     })
 
-    it('should have 11 menu choices', () => {
-      const result = agentExec('docker --machine')
+    it('should have 11 menu choices', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -822,8 +822,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker index menu - individual choices', () => {
-    it('should have "Check Docker status" choice with correct command', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Check Docker status" choice with correct command', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -833,8 +833,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.equal('prlt docker status --json')
     })
 
-    it('should have "List containers" choice with correct command', () => {
-      const result = agentExec('docker --machine')
+    it('should have "List containers" choice with correct command', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -844,8 +844,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.equal('prlt docker list --json')
     })
 
-    it('should have "View container logs" choice with target placeholder', () => {
-      const result = agentExec('docker --machine')
+    it('should have "View container logs" choice with target placeholder', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -856,8 +856,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.include('<target>')
     })
 
-    it('should have "Start a container" choice with target placeholder', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Start a container" choice with target placeholder', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -868,8 +868,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.include('<target>')
     })
 
-    it('should have "Stop a container" choice with target placeholder', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Stop a container" choice with target placeholder', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -880,8 +880,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.include('<target>')
     })
 
-    it('should have "Shell into container" choice with target placeholder', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Shell into container" choice with target placeholder', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -892,8 +892,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.include('<target>')
     })
 
-    it('should have "Restart a container" choice with target placeholder', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Restart a container" choice with target placeholder', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -904,8 +904,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.include('<target>')
     })
 
-    it('should have "Sync containers" choice with correct command', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Sync containers" choice with correct command', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -915,8 +915,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.equal('prlt docker sync --json')
     })
 
-    it('should have "Clean orphaned containers" choice with correct command', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Clean orphaned containers" choice with correct command', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -926,8 +926,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.equal('prlt docker clean --json')
     })
 
-    it('should have "Prune unused resources" choice with correct command', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Prune unused resources" choice with correct command', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -937,8 +937,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(choice!.command).to.equal('prlt docker prune --json')
     })
 
-    it('should have "Exit" choice', () => {
-      const result = agentExec('docker --machine')
+    it('should have "Exit" choice', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -953,8 +953,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker index menu - flag accumulation', () => {
-    it('should include --json in all non-exit choice commands', () => {
-      const result = agentExec('docker --machine')
+    it('should include --json in all non-exit choice commands', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -965,8 +965,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should include <target> in commands requiring a container target', () => {
-      const result = agentExec('docker --machine')
+    it('should include <target> in commands requiring a container target', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -978,8 +978,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should NOT include <target> in commands that do not require one', () => {
-      const result = agentExec('docker --machine')
+    it('should NOT include <target> in commands that do not require one', async () => {
+      const result = await agentExec('docker --machine')
 
       if (!result) return
 
@@ -997,8 +997,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker stop - confirmation flow', () => {
-    it('should output confirmation prompt with --machine flag', () => {
-      const result = agentExec('docker stop test-container --machine')
+    it('should output confirmation prompt with --machine flag', async () => {
+      const result = await agentExec('docker stop test-container --machine')
 
       // Skip if Docker not running
       if (!result) return
@@ -1009,8 +1009,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.command).to.equal('docker stop')
     })
 
-    it('should have Yes and No choices', () => {
-      const result = agentExec('docker stop test-container --machine')
+    it('should have Yes and No choices', async () => {
+      const result = await agentExec('docker stop test-container --machine')
 
       if (!result) return
 
@@ -1023,8 +1023,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(noChoice).to.exist
     })
 
-    it('should include --force flag in Yes choice command', () => {
-      const result = agentExec('docker stop test-container --machine')
+    it('should include --force flag in Yes choice command', async () => {
+      const result = await agentExec('docker stop test-container --machine')
 
       if (!result) return
 
@@ -1038,8 +1038,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should include target in Yes choice command', () => {
-      const result = agentExec('docker stop my-container --machine')
+    it('should include target in Yes choice command', async () => {
+      const result = await agentExec('docker stop my-container --machine')
 
       if (!result) return
 
@@ -1050,8 +1050,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should skip confirmation with --force flag', () => {
-      const output = exec('docker stop test-container --force')
+    it('should skip confirmation with --force flag', async () => {
+      const output = await execInProcess('docker stop test-container --force')
 
       // With --force, should NOT output a prompt - goes straight to action
       // (will fail because container doesn't exist, but no prompt was shown)
@@ -1061,8 +1061,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should work with -m shorthand', () => {
-      const result = agentExec('docker stop test-container -m')
+    it('should work with -m shorthand', async () => {
+      const result = await agentExec('docker stop test-container -m')
 
       if (!result) return
 
@@ -1077,8 +1077,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker restart - confirmation flow', () => {
-    it('should output confirmation prompt with --machine flag', () => {
-      const result = agentExec('docker restart test-container --machine')
+    it('should output confirmation prompt with --machine flag', async () => {
+      const result = await agentExec('docker restart test-container --machine')
 
       if (!result) return
 
@@ -1088,8 +1088,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.command).to.equal('docker restart')
     })
 
-    it('should have Yes and No choices', () => {
-      const result = agentExec('docker restart test-container --machine')
+    it('should have Yes and No choices', async () => {
+      const result = await agentExec('docker restart test-container --machine')
 
       if (!result) return
 
@@ -1101,8 +1101,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(noChoice).to.exist
     })
 
-    it('should include --force flag in Yes choice command', () => {
-      const result = agentExec('docker restart test-container --machine')
+    it('should include --force flag in Yes choice command', async () => {
+      const result = await agentExec('docker restart test-container --machine')
 
       if (!result) return
 
@@ -1115,8 +1115,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should include target in Yes choice command', () => {
-      const result = agentExec('docker restart my-container --machine')
+    it('should include target in Yes choice command', async () => {
+      const result = await agentExec('docker restart my-container --machine')
 
       if (!result) return
 
@@ -1127,8 +1127,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should skip confirmation with --force flag', () => {
-      const output = exec('docker restart test-container --force')
+    it('should skip confirmation with --force flag', async () => {
+      const output = await execInProcess('docker restart test-container --force')
 
       const hasPrompt = output.includes('"prompt"')
       if (!hasDockerOrWorkspaceError(output)) {
@@ -1136,8 +1136,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should work with -m shorthand', () => {
-      const result = agentExec('docker restart test-container -m')
+    it('should work with -m shorthand', async () => {
+      const result = await agentExec('docker restart test-container -m')
 
       if (!result) return
 
@@ -1151,8 +1151,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker clean - confirmation flow', () => {
-    it('should output confirmation prompt with --machine flag', () => {
-      const result = agentExec('docker clean --machine')
+    it('should output confirmation prompt with --machine flag', async () => {
+      const result = await agentExec('docker clean --machine')
 
       if (!result) return
 
@@ -1162,8 +1162,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.command).to.equal('docker clean')
     })
 
-    it('should have Yes and No choices', () => {
-      const result = agentExec('docker clean --machine')
+    it('should have Yes and No choices', async () => {
+      const result = await agentExec('docker clean --machine')
 
       if (!result) return
 
@@ -1173,8 +1173,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(noChoice).to.exist
     })
 
-    it('should include command in Yes choice for flag accumulation', () => {
-      const result = agentExec('docker clean --machine')
+    it('should include command in Yes choice for flag accumulation', async () => {
+      const result = await agentExec('docker clean --machine')
 
       if (!result) return
 
@@ -1186,8 +1186,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should skip confirmation with --force flag', () => {
-      const output = exec('docker clean --force')
+    it('should skip confirmation with --force flag', async () => {
+      const output = await execInProcess('docker clean --force')
 
       const hasPrompt = output.includes('"prompt"')
       if (!hasDockerOrWorkspaceError(output) && !output.includes('No orphaned containers')) {
@@ -1195,8 +1195,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should accept --dry-run to show preview without removing', () => {
-      const output = exec('docker clean --dry-run')
+    it('should accept --dry-run to show preview without removing', async () => {
+      const output = await execInProcess('docker clean --dry-run')
 
       // --dry-run should not ask for confirmation, it just shows preview
       if (!hasDockerOrWorkspaceError(output)) {
@@ -1208,8 +1208,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should work with -m shorthand', () => {
-      const result = agentExec('docker clean -m')
+    it('should work with -m shorthand', async () => {
+      const result = await agentExec('docker clean -m')
 
       if (!result) return
 
@@ -1223,8 +1223,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('docker prune - confirmation flow', () => {
-    it('should output confirmation prompt with --machine flag', () => {
-      const result = agentExec('docker prune --machine')
+    it('should output confirmation prompt with --machine flag', async () => {
+      const result = await agentExec('docker prune --machine')
 
       if (!result) return
 
@@ -1234,8 +1234,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.command).to.equal('docker prune')
     })
 
-    it('should have Yes and No choices', () => {
-      const result = agentExec('docker prune --machine')
+    it('should have Yes and No choices', async () => {
+      const result = await agentExec('docker prune --machine')
 
       if (!result) return
 
@@ -1245,8 +1245,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(noChoice).to.exist
     })
 
-    it('should include command in Yes choice for flag accumulation', () => {
-      const result = agentExec('docker prune --machine')
+    it('should include command in Yes choice for flag accumulation', async () => {
+      const result = await agentExec('docker prune --machine')
 
       if (!result) return
 
@@ -1258,8 +1258,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should include volumes warning in confirmation message with --volumes', () => {
-      const result = agentExec('docker prune --volumes --machine')
+    it('should include volumes warning in confirmation message with --volumes', async () => {
+      const result = await agentExec('docker prune --volumes --machine')
 
       if (!result) return
 
@@ -1267,8 +1267,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.prompt.message.toLowerCase()).to.include('volume')
     })
 
-    it('should skip confirmation with --force flag', () => {
-      const output = exec('docker prune --force')
+    it('should skip confirmation with --force flag', async () => {
+      const output = await execInProcess('docker prune --force')
 
       const hasPrompt = output.includes('"prompt"')
       if (!hasDockerOrWorkspaceError(output)) {
@@ -1276,16 +1276,16 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('should accept --dry-run to show preview without pruning', () => {
-      const output = exec('docker prune --dry-run')
+    it('should accept --dry-run to show preview without pruning', async () => {
+      const output = await execInProcess('docker prune --dry-run')
 
       if (!hasDockerOrWorkspaceError(output)) {
         expect(output.includes('DRY RUN') || output.includes('preview')).to.be.true
       }
     })
 
-    it('should work with -m shorthand', () => {
-      const result = agentExec('docker prune -m')
+    it('should work with -m shorthand', async () => {
+      const result = await agentExec('docker prune -m')
 
       if (!result) return
 
@@ -1299,9 +1299,9 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('full agent navigation flows', () => {
-    it('should navigate: main menu → select clean → get confirmation prompt', () => {
+    it('should navigate: main menu → select clean → get confirmation prompt', async () => {
       // Step 1: Get main menu
-      const step1 = agentExec('docker --machine')
+      const step1 = await agentExec('docker --machine')
 
       if (!step1) return
 
@@ -1312,7 +1312,7 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(cleanChoice!.command).to.include('--json')
 
       // Step 3: Execute the clean command from the choice
-      const step2 = agentExec(execChoice(cleanChoice!))
+      const step2 = await agentExec(execChoice(cleanChoice!))
 
       // If Docker not running, step2 will be null (graceful skip)
       if (!step2) return
@@ -1323,8 +1323,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(step2.prompt.choices.length).to.equal(2)
     })
 
-    it('should navigate: main menu → select prune → get confirmation prompt', () => {
-      const step1 = agentExec('docker --machine')
+    it('should navigate: main menu → select prune → get confirmation prompt', async () => {
+      const step1 = await agentExec('docker --machine')
 
       if (!step1) return
 
@@ -1333,7 +1333,7 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(pruneChoice!.command).to.include('docker prune')
       expect(pruneChoice!.command).to.include('--json')
 
-      const step2 = agentExec(execChoice(pruneChoice!))
+      const step2 = await agentExec(execChoice(pruneChoice!))
 
       if (!step2) return
 
@@ -1341,8 +1341,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(step2.prompt.name).to.equal('confirmed')
     })
 
-    it('should navigate: main menu → select status → direct execution (no prompt)', () => {
-      const step1 = agentExec('docker --machine')
+    it('should navigate: main menu → select status → direct execution (no prompt)', async () => {
+      const step1 = await agentExec('docker --machine')
 
       if (!step1) return
 
@@ -1352,13 +1352,13 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
 
       // Status command executes directly - no confirmation prompt
       // It returns JSON status output (the choice command includes --json)
-      const output = exec(execChoice(statusChoice!))
+      const output = await execInProcess(execChoice(statusChoice!))
       const json = JSON.parse(output)
       expect(json).to.have.property('running')
     })
 
-    it('should navigate: main menu → select list → direct execution (no prompt)', () => {
-      const step1 = agentExec('docker --machine')
+    it('should navigate: main menu → select list → direct execution (no prompt)', async () => {
+      const step1 = await agentExec('docker --machine')
 
       if (!step1) return
 
@@ -1367,8 +1367,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(listChoice!.command).to.equal('prlt docker list --json')
     })
 
-    it('should navigate: main menu → select sync → direct execution (no prompt)', () => {
-      const step1 = agentExec('docker --machine')
+    it('should navigate: main menu → select sync → direct execution (no prompt)', async () => {
+      const step1 = await agentExec('docker --machine')
 
       if (!step1) return
 
@@ -1383,9 +1383,9 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
   // ===========================================================================
 
   describe('--machine vs --json vs -m equivalence', () => {
-    it('--machine and --json should produce equivalent output structure', () => {
-      const machineOutput = exec('docker --machine')
-      const jsonOutput = exec('docker --json')
+    it('--machine and --json should produce equivalent output structure', async () => {
+      const machineOutput = await execInProcess('docker --machine')
+      const jsonOutput = await execInProcess('docker --json')
 
       const machineResult = extractJson<AgentPrompt>(machineOutput)
       const jsonResult = extractJson<AgentPrompt>(jsonOutput)
@@ -1398,9 +1398,9 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       }
     })
 
-    it('--machine and --json should have same choice values', () => {
-      const machineResult = agentExec('docker --machine')
-      const jsonResult = agentExec('docker --json')
+    it('--machine and --json should have same choice values', async () => {
+      const machineResult = await agentExec('docker --machine')
+      const jsonResult = await agentExec('docker --json')
 
       if (!machineResult || !jsonResult) return
 
@@ -1409,8 +1409,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(machineValues).to.deep.equal(jsonValues)
     })
 
-    it('-m shorthand should work for docker index', () => {
-      const result = agentExec('docker -m')
+    it('-m shorthand should work for docker index', async () => {
+      const result = await agentExec('docker -m')
 
       if (!result) return
 
@@ -1420,8 +1420,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.flags.machine).to.equal(true)
     })
 
-    it('-m shorthand should work for docker stop (Docker-dependent)', () => {
-      const result = agentExec('docker stop test-container -m')
+    it('-m shorthand should work for docker stop (Docker-dependent)', async () => {
+      const result = await agentExec('docker stop test-container -m')
 
       if (!result) return
 
@@ -1430,8 +1430,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.flags.machine).to.equal(true)
     })
 
-    it('-m shorthand should work for docker clean (Docker-dependent)', () => {
-      const result = agentExec('docker clean -m')
+    it('-m shorthand should work for docker clean (Docker-dependent)', async () => {
+      const result = await agentExec('docker clean -m')
 
       if (!result) return
 
@@ -1440,8 +1440,8 @@ describe('Docker Agent Flow E2E Tests (--machine flag)', () => {
       expect(result.metadata.flags.machine).to.equal(true)
     })
 
-    it('-m shorthand should work for docker prune (Docker-dependent)', () => {
-      const result = agentExec('docker prune -m')
+    it('-m shorthand should work for docker prune (Docker-dependent)', async () => {
+      const result = await agentExec('docker prune -m')
 
       if (!result) return
 

--- a/apps/cli/test/e2e/execution-commands.test.ts
+++ b/apps/cli/test/e2e/execution-commands.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import Database from 'better-sqlite3';
 import {
-  exec,
+  execInProcess,
   extractJson,
   findChoice,
   findChoiceByValue,
@@ -79,8 +79,8 @@ describe('Execution Commands E2E Tests', () => {
   // ===========================================================================
   describe('prlt execution (main menu)', () => {
     describe('--json mode', () => {
-      it('should output JSON prompt schema with all menu choices', () => {
-        const output = exec('execution --json');
+      it('should output JSON prompt schema with all menu choices', async () => {
+        const output = await execInProcess('execution --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -91,8 +91,8 @@ describe('Execution Commands E2E Tests', () => {
         expect(json!.prompt.choices.length).to.be.greaterThanOrEqual(4);
       });
 
-      it('should include command field in each choice for agent navigation', () => {
-        const output = exec('execution --json');
+      it('should include command field in each choice for agent navigation', async () => {
+        const output = await execInProcess('execution --json');
         const json = extractJson<AgentPromptResponse>(output);
         const choices = json!.prompt.choices;
 
@@ -116,8 +116,8 @@ describe('Execution Commands E2E Tests', () => {
         expect(cancelChoice).to.exist;
       });
 
-      it('should include metadata with command name', () => {
-        const output = exec('execution --json');
+      it('should include metadata with command name', async () => {
+        const output = await execInProcess('execution --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json!.metadata).to.exist;
@@ -126,8 +126,8 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--machine mode', () => {
-      it('should output identical prompt schema as --json', () => {
-        const output = exec('execution --machine');
+      it('should output identical prompt schema as --json', async () => {
+        const output = await execInProcess('execution --machine');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -137,8 +137,8 @@ describe('Execution Commands E2E Tests', () => {
         expect(json!.prompt.choices.length).to.be.greaterThanOrEqual(4);
       });
 
-      it('should include command fields in choices with --machine', () => {
-        const output = exec('execution --machine');
+      it('should include command fields in choices with --machine', async () => {
+        const output = await execInProcess('execution --machine');
         const json = extractJson<AgentPromptResponse>(output);
 
         const listChoice = findChoiceByValue(json!.prompt.choices, 'list');
@@ -150,11 +150,11 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('full agent workflow', () => {
-      it('should navigate menu → list → verify output with all key fields', () => {
+      it('should navigate menu → list → verify output with all key fields', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running', { environment: 'host' });
 
         // Step 1: Get the main menu prompt
-        const menuOutput = exec('execution --json');
+        const menuOutput = await execInProcess('execution --json');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         expect(menu).to.not.be.null;
 
@@ -174,19 +174,19 @@ describe('Execution Commands E2E Tests', () => {
         expect(listOutput).to.contain('host');
       });
 
-      it('should navigate menu → logs → select execution → verify logs', () => {
+      it('should navigate menu → logs → select execution → verify logs', async () => {
         const logPath = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         fs.writeFileSync(logPath, 'Build started\nCompilation complete\nTests passed\n');
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath });
 
         // Step 1: Get menu, find logs choice
-        const menuOutput = exec('execution --json');
+        const menuOutput = await execInProcess('execution --json');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         const logsChoice = findChoiceByValue(menu!.prompt.choices, 'logs');
         expect(logsChoice).to.exist;
 
         // Step 2: Execute logs command (which prompts for execution selection in JSON mode)
-        const logsPromptOutput = exec(execChoice(logsChoice!));
+        const logsPromptOutput = await execInProcess(execChoice(logsChoice!));
         const logsPrompt = extractJson<AgentPromptResponse>(logsPromptOutput);
         expect(logsPrompt).to.not.be.null;
         expect(logsPrompt!.prompt.name).to.equal('selectedId');
@@ -202,17 +202,17 @@ describe('Execution Commands E2E Tests', () => {
         expect(logsOutput).to.contain('Tests passed');
       });
 
-      it('should navigate menu → stop → select execution → verify stopped', () => {
+      it('should navigate menu → stop → select execution → verify stopped', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
         // Step 1: Get menu, find stop choice
-        const menuOutput = exec('execution --json');
+        const menuOutput = await execInProcess('execution --json');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         const stopMenuChoice = findChoiceByValue(menu!.prompt.choices, 'stop');
         expect(stopMenuChoice).to.exist;
 
         // Step 2: Execute stop command (prompts for execution selection)
-        const stopPromptOutput = exec(execChoice(stopMenuChoice!));
+        const stopPromptOutput = await execInProcess(execChoice(stopMenuChoice!));
         const stopPrompt = extractJson<AgentPromptResponse>(stopPromptOutput);
         expect(stopPrompt).to.not.be.null;
         expect(stopPrompt!.prompt.name).to.equal('selectedId');
@@ -228,12 +228,12 @@ describe('Execution Commands E2E Tests', () => {
         expect(row.status).to.equal('stopped');
       });
 
-      it('should navigate menu → stop-all → verify all stopped', () => {
+      it('should navigate menu → stop-all → verify all stopped', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
         // Step 1: Get menu, find stop-all choice
-        const menuOutput = exec('execution --json');
+        const menuOutput = await execInProcess('execution --json');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         const stopAllChoice = findChoiceByValue(menu!.prompt.choices, 'stop-all');
         expect(stopAllChoice).to.exist;
@@ -249,11 +249,11 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('full agent workflow with --machine', () => {
-      it('should navigate menu → list → verify output with all key fields using --machine', () => {
+      it('should navigate menu → list → verify output with all key fields using --machine', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running', { environment: 'host' });
 
         // Step 1: Get the main menu prompt via --machine
-        const menuOutput = exec('execution --machine');
+        const menuOutput = await execInProcess('execution --machine');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         expect(menu).to.not.be.null;
 
@@ -273,19 +273,19 @@ describe('Execution Commands E2E Tests', () => {
         expect(listOutput).to.contain('host');
       });
 
-      it('should navigate menu → logs → select execution → verify logs using --machine', () => {
+      it('should navigate menu → logs → select execution → verify logs using --machine', async () => {
         const logPath = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         fs.writeFileSync(logPath, 'Machine mode log output\n');
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath });
 
         // Step 1: Get menu via --machine, find logs choice
-        const menuOutput = exec('execution --machine');
+        const menuOutput = await execInProcess('execution --machine');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         const logsChoice = findChoiceByValue(menu!.prompt.choices, 'logs');
         expect(logsChoice).to.exist;
 
         // Step 2: Execute logs command (prompts for execution selection)
-        const logsPromptOutput = exec(execChoice(logsChoice!));
+        const logsPromptOutput = await execInProcess(execChoice(logsChoice!));
         const logsPrompt = extractJson<AgentPromptResponse>(logsPromptOutput);
         expect(logsPrompt).to.not.be.null;
         expect(logsPrompt!.prompt.name).to.equal('selectedId');
@@ -299,17 +299,17 @@ describe('Execution Commands E2E Tests', () => {
         expect(logsOutput).to.contain('Machine mode log output');
       });
 
-      it('should navigate menu → stop → select execution → verify stopped using --machine', () => {
+      it('should navigate menu → stop → select execution → verify stopped using --machine', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
         // Step 1: Get menu via --machine, find stop choice
-        const menuOutput = exec('execution --machine');
+        const menuOutput = await execInProcess('execution --machine');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         const stopMenuChoice = findChoiceByValue(menu!.prompt.choices, 'stop');
         expect(stopMenuChoice).to.exist;
 
         // Step 2: Execute stop command (prompts for execution selection)
-        const stopPromptOutput = exec(execChoice(stopMenuChoice!));
+        const stopPromptOutput = await execInProcess(execChoice(stopMenuChoice!));
         const stopPrompt = extractJson<AgentPromptResponse>(stopPromptOutput);
         expect(stopPrompt).to.not.be.null;
         expect(stopPrompt!.prompt.name).to.equal('selectedId');
@@ -325,12 +325,12 @@ describe('Execution Commands E2E Tests', () => {
         expect(row.status).to.equal('stopped');
       });
 
-      it('should navigate menu → stop-all → verify all stopped using --machine', () => {
+      it('should navigate menu → stop-all → verify all stopped using --machine', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
         // Step 1: Get menu via --machine, find stop-all choice
-        const menuOutput = exec('execution --machine');
+        const menuOutput = await execInProcess('execution --machine');
         const menu = extractJson<AgentPromptResponse>(menuOutput);
         const stopAllChoice = findChoiceByValue(menu!.prompt.choices, 'stop-all');
         expect(stopAllChoice).to.exist;
@@ -350,10 +350,10 @@ describe('Execution Commands E2E Tests', () => {
   // execution list
   // ===========================================================================
   describe('prlt execution list', () => {
-    it('should list executions with all key data columns', () => {
+    it('should list executions with all key data columns', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running', { environment: 'host', display_mode: 'terminal' });
 
-      const output = exec('execution list');
+      const output = await execInProcess('execution list');
 
       expect(output).to.contain('WORK-001');
       expect(output).to.contain('TKT-001');
@@ -362,12 +362,12 @@ describe('Execution Commands E2E Tests', () => {
       expect(output).to.contain('terminal');
     });
 
-    it('should list multiple executions with different statuses', () => {
+    it('should list multiple executions with different statuses', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
       createExecution(db, 'TKT-002', 'agent-2', 'completed');
       createExecution(db, 'TKT-003', 'agent-3', 'failed');
 
-      const output = exec('execution list');
+      const output = await execInProcess('execution list');
 
       expect(output).to.contain('agent-1');
       expect(output).to.contain('agent-2');
@@ -377,77 +377,77 @@ describe('Execution Commands E2E Tests', () => {
       expect(output).to.contain('failed');
     });
 
-    it('should show empty message when no executions', () => {
-      const output = exec('execution list');
+    it('should show empty message when no executions', async () => {
+      const output = await execInProcess('execution list');
       expect(output).to.contain('No executions found');
     });
 
-    it('should filter by --status running', () => {
+    it('should filter by --status running', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
       createExecution(db, 'TKT-002', 'agent-2', 'completed');
 
-      const output = exec('execution list --status running');
+      const output = await execInProcess('execution list --status running');
       expect(output).to.contain('agent-1');
       expect(output).not.to.contain('agent-2');
     });
 
-    it('should filter by --status completed', () => {
+    it('should filter by --status completed', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
       createExecution(db, 'TKT-002', 'agent-2', 'completed');
 
-      const output = exec('execution list --status completed');
+      const output = await execInProcess('execution list --status completed');
       expect(output).not.to.contain('agent-1');
       expect(output).to.contain('agent-2');
     });
 
-    it('should filter by --status failed', () => {
+    it('should filter by --status failed', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
       createExecution(db, 'TKT-002', 'agent-2', 'failed');
 
-      const output = exec('execution list --status failed');
+      const output = await execInProcess('execution list --status failed');
       expect(output).not.to.contain('agent-1');
       expect(output).to.contain('agent-2');
     });
 
-    it('should filter by --agent', () => {
+    it('should filter by --agent', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
       createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-      const output = exec('execution list --agent agent-1');
+      const output = await execInProcess('execution list --agent agent-1');
       expect(output).to.contain('agent-1');
       expect(output).not.to.contain('agent-2');
     });
 
-    it('should respect --limit flag', () => {
+    it('should respect --limit flag', async () => {
       for (let i = 1; i <= 5; i++) {
         createExecution(db, `TKT-${String(i).padStart(3, '0')}`, 'agent-1', 'completed');
       }
 
-      const output = exec('execution list --limit 2');
+      const output = await execInProcess('execution list --limit 2');
       const matches = output.match(/WORK-/g) || [];
       expect(matches.length).to.equal(2);
     });
 
-    it('should show suggested commands for running executions', () => {
+    it('should show suggested commands for running executions', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-      const output = exec('execution list');
+      const output = await execInProcess('execution list');
       expect(output).to.contain('prlt execution logs');
       expect(output).to.contain('prlt execution stop');
     });
 
-    it('should display devcontainer environment correctly', () => {
+    it('should display devcontainer environment correctly', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running', { environment: 'devcontainer' });
 
-      const output = exec('execution list');
+      const output = await execInProcess('execution list');
       expect(output).to.contain('devcontainer');
     });
 
-    it('should display sandbox status correctly', () => {
+    it('should display sandbox status correctly', async () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running', { permission_mode: 'safe' });
       createExecution(db, 'TKT-002', 'agent-2', 'running', { permission_mode: 'danger' });
 
-      const output = exec('execution list');
+      const output = await execInProcess('execution list');
       expect(output).to.contain('safe');
       expect(output).to.contain('danger');
     });
@@ -458,55 +458,55 @@ describe('Execution Commands E2E Tests', () => {
   // ===========================================================================
   describe('prlt execution logs', () => {
     describe('direct execution with ID', () => {
-      it('should display full log content for an execution', () => {
+      it('should display full log content for an execution', async () => {
         const logContent = 'Line 1: Starting agent\nLine 2: Processing ticket\nLine 3: Done\n';
         const logPath = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         fs.writeFileSync(logPath, logContent);
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath });
 
-        const output = exec('execution logs WORK-001');
+        const output = await execInProcess('execution logs WORK-001');
 
         expect(output).to.contain('Line 1: Starting agent');
         expect(output).to.contain('Line 2: Processing ticket');
         expect(output).to.contain('Line 3: Done');
       });
 
-      it('should show execution header with ID and ticket', () => {
+      it('should show execution header with ID and ticket', async () => {
         const logPath = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         fs.writeFileSync(logPath, 'test log content\n');
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath });
 
-        const output = exec('execution logs WORK-001');
+        const output = await execInProcess('execution logs WORK-001');
         expect(output).to.contain('WORK-001');
         expect(output).to.contain('TKT-001');
       });
 
-      it('should show message when execution has no log file', () => {
+      it('should show message when execution has no log file', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution logs WORK-001');
+        const output = await execInProcess('execution logs WORK-001');
         expect(output).to.contain('No log file');
       });
 
-      it('should show tmux attach command when session exists', () => {
+      it('should show tmux attach command when session exists', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running', { session_id: 'prlt-session-1' });
 
-        const output = exec('execution logs WORK-001');
+        const output = await execInProcess('execution logs WORK-001');
         expect(output).to.contain('tmux attach -t prlt-session-1');
       });
 
-      it('should error when execution not found', () => {
-        const output = exec('execution logs NONEXISTENT');
+      it('should error when execution not found', async () => {
+        const output = await execInProcess('execution logs NONEXISTENT');
         expect(output.toLowerCase()).to.contain('not found');
       });
 
-      it('should display last N lines with --tail flag', () => {
+      it('should display last N lines with --tail flag', async () => {
         const logPath = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         const lines = Array.from({ length: 20 }, (_, i) => `Log line ${i + 1}`).join('\n') + '\n';
         fs.writeFileSync(logPath, lines);
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath });
 
-        const output = exec('execution logs WORK-001 --tail 3');
+        const output = await execInProcess('execution logs WORK-001 --tail 3');
 
         expect(output).to.contain('Log line 18');
         expect(output).to.contain('Log line 19');
@@ -516,11 +516,11 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--json mode (no ID - prompt for selection)', () => {
-      it('should output JSON prompt with execution choices', () => {
+      it('should output JSON prompt with execution choices', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'completed');
 
-        const output = exec('execution logs --json');
+        const output = await execInProcess('execution logs --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -530,10 +530,10 @@ describe('Execution Commands E2E Tests', () => {
         expect(json!.prompt.choices.length).to.equal(2);
       });
 
-      it('should include command field with execution ID in each choice', () => {
+      it('should include command field with execution ID in each choice', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution logs --json');
+        const output = await execInProcess('execution logs --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         const choice = json!.prompt.choices[0];
@@ -542,10 +542,10 @@ describe('Execution Commands E2E Tests', () => {
         expect(choice.command).to.include('--json');
       });
 
-      it('should include execution details in choice names', () => {
+      it('should include execution details in choice names', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution logs --json');
+        const output = await execInProcess('execution logs --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         const choice = json!.prompt.choices[0];
@@ -555,10 +555,10 @@ describe('Execution Commands E2E Tests', () => {
         expect(choice.name).to.contain('running');
       });
 
-      it('should include metadata with command name', () => {
+      it('should include metadata with command name', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution logs --json');
+        const output = await execInProcess('execution logs --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json!.metadata.command).to.equal('execution logs');
@@ -566,10 +566,10 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--machine mode (no ID - prompt for selection)', () => {
-      it('should output identical prompt schema as --json', () => {
+      it('should output identical prompt schema as --json', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution logs --machine');
+        const output = await execInProcess('execution logs --machine');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -581,22 +581,22 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--json error cases', () => {
-      it('should output JSON error when no executions exist and --json used', () => {
-        const output = exec('execution logs --json');
+      it('should output JSON error when no executions exist and --json used', async () => {
+        const output = await execInProcess('execution logs --json');
 
         // Should contain error JSON (not a prompt)
         expect(output.toLowerCase()).to.contain('no executions found');
       });
 
-      it('should output JSON error when no executions exist and --machine used', () => {
-        const output = exec('execution logs --machine');
+      it('should output JSON error when no executions exist and --machine used', async () => {
+        const output = await execInProcess('execution logs --machine');
 
         expect(output.toLowerCase()).to.contain('no executions found');
       });
     });
 
     describe('full agent workflow for logs', () => {
-      it('should complete: get prompt → select specific execution → see correct logs (not other)', () => {
+      it('should complete: get prompt → select specific execution → see correct logs (not other)', async () => {
         const logPath1 = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         fs.writeFileSync(logPath1, 'Agent-1 output: building frontend\n');
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath1 });
@@ -606,7 +606,7 @@ describe('Execution Commands E2E Tests', () => {
         createExecution(db, 'TKT-002', 'agent-2', 'running', { log_path: logPath2 });
 
         // Step 1: Agent requests execution selection
-        const promptOutput = exec('execution logs --json');
+        const promptOutput = await execInProcess('execution logs --json');
         const prompt = extractJson<AgentPromptResponse>(promptOutput);
         expect(prompt).to.not.be.null;
         expect(prompt!.prompt.choices.length).to.equal(2);
@@ -624,7 +624,7 @@ describe('Execution Commands E2E Tests', () => {
         expect(logsOutput).not.to.contain('Agent-1 output: building frontend');
       });
 
-      it('should complete workflow with --machine flag and show correct logs', () => {
+      it('should complete workflow with --machine flag and show correct logs', async () => {
         const logPath1 = path.join(testDir, '.proletariat', 'logs', 'work-WORK-001.log');
         fs.writeFileSync(logPath1, 'First execution logs\n');
         createExecution(db, 'TKT-001', 'agent-1', 'running', { log_path: logPath1 });
@@ -634,7 +634,7 @@ describe('Execution Commands E2E Tests', () => {
         createExecution(db, 'TKT-002', 'agent-2', 'completed', { log_path: logPath2 });
 
         // Step 1: Agent requests execution selection via --machine
-        const promptOutput = exec('execution logs --machine');
+        const promptOutput = await execInProcess('execution logs --machine');
         const prompt = extractJson<AgentPromptResponse>(promptOutput);
         expect(prompt).to.not.be.null;
         expect(prompt!.prompt.choices.length).to.equal(2);
@@ -659,10 +659,10 @@ describe('Execution Commands E2E Tests', () => {
   // ===========================================================================
   describe('prlt execution stop', () => {
     describe('single stop with ID', () => {
-      it('should stop a running execution and update DB status', () => {
+      it('should stop a running execution and update DB status', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution stop WORK-001');
+        const output = await execInProcess('execution stop WORK-001');
 
         expect(output).to.contain('Stopped');
         expect(output).to.contain('WORK-001');
@@ -672,20 +672,20 @@ describe('Execution Commands E2E Tests', () => {
         expect(row.status).to.equal('stopped');
       });
 
-      it('should show agent and ticket details after stop', () => {
+      it('should show agent and ticket details after stop', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution stop WORK-001');
+        const output = await execInProcess('execution stop WORK-001');
 
         expect(output).to.contain('TKT-001');
         expect(output).to.contain('agent-1');
       });
 
-      it('should only stop the targeted execution, leaving others unchanged', () => {
+      it('should only stop the targeted execution, leaving others unchanged', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution stop WORK-001');
+        const output = await execInProcess('execution stop WORK-001');
 
         expect(output).to.contain('Stopped');
         // Target execution stopped
@@ -696,45 +696,45 @@ describe('Execution Commands E2E Tests', () => {
         expect(untouched.status).to.equal('running');
       });
 
-      it('should stop a starting execution', () => {
+      it('should stop a starting execution', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'starting');
 
-        const output = exec('execution stop WORK-001');
+        const output = await execInProcess('execution stop WORK-001');
 
         expect(output).to.contain('Stopped');
         const row = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-001') as { status: string };
         expect(row.status).to.equal('stopped');
       });
 
-      it('should show message when execution is already stopped and not change DB', () => {
+      it('should show message when execution is already stopped and not change DB', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'stopped');
 
-        const output = exec('execution stop WORK-001');
+        const output = await execInProcess('execution stop WORK-001');
         expect(output).to.contain('not running');
         // Verify DB status was NOT changed
         const row = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-001') as { status: string };
         expect(row.status).to.equal('stopped');
       });
 
-      it('should show message when execution is completed and not change DB', () => {
+      it('should show message when execution is completed and not change DB', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'completed');
 
-        const output = exec('execution stop WORK-001');
+        const output = await execInProcess('execution stop WORK-001');
         expect(output).to.contain('not running');
         // Verify DB status was NOT changed to 'stopped'
         const row = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-001') as { status: string };
         expect(row.status).to.equal('completed');
       });
 
-      it('should error when execution not found', () => {
-        const output = exec('execution stop NONEXISTENT');
+      it('should error when execution not found', async () => {
+        const output = await execInProcess('execution stop NONEXISTENT');
         expect(output.toLowerCase()).to.contain('not found');
       });
 
-      it('should handle --force flag', () => {
+      it('should handle --force flag', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution stop WORK-001 --force');
+        const output = await execInProcess('execution stop WORK-001 --force');
 
         expect(output).to.contain('Stopped');
         const row = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-001') as { status: string };
@@ -743,11 +743,11 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('bulk stop with --all', () => {
-      it('should stop all running executions and verify each by ID', () => {
+      it('should stop all running executions and verify each by ID', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution stop --all');
+        const output = await execInProcess('execution stop --all');
 
         expect(output).to.contain('Stopping 2 execution(s)');
         // Verify each specific execution was stopped
@@ -757,23 +757,23 @@ describe('Execution Commands E2E Tests', () => {
         expect(row2.status).to.equal('stopped');
       });
 
-      it('should include starting executions in bulk stop', () => {
+      it('should include starting executions in bulk stop', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'starting');
 
-        const output = exec('execution stop --all');
+        const output = await execInProcess('execution stop --all');
 
         expect(output).to.contain('Stopping 2 execution(s)');
         const rows = db.prepare('SELECT status FROM agent_work WHERE status = ?').all('stopped') as { status: string }[];
         expect(rows.length).to.equal(2);
       });
 
-      it('should not stop already completed/failed executions', () => {
+      it('should not stop already completed/failed executions', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'completed');
         createExecution(db, 'TKT-003', 'agent-3', 'failed');
 
-        const output = exec('execution stop --all');
+        const output = await execInProcess('execution stop --all');
 
         expect(output).to.contain('Stopping 1 execution(s)');
         const completedRow = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-002') as { status: string };
@@ -782,26 +782,26 @@ describe('Execution Commands E2E Tests', () => {
         expect(failedRow.status).to.equal('failed');
       });
 
-      it('should show summary with stopped count', () => {
+      it('should show summary with stopped count', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution stop --all');
+        const output = await execInProcess('execution stop --all');
 
         expect(output).to.contain('Summary');
         expect(output).to.contain('Stopped: 2');
       });
 
-      it('should show empty message when no running executions', () => {
-        const output = exec('execution stop --all');
+      it('should show empty message when no running executions', async () => {
+        const output = await execInProcess('execution stop --all');
         expect(output).to.contain('No running executions');
       });
 
-      it('should work with --all --force combined', () => {
+      it('should work with --all --force combined', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution stop --all --force');
+        const output = await execInProcess('execution stop --all --force');
 
         expect(output).to.contain('Stopping 2 execution(s)');
         const rows = db.prepare('SELECT status FROM agent_work WHERE status = ?').all('stopped') as { status: string }[];
@@ -810,11 +810,11 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('stop by agent with --agent', () => {
-      it('should stop only executions for the specified agent', () => {
+      it('should stop only executions for the specified agent', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution stop --agent agent-1');
+        const output = await execInProcess('execution stop --agent agent-1');
 
         expect(output).to.contain('Stopping 1 execution(s)');
 
@@ -825,33 +825,33 @@ describe('Execution Commands E2E Tests', () => {
         expect(agent2.status).to.equal('running');
       });
 
-      it('should stop multiple executions for the same agent', () => {
+      it('should stop multiple executions for the same agent', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-1', 'running');
         createExecution(db, 'TKT-003', 'agent-2', 'running');
 
-        const output = exec('execution stop --agent agent-1');
+        const output = await execInProcess('execution stop --agent agent-1');
 
         expect(output).to.contain('Stopping 2 execution(s)');
         const rows = db.prepare('SELECT status FROM agent_work WHERE agent_name = ? AND status = ?').all('agent-1', 'stopped') as { status: string }[];
         expect(rows.length).to.equal(2);
       });
 
-      it('should show empty message when agent has no running executions', () => {
+      it('should show empty message when agent has no running executions', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'completed');
 
-        const output = exec('execution stop --agent agent-1');
+        const output = await execInProcess('execution stop --agent agent-1');
         expect(output).to.contain('No running executions');
         expect(output).to.contain('agent-1');
       });
     });
 
     describe('--json mode (no ID - prompt for selection)', () => {
-      it('should output JSON prompt with active execution choices', () => {
+      it('should output JSON prompt with active execution choices', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'starting');
 
-        const output = exec('execution stop --json');
+        const output = await execInProcess('execution stop --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -861,10 +861,10 @@ describe('Execution Commands E2E Tests', () => {
         expect(json!.prompt.choices.length).to.equal(2);
       });
 
-      it('should include command field with execution ID in choices', () => {
+      it('should include command field with execution ID in choices', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution stop --json');
+        const output = await execInProcess('execution stop --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         const choice = json!.prompt.choices[0];
@@ -873,10 +873,10 @@ describe('Execution Commands E2E Tests', () => {
         expect(choice.command).to.include('--json');
       });
 
-      it('should include execution details in choice names', () => {
+      it('should include execution details in choice names', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running', { environment: 'devcontainer' });
 
-        const output = exec('execution stop --json');
+        const output = await execInProcess('execution stop --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         const choice = json!.prompt.choices[0];
@@ -886,21 +886,21 @@ describe('Execution Commands E2E Tests', () => {
         expect(choice.name).to.contain('devcontainer');
       });
 
-      it('should include metadata with command name', () => {
+      it('should include metadata with command name', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution stop --json');
+        const output = await execInProcess('execution stop --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json!.metadata.command).to.equal('execution stop');
       });
 
-      it('should only show running and starting executions (not completed/failed)', () => {
+      it('should only show running and starting executions (not completed/failed)', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'completed');
         createExecution(db, 'TKT-003', 'agent-3', 'starting');
 
-        const output = exec('execution stop --json');
+        const output = await execInProcess('execution stop --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json!.prompt.choices.length).to.equal(2);
@@ -912,10 +912,10 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--machine mode (no ID - prompt for selection)', () => {
-      it('should output identical prompt schema as --json', () => {
+      it('should output identical prompt schema as --json', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution stop --machine');
+        const output = await execInProcess('execution stop --machine');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -928,34 +928,34 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--json/--machine with no active executions', () => {
-      it('should show no running executions message with --json when all completed', () => {
+      it('should show no running executions message with --json when all completed', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'completed');
         createExecution(db, 'TKT-002', 'agent-2', 'failed');
 
-        const output = exec('execution stop --json');
+        const output = await execInProcess('execution stop --json');
         expect(output).to.contain('No running executions');
       });
 
-      it('should show no running executions message with --machine when all completed', () => {
+      it('should show no running executions message with --machine when all completed', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'completed');
 
-        const output = exec('execution stop --machine');
+        const output = await execInProcess('execution stop --machine');
         expect(output).to.contain('No running executions');
       });
 
-      it('should show no running executions message with --json when no executions at all', () => {
-        const output = exec('execution stop --json');
+      it('should show no running executions message with --json when no executions at all', async () => {
+        const output = await execInProcess('execution stop --json');
         expect(output).to.contain('No running executions');
       });
     });
 
     describe('full agent workflow for stop', () => {
-      it('should complete: get prompt → select specific execution → stop → verify only that one stopped', () => {
+      it('should complete: get prompt → select specific execution → stop → verify only that one stopped', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
         // Step 1: Agent requests execution selection
-        const promptOutput = exec('execution stop --json');
+        const promptOutput = await execInProcess('execution stop --json');
         const prompt = extractJson<AgentPromptResponse>(promptOutput);
         expect(prompt).to.not.be.null;
         expect(prompt!.prompt.choices.length).to.equal(2);
@@ -979,12 +979,12 @@ describe('Execution Commands E2E Tests', () => {
         expect(untouchedRow.status).to.equal('running');
       });
 
-      it('should complete workflow with --machine flag and verify correct execution stopped', () => {
+      it('should complete workflow with --machine flag and verify correct execution stopped', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
         // Step 1: Use --machine flag
-        const promptOutput = exec('execution stop --machine');
+        const promptOutput = await execInProcess('execution stop --machine');
         const prompt = extractJson<AgentPromptResponse>(promptOutput);
         expect(prompt).to.not.be.null;
         expect(prompt!.prompt.choices.length).to.equal(2);
@@ -1012,10 +1012,10 @@ describe('Execution Commands E2E Tests', () => {
   // ===========================================================================
   describe('prlt execution kill (alias for stop)', () => {
     describe('single kill with ID', () => {
-      it('should stop a running execution and update DB status', () => {
+      it('should stop a running execution and update DB status', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution kill WORK-001');
+        const output = await execInProcess('execution kill WORK-001');
 
         expect(output).to.contain('Stopped');
         expect(output).to.contain('WORK-001');
@@ -1025,55 +1025,55 @@ describe('Execution Commands E2E Tests', () => {
         expect(row.status).to.equal('stopped');
       });
 
-      it('should show agent and ticket details after kill', () => {
+      it('should show agent and ticket details after kill', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution kill WORK-001');
+        const output = await execInProcess('execution kill WORK-001');
 
         expect(output).to.contain('TKT-001');
         expect(output).to.contain('agent-1');
       });
 
-      it('should handle --force flag', () => {
+      it('should handle --force flag', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution kill WORK-001 --force');
+        const output = await execInProcess('execution kill WORK-001 --force');
 
         expect(output).to.contain('Stopped');
         const row = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-001') as { status: string };
         expect(row.status).to.equal('stopped');
       });
 
-      it('should error when execution not found', () => {
-        const output = exec('execution kill NONEXISTENT');
+      it('should error when execution not found', async () => {
+        const output = await execInProcess('execution kill NONEXISTENT');
         expect(output.toLowerCase()).to.contain('not found');
       });
     });
 
     describe('bulk kill with --all', () => {
-      it('should stop all running executions', () => {
+      it('should stop all running executions', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution kill --all');
+        const output = await execInProcess('execution kill --all');
 
         expect(output).to.contain('Stopping 2 execution(s)');
         const rows = db.prepare('SELECT status FROM agent_work WHERE status = ?').all('stopped') as { status: string }[];
         expect(rows.length).to.equal(2);
       });
 
-      it('should show empty message when no running executions', () => {
-        const output = exec('execution kill --all');
+      it('should show empty message when no running executions', async () => {
+        const output = await execInProcess('execution kill --all');
         expect(output).to.contain('No running executions');
       });
     });
 
     describe('kill by agent with --agent', () => {
-      it('should stop only executions for the specified agent', () => {
+      it('should stop only executions for the specified agent', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
-        const output = exec('execution kill --agent agent-1');
+        const output = await execInProcess('execution kill --agent agent-1');
 
         expect(output).to.contain('Stopping 1 execution(s)');
 
@@ -1086,10 +1086,10 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('--json mode', () => {
-      it('should output JSON prompt with active execution choices', () => {
+      it('should output JSON prompt with active execution choices', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution kill --json');
+        const output = await execInProcess('execution kill --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         expect(json).to.not.be.null;
@@ -1099,10 +1099,10 @@ describe('Execution Commands E2E Tests', () => {
         expect(json!.prompt.choices.length).to.equal(1);
       });
 
-      it('should include command field with execution ID in choices', () => {
+      it('should include command field with execution ID in choices', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
 
-        const output = exec('execution kill --json');
+        const output = await execInProcess('execution kill --json');
         const json = extractJson<AgentPromptResponse>(output);
 
         const choice = json!.prompt.choices[0];
@@ -1114,12 +1114,12 @@ describe('Execution Commands E2E Tests', () => {
     });
 
     describe('full agent workflow', () => {
-      it('should complete: get prompt → select execution → kill → verify stopped', () => {
+      it('should complete: get prompt → select execution → kill → verify stopped', async () => {
         createExecution(db, 'TKT-001', 'agent-1', 'running');
         createExecution(db, 'TKT-002', 'agent-2', 'running');
 
         // Step 1: Agent requests execution selection
-        const promptOutput = exec('execution kill --json');
+        const promptOutput = await execInProcess('execution kill --json');
         const prompt = extractJson<AgentPromptResponse>(promptOutput);
         expect(prompt).to.not.be.null;
         expect(prompt!.prompt.choices.length).to.equal(2);
@@ -1129,7 +1129,7 @@ describe('Execution Commands E2E Tests', () => {
         expect(selectedExec).to.exist;
 
         // Step 3: Agent executes the kill command (use execution kill directly)
-        const killOutput = exec('execution kill WORK-001');
+        const killOutput = await execInProcess('execution kill WORK-001');
 
         // Step 4: Verify ONLY the selected execution was stopped
         expect(killOutput).to.contain('Stopped');

--- a/apps/cli/test/e2e/gh-agent-flow.test.ts
+++ b/apps/cli/test/e2e/gh-agent-flow.test.ts
@@ -3,7 +3,7 @@ import {
   agentExec,
   findChoice,
   execChoice,
-  execProduction,
+  execInProcess,
   extractJson,
 } from './test-helpers.js';
 
@@ -73,7 +73,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(tokenChoice!.command).to.include('--json');
     });
 
-    it('should complete flow: select status → get status info', () => {
+    it('should complete flow: select status → get status info', async () => {
       // Step 1: Get menu choices
       const step1 = agentExec('gh --machine');
       expect(step1).to.not.be.null;
@@ -82,7 +82,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(statusChoice).to.exist;
 
       // Step 2: Execute status command (from choice.command)
-      const statusOutput = execProduction(execChoice(statusChoice!));
+      const statusOutput = await execInProcess(execChoice(statusChoice!));
 
       // Should get JSON response with status info
       const statusJson = extractJson<{ success: boolean; result: Record<string, unknown> }>(statusOutput);
@@ -97,8 +97,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
    * Returns JSON with GitHub CLI status information
    */
   describe('prlt gh status --machine', () => {
-    it('should output JSON with status fields', () => {
-      const output = execProduction('gh status --machine');
+    it('should output JSON with status fields', async () => {
+      const output = await execInProcess('gh status --machine');
       const json = extractJson<{ success: boolean; result: Record<string, unknown> }>(output);
 
       expect(json).to.not.be.null;
@@ -109,16 +109,16 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(json!.result).to.have.property('ready');
     });
 
-    it('should have ghInstalled as boolean', () => {
-      const output = execProduction('gh status --machine');
+    it('should have ghInstalled as boolean', async () => {
+      const output = await execInProcess('gh status --machine');
       const json = extractJson<{ success: boolean; result: { ghInstalled: boolean } }>(output);
 
       expect(json).to.not.be.null;
       expect(typeof json!.result.ghInstalled).to.equal('boolean');
     });
 
-    it('should include metadata with command info', () => {
-      const output = execProduction('gh status --machine');
+    it('should include metadata with command info', async () => {
+      const output = await execInProcess('gh status --machine');
       const json = extractJson<{ metadata: { command: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -132,8 +132,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
    * Returns JSON with authentication status or error
    */
   describe('prlt gh login --machine', () => {
-    it('should output JSON response', () => {
-      const output = execProduction('gh login --machine');
+    it('should output JSON response', async () => {
+      const output = await execInProcess('gh login --machine');
       const json = extractJson<Record<string, unknown>>(output);
 
       expect(json).to.not.be.null;
@@ -142,8 +142,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(hasExpectedField).to.be.true;
     });
 
-    it('should include metadata', () => {
-      const output = execProduction('gh login --machine');
+    it('should include metadata', async () => {
+      const output = await execInProcess('gh login --machine');
       const json = extractJson<{ metadata: { command: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -151,8 +151,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(json!.metadata.command).to.equal('gh login');
     });
 
-    it('should return error if gh CLI not installed', () => {
-      const output = execProduction('gh login --machine');
+    it('should return error if gh CLI not installed', async () => {
+      const output = await execInProcess('gh login --machine');
       const json = extractJson<{ error?: { code: string }; success?: boolean; result?: { authenticated: boolean } }>(output);
 
       expect(json).to.not.be.null;
@@ -173,8 +173,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
    * Returns JSON with GH_TOKEN setup information
    */
   describe('prlt gh token --machine', () => {
-    it('should output JSON response', () => {
-      const output = execProduction('gh token --machine');
+    it('should output JSON response', async () => {
+      const output = await execInProcess('gh token --machine');
       const json = extractJson<Record<string, unknown>>(output);
 
       expect(json).to.not.be.null;
@@ -183,8 +183,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(hasExpectedField).to.be.true;
     });
 
-    it('should include metadata', () => {
-      const output = execProduction('gh token --machine');
+    it('should include metadata', async () => {
+      const output = await execInProcess('gh token --machine');
       const json = extractJson<{ metadata: { command: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -192,8 +192,8 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(json!.metadata.command).to.equal('gh token');
     });
 
-    it('should return appropriate response based on gh CLI state', () => {
-      const output = execProduction('gh token --machine');
+    it('should return appropriate response based on gh CLI state', async () => {
+      const output = await execInProcess('gh token --machine');
       const json = extractJson<{
         error?: { code: string; message: string };
         success?: boolean;
@@ -224,7 +224,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
    * Full agent navigation flow tests
    */
   describe('Full agent navigation flows', () => {
-    it('should navigate: gh menu → status → get status info', () => {
+    it('should navigate: gh menu → status → get status info', async () => {
       // Step 1: Start at gh menu
       const menu = agentExec('gh --machine');
       expect(menu).to.not.be.null;
@@ -236,7 +236,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
 
       // Step 3: Execute status command from choice
       const statusCmd = execChoice(statusChoice!);
-      const statusOutput = execProduction(statusCmd);
+      const statusOutput = await execInProcess(statusCmd);
       const statusJson = extractJson<{ success: boolean; result: { ghInstalled: boolean } }>(statusOutput);
 
       expect(statusJson).to.not.be.null;
@@ -244,7 +244,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(statusJson!.result).to.have.property('ghInstalled');
     });
 
-    it('should navigate: gh menu → login → get login status', () => {
+    it('should navigate: gh menu → login → get login status', async () => {
       // Step 1: Start at gh menu
       const menu = agentExec('gh --machine');
       expect(menu).to.not.be.null;
@@ -256,7 +256,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
 
       // Step 3: Execute login command from choice
       const loginCmd = execChoice(loginChoice!);
-      const loginOutput = execProduction(loginCmd);
+      const loginOutput = await execInProcess(loginCmd);
       const loginJson = extractJson<Record<string, unknown>>(loginOutput);
 
       expect(loginJson).to.not.be.null;
@@ -264,7 +264,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect('success' in loginJson! || 'error' in loginJson!).to.be.true;
     });
 
-    it('should navigate: gh menu → token → get token setup info', () => {
+    it('should navigate: gh menu → token → get token setup info', async () => {
       // Step 1: Start at gh menu
       const menu = agentExec('gh --machine');
       expect(menu).to.not.be.null;
@@ -276,7 +276,7 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
 
       // Step 3: Execute token command from choice
       const tokenCmd = execChoice(tokenChoice!);
-      const tokenOutput = execProduction(tokenCmd);
+      const tokenOutput = await execInProcess(tokenCmd);
       const tokenJson = extractJson<Record<string, unknown>>(tokenOutput);
 
       expect(tokenJson).to.not.be.null;
@@ -301,9 +301,9 @@ describe('GitHub CLI Commands - Agent Flow E2E Tests', () => {
       expect(machineOutput!.prompt.name).to.equal(jsonOutput!.prompt.name);
     });
 
-    it('gh status --json should work same as --machine', () => {
-      const machineOutput = execProduction('gh status --machine');
-      const jsonOutput = execProduction('gh status --json');
+    it('gh status --json should work same as --machine', async () => {
+      const machineOutput = await execInProcess('gh status --machine');
+      const jsonOutput = await execInProcess('gh status --json');
 
       const machineJson = extractJson<{ success: boolean }>(machineOutput);
       const legacyJson = extractJson<{ success: boolean }>(jsonOutput);

--- a/apps/cli/test/e2e/gh-commands.test.ts
+++ b/apps/cli/test/e2e/gh-commands.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { execProduction as exec } from './test-helpers.js'
+import { execInProcess } from './test-helpers.js'
 
 /**
  * Helper to check if output is JSON format
@@ -44,15 +44,15 @@ describe('GitHub CLI Commands E2E Tests', () => {
    * Shows GitHub CLI authentication status
    */
   describe('prlt gh status', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('gh status --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('gh status --help')
 
       expect(output).to.contain('Check GitHub CLI status')
       expect(output).to.contain('USAGE')
     })
 
-    it('should check GitHub CLI status', () => {
-      const output = exec('gh status')
+    it('should check GitHub CLI status', async () => {
+      const output = await execInProcess('gh status')
 
       // In non-TTY mode, output is JSON
       if (isJsonOutput(output)) {
@@ -74,8 +74,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       }
     })
 
-    it('should indicate when gh CLI is not installed', () => {
-      const output = exec('gh status')
+    it('should indicate when gh CLI is not installed', async () => {
+      const output = await execInProcess('gh status')
 
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
@@ -91,8 +91,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       }
     })
 
-    it('should indicate authentication status when gh is installed', () => {
-      const output = exec('gh status')
+    it('should indicate authentication status when gh is installed', async () => {
+      const output = await execInProcess('gh status')
 
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
@@ -108,8 +108,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       }
     })
 
-    it('should check GH_TOKEN status when authenticated', () => {
-      const output = exec('gh status')
+    it('should check GH_TOKEN status when authenticated', async () => {
+      const output = await execInProcess('gh status')
 
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
@@ -131,22 +131,22 @@ describe('GitHub CLI Commands E2E Tests', () => {
    * Initiates GitHub login flow
    */
   describe('prlt gh login', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('gh login --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('gh login --help')
 
       expect(output).to.contain('Login to GitHub CLI')
       expect(output).to.contain('USAGE')
     })
 
-    it('should display login command description in help', () => {
-      const output = exec('gh login --help')
+    it('should display login command description in help', async () => {
+      const output = await execInProcess('gh login --help')
 
       expect(output).to.contain('Login to GitHub CLI')
       expect(output).to.contain('USAGE')
     })
 
-    it('should reference gh CLI in login help', () => {
-      const output = exec('gh login --help')
+    it('should reference gh CLI in login help', async () => {
+      const output = await execInProcess('gh login --help')
 
       const hasGhReference =
         output.includes('gh') ||
@@ -154,8 +154,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(hasGhReference).to.be.true
     })
 
-    it('should show login-related flags or description in help', () => {
-      const output = exec('gh login --help')
+    it('should show login-related flags or description in help', async () => {
+      const output = await execInProcess('gh login --help')
 
       // Help output should contain relevant login info
       const hasLoginInfo =
@@ -172,29 +172,29 @@ describe('GitHub CLI Commands E2E Tests', () => {
    * Displays/manages GitHub token for devcontainer PR creation
    */
   describe('prlt gh token', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('gh token --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('gh token --help')
 
       expect(output).to.contain('GH_TOKEN setup')
       expect(output).to.contain('devcontainer')
       expect(output).to.contain('USAGE')
     })
 
-    it('should display token command description in help', () => {
-      const output = exec('gh token --help')
+    it('should display token command description in help', async () => {
+      const output = await execInProcess('gh token --help')
 
       expect(output).to.contain('GH_TOKEN setup')
       expect(output).to.contain('USAGE')
     })
 
-    it('should reference devcontainer in token help', () => {
-      const output = exec('gh token --help')
+    it('should reference devcontainer in token help', async () => {
+      const output = await execInProcess('gh token --help')
 
       expect(output).to.contain('devcontainer')
     })
 
-    it('should reference GH_TOKEN in token help', () => {
-      const output = exec('gh token --help')
+    it('should reference GH_TOKEN in token help', async () => {
+      const output = await execInProcess('gh token --help')
 
       const hasTokenReference =
         output.includes('GH_TOKEN') ||
@@ -202,8 +202,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(hasTokenReference).to.be.true
     })
 
-    it('should show token-related usage information in help', () => {
-      const output = exec('gh token --help')
+    it('should show token-related usage information in help', async () => {
+      const output = await execInProcess('gh token --help')
 
       const hasUsageInfo =
         output.includes('USAGE') ||
@@ -211,8 +211,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(hasUsageInfo).to.be.true
     })
 
-    it('should reference GitHub in token help', () => {
-      const output = exec('gh token --help')
+    it('should reference GitHub in token help', async () => {
+      const output = await execInProcess('gh token --help')
 
       const hasGhReference =
         output.includes('gh') ||
@@ -226,15 +226,15 @@ describe('GitHub CLI Commands E2E Tests', () => {
    * Tests the interactive menu when no subcommand is provided
    */
   describe('prlt gh', () => {
-    it('should show help with --help flag', () => {
-      const output = exec('gh --help')
+    it('should show help with --help flag', async () => {
+      const output = await execInProcess('gh --help')
 
       expect(output).to.contain('GitHub CLI setup')
       expect(output).to.contain('USAGE')
     })
 
-    it('should list available subcommands in help', () => {
-      const output = exec('gh --help')
+    it('should list available subcommands in help', async () => {
+      const output = await execInProcess('gh --help')
 
       // Help should show subcommands or examples
       const hasSubcommands =
@@ -245,8 +245,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(hasSubcommands).to.be.true
     })
 
-    it('should show examples in help', () => {
-      const output = exec('gh --help')
+    it('should show examples in help', async () => {
+      const output = await execInProcess('gh --help')
 
       // Should have examples section
       const hasExamples =
@@ -265,8 +265,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
    * can be called directly.
    */
   describe('Command delegation', () => {
-    it('should delegate to status command', () => {
-      const output = exec('gh status')
+    it('should delegate to status command', async () => {
+      const output = await execInProcess('gh status')
 
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
@@ -279,15 +279,15 @@ describe('GitHub CLI Commands E2E Tests', () => {
       }
     })
 
-    it('should delegate to login command', () => {
-      const output = exec('gh login --help')
+    it('should delegate to login command', async () => {
+      const output = await execInProcess('gh login --help')
 
       expect(output).to.contain('Login to GitHub CLI')
       expect(output).to.contain('USAGE')
     })
 
-    it('should delegate to token command', () => {
-      const output = exec('gh token --help')
+    it('should delegate to token command', async () => {
+      const output = await execInProcess('gh token --help')
 
       expect(output).to.contain('GH_TOKEN setup')
       expect(output).to.contain('USAGE')
@@ -298,8 +298,8 @@ describe('GitHub CLI Commands E2E Tests', () => {
    * Edge cases and error handling
    */
   describe('Error handling', () => {
-    it('should handle unknown subcommand gracefully', () => {
-      const output = exec('gh unknown-subcommand')
+    it('should handle unknown subcommand gracefully', async () => {
+      const output = await execInProcess('gh unknown-subcommand')
 
       // Should show error about unknown command or help
       const validOutput =
@@ -311,10 +311,10 @@ describe('GitHub CLI Commands E2E Tests', () => {
       expect(validOutput).to.be.true
     })
 
-    it('should accept --help flag on all subcommands', () => {
-      const statusHelp = exec('gh status --help')
-      const loginHelp = exec('gh login --help')
-      const tokenHelp = exec('gh token --help')
+    it('should accept --help flag on all subcommands', async () => {
+      const statusHelp = await execInProcess('gh status --help')
+      const loginHelp = await execInProcess('gh login --help')
+      const tokenHelp = await execInProcess('gh token --help')
 
       expect(statusHelp).to.contain('USAGE')
       expect(loginHelp).to.contain('USAGE')

--- a/apps/cli/test/e2e/pr-agent-flow.test.ts
+++ b/apps/cli/test/e2e/pr-agent-flow.test.ts
@@ -15,7 +15,7 @@ import {
   findChoice,
   type TestEnvironment,
   type AgentPromptResponse,
-  exec,
+  execInProcess,
 } from './test-helpers.js';
 
 /**
@@ -84,8 +84,8 @@ describe('PR Commands - Agent Flow Tests', () => {
   // command discovery in the test environment. Skipping these tests.
   // The subcommand tests (pr:create, pr:status, pr:link) are tested below.
   describe.skip('prlt pr - main menu agent flow (skipped - oclif discovery issue)', () => {
-    it('should output action selection prompt with --machine', () => {
-      const output = exec('pr --machine');
+    it('should output action selection prompt with --machine', async () => {
+      const output = await execInProcess('pr --machine');
       const result = extractJson<AgentPromptResponse>(output);
 
       expect(result).to.not.be.null;
@@ -93,8 +93,8 @@ describe('PR Commands - Agent Flow Tests', () => {
       expect(result!.prompt.name).to.equal('action');
     });
 
-    it('should have command fields for each action', () => {
-      const output = exec('pr --machine');
+    it('should have command fields for each action', async () => {
+      const output = await execInProcess('pr --machine');
       const result = extractJson<AgentPromptResponse>(output);
 
       expect(result).to.not.be.null;
@@ -112,8 +112,8 @@ describe('PR Commands - Agent Flow Tests', () => {
       createLocalTestTicket('TKT-PR-2', 'Ticket without PR', 'default-in-progress');
     });
 
-    it('should output ticket selection prompt with --machine when no ticket specified', () => {
-      const output = exec('pr status -P test-project --machine');
+    it('should output ticket selection prompt with --machine when no ticket specified', async () => {
+      const output = await execInProcess('pr status -P test-project --machine');
 
       // Skip if command not found (oclif test environment issue)
       if (output.includes('command pr:status not found') || output.includes('command pr not found')) {
@@ -137,9 +137,9 @@ describe('PR Commands - Agent Flow Tests', () => {
       expect(ticketWithPR!.command).to.include('TKT-PR-1');
     });
 
-    it('should complete flow: select ticket → view status', () => {
+    it('should complete flow: select ticket → view status', async () => {
       // Step 1: Get ticket choices
-      const output1 = exec('pr status -P test-project --machine');
+      const output1 = await execInProcess('pr status -P test-project --machine');
 
       // Skip if command not found
       if (output1.includes('command pr:status not found') || output1.includes('command pr not found')) {
@@ -159,15 +159,15 @@ describe('PR Commands - Agent Flow Tests', () => {
 
       // Step 2: Execute with ticket selected (final step - shows status)
       const finalCmd = ticketChoice!.command!.replace('prlt ', '').replace(' --json', '').replace(' --machine', '');
-      const result = exec(finalCmd);
+      const result = await execInProcess(finalCmd);
 
       // Should show ticket info
       expect(result).to.include('TKT-PR-1');
     });
 
-    it('should skip selection when ticket ID provided directly', () => {
+    it('should skip selection when ticket ID provided directly', async () => {
       // Direct ticket ID should not prompt for selection
-      const result = exec('pr status TKT-PR-1 -P test-project');
+      const result = await execInProcess('pr status TKT-PR-1 -P test-project');
 
       // Skip if command not found
       if (result.includes('command pr:status not found') || result.includes('command pr not found')) {
@@ -184,8 +184,8 @@ describe('PR Commands - Agent Flow Tests', () => {
       createLocalTestTicket('TKT-LINK-1', 'Ticket to link PR', 'default-in-progress');
     });
 
-    it('should output ticket selection prompt with --machine when no ticket specified', () => {
-      const output = exec('pr link -P test-project --machine');
+    it('should output ticket selection prompt with --machine when no ticket specified', async () => {
+      const output = await execInProcess('pr link -P test-project --machine');
 
       // Skip if command not found
       if (output.includes('command pr:link not found') || output.includes('command pr not found')) {
@@ -208,9 +208,9 @@ describe('PR Commands - Agent Flow Tests', () => {
       }
     });
 
-    it('should complete flow: select ticket → proceed to next step', () => {
+    it('should complete flow: select ticket → proceed to next step', async () => {
       // Step 1: Get ticket choices
-      const output1 = exec('pr link -P test-project --machine');
+      const output1 = await execInProcess('pr link -P test-project --machine');
 
       // Skip if command not found
       if (output1.includes('command pr:link not found') || output1.includes('command pr not found')) {
@@ -229,15 +229,15 @@ describe('PR Commands - Agent Flow Tests', () => {
 
       // Step 2: Execute with ticket selected
       const step2Cmd = ticketChoice!.command!.replace('prlt ', '');
-      const output2 = exec(step2Cmd);
+      const output2 = await execInProcess(step2Cmd);
 
       // Either gets PR selection prompt, confirmation prompt, or gh error
       expect(output2).to.be.a('string');
     });
 
-    it('should skip ticket selection when ticket ID provided directly', () => {
+    it('should skip ticket selection when ticket ID provided directly', async () => {
       // Direct ticket ID should skip to next step
-      const output = exec('pr link TKT-LINK-1 -P test-project --machine');
+      const output = await execInProcess('pr link TKT-LINK-1 -P test-project --machine');
 
       // Skip if command not found
       if (output.includes('command pr:link not found') || output.includes('command pr not found')) {
@@ -273,16 +273,16 @@ describe('PR Commands - Agent Flow Tests', () => {
       }
     });
 
-    it('should auto-detect ticket from branch or prompt for selection with --machine', () => {
-      const output = exec('pr create -P test-project --machine');
+    it('should auto-detect ticket from branch or prompt for selection with --machine', async () => {
+      const output = await execInProcess('pr create -P test-project --machine');
 
       // Either outputs ticket selection prompt, gh error, or proceeds
       // This is a flexible test since the flow depends on environment
       expect(output).to.be.a('string');
     });
 
-    it('should skip ticket selection when --no-link is used', () => {
-      const output = exec('pr create --no-link --machine');
+    it('should skip ticket selection when --no-link is used', async () => {
+      const output = await execInProcess('pr create --no-link --machine');
 
       // Should not prompt for ticket selection
       // Will likely error on gh not installed
@@ -294,8 +294,8 @@ describe('PR Commands - Agent Flow Tests', () => {
       }
     });
 
-    it('should skip ticket selection when ticket ID provided directly', () => {
-      const output = exec('pr create TKT-CREATE-1 --machine');
+    it('should skip ticket selection when ticket ID provided directly', async () => {
+      const output = await execInProcess('pr create TKT-CREATE-1 --machine');
 
       // Should skip ticket prompt
       expect(output).to.be.a('string');
@@ -307,9 +307,9 @@ describe('PR Commands - Agent Flow Tests', () => {
   });
 
   describe('agent flow error handling', () => {
-    it('should output message when no tickets exist for pr status', () => {
+    it('should output message when no tickets exist for pr status', async () => {
       // No tickets created
-      const output = exec('pr status -P test-project --machine');
+      const output = await execInProcess('pr status -P test-project --machine');
 
       // Should output error or empty state message
       expect(output).to.be.a('string');
@@ -320,11 +320,11 @@ describe('PR Commands - Agent Flow Tests', () => {
       ).to.be.true;
     });
 
-    it('should handle gh CLI not installed gracefully', () => {
+    it('should handle gh CLI not installed gracefully', async () => {
       createLocalTestTicket('TKT-ERR-1', 'Error test ticket', 'default-in-progress');
 
       // This will hit gh check which may fail
-      const output = exec('pr create TKT-ERR-1 --machine');
+      const output = await execInProcess('pr create TKT-ERR-1 --machine');
 
       // Should either succeed with prompt or output error message
       expect(output).to.be.a('string');

--- a/apps/cli/test/e2e/pr-commands.test.ts
+++ b/apps/cli/test/e2e/pr-commands.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { execSync } from 'node:child_process';
 import Database from 'better-sqlite3';
-import { exec } from './test-helpers.js';
+import { execInProcess } from './test-helpers.js';
 import { initializePMOTables } from '../../src/lib/pmo/storage/base.js';
 import { CREATE_TABLES_SQL } from '../../src/lib/database/index.js';
 
@@ -183,10 +183,10 @@ describe('PR Commands E2E Tests', () => {
    * Note: Cannot test actual PR creation without GitHub, but we can test prerequisites
    */
   describe('prlt pr create prerequisites', () => {
-    it('should check for gh CLI availability', () => {
+    it('should check for gh CLI availability', async () => {
       // The command should check for gh CLI
       // If gh is not installed/authenticated, it should show appropriate message
-      const output = exec('pr create');
+      const output = await execInProcess('pr create');
 
       // Either shows gh not installed, not authenticated, or proceeds with PR creation
       // All are valid responses depending on environment
@@ -459,19 +459,19 @@ describe('PR Commands E2E Tests', () => {
    * Test that pr commands output proper JSON when --json flag is used
    */
   describe('JSON Mode Output (FlagResolver)', () => {
-    it('prlt pr --json should output prompt config for action selection', () => {
-      const output = exec('pr --json');
+    it('prlt pr --json should output prompt config for action selection', async () => {
+      const output = await execInProcess('pr --json');
 
       // Should output JSON with prompt config
       expect(output).to.include('"type"');
       expect(output).to.include('"action"');
     });
 
-    it('prlt pr status --json should output prompt config for ticket selection', () => {
+    it('prlt pr status --json should output prompt config for ticket selection', async () => {
       // Create a ticket first
       createTicket(db, 'JSON mode test ticket', 'in-progress');
 
-      const output = exec('pr status --json');
+      const output = await execInProcess('pr status --json');
 
       // Command may output "No tickets found." or JSON with prompt config
       if (output.includes('No tickets found') || output.includes('NO_TICKETS')) {
@@ -481,41 +481,41 @@ describe('PR Commands E2E Tests', () => {
       }
     });
 
-    it('prlt pr link --json should output prompt config for ticket selection', () => {
+    it('prlt pr link --json should output prompt config for ticket selection', async () => {
       // Create a ticket first
       createTicket(db, 'Link JSON test ticket', 'in-progress');
 
-      const output = exec('pr link --json');
+      const output = await execInProcess('pr link --json');
 
       // Should output JSON prompt config
       expect(output).to.include('"type"');
     });
 
-    it('prlt pr create with --ticket flag should skip ticket selection prompt', () => {
+    it('prlt pr create with --ticket flag should skip ticket selection prompt', async () => {
       const ticketId = createTicket(db, 'Create test ticket', 'in-progress');
 
       // With ticket provided, should not prompt for ticket
-      const output = exec(`pr create --ticket ${ticketId} --no-link --json`);
+      const output = await execInProcess(`pr create --ticket ${ticketId} --no-link --json`);
 
       // Either outputs error (gh not installed) or proceeds without ticket prompt
       expect(output).to.be.a('string');
     });
 
-    it('prlt pr status with ticket arg should skip selection', () => {
+    it('prlt pr status with ticket arg should skip selection', async () => {
       const ticketId = createTicket(db, 'Status test ticket', 'in-progress');
 
       // With ticket ID provided, should show status directly
-      const output = exec(`pr status ${ticketId}`);
+      const output = await execInProcess(`pr status ${ticketId}`);
 
       // Should show ticket info
       expect(output).to.include(ticketId);
     });
 
-    it('prlt pr link with ticket arg should proceed to PR selection', () => {
+    it('prlt pr link with ticket arg should proceed to PR selection', async () => {
       const ticketId = createTicket(db, 'Link test ticket', 'in-progress');
 
       // With ticket ID provided, should skip ticket selection
-      const output = exec(`pr link ${ticketId} --json`);
+      const output = await execInProcess(`pr link ${ticketId} --json`);
 
       // Should either prompt for PR or error (gh not installed)
       expect(output).to.be.a('string');

--- a/apps/cli/test/e2e/pr-json-mode.test.ts
+++ b/apps/cli/test/e2e/pr-json-mode.test.ts
@@ -11,7 +11,7 @@ import {
   createPMODirectories,
   setupProductionSchema,
   createTestProject,
-  exec,
+  execInProcess,
   type TestEnvironment,
 } from './test-helpers.js';
 
@@ -103,8 +103,8 @@ describe('PR Commands JSON Mode', () => {
   }
 
   describe('pr index --machine (main menu)', () => {
-    it('should output valid JSON with action selection prompt', () => {
-      const output = exec('pr -P test-project --machine');
+    it('should output valid JSON with action selection prompt', async () => {
+      const output = await execInProcess('pr -P test-project --machine');
       const json = extractJson<{
         prompt: { type: string; name: string; message: string; choices: Array<{ name: string; value: string; command?: string }> };
         metadata: { command: string };
@@ -122,8 +122,8 @@ describe('PR Commands JSON Mode', () => {
       expect(values).to.include('status');
     });
 
-    it('should include --json in action command choices', () => {
-      const output = exec('pr -P test-project --machine');
+    it('should include --json in action command choices', async () => {
+      const output = await execInProcess('pr -P test-project --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ command?: string; value: string }> };
       }>(output);
@@ -135,15 +135,15 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should work with --json flag (legacy)', () => {
-      const output = exec('pr -P test-project --json');
+    it('should work with --json flag (legacy)', async () => {
+      const output = await execInProcess('pr -P test-project --json');
       const json = extractJson<{ prompt: { name: string } }>(output);
 
       expect(json.prompt.name).to.equal('action');
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('pr -P test-project -m');
+    it('should work with -m shorthand', async () => {
+      const output = await execInProcess('pr -P test-project -m');
       const json = extractJson<{ prompt: { name: string } }>(output);
 
       expect(json.prompt.name).to.equal('action');
@@ -156,8 +156,8 @@ describe('PR Commands JSON Mode', () => {
       createTestTicket('TKT-STATUS-2', 'Status ticket two', 'in-progress', 'https://github.com/test/repo/pull/42');
     });
 
-    it('should output ticket selection prompt when no ticket provided', () => {
-      const output = exec('pr status -P test-project --machine');
+    it('should output ticket selection prompt when no ticket provided', async () => {
+      const output = await execInProcess('pr status -P test-project --machine');
       const json = extractJson<{
         prompt: { type: string; name: string; message: string; choices: Array<{ name: string; value: string; command?: string }> };
         metadata: { command: string };
@@ -170,8 +170,8 @@ describe('PR Commands JSON Mode', () => {
       expect(json.prompt.choices.length).to.be.greaterThan(0);
     });
 
-    it('should include --json in ticket selection commands', () => {
-      const output = exec('pr status -P test-project --machine');
+    it('should include --json in ticket selection commands', async () => {
+      const output = await execInProcess('pr status -P test-project --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ command?: string }> };
       }>(output);
@@ -183,16 +183,16 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('pr status -P test-project -m');
+    it('should work with -m shorthand', async () => {
+      const output = await execInProcess('pr status -P test-project -m');
       const json = extractJson<{ prompt: { type: string } }>(output);
 
       expect(json.prompt).to.exist;
       expect(json.prompt.type).to.equal('list');
     });
 
-    it('should skip ticket selection when ticket ID provided directly', () => {
-      const output = exec('pr status TKT-STATUS-1 -P test-project');
+    it('should skip ticket selection when ticket ID provided directly', async () => {
+      const output = await execInProcess('pr status TKT-STATUS-1 -P test-project');
 
       // Should show ticket info directly (no JSON prompt)
       expect(output).to.include('TKT-STATUS-1');
@@ -205,8 +205,8 @@ describe('PR Commands JSON Mode', () => {
       createTestTicket('TKT-LINK-2', 'Link ticket two', 'in-progress');
     });
 
-    it('should output ticket selection prompt when no ticket provided', () => {
-      const output = exec('pr link -P test-project --machine');
+    it('should output ticket selection prompt when no ticket provided', async () => {
+      const output = await execInProcess('pr link -P test-project --machine');
       const json = extractJson<{
         prompt?: { type: string; name: string; choices: Array<{ name: string; value: string; command?: string }> };
         error?: { code: string };
@@ -224,8 +224,8 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should include --json in ticket selection commands (if gh installed)', () => {
-      const output = exec('pr link -P test-project --machine');
+    it('should include --json in ticket selection commands (if gh installed)', async () => {
+      const output = await execInProcess('pr link -P test-project --machine');
       const json = extractJson<{
         prompt?: { choices: Array<{ command?: string }> };
         error?: { code: string };
@@ -241,17 +241,17 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('pr link -P test-project -m');
+    it('should work with -m shorthand', async () => {
+      const output = await execInProcess('pr link -P test-project -m');
       const json = extractJson<{ prompt?: unknown; error?: unknown; metadata: { command: string } }>(output);
 
       // Should produce valid JSON output
       expect(json.metadata.command).to.equal('pr link');
     });
 
-    it('should skip ticket selection when ticket ID provided directly', () => {
+    it('should skip ticket selection when ticket ID provided directly', async () => {
       // When ticket ID provided, should move to next step (PR selection or gh error)
-      const output = exec('pr link TKT-LINK-1 -P test-project --machine');
+      const output = await execInProcess('pr link TKT-LINK-1 -P test-project --machine');
 
       // Either prompts for PR selection or shows gh error
       expect(output).to.be.a('string');
@@ -273,8 +273,8 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should output valid response for PR creation', () => {
-      const output = exec('pr create -P test-project --machine');
+    it('should output valid response for PR creation', async () => {
+      const output = await execInProcess('pr create -P test-project --machine');
 
       // Must get some output
       expect(output).to.be.a('string');
@@ -316,8 +316,8 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('pr create -P test-project -m');
+    it('should work with -m shorthand', async () => {
+      const output = await execInProcess('pr create -P test-project -m');
 
       // Must get some output
       expect(output).to.be.a('string');
@@ -368,8 +368,8 @@ describe('PR Commands JSON Mode', () => {
       };
     }
 
-    function agentExec(cmd: string): AgentPrompt {
-      const output = exec(cmd);
+    async function agentExec(cmd: string): Promise<AgentPrompt> {
+      const output = await execInProcess(cmd);
       return extractJson<AgentPrompt>(output);
     }
 
@@ -396,8 +396,8 @@ describe('PR Commands JSON Mode', () => {
     /**
      * Helper to execute final command (strips --json/--machine flags)
      */
-    function execFinal(cmd: string): string {
-      return exec(cmd.replace(' --json', '').replace(' --machine', ''));
+    async function execFinal(cmd: string): Promise<string> {
+      return await execInProcess(cmd.replace(' --json', '').replace(' --machine', ''));
     }
 
     describe('pr index → subcommand - menu navigation flow', () => {
@@ -405,9 +405,9 @@ describe('PR Commands JSON Mode', () => {
         createTestTicket('TKT-MENU-1', 'Menu navigation test', 'in-progress', 'https://github.com/test/repo/pull/99');
       });
 
-      it('should complete full flow: main menu → status → select ticket → view result', () => {
+      it('should complete full flow: main menu → status → select ticket → view result', async () => {
         // Agent Step 1: Main menu
-        const step1 = agentExec('pr -P test-project --machine');
+        const step1 = await agentExec('pr -P test-project --machine');
         expect(step1.prompt).to.exist;
         expect(step1.prompt!.type).to.equal('list');
         expect(step1.prompt!.name).to.equal('action');
@@ -420,7 +420,7 @@ describe('PR Commands JSON Mode', () => {
         // Agent Step 2: Execute status action command
         // Note: The pr index command runs subcommands directly, so we need to
         // call pr status separately (the menu selection runs the subcommand)
-        const step2 = agentExec('pr status -P test-project --machine');
+        const step2 = await agentExec('pr status -P test-project --machine');
         expect(step2.prompt).to.exist;
         expect(step2.prompt!.type).to.equal('list');
         expect(step2.prompt!.name).to.equal('ticket');
@@ -430,19 +430,19 @@ describe('PR Commands JSON Mode', () => {
         expect(ticketChoice).to.exist;
 
         // Agent Step 3: View ticket status
-        const result = execFinal(execChoice(ticketChoice!));
+        const result = await execFinal(execChoice(ticketChoice!));
 
         // Verify ticket info shown
         expect(result).to.include('TKT-MENU-1');
       });
 
-      it('should complete flow: main menu → link → select ticket → select PR', () => {
+      it('should complete flow: main menu → link → select ticket → select PR', async () => {
         // Create a ticket WITHOUT a PR link for this test
         // (TKT-MENU-1 has a PR, so we need a fresh ticket)
         createTestTicket('TKT-MENU-LINK', 'Menu link test ticket', 'in-progress');
 
         // Agent Step 1: Main menu
-        const step1 = agentExec('pr -P test-project --machine');
+        const step1 = await agentExec('pr -P test-project --machine');
         expect(step1.prompt).to.exist;
 
         // Find link action
@@ -451,7 +451,7 @@ describe('PR Commands JSON Mode', () => {
         expect(linkChoice!.command).to.include('--json');
 
         // Agent Step 2: Execute link command
-        const step2 = agentExec('pr link -P test-project --machine');
+        const step2 = await agentExec('pr link -P test-project --machine');
 
         // If gh not installed, skip rest
         if (step2.error) {
@@ -468,7 +468,7 @@ describe('PR Commands JSON Mode', () => {
         expect(ticketChoice).to.exist;
 
         // Agent Step 3: Select ticket, get PR selection
-        const step3 = agentExec(execChoice(ticketChoice!));
+        const step3 = await agentExec(execChoice(ticketChoice!));
 
         // Either PR selection or no PRs error
         if (step3.error) {
@@ -481,8 +481,8 @@ describe('PR Commands JSON Mode', () => {
         expect(step3.prompt!.name).to.equal('pr');
       });
 
-      it('should provide cancel option in menu', () => {
-        const step1 = agentExec('pr -P test-project --machine');
+      it('should provide cancel option in menu', async () => {
+        const step1 = await agentExec('pr -P test-project --machine');
         expect(step1.prompt).to.exist;
 
         const cancelChoice = findChoice(step1.prompt!.choices!, 'cancel');
@@ -496,7 +496,7 @@ describe('PR Commands JSON Mode', () => {
         createTestTicket('TKT-STATUS-FLOW-1', 'Agent status test', 'in-progress', 'https://github.com/test/repo/pull/123');
       });
 
-      it('should complete flow: select ticket → view status → verify reads from database', () => {
+      it('should complete flow: select ticket → view status → verify reads from database', async () => {
         // First verify the PR URL is in database
         const dbMetadata = db.prepare(`
           SELECT value FROM pmo_ticket_metadata
@@ -506,7 +506,7 @@ describe('PR Commands JSON Mode', () => {
         expect(dbMetadata!.value).to.equal('https://github.com/test/repo/pull/123');
 
         // Agent Step 1: Get ticket choices
-        const step1 = agentExec('pr status -P test-project --machine');
+        const step1 = await agentExec('pr status -P test-project --machine');
         expect(step1.prompt).to.exist;
         expect(step1.prompt!.type).to.equal('list');
         expect(step1.prompt!.name).to.equal('ticket');
@@ -520,7 +520,7 @@ describe('PR Commands JSON Mode', () => {
         expect(ticketChoice!.command).to.include('--json');
 
         // Agent Step 2: View status (final step)
-        const result = execFinal(execChoice(ticketChoice!));
+        const result = await execFinal(execChoice(ticketChoice!));
 
         // Verify status output includes data from database
         expect(result).to.include('TKT-STATUS-FLOW-1');
@@ -532,7 +532,7 @@ describe('PR Commands JSON Mode', () => {
         );
       });
 
-      it('should complete flow with ticket ID provided directly and show stored PR info', () => {
+      it('should complete flow with ticket ID provided directly and show stored PR info', async () => {
         // Verify database has the PR URL
         const dbMetadata = db.prepare(`
           SELECT value FROM pmo_ticket_metadata
@@ -541,7 +541,7 @@ describe('PR Commands JSON Mode', () => {
         expect(dbMetadata!.value).to.equal('https://github.com/test/repo/pull/123');
 
         // Agent provides ticket ID - no prompts needed
-        const result = exec('pr status TKT-STATUS-FLOW-1 -P test-project');
+        const result = await execInProcess('pr status TKT-STATUS-FLOW-1 -P test-project');
 
         // Verify output shows ticket
         expect(result).to.include('TKT-STATUS-FLOW-1');
@@ -552,7 +552,7 @@ describe('PR Commands JSON Mode', () => {
         );
       });
 
-      it('should verify ticket without PR shows appropriate message', () => {
+      it('should verify ticket without PR shows appropriate message', async () => {
         // Create ticket WITHOUT PR link
         createTestTicket('TKT-NO-PR-STATUS', 'Ticket without PR', 'in-progress');
 
@@ -564,7 +564,7 @@ describe('PR Commands JSON Mode', () => {
         expect(dbMetadata).to.not.exist;
 
         // View status
-        const result = exec('pr status TKT-NO-PR-STATUS -P test-project');
+        const result = await execInProcess('pr status TKT-NO-PR-STATUS -P test-project');
 
         // Should indicate no PR linked
         expect(result).to.include('TKT-NO-PR-STATUS');
@@ -577,9 +577,9 @@ describe('PR Commands JSON Mode', () => {
         createTestTicket('TKT-LINK-FLOW-1', 'Agent link test', 'in-progress');
       });
 
-      it('should complete flow: select ticket → select PR → verify link in database', () => {
+      it('should complete flow: select ticket → select PR → verify link in database', async () => {
         // Agent Step 1: Get ticket choices (or gh error)
-        const step1 = agentExec('pr link -P test-project --machine');
+        const step1 = await agentExec('pr link -P test-project --machine');
 
         // If gh not installed, we get an error - skip test
         if (step1.error) {
@@ -599,7 +599,7 @@ describe('PR Commands JSON Mode', () => {
         expect(ticketChoice!.command).to.include('--json');
 
         // Agent Step 2: Select ticket, get PR selection prompt
-        const step2 = agentExec(execChoice(ticketChoice!));
+        const step2 = await agentExec(execChoice(ticketChoice!));
 
         // If no open PRs, we get an error
         if (step2.error) {
@@ -620,7 +620,7 @@ describe('PR Commands JSON Mode', () => {
         expect(prChoice.command).to.include('--json');
 
         // Agent Step 3: Execute the link (final step)
-        const result = execFinal(execChoice(prChoice));
+        const result = await execFinal(execChoice(prChoice));
 
         // Verify link succeeded
         expect(result.toLowerCase()).to.include('linked');
@@ -634,9 +634,9 @@ describe('PR Commands JSON Mode', () => {
         expect(metadata!.value).to.include('github.com');
       });
 
-      it('should complete flow with ticket ID provided directly → select PR → verify link', () => {
+      it('should complete flow with ticket ID provided directly → select PR → verify link', async () => {
         // Agent provides ticket ID - skips ticket selection
-        const step1 = agentExec('pr link TKT-LINK-FLOW-1 -P test-project --machine');
+        const step1 = await agentExec('pr link TKT-LINK-FLOW-1 -P test-project --machine');
 
         // If gh not installed or no PRs, skip
         if (step1.error) {
@@ -656,7 +656,7 @@ describe('PR Commands JSON Mode', () => {
         expect(prChoice).to.exist;
 
         // Execute the link
-        const result = execFinal(execChoice(prChoice));
+        const result = await execFinal(execChoice(prChoice));
 
         // Verify link succeeded
         expect(result.toLowerCase()).to.include('linked');
@@ -670,10 +670,10 @@ describe('PR Commands JSON Mode', () => {
         expect(metadata!.value).to.include('github.com');
       });
 
-      it('should handle --pr flag to skip PR selection entirely', () => {
+      it('should handle --pr flag to skip PR selection entirely', async () => {
         // Agent provides both ticket and PR number - no prompts needed
         // Use PR #221 which exists on this repo
-        const result = exec('pr link TKT-LINK-FLOW-1 --pr 221 -P test-project');
+        const result = await execInProcess('pr link TKT-LINK-FLOW-1 --pr 221 -P test-project');
 
         // Should either succeed or show error if PR not found
         expect(result).to.be.a('string');
@@ -688,12 +688,12 @@ describe('PR Commands JSON Mode', () => {
         }
       });
 
-      it('should complete confirmation flow: ticket with existing PR → confirm replace → select new PR', () => {
+      it('should complete confirmation flow: ticket with existing PR → confirm replace → select new PR', async () => {
         // Create a ticket that ALREADY has a PR linked
         createTestTicket('TKT-LINK-REPLACE', 'Replace PR test', 'in-progress', 'https://github.com/existing/pr/123');
 
         // Agent Step 1: Select this ticket (provide directly to skip ticket selection)
-        const step1 = agentExec('pr link TKT-LINK-REPLACE -P test-project --machine');
+        const step1 = await agentExec('pr link TKT-LINK-REPLACE -P test-project --machine');
 
         // If gh not installed, skip
         if (step1.error) {
@@ -716,7 +716,7 @@ describe('PR Commands JSON Mode', () => {
         // Agent Step 2: Use --confirm flag directly to confirm and get PR selection
         // (FlagResolver builds command with value, but --confirm is a boolean flag,
         // so we use the flag directly instead of the generated command)
-        const step2 = agentExec('pr link TKT-LINK-REPLACE -P test-project --confirm --machine');
+        const step2 = await agentExec('pr link TKT-LINK-REPLACE -P test-project --confirm --machine');
 
         // If no open PRs, we get an error
         if (step2.error) {
@@ -736,7 +736,7 @@ describe('PR Commands JSON Mode', () => {
         // Agent Step 3: Execute the link (final step)
         // Include --confirm since the ticket still has the old PR until we update it
         const finalCmd = execChoice(prChoice).replace(' --json', ' --confirm').replace(' --machine', ' --confirm');
-        const result = exec(finalCmd.includes('--confirm') ? finalCmd : finalCmd + ' --confirm');
+        const result = await execInProcess(finalCmd.includes('--confirm') ? finalCmd : finalCmd + ' --confirm');
 
         // Verify link succeeded
         expect(result.toLowerCase()).to.include('linked');
@@ -751,12 +751,12 @@ describe('PR Commands JSON Mode', () => {
         expect(metadata!.value).to.not.equal('https://github.com/existing/pr/123');
       });
 
-      it('should allow canceling confirmation when ticket has existing PR', () => {
+      it('should allow canceling confirmation when ticket has existing PR', async () => {
         // Create a ticket with existing PR
         createTestTicket('TKT-LINK-CANCEL', 'Cancel replace test', 'in-progress', 'https://github.com/existing/pr/456');
 
         // Agent Step 1: Select this ticket
-        const step1 = agentExec('pr link TKT-LINK-CANCEL -P test-project --machine');
+        const step1 = await agentExec('pr link TKT-LINK-CANCEL -P test-project --machine');
 
         // If gh not installed, skip
         if (step1.error) {
@@ -774,7 +774,7 @@ describe('PR Commands JSON Mode', () => {
 
         // Agent Step 2: Don't use --confirm flag - just run without it
         // (equivalent to selecting "No" - will show the existing PR info and return)
-        const result = exec('pr link TKT-LINK-CANCEL -P test-project');
+        const result = await execInProcess('pr link TKT-LINK-CANCEL -P test-project');
 
         // Should complete (shows existing PR info)
         expect(result).to.be.a('string');
@@ -802,10 +802,10 @@ describe('PR Commands JSON Mode', () => {
         }
       });
 
-      it('should auto-detect ticket from branch and skip ticket selection', () => {
+      it('should auto-detect ticket from branch and skip ticket selection', async () => {
         // Agent starts PR creation - should auto-detect ticket from branch name
         // Branch is feat/TKT-CREATE-FLOW-1-test so it should detect TKT-CREATE-FLOW-1
-        const output = exec('pr create -P test-project --machine');
+        const output = await execInProcess('pr create -P test-project --machine');
 
         expect(output).to.be.a('string');
         expect(output.length).to.be.greaterThan(0);
@@ -845,9 +845,9 @@ describe('PR Commands JSON Mode', () => {
         }
       });
 
-      it('should handle --no-link flag and skip ticket prompt entirely', () => {
+      it('should handle --no-link flag and skip ticket prompt entirely', async () => {
         // Agent uses --no-link to create PR without linking to ticket
-        const output = exec('pr create --no-link --machine');
+        const output = await execInProcess('pr create --no-link --machine');
 
         expect(output).to.be.a('string');
         expect(output.length).to.be.greaterThan(0);
@@ -885,14 +885,14 @@ describe('PR Commands JSON Mode', () => {
         }
       });
 
-      it('should complete ticket selection flow when branch has no ticket ID', () => {
+      it('should complete ticket selection flow when branch has no ticket ID', async () => {
         // Create some in-progress tickets for selection
         createTestTicket('TKT-CREATE-SELECT-1', 'First selectable ticket', 'in-progress');
         createTestTicket('TKT-CREATE-SELECT-2', 'Second selectable ticket', 'in-progress');
 
         // Agent Step 1: Start PR creation - should get ticket selection prompt
         // Note: This runs in the current git repo context
-        const output = exec('pr create -P test-project --machine');
+        const output = await execInProcess('pr create -P test-project --machine');
 
         // Check if PR already exists (outputs text instead of JSON)
         if (output.includes('PR already exists')) {
@@ -938,11 +938,11 @@ describe('PR Commands JSON Mode', () => {
         }
       });
 
-      it('should allow skipping ticket selection in PR creation', () => {
+      it('should allow skipping ticket selection in PR creation', async () => {
         // Create in-progress tickets
         createTestTicket('TKT-SKIP-TEST', 'Skip test ticket', 'in-progress');
 
-        const output = exec('pr create -P test-project --machine');
+        const output = await execInProcess('pr create -P test-project --machine');
 
         // Check if PR already exists
         if (output.includes('PR already exists')) {
@@ -972,7 +972,7 @@ describe('PR Commands JSON Mode', () => {
         expect(skipChoice.command).to.include('--json');
 
         // Agent selects "Skip" - should proceed with PR creation without ticket
-        const result = execFinal(execChoice(skipChoice!));
+        const result = await execFinal(execChoice(skipChoice!));
 
         // Verify output indicates PR creation proceeded (or valid error)
         expect(result).to.be.a('string');
@@ -1001,9 +1001,9 @@ describe('PR Commands JSON Mode', () => {
         createTestTicket('TKT-JSON-COMPAT', 'JSON compat ticket', 'in-progress', 'https://github.com/test/repo/pull/99');
       });
 
-      it('should complete status flow with --json flag (legacy) and show PR info', () => {
+      it('should complete status flow with --json flag (legacy) and show PR info', async () => {
         // Use --json instead of --machine (legacy flag)
-        const step1 = agentExec('pr status -P test-project --json');
+        const step1 = await agentExec('pr status -P test-project --json');
 
         // Verify JSON structure is identical to --machine
         expect(step1.prompt).to.exist;
@@ -1020,14 +1020,14 @@ describe('PR Commands JSON Mode', () => {
         expect(ticketChoice!.name).to.include('PR linked');  // Should show PR indicator
 
         // Execute and verify status output
-        const result = execFinal(execChoice(ticketChoice!));
+        const result = await execFinal(execChoice(ticketChoice!));
         expect(result).to.include('TKT-JSON-COMPAT');
         expect(result).to.include('PR Status');  // Header
         expect(result).to.include('Title:');    // Ticket info shown
       });
 
-      it('should complete main menu flow with --json flag (legacy) with full choice verification', () => {
-        const step1 = agentExec('pr -P test-project --json');
+      it('should complete main menu flow with --json flag (legacy) with full choice verification', async () => {
+        const step1 = await agentExec('pr -P test-project --json');
 
         // Verify prompt structure
         expect(step1.prompt).to.exist;
@@ -1058,10 +1058,10 @@ describe('PR Commands JSON Mode', () => {
         expect(statusChoice!.value).to.equal('status');
       });
 
-      it('should produce identical structure with --json and --machine flags', () => {
+      it('should produce identical structure with --json and --machine flags', async () => {
         // Get output with both flags
-        const jsonOutput = agentExec('pr -P test-project --json');
-        const machineOutput = agentExec('pr -P test-project --machine');
+        const jsonOutput = await agentExec('pr -P test-project --json');
+        const machineOutput = await agentExec('pr -P test-project --machine');
 
         // Structure should be identical (except command field may differ)
         expect(jsonOutput.prompt!.type).to.equal(machineOutput.prompt!.type);
@@ -1073,9 +1073,9 @@ describe('PR Commands JSON Mode', () => {
   });
 
   describe('Error handling in JSON mode', () => {
-    it('should show informative message when no tickets exist for pr status', () => {
+    it('should show informative message when no tickets exist for pr status', async () => {
       // No tickets created in this test
-      const output = exec('pr status -P test-project --machine');
+      const output = await execInProcess('pr status -P test-project --machine');
 
       // Must indicate no tickets found
       expect(output.toLowerCase()).to.include('no tickets');
@@ -1084,11 +1084,11 @@ describe('PR Commands JSON Mode', () => {
       expect(output.length).to.be.greaterThan(10);
     });
 
-    it('should return structured error JSON for gh CLI issues', () => {
+    it('should return structured error JSON for gh CLI issues', async () => {
       createTestTicket('TKT-ERR-1', 'Error test ticket', 'in-progress');
 
       // pr link requires gh CLI - test error structure
-      const output = exec('pr link TKT-ERR-1 -P test-project --machine');
+      const output = await execInProcess('pr link TKT-ERR-1 -P test-project --machine');
       const json = extractJson<{
         prompt?: { type: string; name: string };
         error?: { code: string; message: string };
@@ -1121,9 +1121,9 @@ describe('PR Commands JSON Mode', () => {
       }
     });
 
-    it('should return valid error structure for invalid ticket ID', () => {
+    it('should return valid error structure for invalid ticket ID', async () => {
       // Try to view status of non-existent ticket
-      const output = exec('pr status INVALID-TICKET-123 -P test-project --machine');
+      const output = await execInProcess('pr status INVALID-TICKET-123 -P test-project --machine');
 
       // Should either error or show "not found" message
       expect(output).to.be.a('string');

--- a/apps/cli/test/e2e/pr-list-commands.test.ts
+++ b/apps/cli/test/e2e/pr-list-commands.test.ts
@@ -10,7 +10,7 @@ import {
   createPMODirectories,
   setupProductionSchema,
   createTestProject,
-  exec,
+  execInProcess,
   type TestEnvironment,
 } from './test-helpers.js';
 
@@ -103,9 +103,9 @@ describe('PR List Command E2E Tests', () => {
   }
 
   describe('prlt pr list command structure', () => {
-    it('should have correct command flags', () => {
+    it('should have correct command flags', async () => {
       // Check help output includes expected flags
-      const output = exec('pr list --help');
+      const output = await execInProcess('pr list --help');
 
       expect(output).to.include('--state');
       expect(output).to.include('--format');
@@ -114,9 +114,9 @@ describe('PR List Command E2E Tests', () => {
       expect(output).to.include('--json');
     });
 
-    it('should be accessible via pr menu', () => {
+    it('should be accessible via pr menu', async () => {
       // The pr index command should include list option
-      const output = exec('pr -P test-project --machine');
+      const output = await execInProcess('pr -P test-project --machine');
 
       // Should have list in the menu choices
       expect(output).to.include('list');
@@ -124,8 +124,8 @@ describe('PR List Command E2E Tests', () => {
   });
 
   describe('prlt pr list --machine (JSON mode)', () => {
-    it('should output valid JSON when --machine flag is used', () => {
-      const output = exec('pr list -P test-project --machine');
+    it('should output valid JSON when --machine flag is used', async () => {
+      const output = await execInProcess('pr list -P test-project --machine');
 
       // Must get some output
       expect(output).to.be.a('string');
@@ -148,15 +148,15 @@ describe('PR List Command E2E Tests', () => {
       }
     });
 
-    it('should work with -m shorthand', () => {
-      const output = exec('pr list -P test-project -m');
+    it('should work with -m shorthand', async () => {
+      const output = await execInProcess('pr list -P test-project -m');
 
       expect(output).to.be.a('string');
       expect(output.length).to.be.greaterThan(0);
     });
 
-    it('should work with --json flag (legacy)', () => {
-      const output = exec('pr list -P test-project --json');
+    it('should work with --json flag (legacy)', async () => {
+      const output = await execInProcess('pr list -P test-project --json');
 
       expect(output).to.be.a('string');
       expect(output.length).to.be.greaterThan(0);
@@ -164,64 +164,64 @@ describe('PR List Command E2E Tests', () => {
   });
 
   describe('prlt pr list with state filter', () => {
-    it('should accept --state open filter', () => {
-      const output = exec('pr list --state open -P test-project --machine');
+    it('should accept --state open filter', async () => {
+      const output = await execInProcess('pr list --state open -P test-project --machine');
 
       expect(output).to.be.a('string');
     });
 
-    it('should accept --state draft filter', () => {
-      const output = exec('pr list --state draft -P test-project --machine');
+    it('should accept --state draft filter', async () => {
+      const output = await execInProcess('pr list --state draft -P test-project --machine');
 
       expect(output).to.be.a('string');
     });
 
-    it('should accept --state all filter', () => {
-      const output = exec('pr list --state all -P test-project --machine');
+    it('should accept --state all filter', async () => {
+      const output = await execInProcess('pr list --state all -P test-project --machine');
 
       expect(output).to.be.a('string');
     });
   });
 
   describe('prlt pr list with format options', () => {
-    it('should accept --format table (default)', () => {
-      const output = exec('pr list --format table -P test-project');
+    it('should accept --format table (default)', async () => {
+      const output = await execInProcess('pr list --format table -P test-project');
 
       expect(output).to.be.a('string');
     });
 
-    it('should accept --format compact', () => {
-      const output = exec('pr list --format compact -P test-project');
+    it('should accept --format compact', async () => {
+      const output = await execInProcess('pr list --format compact -P test-project');
 
       expect(output).to.be.a('string');
     });
 
-    it('should accept --format json', () => {
-      const output = exec('pr list --format json -P test-project');
+    it('should accept --format json', async () => {
+      const output = await execInProcess('pr list --format json -P test-project');
 
       expect(output).to.be.a('string');
     });
   });
 
   describe('prlt pr list with limit option', () => {
-    it('should accept --limit flag', () => {
-      const output = exec('pr list --limit 10 -P test-project --machine');
+    it('should accept --limit flag', async () => {
+      const output = await execInProcess('pr list --limit 10 -P test-project --machine');
 
       expect(output).to.be.a('string');
     });
 
-    it('should accept -l shorthand for limit', () => {
-      const output = exec('pr list -l 5 -P test-project --machine');
+    it('should accept -l shorthand for limit', async () => {
+      const output = await execInProcess('pr list -l 5 -P test-project --machine');
 
       expect(output).to.be.a('string');
     });
   });
 
   describe('prlt pr list error handling', () => {
-    it('should return structured error when gh CLI not installed', () => {
+    it('should return structured error when gh CLI not installed', async () => {
       // Mock gh not installed by running in isolated environment
       // This test depends on gh CLI availability
-      const output = exec('pr list -P test-project --machine');
+      const output = await execInProcess('pr list -P test-project --machine');
 
       // If gh not installed, should have error code
       if (output.includes('GH_NOT_INSTALLED')) {
@@ -237,8 +237,8 @@ describe('PR List Command E2E Tests', () => {
       }
     });
 
-    it('should return structured error when gh CLI not authenticated', () => {
-      const output = exec('pr list -P test-project --machine');
+    it('should return structured error when gh CLI not authenticated', async () => {
+      const output = await execInProcess('pr list -P test-project --machine');
 
       // If gh not authenticated, should have error code
       if (output.includes('GH_NOT_AUTHENTICATED')) {
@@ -262,8 +262,8 @@ describe('PR List Command E2E Tests', () => {
       createTestTicket('TKT-NO-PR', 'Ticket without PR', 'in-progress');
     });
 
-    it('should have ticket association data in JSON output (if gh installed)', () => {
-      const output = exec('pr list -P test-project --machine');
+    it('should have ticket association data in JSON output (if gh installed)', async () => {
+      const output = await execInProcess('pr list -P test-project --machine');
 
       // If we get valid JSON array output
       if (output.startsWith('[')) {
@@ -287,7 +287,7 @@ describe('PR List Command E2E Tests', () => {
       }
     });
 
-    it('should store ticket metadata for association lookup', () => {
+    it('should store ticket metadata for association lookup', async () => {
       // Verify the metadata is in database (what pr list uses)
       const metadata = db.prepare(`
         SELECT ticket_id, key, value FROM pmo_ticket_metadata
@@ -310,8 +310,8 @@ describe('PR List Command E2E Tests', () => {
   });
 
   describe('prlt pr list interactive output', () => {
-    it('should display pull requests header in table format', () => {
-      const output = exec('pr list -P test-project --format table');
+    it('should display pull requests header in table format', async () => {
+      const output = await execInProcess('pr list -P test-project --format table');
 
       // Should show "Pull Requests" header or "No open pull requests"
       expect(output).to.satisfy((s: string) =>
@@ -323,8 +323,8 @@ describe('PR List Command E2E Tests', () => {
       );
     });
 
-    it('should display compact output when requested', () => {
-      const output = exec('pr list -P test-project --format compact');
+    it('should display compact output when requested', async () => {
+      const output = await execInProcess('pr list -P test-project --format compact');
 
       // Should show output or appropriate message
       expect(output).to.be.a('string');
@@ -333,8 +333,8 @@ describe('PR List Command E2E Tests', () => {
   });
 
   describe('pr menu integration', () => {
-    it('should include list in pr menu choices', () => {
-      const output = exec('pr -P test-project --machine');
+    it('should include list in pr menu choices', async () => {
+      const output = await execInProcess('pr -P test-project --machine');
       const json = extractJson<{
         prompt: { choices: Array<{ name: string; value: string }> };
       }>(output);
@@ -345,9 +345,9 @@ describe('PR List Command E2E Tests', () => {
       expect(listChoice!.name.toLowerCase()).to.include('list');
     });
 
-    it('should invoke pr list when list action is selected', () => {
+    it('should invoke pr list when list action is selected', async () => {
       // Verify the action 'list' maps to pr:list command
-      const output = exec('pr -a list -P test-project --machine');
+      const output = await execInProcess('pr -a list -P test-project --machine');
 
       // Should invoke pr list command
       // Output depends on gh CLI availability

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import Database from 'better-sqlite3';
 import {
-  execProduction,
+  execInProcess,
   extractJson,
   agentExec,
   findChoiceByValue,
@@ -80,7 +80,7 @@ describe('Session Commands E2E Tests', () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     originalCwd = process.cwd();
     testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-e2e-')));
     process.chdir(testDir);
@@ -107,7 +107,7 @@ describe('Session Commands E2E Tests', () => {
 
     // Run a safe command to trigger PMO table initialization
     // The CLI's PMOCommand.init() creates all PMO tables via ensurePMOTables()
-    execProduction('session --machine');
+    await execInProcess('session --machine');
 
     // Create workspace tables needed by getWorkspaceInfo() (used by session list/attach)
     // These are separate from PMO tables and created by the workspace init flow
@@ -257,14 +257,14 @@ describe('Session Commands E2E Tests', () => {
   // prlt session list - direct invocation with flags
   // =========================================================================
   describe('prlt session list', () => {
-    it('should return JSON array when DB has no execution records', () => {
-      const output = execProduction('session list --json');
+    it('should return JSON array when DB has no execution records', async () => {
+      const output = await execInProcess('session list --json');
       // Output is JSON in non-TTY (piped) environments
       const sessions = JSON.parse(output) as Array<{ sessionId: string }>;
       expect(sessions).to.be.an('array');
     });
 
-    it('should return DB-tracked sessions even without tmux verification (default mode)', () => {
+    it('should return DB-tracked sessions even without tmux verification (default mode)', async () => {
       // Seed a running execution - no tmux session exists to verify it
       seedExecutionRecords([{
         id: 'exec-001',
@@ -275,7 +275,7 @@ describe('Session Commands E2E Tests', () => {
       }]);
 
       // Sessions are always shown from DB, even without tmux verification
-      const output = execProduction('session list --json');
+      const output = await execInProcess('session list --json');
       const sessions = JSON.parse(output) as Array<{ sessionId: string; status: string; exists: boolean; source: string; ticketId: string }>;
       expect(sessions).to.be.an('array');
       // Filter to DB-sourced sessions for our seeded ticket (host may have real orphan tmux sessions)
@@ -287,7 +287,7 @@ describe('Session Commands E2E Tests', () => {
       }
     });
 
-    it('should show stale sessions with --all flag including ticket ID and agent name', () => {
+    it('should show stale sessions with --all flag including ticket ID and agent name', async () => {
       seedExecutionRecords([{
         id: 'exec-001',
         ticketId: 'TKT-100',
@@ -296,7 +296,7 @@ describe('Session Commands E2E Tests', () => {
         sessionId: 'TKT-100-implement-bold-turing',
       }]);
 
-      const output = execProduction('session list --all --json');
+      const output = await execInProcess('session list --all --json');
 
       // Output is JSON array in non-TTY environments
       const sessions = JSON.parse(output) as Array<{ sessionId: string; ticketId: string; agentName: string; status: string }>;
@@ -307,7 +307,7 @@ describe('Session Commands E2E Tests', () => {
       expect(session!.status).to.equal('stale');
     });
 
-    it('should include stale sessions in JSON output when using --all', () => {
+    it('should include stale sessions in JSON output when using --all', async () => {
       seedExecutionRecords([{
         id: 'exec-001',
         ticketId: 'TKT-100',
@@ -316,13 +316,13 @@ describe('Session Commands E2E Tests', () => {
         sessionId: 'TKT-100-implement-bold-turing',
       }]);
 
-      const output = execProduction('session list --all --json');
+      const output = await execInProcess('session list --all --json');
       const sessions = JSON.parse(output) as Array<{ status: string }>;
       const staleSessions = sessions.filter(s => s.status === 'stale');
       expect(staleSessions.length).to.be.greaterThanOrEqual(1);
     });
 
-    it('should show multiple stale sessions with --all when multiple executions exist', () => {
+    it('should show multiple stale sessions with --all when multiple executions exist', async () => {
       seedExecutionRecords([
         {
           id: 'exec-001',
@@ -340,7 +340,7 @@ describe('Session Commands E2E Tests', () => {
         },
       ]);
 
-      const output = execProduction('session list --all --json');
+      const output = await execInProcess('session list --all --json');
 
       // Output is JSON array in non-TTY environments
       const sessions = JSON.parse(output) as Array<{ sessionId: string; ticketId: string; agentName: string; status: string }>;
@@ -355,7 +355,7 @@ describe('Session Commands E2E Tests', () => {
       expect(session2!.agentName).to.equal('clever-lovelace');
     });
 
-    it('should show session ID in the output', () => {
+    it('should show session ID in the output', async () => {
       seedExecutionRecords([{
         id: 'exec-001',
         ticketId: 'TKT-100',
@@ -364,13 +364,13 @@ describe('Session Commands E2E Tests', () => {
         sessionId: 'TKT-100-implement-bold-turing',
       }]);
 
-      const output = execProduction('session list --all --json');
+      const output = await execInProcess('session list --all --json');
       const sessions = JSON.parse(output) as Array<{ sessionId: string }>;
       const session = sessions.find(s => s.sessionId === 'TKT-100-implement-bold-turing');
       expect(session).to.not.be.undefined;
     });
 
-    it('should show host type indicator for host sessions', () => {
+    it('should show host type indicator for host sessions', async () => {
       seedExecutionRecords([{
         id: 'exec-001',
         ticketId: 'TKT-100',
@@ -380,7 +380,7 @@ describe('Session Commands E2E Tests', () => {
         environment: 'host',
       }]);
 
-      const output = execProduction('session list --all --json');
+      const output = await execInProcess('session list --all --json');
       const sessions = JSON.parse(output) as Array<{ sessionId: string; environment: string }>;
       const session = sessions.find(s => s.sessionId === 'TKT-100-implement-bold-turing');
       expect(session).to.not.be.undefined;
@@ -396,8 +396,8 @@ describe('Session Commands E2E Tests', () => {
   // since it's already migrated using this.selectFromList() in base-command.ts.
   // =========================================================================
   describe('prlt session attach', () => {
-    it('should output JSON error NO_SESSIONS when no sessions exist (--json)', () => {
-      const output = execProduction('session attach --json');
+    it('should output JSON error NO_SESSIONS when no sessions exist (--json)', async () => {
+      const output = await execInProcess('session attach --json');
       const json = extractJson<{ error: { code: string; message: string }; prompt?: unknown }>(output);
 
       // If real tmux sessions exist on host, attach may return a prompt instead of error
@@ -408,8 +408,8 @@ describe('Session Commands E2E Tests', () => {
       expect(json.error.message).to.include('No active sessions');
     });
 
-    it('should output JSON error NO_SESSIONS when no sessions exist (--machine)', () => {
-      const output = execProduction('session attach --machine');
+    it('should output JSON error NO_SESSIONS when no sessions exist (--machine)', async () => {
+      const output = await execInProcess('session attach --machine');
       const json = extractJson<{ error: { code: string; message: string }; prompt?: unknown }>(output);
 
       // If real tmux sessions exist on host, attach may return a prompt instead of error
@@ -419,7 +419,7 @@ describe('Session Commands E2E Tests', () => {
       expect(json.error.code).to.equal('NO_SESSIONS');
     });
 
-    it('should output NO_SESSIONS even when execution records exist (tmux verification fails)', () => {
+    it('should output NO_SESSIONS even when execution records exist (tmux verification fails)', async () => {
       // Seed execution records - but no tmux sessions exist
       seedExecutionRecords([{
         id: 'exec-001',
@@ -429,7 +429,7 @@ describe('Session Commands E2E Tests', () => {
         sessionId: 'TKT-100-implement-bold-turing',
       }]);
 
-      const output = execProduction('session attach --json');
+      const output = await execInProcess('session attach --json');
       const json = extractJson<{ error: { code: string; message: string }; prompt?: unknown }>(output);
 
       // If real tmux sessions exist on host, attach may return a prompt instead of error
@@ -440,8 +440,8 @@ describe('Session Commands E2E Tests', () => {
       expect(json.error.code).to.equal('NO_SESSIONS');
     });
 
-    it('should output NO_SESSIONS for named session arg when no tmux sessions exist', () => {
-      const output = execProduction('session attach TKT-100-implement --json');
+    it('should output NO_SESSIONS for named session arg when no tmux sessions exist', async () => {
+      const output = await execInProcess('session attach TKT-100-implement --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       // If real tmux sessions exist on host, error code may differ
@@ -461,7 +461,7 @@ describe('Session Commands E2E Tests', () => {
   // Tests the COMPLETE agentic flow: get menu → pick choice → follow command → verify result
   // =========================================================================
   describe('Agent flow: session menu → session list (with data)', () => {
-    it('should navigate menu → list choice → execute → verify session data appears', () => {
+    it('should navigate menu → list choice → execute → verify session data appears', async () => {
       // Seed execution data first
       seedExecutionRecords([{
         id: 'exec-001',
@@ -482,7 +482,7 @@ describe('Session Commands E2E Tests', () => {
       expect(listChoice!.command).to.equal('prlt session list --json');
 
       // Step 3: Agent executes the list command
-      const listOutput = execProduction('session list --json');
+      const listOutput = await execInProcess('session list --json');
 
       // Step 4: Verify END RESULT - check list returns valid JSON array
       const sessions = JSON.parse(listOutput) as Array<{ sessionId: string; ticketId: string; agentName: string; status: string }>;
@@ -497,7 +497,7 @@ describe('Session Commands E2E Tests', () => {
   });
 
   describe('Agent flow: session menu → session attach (error path)', () => {
-    it('should navigate menu → attach choice → execute → verify NO_SESSIONS JSON error', () => {
+    it('should navigate menu → attach choice → execute → verify NO_SESSIONS JSON error', async () => {
       // Step 1: Agent gets session menu
       const menuResult = agentExec('session --machine');
       expect(menuResult).to.not.be.null;
@@ -509,7 +509,7 @@ describe('Session Commands E2E Tests', () => {
 
       // Step 3: Agent executes the attach command from the choice
       const attachCmd = attachChoice!.command!.replace('prlt ', '');
-      const attachOutput = execProduction(attachCmd);
+      const attachOutput = await execInProcess(attachCmd);
 
       // Step 4: Verify END RESULT - structured JSON response returned
       const json = extractJson<{ error?: { code: string; message: string }; prompt?: unknown }>(attachOutput);
@@ -521,7 +521,7 @@ describe('Session Commands E2E Tests', () => {
       }
     });
 
-    it('should navigate menu → attach choice → with seeded data → still NO_SESSIONS (tmux required)', () => {
+    it('should navigate menu → attach choice → with seeded data → still NO_SESSIONS (tmux required)', async () => {
       // Seed execution records
       seedExecutionRecords([{
         id: 'exec-001',
@@ -538,7 +538,7 @@ describe('Session Commands E2E Tests', () => {
       // Step 2: Navigate to attach
       const attachChoice = findChoiceByValue(menuResult!.prompt.choices, 'attach');
       const attachCmd = attachChoice!.command!.replace('prlt ', '');
-      const attachOutput = execProduction(attachCmd);
+      const attachOutput = await execInProcess(attachCmd);
 
       // Step 3: Verify - structured JSON response (error or prompt if real sessions exist)
       const json = extractJson<{ error?: { code: string }; prompt?: unknown }>(attachOutput);
@@ -556,8 +556,8 @@ describe('Session Commands E2E Tests', () => {
   // we can only test error paths (no matching execution, no active session).
   // =========================================================================
   describe('prlt session poke', () => {
-    it('should output JSON error NO_ACTIVE_EXECUTION when no executions match agent name (--json)', () => {
-      const output = execProduction('session poke nonexistent-agent "hello" --json');
+    it('should output JSON error NO_ACTIVE_EXECUTION when no executions match agent name (--json)', async () => {
+      const output = await execInProcess('session poke nonexistent-agent "hello" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -567,8 +567,8 @@ describe('Session Commands E2E Tests', () => {
       expect(json!.error.message).to.include('no active session');
     });
 
-    it('should output JSON error NO_ACTIVE_EXECUTION when no executions match ticket ID (--json)', () => {
-      const output = execProduction('session poke TKT-999 "hello" --json');
+    it('should output JSON error NO_ACTIVE_EXECUTION when no executions match ticket ID (--json)', async () => {
+      const output = await execInProcess('session poke TKT-999 "hello" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -577,7 +577,7 @@ describe('Session Commands E2E Tests', () => {
       expect(json!.error.message).to.include('TKT-999');
     });
 
-    it('should output JSON error NO_ACTIVE_EXECUTION when execution exists but is not running', () => {
+    it('should output JSON error NO_ACTIVE_EXECUTION when execution exists but is not running', async () => {
       // Seed a completed execution - should not be matched
       seedExecutionRecords([{
         id: 'exec-done-001',
@@ -588,7 +588,7 @@ describe('Session Commands E2E Tests', () => {
         status: 'completed',
       }]);
 
-      const output = execProduction('session poke done-agent "hello" --json');
+      const output = await execInProcess('session poke done-agent "hello" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -596,7 +596,7 @@ describe('Session Commands E2E Tests', () => {
       expect(json!.error.code).to.equal('NO_ACTIVE_EXECUTION');
     });
 
-    it('should resolve agent by exact agent name and fail at tmux level (no tmux in test env)', () => {
+    it('should resolve agent by exact agent name and fail at tmux level (no tmux in test env)', async () => {
       seedExecutionRecords([{
         id: 'exec-poke-001',
         ticketId: 'TKT-600',
@@ -606,7 +606,7 @@ describe('Session Commands E2E Tests', () => {
         status: 'running',
       }]);
 
-      const output = execProduction('session poke poke-target "test message" --json');
+      const output = await execInProcess('session poke poke-target "test message" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       // Should resolve execution but fail at tmux send-keys (no tmux in test)
@@ -616,7 +616,7 @@ describe('Session Commands E2E Tests', () => {
       expect(['SESSION_NOT_FOUND', 'SEND_FAILED']).to.include(json!.error.code);
     });
 
-    it('should resolve agent by ticket ID and fail at tmux level', () => {
+    it('should resolve agent by ticket ID and fail at tmux level', async () => {
       seedExecutionRecords([{
         id: 'exec-poke-002',
         ticketId: 'TKT-601',
@@ -626,7 +626,7 @@ describe('Session Commands E2E Tests', () => {
         status: 'running',
       }]);
 
-      const output = execProduction('session poke TKT-601 "test message" --json');
+      const output = await execInProcess('session poke TKT-601 "test message" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -634,7 +634,7 @@ describe('Session Commands E2E Tests', () => {
       expect(['SESSION_NOT_FOUND', 'SEND_FAILED']).to.include(json!.error.code);
     });
 
-    it('should require exact agent name match (partial names do not match)', () => {
+    it('should require exact agent name match (partial names do not match)', async () => {
       seedExecutionRecords([{
         id: 'exec-poke-003a',
         ticketId: 'TKT-700',
@@ -645,7 +645,7 @@ describe('Session Commands E2E Tests', () => {
       }]);
 
       // "alpha" is not an exact match for "alpha-agent"
-      const output = execProduction('session poke alpha "test" --json');
+      const output = await execInProcess('session poke alpha "test" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -653,7 +653,7 @@ describe('Session Commands E2E Tests', () => {
       expect(json!.error.code).to.equal('NO_ACTIVE_EXECUTION');
     });
 
-    it('should resolve docker container agent by name and attempt docker exec (not host tmux)', () => {
+    it('should resolve docker container agent by name and attempt docker exec (not host tmux)', async () => {
       seedExecutionRecords([{
         id: 'exec-poke-docker-001',
         ticketId: 'TKT-800',
@@ -665,7 +665,7 @@ describe('Session Commands E2E Tests', () => {
         containerId: 'abc123def456',
       }]);
 
-      const output = execProduction('session poke docker-agent "test message" --json');
+      const output = await execInProcess('session poke docker-agent "test message" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -675,7 +675,7 @@ describe('Session Commands E2E Tests', () => {
       expect(['SEND_FAILED', 'CONTAINER_NOT_RUNNING']).to.include(json!.error.code);
     });
 
-    it('should resolve devcontainer agent by name and attempt docker exec', () => {
+    it('should resolve devcontainer agent by name and attempt docker exec', async () => {
       seedExecutionRecords([{
         id: 'exec-poke-devcontainer-001',
         ticketId: 'TKT-801',
@@ -687,7 +687,7 @@ describe('Session Commands E2E Tests', () => {
         containerId: 'def456abc789',
       }]);
 
-      const output = execProduction('session poke devcontainer-agent "test message" --json');
+      const output = await execInProcess('session poke devcontainer-agent "test message" --json');
       const json = extractJson<{ error: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;

--- a/apps/cli/test/e2e/session-peek-commands.test.ts
+++ b/apps/cli/test/e2e/session-peek-commands.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import Database from 'better-sqlite3';
 import {
-  execProduction,
+  execInProcess,
   extractJson,
   agentExec,
   findChoiceByValue,
@@ -27,7 +27,7 @@ describe('Session Peek Commands E2E Tests', () => {
   let originalCwd: string;
   let dbPath: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     originalCwd = process.cwd();
     testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-peek-e2e-')));
     process.chdir(testDir);
@@ -49,7 +49,7 @@ describe('Session Peek Commands E2E Tests', () => {
     fs.mkdirSync(path.join(testDir, 'pmo', 'projects', 'default'), { recursive: true });
 
     // Trigger PMO table initialization
-    execProduction('session --machine');
+    await execInProcess('session --machine');
 
     // Create workspace tables
     const initDb = new Database(dbPath);
@@ -150,8 +150,8 @@ describe('Session Peek Commands E2E Tests', () => {
   // success data (with target). When no tmux, it returns NO_SESSIONS error.
   // =========================================================================
   describe('prlt session peek --json (output structure)', () => {
-    it('should return valid JSON with known type field', () => {
-      const output = execProduction('session peek --json');
+    it('should return valid JSON with known type field', async () => {
+      const output = await execInProcess('session peek --json');
       const json = extractJson<{ type: string }>(output);
 
       expect(json).to.not.be.null;
@@ -159,8 +159,8 @@ describe('Session Peek Commands E2E Tests', () => {
       expect(json!.type).to.be.oneOf(['error', 'prompt']);
     });
 
-    it('should return NO_SESSIONS error or prompt depending on environment', () => {
-      const output = execProduction('session peek --json');
+    it('should return NO_SESSIONS error or prompt depending on environment', async () => {
+      const output = await execInProcess('session peek --json');
       const json = extractJson<{ type: string; error?: { code: string }; prompt?: { type: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -177,8 +177,8 @@ describe('Session Peek Commands E2E Tests', () => {
   // prlt session peek <target> --json (non-existent target)
   // =========================================================================
   describe('prlt session peek <nonexistent-target> --json', () => {
-    it('should return SESSION_NOT_FOUND or NO_SESSIONS for non-existent target', () => {
-      const output = execProduction('session peek NONEXISTENT-TARGET-12345 --json');
+    it('should return SESSION_NOT_FOUND or NO_SESSIONS for non-existent target', async () => {
+      const output = await execInProcess('session peek NONEXISTENT-TARGET-12345 --json');
       const json = extractJson<{ type: string; error?: { code: string; message: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -188,8 +188,8 @@ describe('Session Peek Commands E2E Tests', () => {
       expect(json!.error!.code).to.be.oneOf(['NO_SESSIONS', 'SESSION_NOT_FOUND']);
     });
 
-    it('should return error for non-existent ticket ID', () => {
-      const output = execProduction('session peek TKT-99999 --json');
+    it('should return error for non-existent ticket ID', async () => {
+      const output = await execInProcess('session peek TKT-99999 --json');
       const json = extractJson<{ type: string; error?: { code: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -197,8 +197,8 @@ describe('Session Peek Commands E2E Tests', () => {
       expect(json!.error!.code).to.be.oneOf(['NO_SESSIONS', 'SESSION_NOT_FOUND']);
     });
 
-    it('should return error for non-existent execution ID', () => {
-      const output = execProduction('session peek WORK-ZZZZZZZZ --json');
+    it('should return error for non-existent execution ID', async () => {
+      const output = await execInProcess('session peek WORK-ZZZZZZZZ --json');
       const json = extractJson<{ type: string; error?: { code: string } }>(output);
 
       expect(json).to.not.be.null;
@@ -211,8 +211,8 @@ describe('Session Peek Commands E2E Tests', () => {
   // prlt session peek --lines flag parsing
   // =========================================================================
   describe('prlt session peek --lines flag', () => {
-    it('should accept --lines flag without error', () => {
-      const output = execProduction('session peek --lines 100 --json');
+    it('should accept --lines flag without error', async () => {
+      const output = await execInProcess('session peek --lines 100 --json');
       const json = extractJson<{ type: string; metadata?: { flags?: { lines?: number } } }>(output);
 
       expect(json).to.not.be.null;
@@ -220,8 +220,8 @@ describe('Session Peek Commands E2E Tests', () => {
       expect(json!.type).to.be.oneOf(['error', 'prompt']);
     });
 
-    it('should accept -l shorthand flag', () => {
-      const output = execProduction('session peek -l 25 --json');
+    it('should accept -l shorthand flag', async () => {
+      const output = await execInProcess('session peek -l 25 --json');
       const json = extractJson<{ type: string }>(output);
 
       expect(json).to.not.be.null;
@@ -233,7 +233,7 @@ describe('Session Peek Commands E2E Tests', () => {
   // Agent flow: session menu → peek
   // =========================================================================
   describe('Agent flow: session menu → peek choice', () => {
-    it('should navigate menu → peek choice → execute → verify valid JSON output', () => {
+    it('should navigate menu → peek choice → execute → verify valid JSON output', async () => {
       // Step 1: Get session menu
       const menuResult = agentExec('session --machine');
       expect(menuResult).to.not.be.null;
@@ -245,7 +245,7 @@ describe('Session Peek Commands E2E Tests', () => {
 
       // Step 3: Execute the peek command
       const peekCmd = peekChoice!.command!.replace('prlt ', '');
-      const peekOutput = execProduction(peekCmd);
+      const peekOutput = await execInProcess(peekCmd);
 
       // Step 4: Verify structured JSON output (either error or prompt)
       const json = extractJson<{ type: string }>(peekOutput);
@@ -258,10 +258,10 @@ describe('Session Peek Commands E2E Tests', () => {
   // JSON output structure for success case
   // =========================================================================
   describe('prlt session peek --json (success structure)', () => {
-    it('should include expected fields when session is found and captured', () => {
+    it('should include expected fields when session is found and captured', async () => {
       // This test may not always produce a success result (depends on tmux).
       // But when it does, verify the structure.
-      const output = execProduction('session peek --json');
+      const output = await execInProcess('session peek --json');
       const json = extractJson<{
         type: string;
         result?: {


### PR DESCRIPTION
## Summary

Converts 12 integration e2e test files from child-process exec/execProduction/execAsAgent spawning to async in-process execInProcess/execInProcessAsAgent helpers (built in TKT-1223).

### Changes
- **12 files converted** with 838 insertions / 838 deletions (pure mechanical conversion)
- All affected it() / beforeEach() callbacks made async
- Imports updated from exec/execProduction to execInProcess
- execSync (git ops), db.exec() (SQLite), and higher-level helpers (agentExec, execChoice, execFinal) correctly preserved

### Files
- gh-commands.test.ts, gh-agent-flow.test.ts
- docker-commands.test.ts
- execution-commands.test.ts
- session-commands.test.ts, session-peek-commands.test.ts
- pr-commands.test.ts, pr-agent-flow.test.ts, pr-json-mode.test.ts, pr-list-commands.test.ts
- branch-commands.test.ts, branch-json-mode.test.ts

### Not converted (by design)
- linear-integration.test.ts, linear-adapter-flows.test.ts, monday-integration.test.ts — only use db.exec() (SQLite)
- mcp-server.test.ts, mcp-board-view-filtering.test.ts — use execSync directly for stdin piping