### PR TITLE
TKT-1254: Fix CI: pin Node version and fix better-sqlite3 rebuild race condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,7 +201,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: ['22']
     steps:
       - uses: actions/checkout@v4
 
@@ -241,7 +241,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: ['22']
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -270,8 +270,9 @@ jobs:
 
       # Rebuild better-sqlite3 native binding for the current Node.js ABI.
       # pnpm skips this during install because better-sqlite3 is in ignoredBuiltDependencies.
+      # Retry once on failure to handle EEXIST race condition in node-gyp symlink creation.
       - name: Rebuild better-sqlite3 native binding
-        run: npm rebuild better-sqlite3
+        run: npm rebuild better-sqlite3 || npm rebuild better-sqlite3
         working-directory: apps/cli
 
       # Fail fast if the native binding is missing or was compiled for a different ABI.
@@ -347,7 +348,7 @@ jobs:
     timeout-minutes: 35
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: ['22']
         shard: ${{ fromJson(needs.detect-changes.outputs.e2e_shards) }}
       fail-fast: false
     steps:
@@ -377,8 +378,9 @@ jobs:
 
       # Rebuild better-sqlite3 native binding for the current Node.js ABI.
       # pnpm skips this during install because better-sqlite3 is in ignoredBuiltDependencies.
+      # Retry once on failure to handle EEXIST race condition in node-gyp symlink creation.
       - name: Rebuild better-sqlite3 native binding
-        run: npm rebuild better-sqlite3
+        run: npm rebuild better-sqlite3 || npm rebuild better-sqlite3
         working-directory: apps/cli
 
       # Fail fast if the native binding is missing or was compiled for a different ABI.


### PR DESCRIPTION
## Summary

Resolves TKT-1254: Fix CI: pin Node version and fix better-sqlite3 rebuild race condition

## Description

## Problem
Unit-tests job on PR #652 failed with `EEXIST: file already exists, symlink` error during `npm rebuild better-sqlite3`. This is a race condition in node-gyp on Node v24.14.0 where multiple jobs try to create the same python3 symlink.

The workflow uses `lts/*` for Node version which dynamically resolves — CI can break when GitHub Actions updates its LTS resolution.

## File
`.github/workflows/test.yml`

## Fixes needed

### 1. Pin Node version
Change `node-version: [lts/*]` to a specific version like `node-version: ['22']` in all three jobs (build, unit-tests, e2e-tests). This prevents random breakage when GitHub updates LTS resolution.

Lines affected: the matrix strategy in build, unit-tests, and e2e-tests jobs.

### 2. Fix better-sqlite3 rebuild
The rebuild step (lines 273-275 and 380-382) uses `npm rebuild better-sqlite3`. Options:
- Add error handling: `npm rebuild better-sqlite3 || npm rebuild better-sqlite3` (retry on EEXIST)
- Or use `npx node-gyp rebuild --release` directly in the better-sqlite3 directory
- Or add `--force` flag

The comment on lines 18-19 explains why `npm rebuild` is used instead of `pnpm rebuild` (pnpm ignores built dependencies). Keep this constraint in mind.

## Verification
All 3 jobs (build, unit-tests, e2e-tests) should pass consistently. Re-run CI multiple times to confirm no flakiness.

## Changes

- 1a2e2acb fix(TKT-1254): pin Node 22 and add retry for better-sqlite3 rebuild race condition

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
