### PR TITLE
TKT-1239: Fix branch create e2e test hang (blocks CI suite)

### DIFF
--- a/apps/cli/test/e2e/branch-commands.test.ts
+++ b/apps/cli/test/e2e/branch-commands.test.ts
@@ -192,7 +192,7 @@ describe('Branch Commands E2E Tests', () => {
 
   describe('prlt branch create', () => {
     it('should create branch with type and description flags', async () => {
-      const output = await execInProcess('branch create -t feat -d add-user-auth');
+      const output = await execInProcess('branch create -t feat -d add-user-auth --machine');
 
       expect(output).to.contain('Creating branch');
 
@@ -202,7 +202,7 @@ describe('Branch Commands E2E Tests', () => {
     });
 
     it('should create branch with owner flag', async () => {
-      const output = await execInProcess('branch create -t fix -c chris -d fix-login-bug');
+      const output = await execInProcess('branch create -t fix -c chris -d fix-login-bug --machine');
 
       expect(output).to.contain('Creating branch');
 
@@ -212,7 +212,7 @@ describe('Branch Commands E2E Tests', () => {
 
     it('should create branch with ticket flag', async () => {
       // Need PMO context for ticket lookup, so test direct name instead
-      const output = await execInProcess('branch create TKT-001/feat/test/add-feature');
+      const output = await execInProcess('branch create TKT-001/feat/test/add-feature --machine');
 
       // Branch may or may not be created depending on prompt answer
       // Just verify command ran without crash
@@ -220,7 +220,7 @@ describe('Branch Commands E2E Tests', () => {
     });
 
     it('should create branch with empty commit flag', async () => {
-      const output = await execInProcess('branch create -t chore -d setup-ci -e');
+      const output = await execInProcess('branch create -t chore -d setup-ci -e --machine');
 
       // Check that branch was created
       expect(output).to.contain('Creating branch');
@@ -238,7 +238,7 @@ describe('Branch Commands E2E Tests', () => {
       execSync('git checkout -b feat/existing-branch', { stdio: 'pipe' });
       execSync('git checkout -', { stdio: 'pipe' });
 
-      const output = await execInProcess('branch create feat/existing-branch');
+      const output = await execInProcess('branch create feat/existing-branch --machine');
 
       expect(output.toLowerCase()).to.contain('already exists');
     });
@@ -247,7 +247,7 @@ describe('Branch Commands E2E Tests', () => {
       // Create a fake origin for testing
       execSync('git remote add origin .', { stdio: 'pipe' });
 
-      const output = await execInProcess('branch create -t feat -d from-origin -o');
+      const output = await execInProcess('branch create -t feat -d from-origin -o --machine');
 
       // Should attempt to fetch (may warn about no origin/main)
       expect(output).to.be.a('string');
@@ -256,7 +256,7 @@ describe('Branch Commands E2E Tests', () => {
     it('should support no-switch flag', async () => {
       const currentBranch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
 
-      await execInProcess('branch create -t docs -d readme-update --no-switch');
+      await execInProcess('branch create -t docs -d readme-update --no-switch --machine');
 
       // Should still be on original branch
       const afterBranch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
@@ -268,14 +268,14 @@ describe('Branch Commands E2E Tests', () => {
     });
 
     it('should validate branch type option', async () => {
-      const output = await execInProcess('branch create -t invalid-type -d test');
+      const output = await execInProcess('branch create -t invalid-type -d test --machine');
 
       expect(output.toLowerCase()).to.match(/invalid|error|unknown/i);
     });
 
     it('should handle kebab-case conversion for description', async () => {
       // Note: Interactive mode would auto-convert, but flag mode requires kebab-case
-      const output = await execInProcess('branch create -t feat -d "test branch"');
+      const output = await execInProcess('branch create -t feat -d "test branch" --machine');
 
       // Should either work or error about format
       expect(output).to.be.a('string');


### PR DESCRIPTION
## Summary

Resolves TKT-1239: Fix branch create e2e test hang (blocks CI suite)

## Description

## Problem
`branch-commands.test.ts` → `prlt branch create` tests hang in the `before`/`beforeEach` hook, spinning at 128% CPU. This blocks all subsequent test files in the mocha run and is the primary reason CI times out.

## Root Cause
The `branch create` test setup likely hits an interactive prompt (git init, inquirer, etc.) without `--machine` flag, causing it to wait for stdin that never comes.

## Key File
- `apps/cli/test/e2e/branch-commands.test.ts` — `prlt branch create` describe block

## Fix
- Add `--machine` flag to any execInProcess/exec calls in the branch create test setup
- Or mock/skip the interactive prompt in the beforeEach hook
- Verify the fix by running: `npx mocha --timeout 15000 --exit test/e2e/branch-commands.test.ts`

## Impact
This is the #1 CI blocker — fixing this unblocks the entire e2e suite from completing.

## Changes

- 98cdc666 fix(TKT-1239): add --machine flag to branch create e2e tests to prevent interactive prompt hangs

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
