### PR TITLE
TKT-1242: Fix session-peek-commands e2e tests: null JSON output (8 failures)

### DIFF
--- a/apps/cli/test/e2e/session-peek-commands.test.ts
+++ b/apps/cli/test/e2e/session-peek-commands.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import Database from 'better-sqlite3';
 import {
   execInProcess,
   extractJson,
@@ -27,6 +28,7 @@ import {
  */
 describe('Session Peek Commands E2E Tests', () => {
   let env: TestEnvironment;
+  let db: Database.Database;
 
   beforeEach(() => {
     env = createTestEnvironment('session-peek-e2e-');
@@ -36,15 +38,14 @@ describe('Session Peek Commands E2E Tests', () => {
     createPMODirectories(env.pmoPath, 'default');
 
     // Initialize PMO tables using production schema
-    const db = setupProductionSchema(env.dbPath, env.pmoPath);
+    db = setupProductionSchema(env.dbPath, env.pmoPath);
 
-    // Add workspace tables
+    // Add workspace tables (for agent/session discovery)
     addWorkspaceTables(db, { type: 'hq', workspaceName: 'test-hq', hasPmo: true });
-
-    db.close();
   });
 
   afterEach(() => {
+    if (db) db.close();
     cleanupTestEnvironment(env);
   });
 


### PR DESCRIPTION
## Summary

Resolves TKT-1242: Fix session-peek-commands e2e tests: null JSON output (8 failures)

## Description

## Problem
8 tests in `session-peek-commands.test.ts` fail with `expected null not to be null`. The `prlt session peek --json` command returns null instead of parseable JSON output.

## Fix
- Check if session peek is writing to stderr instead of stdout in JSON mode
- Or if the command exits before producing output in the test env
- May need `--machine` flag or test env adjustment

## File
- `apps/cli/test/e2e/session-peek-commands.test.ts`

## Changes

- 6fc7ad30 fix(TKT-1242): fix session-peek-commands e2e tests: use proper PMO schema setup

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
