### PR TITLE
fix(TKT-1253): validate Linear integration end-to-end and fix broken paths

### DIFF
--- a/apps/cli/src/lib/external-issues/linear.ts
+++ b/apps/cli/src/lib/external-issues/linear.ts
@@ -103,6 +103,7 @@ interface LinearIssueNode {
   }
   state?: {
     name?: string
+    type?: string
   }
   team?: {
     key?: string

--- a/apps/cli/src/lib/work-source/client.ts
+++ b/apps/cli/src/lib/work-source/client.ts
@@ -1,0 +1,72 @@
+import {
+  buildJiraMetadata,
+  buildJiraSpawnContextMessage,
+  buildJiraTicketDescription,
+  getJiraIssueByKey,
+} from '../external-issues/jira.js'
+import {
+  buildLinearMetadata,
+  buildLinearSpawnContextMessage,
+  buildLinearTicketDescription,
+  getLinearIssueByIdentifier,
+} from '../external-issues/linear.js'
+import type { NormalizedIssueEnvelope } from '../external-issues/types.js'
+import type { WorkSourceProvider } from './config.js'
+
+export interface WorkSourceClient {
+  readonly provider: WorkSourceProvider
+  fetchByKey(key: string): Promise<NormalizedIssueEnvelope | null>
+  buildTicketDescription(envelope: NormalizedIssueEnvelope): string
+  buildMetadata(envelope: NormalizedIssueEnvelope): Record<string, string>
+  buildSpawnContextMessage(envelope: NormalizedIssueEnvelope, additionalMessage?: string): string
+}
+
+class LinearWorkSourceClient implements WorkSourceClient {
+  readonly provider: WorkSourceProvider = 'linear'
+
+  async fetchByKey(key: string): Promise<NormalizedIssueEnvelope | null> {
+    return getLinearIssueByIdentifier({}, key)
+  }
+
+  buildTicketDescription(envelope: NormalizedIssueEnvelope): string {
+    return buildLinearTicketDescription(envelope)
+  }
+
+  buildMetadata(envelope: NormalizedIssueEnvelope): Record<string, string> {
+    return buildLinearMetadata(envelope)
+  }
+
+  buildSpawnContextMessage(envelope: NormalizedIssueEnvelope, additionalMessage?: string): string {
+    return buildLinearSpawnContextMessage(envelope, additionalMessage)
+  }
+}
+
+class JiraWorkSourceClient implements WorkSourceClient {
+  readonly provider: WorkSourceProvider = 'jira'
+
+  async fetchByKey(key: string): Promise<NormalizedIssueEnvelope | null> {
+    return getJiraIssueByKey({}, key)
+  }
+
+  buildTicketDescription(envelope: NormalizedIssueEnvelope): string {
+    return buildJiraTicketDescription(envelope)
+  }
+
+  buildMetadata(envelope: NormalizedIssueEnvelope): Record<string, string> {
+    return buildJiraMetadata(envelope)
+  }
+
+  buildSpawnContextMessage(envelope: NormalizedIssueEnvelope, additionalMessage?: string): string {
+    return buildJiraSpawnContextMessage(envelope, additionalMessage)
+  }
+}
+
+const SOURCE_CLIENTS: Partial<Record<WorkSourceProvider, WorkSourceClient>> = {
+  linear: new LinearWorkSourceClient(),
+  jira: new JiraWorkSourceClient(),
+}
+
+export function getWorkSourceClient(provider: WorkSourceProvider): WorkSourceClient | null {
+  return SOURCE_CLIENTS[provider] ?? null
+}
+

--- a/apps/cli/src/lib/work-source/index.ts
+++ b/apps/cli/src/lib/work-source/index.ts
@@ -10,3 +10,7 @@ export {
   loadActiveWorkSource,
   getRegisteredWorkSources,
 } from './config.js'
+export {
+  type WorkSourceClient,
+  getWorkSourceClient,
+} from './client.js'


### PR DESCRIPTION
## Summary
- Audited all Linear integration code paths (auth, import, spawn-from-Linear, outbound sync)
- Tracked orphaned `work-source/client.ts` file (WorkSourceClient abstraction) that was on disk but never committed
- Fixed `LinearIssueNode.state` TypeScript interface to include `type` field matching the GraphQL query
- Exported `WorkSourceClient` and `getWorkSourceClient` from `work-source/index.ts`
- All 284 Linear-related tests pass (42 unit + 32 e2e integration + 34 adapter flows + 10 work-source + 35 external-issue-spawn + 4 work-start + 23 redaction + 2 command + 79 external-issues + 9 mapping-store + 14 work-source-config)

## What was found

### Issues fixed
1. **`work-source/client.ts` not tracked** - This file provides the `WorkSourceClient` interface and `getWorkSourceClient()` factory function used for provider-agnostic issue fetching (Linear, Jira). It existed on disk but was never committed to main.
2. **`LinearIssueNode.state` missing `type` field** - The GraphQL query fetches `state { name type }` but the TypeScript interface only declared `name?`. Added `type?` for type safety.
3. **`work-source/index.ts` missing client exports** - Added exports for `WorkSourceClient` type and `getWorkSourceClient` function.

### Verified working
- Auth flow: API key storage in workspace_settings, env var support (LINEAR_API_KEY, PRLT_LINEAR_API_KEY)
- Import flow: Linear issue → PMO ticket mapping (priority, status, labels), linear_issue_map table schema
- Spawn-from-Linear flow: source resolution → Linear API query → issue selection → PMO mirror → agent spawn
- Outbound sync: status sync mapping (PMO → Linear), PR link attachment, comment posting
- Work source persistence: `prlt work source set linear:TEAM` correctly persists and resolves

## Test plan
- [x] All 284 Linear-related tests pass
- [x] Build succeeds with no TypeScript errors
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)