### PR TITLE
chore: bump prlt version to 0.3.55

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {

--- a/apps/cli/server.json
+++ b/apps/cli/server.json
@@ -7,12 +7,12 @@
     "source": "github",
     "subfolder": "apps/cli"
   },
-  "version": "0.3.52",
+  "version": "0.3.55",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@proletariat/cli",
-      "version": "0.3.52",
+      "version": "0.3.55",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- bump `apps/cli/package.json` version from `0.3.54` to `0.3.55`
- sync `apps/cli/server.json` version fields to `0.3.55`

## Notes
- no runtime logic changes
