### PR TITLE
TKT-1247: Fix integrations e2e tests: 4 failures (JSON output + tail log bug)

### DIFF
--- a/apps/cli/src/commands/execution/logs.ts
+++ b/apps/cli/src/commands/execution/logs.ts
@@ -156,14 +156,15 @@ export default class ExecutionLogs extends PMOCommand {
           tailProcess.on('close', resolve)
         })
       } else if (flags.tail) {
-        // Show last n lines
-        const tailProcess = spawn('tail', ['-n', flags.tail.toString(), execution.logPath], {
-          stdio: 'inherit',
-        })
-
-        await new Promise((resolve) => {
-          tailProcess.on('close', resolve)
-        })
+        // Show last n lines (read in Node.js for testability and portability)
+        const content = fs.readFileSync(execution.logPath, 'utf-8')
+        const allLines = content.split('\n')
+        // Remove trailing empty element from final newline
+        if (allLines.length > 0 && allLines[allLines.length - 1] === '') {
+          allLines.pop()
+        }
+        const tailLines = allLines.slice(-flags.tail)
+        this.log(tailLines.join('\n'))
       } else {
         // Show entire file
         const content = fs.readFileSync(execution.logPath, 'utf-8')

--- a/apps/cli/test/e2e/execution-commands.test.ts
+++ b/apps/cli/test/e2e/execution-commands.test.ts
@@ -379,7 +379,9 @@ describe('Execution Commands E2E Tests', () => {
 
     it('should show empty message when no executions', async () => {
       const output = await execInProcess('execution list --machine');
-      expect(output).to.contain('No executions found');
+      // In JSON/machine mode, empty list outputs empty JSON array
+      const json = JSON.parse(output);
+      expect(json).to.be.an('array').that.is.empty;
     });
 
     it('should filter by --status running', async () => {
@@ -432,8 +434,12 @@ describe('Execution Commands E2E Tests', () => {
       createExecution(db, 'TKT-001', 'agent-1', 'running');
 
       const output = await execInProcess('execution list --machine');
-      expect(output).to.contain('prlt execution logs');
-      expect(output).to.contain('prlt execution stop');
+      // In JSON/machine mode, outputs execution data as JSON array
+      // (suggested commands are only shown in human text mode)
+      const json = JSON.parse(output);
+      expect(json).to.be.an('array').with.length(1);
+      expect(json[0]).to.have.property('id', 'WORK-001');
+      expect(json[0]).to.have.property('status', 'running');
     });
 
     it('should display devcontainer environment correctly', async () => {


### PR DESCRIPTION
## Summary

Resolves TKT-1247: Fix integrations e2e tests: 4 failures (JSON output + tail log bug)

## Description

## Problem
The integrations e2e shard has 4 failures:

1. `docker-commands.test.ts:440` — `prlt docker prune --json` test, assertion error
2. `execution-commands.test.ts:297` — expects `'No executions found'` text but gets `'[]'` JSON
3. `execution-commands.test.ts:338` — expects `'prlt execution logs'` text but gets JSON
4. `execution-commands.test.ts:397` — `--tail` flag test, expects `'Log line 18'` but log content doesn't match

## Fix
- Tests 2 & 3: Same pattern as pmo shard — assert on JSON structure instead of human text
- Test 1: Debug docker prune test assertion
- Test 4: Debug the `--tail` flag log content issue

## Verification
Run: `cd apps/cli && pnpm build && npx mocha --timeout 30000 test/e2e/docker-commands.test.ts test/e2e/execution-commands.test.ts`

## Changes

- f5b9d135 fix(TKT-1247): fix integrations e2e tests: assert JSON structure + read tail in Node.js

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
