### PR TITLE
TKT-025: Fix bun/npm install — better-sqlite3 error handling and troubleshooting

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -697,12 +697,80 @@ Claude Code handles its own authentication via `claude login`.
 
 ## Requirements
 
-- **Node.js 18+**
+- **Node.js 20+** (22 LTS recommended)
 - **Git**
 - **Claude Code** (`claude login` to authenticate)
 - **SQLite**
 - **Tmux** (session persistence)
 - **Docker** (optional—for isolated execution)
+
+---
+
+## Troubleshooting Installation
+
+### `bun install` fails on better-sqlite3
+
+**Symptom**: `bun install -g @proletariat/cli` fails with `isexe` or `node-gyp` errors during the `better-sqlite3` native module build.
+
+**Cause**: Bun's node-gyp compatibility is limited. The `which` dependency inside node-gyp uses `isexe`, which is incompatible with Bun's runtime shims.
+
+**Fix**: Use `npm` or Homebrew instead:
+
+```bash
+# Option 1: Homebrew (macOS, recommended)
+brew install chrismcdermut/proletariat/prlt
+
+# Option 2: npm (all platforms)
+npm install -g @proletariat/cli
+
+# Option 3: pnpm
+pnpm install -g @proletariat/cli
+```
+
+If you must use Bun, ensure Node.js 22 (LTS) is also installed and set `better-sqlite3` to use its prebuilt binaries:
+
+```bash
+npm rebuild better-sqlite3
+```
+
+### npm `EACCES: permission denied`
+
+**Symptom**: `npm install -g @proletariat/cli` fails with `EACCES: permission denied` on `/opt/homebrew/lib/node_modules` or `/usr/local/lib/node_modules`.
+
+**Fix**: Configure npm to use a user-writable directory:
+
+```bash
+mkdir -p ~/.npm-global
+npm config set prefix '~/.npm-global'
+export PATH="$HOME/.npm-global/bin:$PATH"
+# Add the export line to your ~/.zshrc or ~/.bashrc
+npm install -g @proletariat/cli
+```
+
+Or use Homebrew instead (macOS):
+
+```bash
+brew install chrismcdermut/proletariat/prlt
+```
+
+### Native module errors after install
+
+**Symptom**: `prlt` runs but crashes with `better_sqlite3.node` or ABI mismatch errors.
+
+**Fix**:
+
+```bash
+# Rebuild for the current Node version
+npm rebuild better-sqlite3
+
+# Verify it works
+node -e "require('better-sqlite3')"
+
+# If still failing, reinstall
+npm install -g @proletariat/cli --force
+```
+
+See the [full troubleshooting guide](../../docs/troubleshooting.md) for more details.
 
 ---
 

--- a/apps/cli/bin/validate-better-sqlite3.cjs
+++ b/apps/cli/bin/validate-better-sqlite3.cjs
@@ -7,6 +7,11 @@ function parseNodeMajor(version) {
   return match ? Number.parseInt(match[1], 10) : null
 }
 
+function isBunRuntime() {
+  return typeof process.versions.bun === 'string'
+    || typeof globalThis.Bun !== 'undefined'
+}
+
 function runtimeInfo() {
   return {
     nodeVersion: process.version,
@@ -14,24 +19,32 @@ function runtimeInfo() {
     abi: process.versions.modules,
     platform: process.platform,
     arch: process.arch,
+    isBun: isBunRuntime(),
   }
+}
+
+function isBunNodeGypError(error) {
+  if (!(error instanceof Error)) return false
+  const msg = error.message.toLowerCase()
+  return msg.includes('isexe') || msg.includes('which.js') || msg.includes('node-gyp')
 }
 
 function buildMessage(error, context) {
   const info = runtimeInfo()
+  const runtimeLabel = info.isBun ? 'bun' : 'node'
   const nodeMajorHint = info.nodeMajor === null || SUPPORTED_NODE_MAJORS.includes(info.nodeMajor)
     ? ''
     : `\n- Unsupported Node major for this CLI: ${info.nodeMajor} (supported: ${SUPPORTED_NODE_MAJORS.join(', ')})`
   const reason = error instanceof Error ? error.message : String(error)
 
-  return [
+  const lines = [
     '',
     '╔══════════════════════════════════════════════════════════════════╗',
     '║  better-sqlite3 native module validation failed                ║',
     '╚══════════════════════════════════════════════════════════════════╝',
     '',
     `Context: ${context}`,
-    `Runtime: node ${info.nodeVersion} (ABI ${info.abi}) on ${info.platform}-${info.arch}${nodeMajorHint}`,
+    `Runtime: ${runtimeLabel} ${info.nodeVersion} (ABI ${info.abi}) on ${info.platform}-${info.arch}${nodeMajorHint}`,
     `Error:   ${reason}`,
     '',
     'Fix steps:',
@@ -43,8 +56,22 @@ function buildMessage(error, context) {
     'If the problem persists, ensure you have build tools installed:',
     '  macOS:  xcode-select --install',
     '  Linux:  sudo apt-get install build-essential python3',
-    '',
-  ].join('\n')
+  ]
+
+  if (info.isBun || isBunNodeGypError(error)) {
+    lines.push(
+      '',
+      'Bun users:',
+      '  Bun\'s node-gyp compatibility is limited and may fail to compile',
+      '  better-sqlite3. Recommended alternatives:',
+      '  - Install with npm instead: npm install -g @proletariat/cli',
+      '  - Install with Homebrew (macOS): brew install chrismcdermut/proletariat/prlt',
+      '  - Use Node.js 22 (LTS) for best compatibility',
+    )
+  }
+
+  lines.push('')
+  return lines.join('\n')
 }
 
 function validate(context) {
@@ -61,6 +88,18 @@ function validate(context) {
 try {
   validate('postinstall')
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error))
+  const info = runtimeInfo()
+  const message = error instanceof Error ? error.message : String(error)
+  // Under bun, native module build failures are expected — warn instead of
+  // hard-failing so the install can complete. The user will get a clear error
+  // at runtime with actionable fix steps.
+  if (info.isBun) {
+    console.warn(message)
+    console.warn('\n[warn] Continuing installation despite validation failure (bun detected).')
+    console.warn('[warn] Run prlt with Node.js, or reinstall with npm/Homebrew for full support.\n')
+    process.exit(0)
+  }
+
+  console.error(message)
   process.exit(1)
 }

--- a/apps/cli/src/lib/database/native-validation.ts
+++ b/apps/cli/src/lib/database/native-validation.ts
@@ -4,6 +4,7 @@ export interface BetterSqlite3RuntimeInfo {
   abi: string
   platform: NodeJS.Platform
   arch: string
+  isBun: boolean
 }
 
 export interface BetterSqlite3ValidationOptions {
@@ -23,6 +24,15 @@ function parseNodeMajor(version: string): number | null {
   return match ? Number.parseInt(match[1], 10) : null
 }
 
+/**
+ * Detect whether the current runtime is Bun rather than Node.js.
+ * Bun sets `process.versions.bun` and the `Bun` global.
+ */
+function detectBunRuntime(): boolean {
+  return typeof (process.versions as Record<string, string | undefined>).bun === 'string'
+    || typeof (globalThis as Record<string, unknown>).Bun !== 'undefined'
+}
+
 export function getBetterSqlite3RuntimeInfo(): BetterSqlite3RuntimeInfo {
   return {
     nodeVersion: process.version,
@@ -30,6 +40,7 @@ export function getBetterSqlite3RuntimeInfo(): BetterSqlite3RuntimeInfo {
     abi: process.versions.modules,
     platform: process.platform,
     arch: process.arch,
+    isBun: detectBunRuntime(),
   }
 }
 
@@ -39,13 +50,14 @@ export function buildBetterSqlite3ValidationMessage(
   context: string
 ): string {
   const reason = cause instanceof Error ? cause.message : String(cause)
+  const runtimeLabel = info.isBun ? 'bun' : 'node'
   const nodeMajorHint = info.nodeMajor === null || SUPPORTED_NODE_MAJORS.includes(info.nodeMajor)
     ? null
     : `- Unsupported Node major for this CLI: ${info.nodeMajor} (supported: ${SUPPORTED_NODE_MAJORS.join(', ')})`
 
   const lines = [
     `better-sqlite3 native module failed to load (${context}).`,
-    `Runtime: node ${info.nodeVersion} (ABI ${info.abi}) on ${info.platform}-${info.arch}.`,
+    `Runtime: ${runtimeLabel} ${info.nodeVersion} (ABI ${info.abi}) on ${info.platform}-${info.arch}.`,
     `Error: ${reason}`,
     '',
     'Fix steps:',
@@ -59,7 +71,30 @@ export function buildBetterSqlite3ValidationMessage(
     lines.splice(2, 0, nodeMajorHint)
   }
 
+  if (info.isBun || isBunNodeGypError(cause)) {
+    lines.push(
+      '',
+      'Bun users:',
+      '  Bun\'s node-gyp compatibility is limited and may fail to compile',
+      '  better-sqlite3. Recommended alternatives:',
+      '  - Install with npm instead: npm install -g @proletariat/cli',
+      '  - Install with Homebrew (macOS): brew install chrismcdermut/proletariat/prlt',
+      '  - Use Node.js 22 (LTS) for best compatibility',
+    )
+  }
+
   return lines.join('\n')
+}
+
+/**
+ * Detect whether an error looks like a bun-specific node-gyp failure.
+ * Bun's node-gyp integration has known issues with the `isexe` module
+ * (used by `which`) and other native compilation steps.
+ */
+function isBunNodeGypError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const msg = error.message.toLowerCase()
+  return msg.includes('isexe') || msg.includes('which.js') || msg.includes('node-gyp')
 }
 
 /**
@@ -72,6 +107,7 @@ export function buildBetterSqlite3ValidationMessage(
  * - "MODULE_NOT_FOUND" code (Node can't resolve the addon)
  * - "was compiled against a different Node.js version" (ABI mismatch)
  * - "A dynamic link library (DLL) initialization routine failed" (Windows ABI issue)
+ * - "isexe" / "which.js" (bun node-gyp compatibility issues)
  */
 export function isBetterSqlite3NativeError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
@@ -87,6 +123,9 @@ export function isBetterSqlite3NativeError(error: unknown): boolean {
   if (msg.includes('cannot open shared object file')) return true
   if (msg.includes('is not a valid win32 application')) return true
   if (msg.includes('node_module_version')) return true
+  // Bun-specific: node-gyp fails because bun's `which` shim uses an
+  // incompatible `isexe` version that throws at runtime.
+  if (msg.includes('isexe') && msg.includes('not a function')) return true
 
   return false
 }

--- a/apps/cli/test/unit/native-validation.test.ts
+++ b/apps/cli/test/unit/native-validation.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import {
   buildBetterSqlite3ValidationMessage,
+  isBetterSqlite3NativeError,
   validateBetterSqlite3NativeBinding,
 } from '../../src/lib/database/native-validation.js'
 
@@ -14,6 +15,7 @@ describe('better-sqlite3 native validation', () => {
         abi: '127',
         platform: 'darwin',
         arch: 'arm64',
+        isBun: false,
       },
       'unit-test'
     )
@@ -22,6 +24,48 @@ describe('better-sqlite3 native validation', () => {
     expect(message).to.include('node v22.8.0 (ABI 127) on darwin-arm64')
     expect(message).to.include('npm rebuild better-sqlite3')
     expect(message).to.include('pnpm install -g @proletariat/cli --force')
+  })
+
+  it('includes bun-specific guidance when isBun is true', () => {
+    const message = buildBetterSqlite3ValidationMessage(
+      new Error('isexe_1.default is not a function'),
+      {
+        nodeVersion: 'v22.8.0',
+        nodeMajor: 22,
+        abi: '127',
+        platform: 'darwin',
+        arch: 'arm64',
+        isBun: true,
+      },
+      'postinstall'
+    )
+
+    expect(message).to.include('bun v22.8.0 (ABI 127) on darwin-arm64')
+    expect(message).to.include('Bun users:')
+    expect(message).to.include('npm install -g @proletariat/cli')
+    expect(message).to.include('brew install chrismcdermut/proletariat/prlt')
+  })
+
+  it('includes bun guidance when error matches bun node-gyp pattern', () => {
+    const message = buildBetterSqlite3ValidationMessage(
+      new Error('node-gyp failed: isexe is not a function'),
+      {
+        nodeVersion: 'v24.5.0',
+        nodeMajor: 24,
+        abi: '131',
+        platform: 'darwin',
+        arch: 'arm64',
+        isBun: false,
+      },
+      'postinstall'
+    )
+
+    expect(message).to.include('Bun users:')
+  })
+
+  it('detects bun isexe error as a native error', () => {
+    const error = new Error('TypeError: (0, isexe_1.default) is not a function')
+    expect(isBetterSqlite3NativeError(error)).to.be.true
   })
 
   it('throws with contextual message when loader fails', async () => {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,6 +73,37 @@ Common valid runtime targets:
 
 If your terminal architecture differs from your Node architecture (for example Rosetta shell with ARM Node), rebuild under the runtime you actually use to run `prlt`.
 
+### Bun Install Fails on better-sqlite3
+
+**Symptom**: `bun install -g @proletariat/cli` fails with errors like:
+- `TypeError: (0, isexe_1.default) is not a function`
+- `node-gyp` build failures referencing `which.js`
+- `better-sqlite3` compilation errors during install
+
+**Cause**: Bun's node-gyp compatibility is limited. The `which` package (a node-gyp dependency) relies on `isexe`, which behaves differently under Bun's runtime shims. This prevents better-sqlite3 from compiling its native C++ addon.
+
+**Solution**: Use a different package manager:
+
+```bash
+# Recommended: Homebrew (macOS) — no compilation needed
+brew install chrismcdermut/proletariat/prlt
+
+# Alternative: npm (all platforms)
+npm install -g @proletariat/cli
+
+# Alternative: pnpm
+pnpm install -g @proletariat/cli
+```
+
+If you want to use Bun for other tools but need `prlt`:
+
+```bash
+# Install prlt with npm, then use bun for everything else
+npm install -g @proletariat/cli
+```
+
+**Background**: `prlt` uses `better-sqlite3` for its local database, which requires a native C++ addon compiled for your specific Node.js version and platform. Bun's node-gyp support is experimental and cannot reliably compile this addon. The `postinstall` validation will warn (not error) under Bun to allow the install to complete, but `prlt` will not work until the native module is properly built with Node.js.
+
 ### Install-Time Native Validation
 
 `apps/cli` now validates `better-sqlite3` during `postinstall`:
@@ -81,24 +112,37 @@ If your terminal architecture differs from your Node architecture (for example R
 npm rebuild better-sqlite3 && node ./bin/validate-better-sqlite3.cjs
 ```
 
-### Permission Denied During Install
+Under **Bun**, the validation script will warn instead of failing, since Bun's node-gyp issues are expected. The install will complete but `prlt` may not function until the native module is rebuilt with Node.js.
 
-**Symptom**: `EACCES: permission denied`
+### Permission Denied During Install (EACCES)
+
+**Symptom**: `EACCES: permission denied, mkdir '/opt/homebrew/lib/node_modules/@proletariat'` or similar `EACCES` errors on `/usr/local/lib/node_modules`.
+
+**Cause**: npm's global install directory is owned by root or another user. This commonly happens on macOS when Node.js was installed via Homebrew (which puts global modules under `/opt/homebrew/`).
 
 **Solutions**:
 
-1. **Use npm prefix** (recommended):
+1. **Use Homebrew instead** (macOS, recommended — avoids the problem entirely):
    ```bash
-   mkdir ~/.npm-global
+   brew install chrismcdermut/proletariat/prlt
+   ```
+
+2. **Set a user-writable npm prefix** (all platforms):
+   ```bash
+   mkdir -p ~/.npm-global
    npm config set prefix '~/.npm-global'
-   export PATH=~/.npm-global/bin:$PATH
+   export PATH="$HOME/.npm-global/bin:$PATH"
+   # Add the export to ~/.zshrc or ~/.bashrc for persistence:
+   echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> ~/.zshrc
    npm install -g @proletariat/cli
    ```
 
-2. **Fix npm permissions**:
+3. **Fix existing npm directory permissions** (use with caution):
    ```bash
    sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
    ```
+
+**Do NOT use `sudo npm install -g`** — this can cause further permission issues and is not recommended.
 
 ## Workspace Issues
 


### PR DESCRIPTION
## Summary
- Improved better-sqlite3 native validation error messages
- Added bun runtime detection with helpful guidance
- Added install troubleshooting docs to README
- Addresses GitHub issue #696

## Test plan
- [ ] Verify `npm i -g @proletariat/cli` works
- [ ] Verify error message is helpful when better-sqlite3 build fails
- [ ] Check README troubleshooting section

🤖 Generated with [Claude Code](https://claude.com/claude-code)