### PR TITLE
TKT-1250: Fix standalone e2e shard: 9 CI-only failures (feedback commands + agent-commands)

### DIFF
--- a/apps/cli/test/e2e/feedback-commands.test.ts
+++ b/apps/cli/test/e2e/feedback-commands.test.ts
@@ -31,6 +31,18 @@ function parseJsonOutput(output: string): {
 }
 
 /**
+ * Check if the JSON response indicates a GitHub auth error.
+ * In CI environments, gh is not authenticated, so commands return
+ * GH_NOT_AUTHENTICATED instead of expected prompts/results.
+ */
+function isGHAuthError(json: ReturnType<typeof parseJsonOutput>): boolean {
+  return json?.type === 'error' && (
+    json?.error?.code === 'GH_NOT_AUTHENTICATED' ||
+    json?.error?.code === 'GH_NOT_INSTALLED'
+  )
+}
+
+/**
  * End-to-end tests for Feedback CLI Commands
  * Tests: prlt feedback, prlt feedback submit, prlt feedback list, prlt feedback view
  *
@@ -38,6 +50,8 @@ function parseJsonOutput(output: string): {
  * the CLI interface, help output, and JSON mode output format.
  *
  * In non-TTY mode (like test environments), commands output JSON by default.
+ * In CI environments, gh may not be authenticated, so tests that require
+ * GitHub auth gracefully skip when GH_NOT_AUTHENTICATED is returned.
  */
 describe('Feedback CLI Commands E2E Tests', () => {
   /**
@@ -116,6 +130,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.type).to.equal('prompt')
         expect(json?.prompt?.name).to.equal('category')
         expect(json?.prompt?.type).to.equal('list')
@@ -134,6 +150,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.type).to.equal('prompt')
         expect(json?.prompt?.name).to.equal('title')
         expect(json?.prompt?.type).to.equal('input')
@@ -146,6 +164,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.type).to.equal('prompt')
         expect(json?.prompt?.name).to.equal('body')
         expect(json?.prompt?.type).to.equal('editor')
@@ -173,6 +193,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.type).to.equal('success')
         expect(json?.success).to.equal(true)
         expect(json?.result).to.have.property('issues')
@@ -187,6 +209,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.result).to.have.property('filters')
 
         const filters = (json?.result as { filters: Record<string, unknown> }).filters
@@ -201,6 +225,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.type).to.equal('success')
 
         const filters = (json?.result as { filters: Record<string, unknown> }).filters
@@ -235,6 +261,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
       if (isJsonOutput(output)) {
         const json = parseJsonOutput(output)
         expect(json).to.not.be.null
+        // Skip if gh is not authenticated (CI environment)
+        if (isGHAuthError(json)) return
         expect(json?.type).to.equal('success')
         expect(json?.result).to.have.property('number', 1)
         expect(json?.result).to.have.property('title')
@@ -253,7 +281,8 @@ describe('Feedback CLI Commands E2E Tests', () => {
         expect(json).to.not.be.null
         expect(json?.type).to.equal('error')
         expect(json?.error).to.have.property('code')
-        expect(json?.error?.code).to.match(/ISSUE_NOT_FOUND|ISSUE_VIEW_FAILED/)
+        // In CI, gh may not be authenticated, so accept that error too
+        expect(json?.error?.code).to.match(/ISSUE_NOT_FOUND|ISSUE_VIEW_FAILED|GH_NOT_AUTHENTICATED|GH_NOT_INSTALLED/)
       }
     })
   })

--- a/apps/cli/test/e2e/standalone-commands.test.ts
+++ b/apps/cli/test/e2e/standalone-commands.test.ts
@@ -104,7 +104,7 @@ describe('Standalone Commands E2E - this.prompt() Migration (TKT-764)', () => {
         if (!result || !result.prompt) return;
 
         expect(result.prompt.type).to.equal('list');
-        expect(result.prompt.name).to.equal('permissionMode');
+        expect(result.prompt.name).to.equal('selectedMode');
         expect(result.prompt.message).to.include('Permission');
         // Check command fields
         const dangerChoice = result.prompt.choices!.find((c) => c.value === 'danger');


### PR DESCRIPTION
## Summary

Resolves TKT-1250: Fix standalone e2e shard: 9 CI-only failures (feedback commands + agent-commands)

## Description

## Problem
PR #651 fixed most e2e failures but standalone shard still has 9 failures that only appear in CI (pass locally). This is the last shard blocking green CI.

## Failures (all in standalone shard)

### feedback-commands (7 failures)
All in `test/e2e/feedback-commands.test.ts`:
1. `feedback submit` — should prompt for category: `expected 'error' to equal 'prompt'`
2. `feedback submit` — should prompt for title: `expected 'error' to equal 'prompt'`
3. `feedback submit` — should prompt for body: `expected 'error' to equal 'prompt'`
4. `feedback list` — should list issues: `expected 'error' to equal 'success'`
5. `feedback list` — should include filter info: `Target cannot be null or undefined`
6. `feedback list` — should filter by category: `expected 'error' to equal 'success'`
7. `feedback view` — should view issue details: `expected 'error' to equal 'success'`
8. `feedback view` — handle non-existent issue: `expected 'GH_NOT_AUTHENTICATED' to match /ISSUE_NOT_FOUND|ISSUE_VIEW_FAILED/`

Root cause: feedback commands likely require GitHub auth (`gh` CLI). In CI, `gh` is not authenticated, so commands return errors instead of expected prompts/results. Tests need to either mock gh auth or handle GH_NOT_AUTHENTICATED as an acceptable error in CI.

### agent-commands (1 failure)
In `test/e2e/agent-commands.test.ts`:
- `outside HQ` — should output permission-mode prompt: `expected 'selectedMode' to equal 'permissionMode'`

Root cause: Test expects a specific prompt field name but the command returns a different one.

## Fix approach
- feedback tests: Accept GH_NOT_AUTHENTICATED as valid error in CI, or skip tests when gh is not authenticated
- agent-commands: Fix the assertion to match actual field name

## Verification
Check CI output — these only reproduce in CI, not locally. Fix should make standalone shard pass in GitHub Actions.

## Context
This is built on top of PR #651. Either amend that PR or create a new one. Rebase onto main first since #646 was just merged.

## Changes

- 60754c07 fix(TKT-1250): fix CI-only e2e test failures in standalone shard

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
