### PR TITLE
TKT-1240: Fix session-commands e2e tests: missing pmo_projects table (18 failures)

### DIFF
--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -1,13 +1,17 @@
 import { expect } from 'chai';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
 import Database from 'better-sqlite3';
 import {
   execInProcess,
   extractJson,
   agentExec,
   findChoiceByValue,
+  createTestEnvironment,
+  cleanupTestEnvironment,
+  createHQConfig,
+  createPMODirectories,
+  setupProductionSchema,
+  addWorkspaceTables,
+  TestEnvironment,
 } from './test-helpers.js';
 
 /**
@@ -23,8 +27,7 @@ import {
  * Each subcommand is tested through the interactive menu flow AND directly with flags.
  */
 describe('Session Commands E2E Tests', () => {
-  let testDir: string;
-  let originalCwd: string;
+  let env: TestEnvironment;
   let dbPath: string;
 
   /**
@@ -80,97 +83,25 @@ describe('Session Commands E2E Tests', () => {
     }
   }
 
-  beforeEach(async () => {
-    originalCwd = process.cwd();
-    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-e2e-')));
-    process.chdir(testDir);
+  beforeEach(() => {
+    env = createTestEnvironment('session-e2e-');
+    dbPath = env.dbPath;
 
-    const proletariatDir = path.join(testDir, '.proletariat');
-    fs.mkdirSync(proletariatDir, { recursive: true });
-    dbPath = path.join(proletariatDir, 'workspace.db');
+    // Create HQ config and PMO directories
+    createHQConfig(env.proletariatDir, { hasPmo: true });
+    createPMODirectories(env.pmoPath, 'default');
 
-    // Create blank DB - let the CLI's ensurePMOTables() create all tables
-    // with the correct schema on first access
-    const db = new Database(dbPath);
+    // Initialize PMO tables using production schema (creates pmo_projects, pmo_tickets, agent_work, etc.)
+    const db = setupProductionSchema(dbPath, env.pmoPath);
+
+    // Add workspace tables (workspace, agents, repositories, etc.)
+    addWorkspaceTables(db, { type: 'hq', workspaceName: 'test-hq', hasPmo: true });
+
     db.close();
-
-    // Create HQ config file (required for findPMO)
-    const configPath = path.join(proletariatDir, 'config.json');
-    fs.writeFileSync(configPath, JSON.stringify({
-      type: 'hq',
-      name: 'test-hq',
-      hasPmo: true,
-    }), 'utf-8');
-
-    // Create PMO directory structure
-    fs.mkdirSync(path.join(testDir, 'pmo', 'projects', 'default'), { recursive: true });
-
-    // Run a safe command to trigger PMO table initialization
-    // The CLI's PMOCommand.init() creates all PMO tables via ensurePMOTables()
-    await execInProcess('session --machine');
-
-    // Create workspace tables needed by getWorkspaceInfo() (used by session list/attach)
-    // These are separate from PMO tables and created by the workspace init flow
-    const initDb = new Database(dbPath);
-    initDb.exec(`
-      CREATE TABLE IF NOT EXISTS agent_themes (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL UNIQUE,
-        display_name TEXT NOT NULL,
-        description TEXT,
-        builtin BOOLEAN DEFAULT FALSE,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS workspace (
-        id INTEGER PRIMARY KEY CHECK (id = 1),
-        type TEXT NOT NULL CHECK (type IN ('hq', 'workspace')),
-        workspace_name TEXT NOT NULL,
-        has_pmo BOOLEAN DEFAULT FALSE,
-        active_theme_id TEXT,
-        created_at TEXT NOT NULL,
-        FOREIGN KEY (active_theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
-      );
-      CREATE TABLE IF NOT EXISTS repositories (
-        name TEXT PRIMARY KEY,
-        path TEXT NOT NULL,
-        type TEXT DEFAULT 'main' CHECK (type IN ('main', 'dependency')),
-        source_url TEXT,
-        action TEXT CHECK (action IN ('clone', 'move', 'link')),
-        added_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS agents (
-        name TEXT PRIMARY KEY,
-        type TEXT NOT NULL DEFAULT 'persistent' CHECK (type IN ('persistent', 'ephemeral')),
-        status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'cleaned')),
-        base_name TEXT,
-        theme_id TEXT,
-        worktree_path TEXT,
-        mount_mode TEXT NOT NULL DEFAULT 'worktree' CHECK (mount_mode IN ('worktree', 'clone')),
-        created_at TEXT NOT NULL,
-        cleaned_at TEXT,
-        FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
-      );
-      CREATE TABLE IF NOT EXISTS agent_worktrees (
-        agent_name TEXT NOT NULL,
-        repo_name TEXT NOT NULL,
-        worktree_path TEXT NOT NULL,
-        branch TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        PRIMARY KEY (agent_name, repo_name),
-        FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
-        FOREIGN KEY (repo_name) REFERENCES repositories(name) ON DELETE CASCADE
-      );
-      INSERT OR IGNORE INTO workspace (id, type, workspace_name, has_pmo, created_at)
-      VALUES (1, 'hq', 'test-hq', 1, datetime('now'));
-    `);
-    initDb.close();
   });
 
   afterEach(() => {
-    process.chdir(originalCwd);
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
+    cleanupTestEnvironment(env);
   });
 
   // =========================================================================

--- a/apps/cli/test/e2e/session-peek-commands.test.ts
+++ b/apps/cli/test/e2e/session-peek-commands.test.ts
@@ -1,13 +1,16 @@
 import { expect } from 'chai';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
-import Database from 'better-sqlite3';
 import {
   execInProcess,
   extractJson,
   agentExec,
   findChoiceByValue,
+  createTestEnvironment,
+  cleanupTestEnvironment,
+  createHQConfig,
+  createPMODirectories,
+  setupProductionSchema,
+  addWorkspaceTables,
+  TestEnvironment,
 } from './test-helpers.js';
 
 /**
@@ -23,95 +26,26 @@ import {
  * - Error paths for non-existent targets
  */
 describe('Session Peek Commands E2E Tests', () => {
-  let testDir: string;
-  let originalCwd: string;
-  let dbPath: string;
+  let env: TestEnvironment;
 
-  beforeEach(async () => {
-    originalCwd = process.cwd();
-    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'session-peek-e2e-')));
-    process.chdir(testDir);
+  beforeEach(() => {
+    env = createTestEnvironment('session-peek-e2e-');
 
-    const proletariatDir = path.join(testDir, '.proletariat');
-    fs.mkdirSync(proletariatDir, { recursive: true });
-    dbPath = path.join(proletariatDir, 'workspace.db');
+    // Create HQ config and PMO directories
+    createHQConfig(env.proletariatDir, { hasPmo: true });
+    createPMODirectories(env.pmoPath, 'default');
 
-    const db = new Database(dbPath);
+    // Initialize PMO tables using production schema
+    const db = setupProductionSchema(env.dbPath, env.pmoPath);
+
+    // Add workspace tables
+    addWorkspaceTables(db, { type: 'hq', workspaceName: 'test-hq', hasPmo: true });
+
     db.close();
-
-    const configPath = path.join(proletariatDir, 'config.json');
-    fs.writeFileSync(configPath, JSON.stringify({
-      type: 'hq',
-      name: 'test-hq',
-      hasPmo: true,
-    }), 'utf-8');
-
-    fs.mkdirSync(path.join(testDir, 'pmo', 'projects', 'default'), { recursive: true });
-
-    // Trigger PMO table initialization
-    await execInProcess('session --machine');
-
-    // Create workspace tables
-    const initDb = new Database(dbPath);
-    initDb.exec(`
-      CREATE TABLE IF NOT EXISTS agent_themes (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL UNIQUE,
-        display_name TEXT NOT NULL,
-        description TEXT,
-        builtin BOOLEAN DEFAULT FALSE,
-        created_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS workspace (
-        id INTEGER PRIMARY KEY CHECK (id = 1),
-        type TEXT NOT NULL CHECK (type IN ('hq', 'workspace')),
-        workspace_name TEXT NOT NULL,
-        has_pmo BOOLEAN DEFAULT FALSE,
-        active_theme_id TEXT,
-        created_at TEXT NOT NULL,
-        FOREIGN KEY (active_theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
-      );
-      CREATE TABLE IF NOT EXISTS repositories (
-        name TEXT PRIMARY KEY,
-        path TEXT NOT NULL,
-        type TEXT DEFAULT 'main' CHECK (type IN ('main', 'dependency')),
-        source_url TEXT,
-        action TEXT CHECK (action IN ('clone', 'move', 'link')),
-        added_at TEXT NOT NULL
-      );
-      CREATE TABLE IF NOT EXISTS agents (
-        name TEXT PRIMARY KEY,
-        type TEXT NOT NULL DEFAULT 'persistent' CHECK (type IN ('persistent', 'ephemeral')),
-        status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'cleaned')),
-        base_name TEXT,
-        theme_id TEXT,
-        worktree_path TEXT,
-        mount_mode TEXT NOT NULL DEFAULT 'worktree' CHECK (mount_mode IN ('worktree', 'clone')),
-        created_at TEXT NOT NULL,
-        cleaned_at TEXT,
-        FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
-      );
-      CREATE TABLE IF NOT EXISTS agent_worktrees (
-        agent_name TEXT NOT NULL,
-        repo_name TEXT NOT NULL,
-        worktree_path TEXT NOT NULL,
-        branch TEXT NOT NULL,
-        created_at TEXT NOT NULL,
-        PRIMARY KEY (agent_name, repo_name),
-        FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
-        FOREIGN KEY (repo_name) REFERENCES repositories(name) ON DELETE CASCADE
-      );
-      INSERT OR IGNORE INTO workspace (id, type, workspace_name, has_pmo, created_at)
-      VALUES (1, 'hq', 'test-hq', 1, datetime('now'));
-    `);
-    initDb.close();
   });
 
   afterEach(() => {
-    process.chdir(originalCwd);
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
-    }
+    cleanupTestEnvironment(env);
   });
 
   // =========================================================================


### PR DESCRIPTION
## Summary

Resolves TKT-1240: Fix session-commands e2e tests: missing pmo_projects table (18 failures)

## Description

## Problem
18 tests in `session-commands.test.ts` fail with `SqliteError: no such table: pmo_projects`. The `seedExecutionRecords()` helper writes to a DB that lacks the expected schema.

Also 2 tests fail with "PMO not found" and 2 with null JSON returns.

## Fix
- Ensure test setup creates the full PMO schema before seeding execution records
- Check that `seedExecutionRecords()` initializes the DB properly

## File
- `apps/cli/test/e2e/session-commands.test.ts`

## Changes

- 4b3d3833 fix(TKT-1240): fix session e2e tests: use setupProductionSchema for proper DB initialization

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
