### PR TITLE
fix: orchestrator permission labels and default prompt

### DIFF
--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -194,10 +194,10 @@ export default class OrchestratorStart extends PromptCommand {
       sandboxed = true
     } else {
       const permissionChoices = [
-        { name: 'Sandboxed (requires approval for dangerous operations)', value: 'sandboxed', command: 'prlt orchestrator start --sandboxed --json' },
-        { name: 'Accept all (--dangerously-skip-permissions)', value: 'skip', command: 'prlt orchestrator start --skip-permissions --json' },
+        { name: '🔒 safe   - Requires approval for dangerous operations (recommended)', value: 'sandboxed', command: 'prlt orchestrator start --sandboxed --json' },
+        { name: '⚠️  danger - Skip permission checks (--dangerously-skip-permissions)', value: 'skip', command: 'prlt orchestrator start --skip-permissions --json' },
       ]
-      const permissionMessage = 'Select permission mode:'
+      const permissionMessage = 'Permission mode:'
 
       if (jsonMode) {
         outputPromptAsJson(
@@ -242,6 +242,33 @@ export default class OrchestratorStart extends PromptCommand {
           db?.close()
         }
       }
+    }
+
+    // Default orchestrator prompt when none provided
+    if (!actionPrompt) {
+      actionPrompt = [
+        `You are an **orchestrator** for this project running inside the prlt runtime.`,
+        ``,
+        `## Your Role`,
+        `- You investigate, plan, delegate, and review — you do NOT implement work yourself`,
+        `- You spawn agent sessions via \`prlt\` to do the actual work`,
+        `- You monitor progress, review results, and coordinate across agents`,
+        ``,
+        `## prlt Runtime Context`,
+        `- You are running in a prlt orchestrator session (tmux)`,
+        `- Board: \`prlt board\`, \`prlt ticket list\`, \`prlt ticket show <id>\``,
+        `- Spawn agents: \`prlt work start <ticket-id>\``,
+        `- Monitor: \`prlt session list\`, \`prlt session peek <session>\`, \`prlt session poke <session> "message"\``,
+        `- Status: \`prlt work status\``,
+        `- PRs: \`gh pr list\`, \`gh pr view\`, \`gh pr merge\``,
+        ``,
+        `## Workflow`,
+        `1. Check the board for Ready tickets`,
+        `2. Spawn agents for tickets that need work`,
+        `3. Monitor agent progress via session peek`,
+        `4. Review completed work and PRs`,
+        `5. Poke agents with guidance when they get stuck`,
+      ].join('\n')
     }
 
     // Build execution context
@@ -338,7 +365,7 @@ export default class OrchestratorStart extends PromptCommand {
       this.log('')
       this.log(styles.muted(`   Starting orchestrator...`))
       this.log(styles.muted(`   Executor: ${selectedExecutor}`))
-      this.log(styles.muted(`   Permission mode: ${sandboxed ? 'sandboxed' : 'skip-permissions'}`))
+      this.log(styles.muted(`   Permission mode: ${sandboxed ? 'safe' : 'danger'}`))
       this.log(styles.muted(`   Display mode: ${displayMode}`))
       this.log(styles.muted(`   Directory: ${hqPath}`))
       if (orchestratorName !== 'main') {


### PR DESCRIPTION
## Summary
- Rename permission mode options from "Sandboxed / Accept all" to "safe / danger" with emoji indicators, matching the style used by `prlt work start` in `config.ts`
- Add a default orchestrator system prompt when no `--prompt` or `--action` is provided — instructs the orchestrator to investigate, plan, delegate, and review (not implement work itself), and lists available `prlt` commands
- Update startup status log to show "safe/danger" instead of "sandboxed/skip-permissions"

## Test plan
- [ ] Run `prlt orchestrator start` and verify permission prompt shows "safe / danger" labels
- [ ] Start orchestrator without `--prompt` flag and verify default system prompt is injected
- [ ] Start orchestrator with `--prompt` flag and verify custom prompt still takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)