### PR TITLE
TKT-1233: Fix Statsig analytics events never reaching dashboard

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -5,7 +5,7 @@ import { findHQRoot } from '../lib/workspace.js'
 import { getCachedUpdateInfo, triggerBackgroundCheck } from '../lib/update-check.js'
 import { handleUpdatePrompt } from '../lib/update-prompt.js'
 import { initSentry } from '../lib/telemetry.js'
-import { initAnalytics } from '../lib/telemetry/analytics.js'
+import { initAnalytics, shutdownAnalytics } from '../lib/telemetry/analytics.js'
 
 /**
  * Init hook - runs before every command
@@ -87,6 +87,7 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
       // in non-TTY it outputs a JSON prompt for the HQ name
       const { run } = await import('@oclif/core')
       await run(['init'], config)
+      await shutdownAnalytics()
       process.exit(0)
     }
     return
@@ -103,6 +104,7 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
     await run(['init'], config)
 
     console.log(chalk.default.blue(`\n✅ Setup complete! You can now run: prlt ${id}\n`))
+    await shutdownAnalytics()
     process.exit(0)
   }
 }

--- a/apps/cli/src/lib/signal-handler.ts
+++ b/apps/cli/src/lib/signal-handler.ts
@@ -22,6 +22,7 @@
  */
 
 import type { ChildProcess } from 'node:child_process'
+import { shutdownAnalytics } from './telemetry/analytics.js'
 
 /** Cleanup callback - should be fast and not throw */
 type CleanupFn = () => void | Promise<void>
@@ -61,6 +62,13 @@ async function shutdown(): Promise<void> {
     }
   }
   cleanupCallbacks.length = 0
+
+  // Flush pending analytics events before exit
+  try {
+    await shutdownAnalytics()
+  } catch {
+    // Never let analytics errors block shutdown
+  }
 
   // Exit with 130 = 128 + 2 (SIGINT)
   process.exit(130)

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -62,6 +62,7 @@ interface StatsigClientInstance {
 let statsigClient: StatsigClientInstance | null = null
 let telemetryConfig: TelemetryConfig | null = null
 let cliVersion: string | null = null
+let initPromise: Promise<void> | null = null
 
 // ─── Telemetry Config ────────────────────────────────────────────────────────
 
@@ -217,29 +218,33 @@ export function getMachineId(): string {
  * Initialize the Statsig SDK. Called from the init hook.
  * No-op if telemetry is disabled.
  */
-export async function initAnalytics(version: string): Promise<void> {
+export function initAnalytics(version: string): Promise<void> {
   cliVersion = version
 
-  if (!isTelemetryEnabled()) return
+  if (!isTelemetryEnabled()) return Promise.resolve()
 
   showTelemetryNotice()
 
-  try {
-    const { StatsigClient: StatsigClientClass } = await import('@statsig/js-client')
-    const client = new StatsigClientClass(
-      STATSIG_CLIENT_KEY,
-      { userID: getMachineId(), custom: { cli_version: version } },
-    )
-    await client.initializeAsync()
-    statsigClient = client
+  initPromise = (async () => {
+    try {
+      const { StatsigClient: StatsigClientClass } = await import('@statsig/js-client')
+      const client = new StatsigClientClass(
+        STATSIG_CLIENT_KEY,
+        { userID: getMachineId(), custom: { cli_version: version } },
+      )
+      await client.initializeAsync()
+      statsigClient = client
 
-    // Share Statsig client with feature-flags for synchronous gate checks
-    const { setStatsigClient } = await import('./feature-flags.js')
-    setStatsigClient(client)
-  } catch {
-    // If Statsig can't initialize, fail silently — analytics should never break the CLI
-    statsigClient = null
-  }
+      // Share Statsig client with feature-flags for synchronous gate checks
+      const { setStatsigClient } = await import('./feature-flags.js')
+      setStatsigClient(client)
+    } catch {
+      // If Statsig can't initialize, fail silently — analytics should never break the CLI
+      statsigClient = null
+    }
+  })()
+
+  return initPromise
 }
 
 // ─── Event Tracking ──────────────────────────────────────────────────────────
@@ -360,6 +365,16 @@ export function trackMCPToolCalled(options: {
  * Called from the postrun hook. Times out to avoid blocking CLI exit.
  */
 export async function shutdownAnalytics(): Promise<void> {
+  // Wait for init to complete so late-tracked events have a client
+  if (initPromise) {
+    try {
+      await initPromise
+    } catch {
+      // Init may have failed — continue to cleanup
+    }
+    initPromise = null
+  }
+
   if (!statsigClient) return
 
   try {


### PR DESCRIPTION
## Summary

Resolves TKT-1233: Fix Statsig analytics events never reaching dashboard

## Description

## Problem
No events appear in the Statsig dashboard despite the SDK being correctly configured and events being tracked in code.

## Root Causes

### 1. process.exit(0) in init hook bypasses postrun flush
`apps/cli/src/hooks/init.ts` lines 88-106 call `process.exit(0)` directly, which kills the process before the `postrun` hook runs. The postrun hook is where `shutdownAnalytics()` flushes events to Statsig.

### 2. Fire-and-forget analytics initialization
`initAnalytics()` is called without await in the init hook (line 57-63). For fast commands, the Statsig client may not be initialized before events are logged.

### 3. No flush on signal handler
`signal-handler.ts` doesn't call `shutdownAnalytics()`, so Ctrl+C also loses queued events.

## Fix
1. Replace `process.exit(0)` calls in `apps/cli/src/hooks/init.ts` with proper oclif exit that allows postrun hooks to run (or explicitly call `shutdownAnalytics()` before exit)
2. Add `shutdownAnalytics()` call to signal handler cleanup in `apps/cli/src/lib/signal-handler.ts`
3. Consider awaiting `initAnalytics()` or guarding event tracking on init completion

## Files
- `apps/cli/src/hooks/init.ts` — process.exit(0) calls
- `apps/cli/src/hooks/postrun.ts` — shutdownAnalytics() call
- `apps/cli/src/lib/telemetry/analytics.ts` — SDK init and flush logic
- `apps/cli/src/lib/signal-handler.ts` — missing analytics flush

## Verification
After fix, run any prlt command and check Statsig dashboard for `command_run` events within a few seconds.

## Changes

- 974f99d6 fix(TKT-1233): fix analytics events never reaching Statsig dashboard

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
