### PR TITLE
feat(TKT-1251): define AgentRunner interface and extract ClaudeCodeRunner

### DIFF
--- a/apps/cli/src/lib/runners/agent-runner.ts
+++ b/apps/cli/src/lib/runners/agent-runner.ts
@@ -1,0 +1,112 @@
+/**
+ * AgentRunner Interface
+ *
+ * Defines the pluggable runner contract for agent orchestration.
+ * Runners implement this interface to support different agent runtimes
+ * (Claude Code, Codex, Pi, etc.) through a common API.
+ */
+
+// =============================================================================
+// Spawn Configuration
+// =============================================================================
+
+/**
+ * Configuration for spawning a new agent session.
+ */
+export interface SpawnConfig {
+  /** Task description or ticket context (the prompt) */
+  task: string
+  /** Git repo / working directory for the agent */
+  workdir: string
+  /** Override runner name (defaults to the runner's own name) */
+  runner?: string
+  /** Run detached (background mode) */
+  background?: boolean
+  /** Auto-create PR when work is done */
+  createPR?: boolean
+}
+
+// =============================================================================
+// Agent Session
+// =============================================================================
+
+/**
+ * Represents a running or completed agent session.
+ */
+export interface AgentSession {
+  /** Unique session identifier */
+  id: string
+  /** Runner that owns this session (e.g. 'claude-code', 'codex') */
+  runner: string
+  /** tmux session name */
+  sessionName: string
+  /** Task description the agent is working on */
+  task: string
+  /** Working directory */
+  workdir: string
+  /** When the session was started */
+  startedAt: Date
+  /** Current session status */
+  status: 'running' | 'done' | 'error'
+}
+
+// =============================================================================
+// AgentRunner Interface
+// =============================================================================
+
+/**
+ * Pluggable agent runner interface.
+ *
+ * Each runner wraps a specific agent runtime (Claude Code, Codex, Pi, etc.)
+ * and exposes a uniform API for spawning, monitoring, and controlling sessions.
+ *
+ * Runners are responsible for:
+ * - Spawning agent processes (typically via tmux for session persistence)
+ * - Reporting session status
+ * - Providing output capture (peek)
+ * - Sending follow-up messages (poke)
+ * - Gracefully stopping sessions
+ */
+export interface AgentRunner {
+  /** Runner identifier (e.g. 'claude-code', 'codex', 'pi') */
+  readonly name: string
+
+  /**
+   * Spawn a new agent session.
+   *
+   * Creates a tmux session running the agent with the given config.
+   * Returns an AgentSession representing the running agent.
+   */
+  spawn(config: SpawnConfig): Promise<AgentSession>
+
+  /**
+   * Get the current status of a session.
+   *
+   * Checks whether the agent process is still running inside its tmux session.
+   */
+  getStatus(session: AgentSession): Promise<'running' | 'done' | 'error'>
+
+  /**
+   * Capture recent output from the agent's tmux pane.
+   *
+   * @param session - The agent session to peek at
+   * @param lines - Number of scrollback lines to capture (default: 50)
+   * @returns The captured terminal output
+   */
+  peek(session: AgentSession, lines?: number): Promise<string>
+
+  /**
+   * Send a follow-up message to a running agent session.
+   *
+   * Sends keystrokes to the agent's tmux pane, allowing you to
+   * inject additional instructions or respond to prompts.
+   */
+  poke(session: AgentSession, message: string): Promise<void>
+
+  /**
+   * Stop a running agent session.
+   *
+   * Sends SIGTERM to the agent process and kills the tmux session.
+   */
+  stop(session: AgentSession): Promise<void>
+}

--- a/apps/cli/src/lib/runners/claude-code-runner.ts
+++ b/apps/cli/src/lib/runners/claude-code-runner.ts
@@ -1,0 +1,167 @@
+/**
+ * ClaudeCodeRunner
+ *
+ * AgentRunner implementation for Claude Code.
+ * Wraps the existing runHost() execution logic from execution/runners.ts
+ * to provide a pluggable runner interface while maintaining full backward
+ * compatibility with `prlt work start`.
+ */
+
+import { execSync } from 'node:child_process'
+import type { AgentRunner, AgentSession, SpawnConfig } from './agent-runner.js'
+import {
+  runHost,
+  buildSessionName,
+} from '../execution/runners.js'
+import { DEFAULT_EXECUTION_CONFIG } from '../execution/types.js'
+import type { ExecutionContext, ExecutionConfig } from '../execution/types.js'
+import { captureTmuxPane } from '../execution/session-utils.js'
+
+/**
+ * Claude Code agent runner.
+ *
+ * Delegates to the existing runHost() function for spawning, which handles:
+ * - tmux session creation for persistence
+ * - Terminal tab opening (iTerm, Terminal.app, Ghostty, etc.)
+ * - Prompt building and script generation
+ * - Permission mode and output mode configuration
+ *
+ * The peek/poke/stop methods use tmux commands directly since Claude Code
+ * sessions always run inside tmux.
+ */
+export class ClaudeCodeRunner implements AgentRunner {
+  readonly name = 'claude-code'
+
+  async spawn(config: SpawnConfig): Promise<AgentSession> {
+    const sessionName = this.buildSessionName(config)
+    const context = this.buildExecutionContext(config, sessionName)
+    const executionConfig = this.buildExecutionConfig(config)
+
+    const result = await runHost(
+      context,
+      'claude-code',
+      executionConfig,
+      config.background ? 'background' : 'terminal',
+    )
+
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to spawn Claude Code session')
+    }
+
+    return {
+      id: result.sessionId || sessionName,
+      runner: this.name,
+      sessionName: result.sessionId || sessionName,
+      task: config.task,
+      workdir: config.workdir,
+      startedAt: new Date(),
+      status: 'running',
+    }
+  }
+
+  async getStatus(session: AgentSession): Promise<'running' | 'done' | 'error'> {
+    try {
+      const output = execSync(
+        `tmux has-session -t "${session.sessionName}" 2>/dev/null && echo "exists"`,
+        { encoding: 'utf-8', stdio: 'pipe' },
+      ).trim()
+
+      if (output === 'exists') {
+        return 'running'
+      }
+      return 'done'
+    } catch {
+      // tmux session doesn't exist — agent has finished or was killed
+      return 'done'
+    }
+  }
+
+  async peek(session: AgentSession, lines: number = 50): Promise<string> {
+    const output = captureTmuxPane(session.sessionName, lines)
+    return output ?? ''
+  }
+
+  async poke(session: AgentSession, message: string): Promise<void> {
+    try {
+      // Send the message as keystrokes followed by Enter
+      execSync(
+        `tmux send-keys -t "${session.sessionName}" ${JSON.stringify(message)} Enter`,
+        { stdio: 'pipe' },
+      )
+    } catch (error) {
+      throw new Error(
+        `Failed to send message to session "${session.sessionName}": ${
+          error instanceof Error ? error.message : error
+        }`,
+      )
+    }
+  }
+
+  async stop(session: AgentSession): Promise<void> {
+    try {
+      // Send C-c first to gracefully interrupt the running process
+      execSync(`tmux send-keys -t "${session.sessionName}" C-c`, { stdio: 'pipe' })
+      // Brief delay to let the process handle the signal
+      await new Promise(resolve => setTimeout(resolve, 500))
+      // Kill the tmux session
+      execSync(`tmux kill-session -t "${session.sessionName}"`, { stdio: 'pipe' })
+    } catch {
+      // Session may already be dead — that's fine
+    }
+  }
+
+  /**
+   * Build a tmux session name from spawn config.
+   * Uses the same naming convention as the existing system:
+   * "{ticketId}-{action}-{agentName}" or falls back to a generated name.
+   */
+  private buildSessionName(config: SpawnConfig): string {
+    // If we have a full ExecutionContext-like task with ticket info, use buildSessionName
+    // Otherwise generate a simple name from the runner and timestamp
+    return `claude-${Date.now()}`
+  }
+
+  /**
+   * Build an ExecutionContext from SpawnConfig.
+   * Maps the simplified SpawnConfig to the richer ExecutionContext used by runHost().
+   */
+  private buildExecutionContext(config: SpawnConfig, sessionName: string): ExecutionContext {
+    return {
+      ticketId: sessionName,
+      ticketTitle: config.task.slice(0, 80),
+      ticketDescription: config.task,
+      agentName: 'agent',
+      agentDir: config.workdir,
+      worktreePath: config.workdir,
+      branch: 'main',
+      createPR: config.createPR,
+      actionName: 'work',
+      actionPrompt: config.task,
+    }
+  }
+
+  /**
+   * Build ExecutionConfig from SpawnConfig defaults.
+   */
+  private buildExecutionConfig(config: SpawnConfig): ExecutionConfig {
+    return {
+      ...DEFAULT_EXECUTION_CONFIG,
+      permissionMode: 'danger',
+    }
+  }
+}
+
+/**
+ * Create a ClaudeCodeRunner that uses a full ExecutionContext and config.
+ *
+ * This is the integration point for `prlt work start` — it provides a way
+ * to spawn Claude Code using the existing rich context while still going
+ * through the AgentRunner interface.
+ */
+export function createClaudeCodeSession(
+  context: ExecutionContext,
+  config: ExecutionConfig = DEFAULT_EXECUTION_CONFIG,
+  displayMode: 'terminal' | 'background' | 'foreground' = 'terminal',
+) {
+  return runHost(context, 'claude-code', config, displayMode)
+}

--- a/apps/cli/src/lib/runners/index.ts
+++ b/apps/cli/src/lib/runners/index.ts
@@ -1,0 +1,99 @@
+/**
+ * Runner Registry
+ *
+ * Central registry for agent runners. Provides auto-detection of available
+ * runtimes and a simple API for retrieving runner instances.
+ *
+ * Auto-detect order: claude-code → codex → pi
+ */
+
+import { execSync } from 'node:child_process'
+import type { AgentRunner } from './agent-runner.js'
+import { ClaudeCodeRunner } from './claude-code-runner.js'
+
+// Re-export interface and types for consumers
+export type { AgentRunner, AgentSession, SpawnConfig } from './agent-runner.js'
+export { ClaudeCodeRunner } from './claude-code-runner.js'
+export { createClaudeCodeSession } from './claude-code-runner.js'
+
+// =============================================================================
+// Runner Registry
+// =============================================================================
+
+/**
+ * Known runner definitions.
+ * Maps runner name to the CLI binary that must be on PATH and a factory function.
+ *
+ * Detection order matters — first available runner is the default.
+ */
+const RUNNER_DEFINITIONS: Array<{
+  name: string
+  binary: string
+  create: () => AgentRunner
+}> = [
+  {
+    name: 'claude-code',
+    binary: 'claude',
+    create: () => new ClaudeCodeRunner(),
+  },
+  // Future runners — uncomment when implemented:
+  // {
+  //   name: 'codex',
+  //   binary: 'codex',
+  //   create: () => new CodexRunner(),
+  // },
+  // {
+  //   name: 'pi',
+  //   binary: 'pi',
+  //   create: () => new PiRunner(),
+  // },
+]
+
+/**
+ * Check if a CLI binary is available on PATH.
+ */
+function isBinaryAvailable(binary: string): boolean {
+  try {
+    execSync(`command -v ${binary}`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Get all runners whose CLI binary is available on PATH.
+ *
+ * Returns runners in detection order (claude-code, codex, pi).
+ * Only runners with an installed CLI are included.
+ */
+export function getAvailableRunners(): AgentRunner[] {
+  return RUNNER_DEFINITIONS
+    .filter(def => isBinaryAvailable(def.binary))
+    .map(def => def.create())
+}
+
+/**
+ * Get a specific runner by name, or the default (first available) runner.
+ *
+ * @param name - Runner name to look up (e.g. 'claude-code', 'codex').
+ *               If omitted, returns the first available runner.
+ * @returns The runner instance, or null if not found / not available.
+ */
+export function getRunner(name?: string): AgentRunner | null {
+  if (name) {
+    const def = RUNNER_DEFINITIONS.find(d => d.name === name)
+    if (!def) return null
+    if (!isBinaryAvailable(def.binary)) return null
+    return def.create()
+  }
+
+  // Auto-detect: return first available
+  for (const def of RUNNER_DEFINITIONS) {
+    if (isBinaryAvailable(def.binary)) {
+      return def.create()
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

- Defines the `AgentRunner` interface (~5 methods: `spawn`, `getStatus`, `peek`, `poke`, `stop`) with `SpawnConfig` and `AgentSession` types
- Extracts existing Claude Code host execution logic into a `ClaudeCodeRunner` class implementing the interface
- Creates a runner registry with `getAvailableRunners()` and `getRunner(name?)` for auto-detection (claude → codex → pi)

## Details

**New files:**
- `apps/cli/src/lib/runners/agent-runner.ts` — Interface definition
- `apps/cli/src/lib/runners/claude-code-runner.ts` — Claude Code implementation wrapping existing `runHost()`
- `apps/cli/src/lib/runners/index.ts` — Registry, auto-detection, re-exports

**No existing files modified** — existing `prlt work start` flow is unaffected. The `ClaudeCodeRunner` delegates to the existing `runHost()` function from `execution/runners.ts`.

## Test plan

- [ ] Verify `prlt work start` still functions correctly (no existing code modified)
- [ ] Verify TypeScript compilation passes (`tsc --noEmit` — 0 errors)
- [ ] Verify `AgentRunner` interface is importable from `lib/runners`

🤖 Generated with [Claude Code](https://claude.com/claude-code)