### PR TITLE
TKT-1246: Fix pmo e2e tests: assertions expect human text but get JSON in non-TTY (17 failures)

### DIFF
--- a/apps/cli/test/e2e/pmo-epic-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-epic-commands.test.ts
@@ -56,7 +56,7 @@ describe('PMO Epic Commands E2E Tests', () => {
 
   describe('prlt epic create', () => {
     it('should create epic with auto-generated ID', async () => {
-      await execInProcess('epic create --title "User Authentication" --machine');
+      await execInProcess('epic create --title "User Authentication"');
 
       const epics = db.prepare('SELECT * FROM pmo_epics WHERE title = ?').all('User Authentication') as Array<{ id: string; status: string }>;
       expect(epics).to.have.lengthOf(1);
@@ -65,7 +65,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should create epic with specified status', async () => {
-      await execInProcess('epic create --title "Future Feature" --status draft --machine');
+      await execInProcess('epic create --title "Future Feature" --status draft');
 
       const epics = db.prepare('SELECT * FROM pmo_epics WHERE title = ?').all('Future Feature') as Array<{ status: string }>;
       expect(epics).to.have.lengthOf(1);
@@ -73,7 +73,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should create markdown file in correct status folder', async () => {
-      await execInProcess('epic create --title "Active Epic" --status active --machine');
+      await execInProcess('epic create --title "Active Epic" --status active');
 
       const epic = db.prepare('SELECT id FROM pmo_epics WHERE title = ?').get('Active Epic') as { id: string };
       const filePath = path.join(epicsDir, 'active', `${epic.id}.md`);
@@ -82,7 +82,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should create markdown file with correct template sections', async () => {
-      await execInProcess('epic create --title "Template Test" --machine');
+      await execInProcess('epic create --title "Template Test"');
 
       const epic = db.prepare('SELECT id FROM pmo_epics WHERE title = ?').get('Template Test') as { id: string };
       const filePath = path.join(epicsDir, 'active', `${epic.id}.md`);
@@ -103,8 +103,8 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should increment epic ID counter', async () => {
-      await execInProcess('epic create --title "First Epic" --machine');
-      await execInProcess('epic create --title "Second Epic" --machine');
+      await execInProcess('epic create --title "First Epic"');
+      await execInProcess('epic create --title "Second Epic"');
 
       const epics = db.prepare('SELECT id FROM pmo_epics ORDER BY created_at').all() as Array<{ id: string }>;
       expect(epics).to.have.lengthOf(2);
@@ -113,7 +113,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should store file path in database', async () => {
-      await execInProcess('epic create --title "File Path Test" --machine');
+      await execInProcess('epic create --title "File Path Test"');
 
       const epic = db.prepare('SELECT file_path FROM pmo_epics WHERE title = ?').get('File Path Test') as { file_path: string };
       expect(epic.file_path).to.contain('epics/active/EPIC-');
@@ -131,7 +131,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should list all epics', async () => {
-      const output = await execInProcess('epic list --machine');
+      const output = await execInProcess('epic list');
 
       expect(output).to.contain('EPIC-001');
       expect(output).to.contain('Active Epic 1');
@@ -141,7 +141,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should filter by status', async () => {
-      const output = await execInProcess('epic list --status active --machine');
+      const output = await execInProcess('epic list --status active');
 
       expect(output).to.contain('EPIC-001');
       expect(output).to.contain('EPIC-002');
@@ -150,7 +150,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should show epic status in output', async () => {
-      const output = await execInProcess('epic list --machine');
+      const output = await execInProcess('epic list');
 
       expect(output).to.contain('active');
       expect(output).to.contain('draft');
@@ -161,7 +161,7 @@ describe('PMO Epic Commands E2E Tests', () => {
       // Clear all epics
       db.prepare('DELETE FROM pmo_epics').run();
 
-      const output = await execInProcess('epic list --machine');
+      const output = await execInProcess('epic list');
 
       expect(output.toLowerCase()).to.match(/no epics|empty|0 epics/i);
     });
@@ -174,7 +174,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should display epic details', async () => {
-      const output = await execInProcess('epic view EPIC-001 --machine');
+      const output = await execInProcess('epic view EPIC-001');
 
       expect(output).to.contain('EPIC-001');
       expect(output).to.contain('View Test Epic');
@@ -186,7 +186,7 @@ describe('PMO Epic Commands E2E Tests', () => {
       createTestTicket(db, 'TKT-001', 'Ticket 1', 'EPIC-001', 'backlog');
       createTestTicket(db, 'TKT-002', 'Ticket 2', 'EPIC-001', 'done');
 
-      const output = await execInProcess('epic view EPIC-001 --machine');
+      const output = await execInProcess('epic view EPIC-001');
 
       expect(output).to.contain('TKT-001');
       expect(output).to.contain('Ticket 1');
@@ -198,14 +198,14 @@ describe('PMO Epic Commands E2E Tests', () => {
       createTestTicket(db, 'TKT-001', 'Incomplete', 'EPIC-001', 'backlog');
       createTestTicket(db, 'TKT-002', 'Complete', 'EPIC-001', 'done');
 
-      const output = await execInProcess('epic view EPIC-001 --machine');
+      const output = await execInProcess('epic view EPIC-001');
 
       // Should show progress indicator (1/2 = 50%)
       expect(output).to.match(/50%|1\/2|progress/i);
     });
 
     it('should error for non-existent epic', async () => {
-      const output = await execInProcess('epic view EPIC-999 --machine');
+      const output = await execInProcess('epic view EPIC-999');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
@@ -218,14 +218,14 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should move epic to complete status', async () => {
-      await execInProcess('epic archive EPIC-001 --force --machine');
+      await execInProcess('epic archive EPIC-001 --force');
 
       const epic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(epic.status).to.equal('complete');
     });
 
     it('should move markdown file to complete folder', async () => {
-      await execInProcess('epic archive EPIC-001 --force --machine');
+      await execInProcess('epic archive EPIC-001 --force');
 
       const oldPath = path.join(epicsDir, 'active', 'EPIC-001.md');
       const newPath = path.join(epicsDir, 'complete', 'EPIC-001.md');
@@ -235,7 +235,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should update status in markdown frontmatter', async () => {
-      await execInProcess('epic archive EPIC-001 --force --machine');
+      await execInProcess('epic archive EPIC-001 --force');
 
       const filePath = path.join(epicsDir, 'complete', 'EPIC-001.md');
       const content = fs.readFileSync(filePath, 'utf-8');
@@ -248,6 +248,7 @@ describe('PMO Epic Commands E2E Tests', () => {
 
       const output = await execInProcess('epic archive EPIC-001 --machine');
 
+      // In JSON mode, the prompt message contains the warning text
       expect(output.toLowerCase()).to.match(/not all|incomplete|warning/i);
     });
   });
@@ -259,14 +260,14 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should move epic to active status', async () => {
-      await execInProcess('epic activate EPIC-001 --machine');
+      await execInProcess('epic activate EPIC-001');
 
       const epic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(epic.status).to.equal('active');
     });
 
     it('should move markdown file to active folder', async () => {
-      await execInProcess('epic activate EPIC-001 --machine');
+      await execInProcess('epic activate EPIC-001');
 
       const oldPath = path.join(epicsDir, 'draft', 'EPIC-001.md');
       const newPath = path.join(epicsDir, 'active', 'EPIC-001.md');
@@ -276,7 +277,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should update status in markdown frontmatter', async () => {
-      await execInProcess('epic activate EPIC-001 --machine');
+      await execInProcess('epic activate EPIC-001');
 
       const filePath = path.join(epicsDir, 'active', 'EPIC-001.md');
       const content = fs.readFileSync(filePath, 'utf-8');
@@ -291,7 +292,7 @@ describe('PMO Epic Commands E2E Tests', () => {
       const epic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(epic.status).to.equal('draft'); // Verify starting status
 
-      await execInProcess('epic activate EPIC-001 --machine');
+      await execInProcess('epic activate EPIC-001');
 
       const updatedEpic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(updatedEpic.status).to.equal('active');
@@ -306,14 +307,14 @@ describe('PMO Epic Commands E2E Tests', () => {
 
     it('should move epic to specified status', async () => {
       // Moving to 'dropped' requires --force to skip confirmation
-      await execInProcess('epic move EPIC-001 dropped --force --machine');
+      await execInProcess('epic move EPIC-001 dropped --force');
 
       const epic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(epic.status).to.equal('dropped');
     });
 
     it('should move to draft status', async () => {
-      await execInProcess('epic move EPIC-001 draft --machine');
+      await execInProcess('epic move EPIC-001 draft');
 
       const epic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(epic.status).to.equal('draft');
@@ -323,7 +324,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should move to future status', async () => {
-      await execInProcess('epic move EPIC-001 future --machine');
+      await execInProcess('epic move EPIC-001 future');
 
       const epic = db.prepare('SELECT status FROM pmo_epics WHERE id = ?').get('EPIC-001') as { status: string };
       expect(epic.status).to.equal('future');
@@ -337,17 +338,18 @@ describe('PMO Epic Commands E2E Tests', () => {
 
       const output = await execInProcess('epic move EPIC-001 complete --machine');
 
+      // In JSON mode, the prompt message contains the warning text
       expect(output.toLowerCase()).to.match(/not all|incomplete|warning/i);
     });
 
     it('should reject invalid status', async () => {
-      const output = await execInProcess('epic move EPIC-001 invalid_status --machine');
+      const output = await execInProcess('epic move EPIC-001 invalid_status');
 
       expect(output.toLowerCase()).to.match(/invalid|error|unknown/i);
     });
 
     it('should noop if already in target status', async () => {
-      const output = await execInProcess('epic move EPIC-001 active --machine');
+      const output = await execInProcess('epic move EPIC-001 active');
 
       expect(output.toLowerCase()).to.match(/already|same/i);
     });
@@ -360,7 +362,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should show 0% when no tickets', async () => {
-      const output = await execInProcess('epic progress EPIC-001 --machine');
+      const output = await execInProcess('epic progress EPIC-001');
 
       expect(output).to.match(/0%|0\/0|no tickets/i);
     });
@@ -369,7 +371,7 @@ describe('PMO Epic Commands E2E Tests', () => {
       createTestTicket(db, 'TKT-001', 'Done', 'EPIC-001', 'done');
       createTestTicket(db, 'TKT-002', 'Not done', 'EPIC-001', 'backlog');
 
-      const output = await execInProcess('epic progress EPIC-001 --machine');
+      const output = await execInProcess('epic progress EPIC-001');
 
       expect(output).to.match(/50%|1\/2/i);
     });
@@ -378,7 +380,7 @@ describe('PMO Epic Commands E2E Tests', () => {
       createTestTicket(db, 'TKT-001', 'Done 1', 'EPIC-001', 'done');
       createTestTicket(db, 'TKT-002', 'Done 2', 'EPIC-001', 'done');
 
-      const output = await execInProcess('epic progress EPIC-001 --machine');
+      const output = await execInProcess('epic progress EPIC-001');
 
       expect(output).to.match(/100%|2\/2|complete/i);
     });
@@ -388,7 +390,7 @@ describe('PMO Epic Commands E2E Tests', () => {
       createTestTicket(db, 'TKT-002', 'In Progress', 'EPIC-001', 'in_progress');
       createTestTicket(db, 'TKT-003', 'Backlog', 'EPIC-001', 'backlog');
 
-      const output = await execInProcess('epic progress EPIC-001 --machine');
+      const output = await execInProcess('epic progress EPIC-001');
 
       // Should show remaining work with non-done tickets
       // TKT-001 is done so won't appear in "Remaining work", but TKT-002 and TKT-003 will
@@ -397,7 +399,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should error for non-existent epic', async () => {
-      const output = await execInProcess('epic progress EPIC-999 --machine');
+      const output = await execInProcess('epic progress EPIC-999');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
@@ -417,7 +419,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should link ticket to epic via ticket create --epic', async () => {
-      await execInProcess('ticket create --title "Linked Ticket" --epic EPIC-001 --column Backlog --machine');
+      await execInProcess('ticket create --title "Linked Ticket" --epic EPIC-001 --column Backlog');
 
       // Open fresh connection after CLI subprocess completes
       const freshDb = new Database(env.dbPath);
@@ -429,7 +431,7 @@ describe('PMO Epic Commands E2E Tests', () => {
     });
 
     it('should update epic markdown when ticket is linked', async () => {
-      await execInProcess('ticket create --title "Sync Test" --epic EPIC-001 --column Backlog --machine');
+      await execInProcess('ticket create --title "Sync Test" --epic EPIC-001 --column Backlog');
 
       const filePath = path.join(epicsDir, 'active', 'EPIC-001.md');
       const content = fs.readFileSync(filePath, 'utf-8');

--- a/apps/cli/test/e2e/pmo-phase-template-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-phase-template-commands.test.ts
@@ -38,7 +38,7 @@ describe('PMO Phase Template Commands E2E Tests', () => {
 
   describe('prlt phase template list', () => {
     it('should list all phase templates', async () => {
-      const output = await execInProcess('phase template list --machine');
+      const output = await execInProcess('phase template list');
 
       expect(output).to.contain('Phase Templates');
       expect(output).to.contain('default');
@@ -46,20 +46,20 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should show built-in templates section', async () => {
-      const output = await execInProcess('phase template list --machine');
+      const output = await execInProcess('phase template list');
 
       expect(output).to.contain('Built-in Templates');
     });
 
     it('should filter to builtin only with --builtin', async () => {
-      const output = await execInProcess('phase template list --builtin --machine');
+      const output = await execInProcess('phase template list --builtin');
 
       expect(output).to.contain('Built-in Templates');
       expect(output).not.to.contain('Custom Templates');
     });
 
     it('should show template descriptions', async () => {
-      const output = await execInProcess('phase template list --machine');
+      const output = await execInProcess('phase template list');
 
       expect(output).to.contain('Standard project lifecycle');
       expect(output).to.contain('Agile/Scrum');
@@ -75,7 +75,7 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should show phases grouped by category', async () => {
-      const output = await execInProcess('phase template list --machine');
+      const output = await execInProcess('phase template list');
 
       // Should show category groupings with emojis
       expect(output).to.match(/📥|📋|🚀|✅|🚫/);
@@ -84,7 +84,7 @@ describe('PMO Phase Template Commands E2E Tests', () => {
 
   describe('prlt phase template apply', () => {
     it('should apply template to workspace', async () => {
-      const output = await execInProcess('phase template apply agile --force --machine');
+      const output = await execInProcess('phase template apply agile --force');
 
       expect(output).to.contain('Applied phase template');
       expect(output).to.contain('Agile');
@@ -95,7 +95,7 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should create phases from template', async () => {
-      await execInProcess('phase template apply agile --force --machine');
+      await execInProcess('phase template apply agile --force');
 
       const phases = db.prepare('SELECT name FROM pmo_phases').all() as { name: string }[];
       const names = phases.map(p => p.name);
@@ -106,24 +106,24 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should set a default phase', async () => {
-      await execInProcess('phase template apply agile --force --machine');
+      await execInProcess('phase template apply agile --force');
 
       const defaultPhase = db.prepare('SELECT * FROM pmo_phases WHERE is_default = 1').get();
       expect(defaultPhase).to.not.be.undefined;
     });
 
     it('should error when template not found', async () => {
-      const output = await execInProcess('phase template apply non-existent --force --machine');
+      const output = await execInProcess('phase template apply non-existent --force');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
 
     it('should replace existing phases', async () => {
       // First apply default
-      await execInProcess('phase template apply default --force --machine');
+      await execInProcess('phase template apply default --force');
 
       // Then apply agile
-      await execInProcess('phase template apply agile --force --machine');
+      await execInProcess('phase template apply agile --force');
 
       const phases = db.prepare('SELECT * FROM pmo_phases').all() as { name: string }[];
       const names = phases.map(p => p.name);
@@ -134,7 +134,7 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should apply product template', async () => {
-      await execInProcess('phase template apply product --force --machine');
+      await execInProcess('phase template apply product --force');
 
       const phases = db.prepare('SELECT name FROM pmo_phases').all() as { name: string }[];
       const names = phases.map(p => p.name);
@@ -147,7 +147,7 @@ describe('PMO Phase Template Commands E2E Tests', () => {
 
   describe('prlt phase template create', () => {
     it('should create template from workspace phases', async () => {
-      const output = await execInProcess('phase template create "My Custom Phases" --description "" --machine');
+      const output = await execInProcess('phase template create "My Custom Phases" --description ""');
 
       // In non-TTY mode, output is JSON; in TTY mode, output is text
       // Check for either format
@@ -167,35 +167,35 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should generate slugified ID', async () => {
-      await execInProcess('phase template create "My Workflow Phases" --description "" --machine');
+      await execInProcess('phase template create "My Workflow Phases" --description ""');
 
       const template = db.prepare('SELECT id FROM pmo_phase_templates WHERE name = ?').get('My Workflow Phases') as { id: string };
       expect(template.id).to.equal('my-workflow-phases');
     });
 
     it('should include description when provided', async () => {
-      await execInProcess('phase template create "Team Phases" --description "Our team phase workflow" --machine');
+      await execInProcess('phase template create "Team Phases" --description "Our team phase workflow"');
 
       const template = db.prepare('SELECT description FROM pmo_phase_templates WHERE name = ?').get('Team Phases') as { description: string };
       expect(template.description).to.equal('Our team phase workflow');
     });
 
     it('should not be marked as builtin', async () => {
-      await execInProcess('phase template create "User Phases" --description "" --machine');
+      await execInProcess('phase template create "User Phases" --description ""');
 
       const template = db.prepare('SELECT is_builtin FROM pmo_phase_templates WHERE name = ?').get('User Phases') as { is_builtin: number };
       expect(template.is_builtin).to.equal(0);
     });
 
     it('should error when name already exists', async () => {
-      await execInProcess('phase template create "Duplicate" --description "" --machine');
-      const output = await execInProcess('phase template create "Duplicate" --description "" --machine');
+      await execInProcess('phase template create "Duplicate" --description ""');
+      const output = await execInProcess('phase template create "Duplicate" --description ""');
 
       expect(output.toLowerCase()).to.contain('already exists');
     });
 
     it('should preserve phases in template', async () => {
-      await execInProcess('phase template create "Preserved Template" --description "" --machine');
+      await execInProcess('phase template create "Preserved Template" --description ""');
 
       const template = db.prepare('SELECT phases FROM pmo_phase_templates WHERE name = ?').get('Preserved Template') as { phases: string };
       const phases = JSON.parse(template.phases);
@@ -208,31 +208,31 @@ describe('PMO Phase Template Commands E2E Tests', () => {
 
   describe('prlt phase template update', () => {
     beforeEach(async () => {
-      await execInProcess('phase template create "Updatable Template" --description "" --machine');
+      await execInProcess('phase template create "Updatable Template" --description ""');
     });
 
     it('should update template name', async () => {
-      await execInProcess('phase template update updatable-template --name "New Name" --machine');
+      await execInProcess('phase template update updatable-template --name "New Name"');
 
       const template = db.prepare('SELECT name FROM pmo_phase_templates WHERE id = ?').get('updatable-template') as { name: string };
       expect(template.name).to.equal('New Name');
     });
 
     it('should update template description', async () => {
-      await execInProcess('phase template update updatable-template --description "New description" --machine');
+      await execInProcess('phase template update updatable-template --description "New description"');
 
       const template = db.prepare('SELECT description FROM pmo_phase_templates WHERE id = ?').get('updatable-template') as { description: string };
       expect(template.description).to.equal('New description');
     });
 
     it('should error when template not found', async () => {
-      const output = await execInProcess('phase template update non-existent --name "New Name" --machine');
+      const output = await execInProcess('phase template update non-existent --name "New Name"');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
 
     it('should error when updating built-in template', async () => {
-      const output = await execInProcess('phase template update default --name "New Default" --machine');
+      const output = await execInProcess('phase template update default --name "New Default"');
 
       expect(output.toLowerCase()).to.contain('cannot modify');
     });
@@ -240,30 +240,30 @@ describe('PMO Phase Template Commands E2E Tests', () => {
 
   describe('prlt phase template delete', () => {
     beforeEach(async () => {
-      await execInProcess('phase template create "Deletable Template" --description "" --machine');
+      await execInProcess('phase template create "Deletable Template" --description ""');
     });
 
     it('should delete template', async () => {
-      await execInProcess('phase template delete deletable-template --force --machine');
+      await execInProcess('phase template delete deletable-template --force');
 
       const template = db.prepare('SELECT * FROM pmo_phase_templates WHERE id = ?').get('deletable-template');
       expect(template).to.be.undefined;
     });
 
     it('should error when template not found', async () => {
-      const output = await execInProcess('phase template delete non-existent --force --machine');
+      const output = await execInProcess('phase template delete non-existent --force');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
 
     it('should error when deleting built-in template', async () => {
-      const output = await execInProcess('phase template delete default --force --machine');
+      const output = await execInProcess('phase template delete default --force');
 
       expect(output.toLowerCase()).to.contain('cannot delete');
     });
 
     it('should show success message', async () => {
-      const output = await execInProcess('phase template delete deletable-template --force --machine');
+      const output = await execInProcess('phase template delete deletable-template --force');
 
       expect(output).to.contain('Deleted phase template');
     });
@@ -272,16 +272,16 @@ describe('PMO Phase Template Commands E2E Tests', () => {
   describe('phase template workflow', () => {
     it('should allow creating and reapplying custom template', async () => {
       // Apply a template
-      await execInProcess('phase template apply product --force --machine');
+      await execInProcess('phase template apply product --force');
 
       // Create as custom template
-      await execInProcess('phase template create "Product Copy" --description "" --machine');
+      await execInProcess('phase template create "Product Copy" --description ""');
 
       // Apply default to reset
-      await execInProcess('phase template apply default --force --machine');
+      await execInProcess('phase template apply default --force');
 
       // Apply saved template
-      await execInProcess('phase template apply product-copy --force --machine');
+      await execInProcess('phase template apply product-copy --force');
 
       // Verify it worked
       const phases = db.prepare('SELECT name FROM pmo_phases').all() as { name: string }[];
@@ -292,10 +292,10 @@ describe('PMO Phase Template Commands E2E Tests', () => {
     });
 
     it('should list custom templates after creation', async () => {
-      await execInProcess('phase template create "Custom One" --description "" --machine');
-      await execInProcess('phase template create "Custom Two" --description "" --machine');
+      await execInProcess('phase template create "Custom One" --description ""');
+      await execInProcess('phase template create "Custom Two" --description ""');
 
-      const output = await execInProcess('phase template list --custom --machine');
+      const output = await execInProcess('phase template list --custom');
 
       expect(output).to.contain('Custom Templates');
       expect(output).to.contain('Custom One');

--- a/apps/cli/test/e2e/pmo-ticket-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-commands.test.ts
@@ -51,7 +51,7 @@ describe('PMO Ticket Commands E2E Tests', () => {
   describe('prlt ticket create', () => {
     it('should create ticket with all flags', async () => {
       const output = await execInProcess(
-        'ticket create --title "Add login" --priority HIGH --column "Backlog" --machine'
+        'ticket create --title "Add login" --priority HIGH --column "Backlog"'
       );
 
       expect(output).to.contain('Created ticket');
@@ -91,7 +91,7 @@ describe('PMO Ticket Commands E2E Tests', () => {
     });
 
     it('should auto-generate ticket ID', async () => {
-      await execInProcess('ticket create --title "Test ticket" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Test ticket" --column "Backlog"');
 
       const tickets = db.prepare('SELECT id FROM pmo_tickets').all() as Array<{ id: string }>;
       expect(tickets).to.have.lengthOf(1);
@@ -101,7 +101,7 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
     // kanban.md auto-export is disabled (DB is sole source of truth)
     it.skip('should add ticket to kanban.md', async () => {
-      await execInProcess('ticket create --title "Board test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Board test" --column "Backlog"');
 
       const boardPath = path.join(testDir, 'pmo/projects/test-project/kanban.md');
       const content = fs.readFileSync(boardPath, 'utf-8');
@@ -113,13 +113,13 @@ describe('PMO Ticket Commands E2E Tests', () => {
   describe('prlt ticket move', () => {
     it('should move ticket between columns', async () => {
       // Create ticket
-      await execInProcess('ticket create --title "Movable" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Movable" --column "Backlog"');
 
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Movable') as { id: string };
       const ticketId = ticket.id;
 
       // Move ticket
-      await execInProcess(`ticket move ${ticketId} "In Progress" --machine`);
+      await execInProcess(`ticket move ${ticketId} "In Progress"`);
 
       // Verify new column via workflow statuses
       const status = db.prepare(`
@@ -134,10 +134,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
     // kanban.md auto-export is disabled (DB is sole source of truth)
     it.skip('should update kanban.md when moving ticket', async () => {
-      await execInProcess('ticket create --title "Move test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Move test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Move test') as { id: string };
 
-      await execInProcess(`ticket move ${ticket.id} "Merged" --machine`);
+      await execInProcess(`ticket move ${ticket.id} "Merged"`);
 
       const boardPath = path.join(testDir, 'pmo/projects/test-project/kanban.md');
       const content = fs.readFileSync(boardPath, 'utf-8');
@@ -150,10 +150,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket delete', () => {
     it('should delete ticket from database', async () => {
-      await execInProcess('ticket create --title "Delete me" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Delete me" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Delete me') as { id: string };
 
-      await execInProcess(`ticket delete ${ticket.id} --force --machine`);
+      await execInProcess(`ticket delete ${ticket.id} --force`);
 
       const remaining = db.prepare('SELECT * FROM pmo_tickets WHERE id = ?').get(ticket.id);
       expect(remaining).to.be.undefined;
@@ -161,10 +161,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
     // kanban.md auto-export is disabled (DB is sole source of truth)
     it.skip('should remove ticket from kanban.md', async () => {
-      await execInProcess('ticket create --title "Remove from board" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Remove from board" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Remove from board') as { id: string };
 
-      await execInProcess(`ticket delete ${ticket.id} --force --machine`);
+      await execInProcess(`ticket delete ${ticket.id} --force`);
 
       const boardPath = path.join(testDir, 'pmo/projects/test-project/kanban.md');
       const content = fs.readFileSync(boardPath, 'utf-8');
@@ -173,10 +173,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
     });
 
     it('should fully remove ticket from database', async () => {
-      await execInProcess('ticket create --title "Cascade test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Cascade test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Cascade test') as { id: string };
 
-      await execInProcess(`ticket delete ${ticket.id} --force --machine`);
+      await execInProcess(`ticket delete ${ticket.id} --force`);
 
       const remaining = db.prepare('SELECT * FROM pmo_tickets WHERE id = ?').get(ticket.id);
       expect(remaining).to.be.undefined;
@@ -185,10 +185,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket list', () => {
     it('should list all tickets', async () => {
-      await execInProcess('ticket create --title "List test 1" --priority HIGH --column "Backlog" --machine');
-      await execInProcess('ticket create --title "List test 2" --priority MEDIUM --column "Backlog" --machine');
+      await execInProcess('ticket create --title "List test 1" --priority HIGH --column "Backlog"');
+      await execInProcess('ticket create --title "List test 2" --priority MEDIUM --column "Backlog"');
 
-      const output = await execInProcess('ticket list --machine');
+      const output = await execInProcess('ticket list');
 
       expect(output).to.contain('List test 1');
       expect(output).to.contain('List test 2');
@@ -198,20 +198,20 @@ describe('PMO Ticket Commands E2E Tests', () => {
     });
 
     it('should filter by column', async () => {
-      await execInProcess('ticket create --title "In backlog" --column "Backlog" --machine');
-      await execInProcess('ticket create --title "In progress" --column "In Progress" --machine');
+      await execInProcess('ticket create --title "In backlog" --column "Backlog"');
+      await execInProcess('ticket create --title "In progress" --column "In Progress"');
 
-      const output = await execInProcess('ticket list --column "In Progress" --machine');
+      const output = await execInProcess('ticket list --column "In Progress"');
 
       expect(output).to.contain('In progress');
       expect(output).to.not.contain('In backlog');
     });
 
     it('should filter by priority', async () => {
-      await execInProcess('ticket create --title "High priority" --priority P1 --column "Backlog" --machine');
-      await execInProcess('ticket create --title "Low priority" --priority P3 --column "Backlog" --machine');
+      await execInProcess('ticket create --title "High priority" --priority P1 --column "Backlog"');
+      await execInProcess('ticket create --title "Low priority" --priority P3 --column "Backlog"');
 
-      const output = await execInProcess('ticket list --priority P1 --machine');
+      const output = await execInProcess('ticket list --priority P1');
 
       expect(output).to.contain('High priority');
       expect(output).to.not.contain('Low priority');
@@ -220,10 +220,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket view', () => {
     it('should show detailed ticket information', async () => {
-      await execInProcess('ticket create --title "View test" --description "Test description" --priority P1 --column "Backlog" --machine');
+      await execInProcess('ticket create --title "View test" --description "Test description" --priority P1 --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('View test') as { id: string };
 
-      const output = await execInProcess(`ticket view ${ticket.id} --machine`);
+      const output = await execInProcess(`ticket view ${ticket.id}`);
 
       expect(output).to.contain('View test');
       expect(output).to.contain('Test description');
@@ -234,50 +234,50 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket edit', () => {
     it('should edit ticket title with flag', async () => {
-      await execInProcess('ticket create --title "Original title" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Original title" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Original title') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --title "Updated title" --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --title "Updated title"`);
 
       const updatedTicket = db.prepare('SELECT title FROM pmo_tickets WHERE id = ?').get(ticket.id) as { title: string };
       expect(updatedTicket.title).to.equal('Updated title');
     });
 
     it('should edit ticket priority', async () => {
-      await execInProcess('ticket create --title "Priority test" --priority LOW --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Priority test" --priority LOW --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Priority test') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --priority HIGH --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --priority HIGH`);
 
       const updatedTicket = db.prepare('SELECT priority FROM pmo_tickets WHERE id = ?').get(ticket.id) as { priority: string };
       expect(updatedTicket.priority).to.equal('HIGH');
     });
 
     it('should edit ticket description', async () => {
-      await execInProcess('ticket create --title "Desc test" --description "Old desc" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Desc test" --description "Old desc" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Desc test') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --description "New description" --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --description "New description"`);
 
       const updatedTicket = db.prepare('SELECT description FROM pmo_tickets WHERE id = ?').get(ticket.id) as { description: string };
       expect(updatedTicket.description).to.equal('New description');
     });
 
     it('should edit ticket category', async () => {
-      await execInProcess('ticket create --title "Category test" --category bug --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Category test" --category bug --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Category test') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --category feature --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --category feature`);
 
       const updatedTicket = db.prepare('SELECT category FROM pmo_tickets WHERE id = ?').get(ticket.id) as { category: string };
       expect(updatedTicket.category).to.equal('feature');
     });
 
     it('should edit multiple fields at once', async () => {
-      await execInProcess('ticket create --title "Multi test" --priority LOW --category chore --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Multi test" --priority LOW --category chore --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Multi test') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --title "New multi" --priority URGENT --category security --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --title "New multi" --priority URGENT --category security`);
 
       const updatedTicket = db.prepare('SELECT title, priority, category FROM pmo_tickets WHERE id = ?').get(ticket.id) as { title: string; priority: string; category: string };
       expect(updatedTicket.title).to.equal('New multi');
@@ -287,10 +287,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
     // kanban.md auto-export is disabled (DB is sole source of truth)
     it.skip('should update kanban.md after edit', async () => {
-      await execInProcess('ticket create --title "Board edit test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Board edit test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Board edit test') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --title "Edited for board" --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --title "Edited for board"`);
 
       const boardPath = path.join(testDir, 'pmo/projects/test-project/kanban.md');
       const content = fs.readFileSync(boardPath, 'utf-8');
@@ -298,10 +298,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
     });
 
     it('should clear priority with none value', async () => {
-      await execInProcess('ticket create --title "Clear priority" --priority HIGH --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Clear priority" --priority HIGH --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Clear priority') as { id: string };
 
-      await execInProcess(`ticket edit ${ticket.id} --priority none --machine`);
+      await execInProcess(`ticket edit ${ticket.id} --priority none`);
 
       const updatedTicket = db.prepare('SELECT priority FROM pmo_tickets WHERE id = ?').get(ticket.id) as { priority: string | null };
       expect(updatedTicket.priority).to.be.oneOf([null, undefined, '']);
@@ -313,10 +313,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket status', () => {
     it('should display ticket status details', async () => {
-      await execInProcess('ticket create --title "Status view test" --priority HIGH --category bug --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Status view test" --priority HIGH --category bug --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Status view test') as { id: string };
 
-      const output = await execInProcess(`ticket status ${ticket.id} --machine`);
+      const output = await execInProcess(`ticket status ${ticket.id}`);
 
       expect(output).to.contain(ticket.id);
       expect(output).to.contain('Status view test');
@@ -324,35 +324,35 @@ describe('PMO Ticket Commands E2E Tests', () => {
     });
 
     it('should show priority in status', async () => {
-      await execInProcess('ticket create --title "Priority status" --priority URGENT --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Priority status" --priority URGENT --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Priority status') as { id: string };
 
-      const output = await execInProcess(`ticket status ${ticket.id} --machine`);
+      const output = await execInProcess(`ticket status ${ticket.id}`);
 
       // formatPriority converts URGENT → [P0]
       expect(output).to.contain('P0');
     });
 
     it('should show category in status', async () => {
-      await execInProcess('ticket create --title "Category status" --category security --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Category status" --category security --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Category status') as { id: string };
 
-      const output = await execInProcess(`ticket status ${ticket.id} --machine`);
+      const output = await execInProcess(`ticket status ${ticket.id}`);
 
       expect(output).to.contain('security');
     });
 
     it('should show description in status', async () => {
-      await execInProcess('ticket create --title "Desc status" --description "This is a detailed description" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Desc status" --description "This is a detailed description" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Desc status') as { id: string };
 
-      const output = await execInProcess(`ticket status ${ticket.id} --machine`);
+      const output = await execInProcess(`ticket status ${ticket.id}`);
 
       expect(output).to.contain('This is a detailed description');
     });
 
     it('should error for non-existent ticket', async () => {
-      const output = await execInProcess('ticket status NON-EXISTENT --machine');
+      const output = await execInProcess('ticket status NON-EXISTENT');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
@@ -360,10 +360,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket complete', () => {
     it('should move ticket to Done column', async () => {
-      await execInProcess('ticket create --title "Complete test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Complete test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Complete test') as { id: string };
 
-      await execInProcess(`ticket complete ${ticket.id} --machine`);
+      await execInProcess(`ticket complete ${ticket.id}`);
 
       // Verify via workflow statuses (pmo_board_tickets is deprecated)
       const status = db.prepare(`
@@ -378,10 +378,10 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
     // kanban.md auto-export is disabled (DB is sole source of truth)
     it.skip('should update kanban.md after completion', async () => {
-      await execInProcess('ticket create --title "Complete board test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Complete board test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Complete board test') as { id: string };
 
-      await execInProcess(`ticket complete ${ticket.id} --machine`);
+      await execInProcess(`ticket complete ${ticket.id}`);
 
       const boardPath = path.join(testDir, 'pmo/projects/test-project/kanban.md');
       const content = fs.readFileSync(boardPath, 'utf-8');
@@ -392,17 +392,17 @@ describe('PMO Ticket Commands E2E Tests', () => {
     });
 
     it('should display success message', async () => {
-      await execInProcess('ticket create --title "Complete msg test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Complete msg test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Complete msg test') as { id: string };
 
-      const output = await execInProcess(`ticket complete ${ticket.id} --machine`);
+      const output = await execInProcess(`ticket complete ${ticket.id}`);
 
       expect(output).to.contain('Completed');
       expect(output).to.contain(ticket.id);
     });
 
     it('should error for non-existent ticket', async () => {
-      const output = await execInProcess('ticket complete NON-EXISTENT --machine');
+      const output = await execInProcess('ticket complete NON-EXISTENT');
 
       // Complete command reports no incomplete tickets when ticket doesn't exist
       expect(output.toLowerCase()).to.satisfy((s: string) =>
@@ -423,7 +423,7 @@ describe('PMO Ticket Commands E2E Tests', () => {
         VALUES ('EPIC-001', 'test-project', 'Test Epic', 'active')
       `).run();
 
-      await execInProcess('ticket create --title "Link test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Link test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Link test') as { id: string };
 
       db.prepare('UPDATE pmo_tickets SET epic_id = ? WHERE id = ?').run('EPIC-001', ticket.id);
@@ -439,7 +439,7 @@ describe('PMO Ticket Commands E2E Tests', () => {
         VALUES ('EPIC-002', 'test-project', 'Unlink Epic', 'active')
       `).run();
 
-      await execInProcess('ticket create --title "Unlink test" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Unlink test" --column "Backlog"');
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Unlink test') as { id: string };
 
       // Link first
@@ -466,9 +466,9 @@ describe('PMO Ticket Commands E2E Tests', () => {
   describe('prlt ticket bulk move', () => {
     it('should move multiple tickets at once', async () => {
       // Create multiple tickets
-      await execInProcess('ticket create --title "Bulk 1" --column "Backlog" --machine');
-      await execInProcess('ticket create --title "Bulk 2" --column "Backlog" --machine');
-      await execInProcess('ticket create --title "Bulk 3" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Bulk 1" --column "Backlog"');
+      await execInProcess('ticket create --title "Bulk 2" --column "Backlog"');
+      await execInProcess('ticket create --title "Bulk 3" --column "Backlog"');
 
       db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Bulk 1');
       db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Bulk 2');
@@ -490,9 +490,9 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket bulk delete', () => {
     it('should delete multiple tickets', async () => {
-      await execInProcess('ticket create --title "Delete 1" --column "Backlog" --machine');
-      await execInProcess('ticket create --title "Delete 2" --column "Backlog" --machine');
-      await execInProcess('ticket create --title "Keep" --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Delete 1" --column "Backlog"');
+      await execInProcess('ticket create --title "Delete 2" --column "Backlog"');
+      await execInProcess('ticket create --title "Keep" --column "Backlog"');
 
       const beforeCount = db.prepare('SELECT COUNT(*) as count FROM pmo_tickets').get() as { count: number };
       expect(beforeCount.count).to.equal(3);
@@ -504,8 +504,8 @@ describe('PMO Ticket Commands E2E Tests', () => {
 
   describe('prlt ticket bulk update', () => {
     it('should update priority for multiple tickets', async () => {
-      await execInProcess('ticket create --title "Update 1" --priority P3 --column "Backlog" --machine');
-      await execInProcess('ticket create --title "Update 2" --priority P3 --column "Backlog" --machine');
+      await execInProcess('ticket create --title "Update 1" --priority P3 --column "Backlog"');
+      await execInProcess('ticket create --title "Update 2" --priority P3 --column "Backlog"');
 
       // Verify both are P3 priority
       const lowTickets = db.prepare('SELECT * FROM pmo_tickets WHERE priority = ?').all('P3');
@@ -539,7 +539,7 @@ describe('ticket create --label alias', () => {
 
   it('should accept --label as alias for --labels', async () => {
     const output = await execInProcess(
-      'ticket create --title "Label alias test" --column Backlog --label "bug,ui" --machine'
+      'ticket create --title "Label alias test" --column Backlog --label "bug,ui"'
     );
 
     expect(output).to.not.contain('Nonexistent flag');
@@ -550,7 +550,7 @@ describe('ticket create --label alias', () => {
 
   it('should accept --labels (plural) as before', async () => {
     const output = await execInProcess(
-      'ticket create --title "Labels plural test" --column Backlog --labels "feature,backend" --machine'
+      'ticket create --title "Labels plural test" --column Backlog --labels "feature,backend"'
     );
 
     expect(output).to.not.contain('Nonexistent flag');

--- a/apps/cli/test/e2e/pmo-ticket-template-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-template-commands.test.ts
@@ -38,7 +38,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
 
   describe('prlt ticket template list', () => {
     it('should list all ticket templates', async () => {
-      const output = await execInProcess('ticket template list --machine');
+      const output = await execInProcess('ticket template list');
 
       expect(output).to.contain('Ticket Templates');
       expect(output).to.contain('bug-report');
@@ -46,7 +46,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should show built-in templates', async () => {
-      const output = await execInProcess('ticket template list --machine');
+      const output = await execInProcess('ticket template list');
 
       expect(output).to.contain('Built-in Templates');
       expect(output).to.contain('Bug Report');
@@ -55,7 +55,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should filter to builtin only with --builtin', async () => {
-      const output = await execInProcess('ticket template list --builtin --machine');
+      const output = await execInProcess('ticket template list --builtin');
 
       expect(output).to.contain('Built-in Templates');
       expect(output).not.to.contain('Custom Templates');
@@ -64,9 +64,9 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     it('should filter to custom only with --custom', async () => {
       // First create a custom template
       createTestTicket(db, 'TKT-001', 'Test Ticket');
-      await execInProcess('ticket template save TKT-001 "My Custom Template" --description "" --machine');
+      await execInProcess('ticket template save TKT-001 "My Custom Template" --description ""');
 
-      const output = await execInProcess('ticket template list --custom --machine');
+      const output = await execInProcess('ticket template list --custom');
 
       expect(output).to.contain('Custom Templates');
       expect(output).to.contain('My Custom Template');
@@ -86,7 +86,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
 
   describe('prlt ticket template apply', () => {
     it('should create ticket from bug-report template', async () => {
-      const output = await execInProcess('ticket template apply bug-report --title "Login page crashes" --machine');
+      const output = await execInProcess('ticket template apply bug-report --title "Login page crashes"');
 
       expect(output).to.contain('Created ticket');
       expect(output).to.contain('Bug Report');
@@ -99,7 +99,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should create ticket from feature-request template', async () => {
-      const output = await execInProcess('ticket template apply feature-request --title "Add dark mode" --machine');
+      const output = await execInProcess('ticket template apply feature-request --title "Add dark mode"');
 
       expect(output).to.contain('Created ticket');
       expect(output).to.contain('Feature Request');
@@ -111,7 +111,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should create subtasks from template', async () => {
-      await execInProcess('ticket template apply bug-report --title "Fix crash" --machine');
+      await execInProcess('ticket template apply bug-report --title "Fix crash"');
 
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title LIKE ?').get('%Fix crash%') as { id: string } | undefined;
       expect(ticket).to.not.be.undefined;
@@ -121,7 +121,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should override template defaults with flags', async () => {
-      await execInProcess('ticket template apply bug-report --title "Minor issue" --priority LOW --category chore --machine');
+      await execInProcess('ticket template apply bug-report --title "Minor issue" --priority LOW --category chore');
 
       const ticket = db.prepare('SELECT * FROM pmo_tickets WHERE title LIKE ?').get('%Minor issue%') as { priority: string; category: string } | undefined;
       expect(ticket).to.not.be.undefined;
@@ -130,7 +130,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should skip subtasks with --no-subtasks', async () => {
-      await execInProcess('ticket template apply bug-report --title "No subtasks" --no-subtasks --machine');
+      await execInProcess('ticket template apply bug-report --title "No subtasks" --no-subtasks');
 
       const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title LIKE ?').get('%No subtasks%') as { id: string } | undefined;
       expect(ticket).to.not.be.undefined;
@@ -140,7 +140,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should error when template not found', async () => {
-      const output = await execInProcess('ticket template apply non-existent --title "Test" --machine');
+      const output = await execInProcess('ticket template apply non-existent --title "Test"');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
@@ -156,7 +156,7 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should create template from ticket', async () => {
-      const output = await execInProcess('ticket template save TKT-001 "My Template" --description "" --machine');
+      const output = await execInProcess('ticket template save TKT-001 "My Template" --description ""');
 
       expect(output).to.contain('Created template');
       expect(output).to.contain('My Template');
@@ -168,27 +168,27 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should include description in template', async () => {
-      await execInProcess('ticket template save TKT-001 "Template With Desc" --description "A reusable template" --machine');
+      await execInProcess('ticket template save TKT-001 "Template With Desc" --description "A reusable template"');
 
       const template = db.prepare('SELECT * FROM pmo_ticket_templates WHERE name = ?').get('Template With Desc') as { description: string } | undefined;
       expect(template?.description).to.equal('A reusable template');
     });
 
     it('should error when ticket not found', async () => {
-      const output = await execInProcess('ticket template save TKT-999 "Bad Template" --machine');
+      const output = await execInProcess('ticket template save TKT-999 "Bad Template"');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
 
     it('should error when template name already exists', async () => {
-      await execInProcess('ticket template save TKT-001 "Duplicate Name" --description "" --machine');
-      const output = await execInProcess('ticket template save TKT-001 "Duplicate Name" --description "" --machine');
+      await execInProcess('ticket template save TKT-001 "Duplicate Name" --description ""');
+      const output = await execInProcess('ticket template save TKT-001 "Duplicate Name" --description ""');
 
       expect(output.toLowerCase()).to.contain('already exists');
     });
 
     it('should accept --template-name flag instead of positional argument', async () => {
-      const output = await execInProcess('ticket template save TKT-001 --template-name "Flag Template" --description "" --machine');
+      const output = await execInProcess('ticket template save TKT-001 --template-name "Flag Template" --description ""');
 
       expect(output).to.contain('Created template');
       expect(output).to.contain('Flag Template');
@@ -235,11 +235,11 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
   describe('prlt ticket template delete', () => {
     beforeEach(async () => {
       createTestTicket(db, 'TKT-001', 'Source Ticket');
-      await execInProcess('ticket template save TKT-001 "Deletable Template" --description "" --machine');
+      await execInProcess('ticket template save TKT-001 "Deletable Template" --description ""');
     });
 
     it('should delete custom template', async () => {
-      const output = await execInProcess('ticket template delete deletable-template --force --machine');
+      const output = await execInProcess('ticket template delete deletable-template --force');
 
       expect(output).to.contain('Deleted template');
 
@@ -248,13 +248,13 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
     });
 
     it('should error when template not found', async () => {
-      const output = await execInProcess('ticket template delete non-existent --force --machine');
+      const output = await execInProcess('ticket template delete non-existent --force');
 
       expect(output.toLowerCase()).to.contain('not found');
     });
 
     it('should error when deleting built-in template', async () => {
-      const output = await execInProcess('ticket template delete bug-report --force --machine');
+      const output = await execInProcess('ticket template delete bug-report --force');
 
       expect(output.toLowerCase()).to.contain('cannot delete');
     });
@@ -270,10 +270,10 @@ describe('PMO Ticket Template Commands E2E Tests', () => {
       });
 
       // Save as template
-      await execInProcess('ticket template save TKT-001 "Sprint Planning" --description "" --machine');
+      await execInProcess('ticket template save TKT-001 "Sprint Planning" --description ""');
 
       // Create new ticket from template
-      const output = await execInProcess('ticket template apply sprint-planning --title "Sprint 42 Planning" --machine');
+      const output = await execInProcess('ticket template apply sprint-planning --title "Sprint 42 Planning"');
 
       expect(output).to.contain('Created ticket');
       expect(output).to.contain('Sprint Planning');


### PR DESCRIPTION
## Summary

Resolves TKT-1246: Fix pmo e2e tests: assertions expect human text but get JSON in non-TTY (17 failures)

## Description

## Problem
The pmo e2e shard fails with 17 test failures. Tests assert on human-readable text (`'Created ticket'`, `'Built-in Templates'`, `'[P1]'`) but in CI (non-TTY), commands output JSON instead.

## Files
- `apps/cli/test/e2e/pmo-epic-commands.test.ts`
- `apps/cli/test/e2e/pmo-phase-template-commands.test.ts`
- `apps/cli/test/e2e/pmo-ticket-commands.test.ts`
- `apps/cli/test/e2e/pmo-ticket-template-commands.test.ts`

## Fix
These tests use `execInProcess` which runs in non-TTY mode, so commands output JSON. Fix by either:
1. Parsing JSON output and asserting on JSON fields instead of text
2. Or using `extractJson` helper and asserting on the parsed structure

Look at how other successfully converted tests handle this (e.g., session-commands, execution-commands).

## Verification
Run: `cd apps/cli && pnpm build && npx mocha --timeout 30000 test/e2e/pmo-epic-commands.test.ts test/e2e/pmo-phase-template-commands.test.ts test/e2e/pmo-ticket-commands.test.ts test/e2e/pmo-ticket-template-commands.test.ts`

## Changes

- cfd44c29 fix(TKT-1246): fix pmo e2e tests: remove --machine flag so execInProcess uses text mode via PRLT_FORCE_TEXT

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
