### PR TITLE
TKT-039: Fix local remote bug — resolve GitHub remotes for agent clones

### DIFF
--- a/apps/cli/src/commands/repo/fix-remotes.ts
+++ b/apps/cli/src/commands/repo/fix-remotes.ts
@@ -1,0 +1,174 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors, format } from '../../lib/colors.js';
+import { findHQRoot } from '../../lib/repos/index.js';
+import { getWorkspaceRepositories, getWorkspaceAgents, openWorkspaceDatabase } from '../../lib/database/index.js';
+import { isLocalPath, getOriginUrl, resolveRemoteUrl, setOriginUrl } from '../../lib/repos/git.js';
+
+export default class FixRemotes extends PMOCommand {
+  static description = 'Fix agent clone origins that point to local paths instead of GitHub remotes';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --dry-run',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      this.error('Not in an HQ directory. Run "prlt new" first.');
+    }
+
+    this.log(format.title('Fixing repository remotes'));
+    this.log('');
+
+    const repos = getWorkspaceRepositories(hqPath);
+    if (repos.length === 0) {
+      this.log(colors.warning('No repositories found.'));
+      return;
+    }
+
+    let fixedCount = 0;
+    let alreadyOkCount = 0;
+    let warningCount = 0;
+
+    // Fix central repos in repos/ directory
+    for (const repo of repos) {
+      const repoPath = path.join(hqPath, repo.path);
+      if (!fs.existsSync(repoPath)) {
+        this.log(colors.warning(`  ${repo.name}: directory missing, skipping`));
+        warningCount++;
+        continue;
+      }
+
+      const originUrl = getOriginUrl(repoPath);
+      if (!originUrl) {
+        this.log(colors.warning(`  ${repo.name}: no origin remote configured`));
+        warningCount++;
+        continue;
+      }
+
+      if (!isLocalPath(originUrl)) {
+        this.log(colors.textMuted(`  ${repo.name}: origin OK (${originUrl})`));
+        alreadyOkCount++;
+        continue;
+      }
+
+      // Origin is a local path — resolve it
+      const resolved = resolveRemoteUrl(repoPath);
+      if (resolved.isResolved && resolved.url) {
+        setOriginUrl(repoPath, resolved.url);
+        this.log(format.success(`  ${repo.name}: updated origin ${originUrl} → ${resolved.url}`));
+        fixedCount++;
+      } else if (resolved.warning) {
+        this.log(colors.warning(`  ${repo.name}: ${resolved.warning}`));
+        warningCount++;
+      }
+    }
+
+    // Fix agent worktrees/clones
+    this.log('');
+    this.log(format.subtitle('Checking agent worktrees...'));
+
+    const agents = getWorkspaceAgents(hqPath);
+    const db = openWorkspaceDatabase(hqPath);
+    const agentWorktrees = db.prepare('SELECT agent_name, repo_name, worktree_path FROM agent_worktrees').all() as {
+      agent_name: string;
+      repo_name: string;
+      worktree_path: string;
+    }[];
+    db.close();
+
+    for (const wt of agentWorktrees) {
+      const wtPath = path.join(hqPath, wt.worktree_path);
+      if (!fs.existsSync(wtPath)) continue;
+
+      const originUrl = getOriginUrl(wtPath);
+      if (!originUrl) continue;
+
+      if (!isLocalPath(originUrl)) continue;
+
+      // Agent worktree has a local origin — resolve from the central repo
+      const centralRepoPath = path.join(hqPath, 'repos', wt.repo_name);
+      const centralOrigin = getOriginUrl(centralRepoPath);
+
+      if (centralOrigin && !isLocalPath(centralOrigin)) {
+        // Central repo already has a good remote — use it
+        setOriginUrl(wtPath, centralOrigin);
+        this.log(format.success(`  ${wt.agent_name}/${wt.repo_name}: updated origin → ${centralOrigin}`));
+        fixedCount++;
+      } else {
+        // Try resolving from the local path
+        const resolved = resolveRemoteUrl(wtPath);
+        if (resolved.isResolved && resolved.url) {
+          setOriginUrl(wtPath, resolved.url);
+          this.log(format.success(`  ${wt.agent_name}/${wt.repo_name}: updated origin → ${resolved.url}`));
+          fixedCount++;
+        }
+      }
+    }
+
+    // Also scan agent directories for cloned repos not tracked in agent_worktrees
+    for (const agent of agents) {
+      if (!agent.worktree_path) continue;
+      const agentDir = path.join(hqPath, agent.worktree_path);
+      if (!fs.existsSync(agentDir)) continue;
+
+      for (const repo of repos) {
+        const agentRepoPath = path.join(agentDir, repo.name);
+        if (!fs.existsSync(agentRepoPath)) continue;
+
+        // Skip if already handled by agent_worktrees above
+        const alreadyHandled = agentWorktrees.some(
+          wt => wt.agent_name === agent.name && wt.repo_name === repo.name
+        );
+        if (alreadyHandled) continue;
+
+        const originUrl = getOriginUrl(agentRepoPath);
+        if (!originUrl || !isLocalPath(originUrl)) continue;
+
+        // Resolve the remote
+        const centralRepoPath = path.join(hqPath, 'repos', repo.name);
+        const centralOrigin = getOriginUrl(centralRepoPath);
+
+        if (centralOrigin && !isLocalPath(centralOrigin)) {
+          setOriginUrl(agentRepoPath, centralOrigin);
+          this.log(format.success(`  ${agent.name}/${repo.name}: updated origin → ${centralOrigin}`));
+          fixedCount++;
+        } else {
+          const resolved = resolveRemoteUrl(agentRepoPath);
+          if (resolved.isResolved && resolved.url) {
+            setOriginUrl(agentRepoPath, resolved.url);
+            this.log(format.success(`  ${agent.name}/${repo.name}: updated origin → ${resolved.url}`));
+            fixedCount++;
+          }
+        }
+      }
+    }
+
+    // Summary
+    this.log('');
+    this.log(format.subtitle('Summary:'));
+    if (fixedCount > 0) {
+      this.log(format.success(`  ${fixedCount} remote(s) fixed`));
+    }
+    if (alreadyOkCount > 0) {
+      this.log(colors.textMuted(`  ${alreadyOkCount} already pointing to remote URLs`));
+    }
+    if (warningCount > 0) {
+      this.log(colors.warning(`  ${warningCount} warning(s)`));
+    }
+    if (fixedCount === 0 && warningCount === 0) {
+      this.log(colors.textMuted('  All remotes are already configured correctly.'));
+    }
+  }
+}

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -35,6 +35,7 @@ import {
 import { createDevcontainerConfig } from '../execution/devcontainer.js';
 import { getGitIdentity } from '../pr/index.js';
 import { getPMOContext } from '../pmo/index.js';
+import { resolveRemoteUrl } from '../repos/git.js';
 
 /**
  * Resolve the directory for an agent, cascading through resolution strategies.
@@ -644,15 +645,12 @@ export async function createEphemeralAgent(
         if (fs.existsSync(sourceRepoPath) && !fs.existsSync(targetPath)) {
           if (mountMode === 'clone') {
             // CLONE MODE: Create independent git clone
+            // Resolve local paths to GitHub remotes so agents can push/create PRs
             try {
-              const remoteUrl = execSync('git remote get-url origin', {
-                cwd: sourceRepoPath,
-                encoding: 'utf-8',
-                stdio: ['pipe', 'pipe', 'pipe']
-              }).trim();
+              const resolved = resolveRemoteUrl(sourceRepoPath);
 
-              if (remoteUrl) {
-                execSync(`git clone "${remoteUrl}" "${targetPath}"`, {
+              if (resolved.url) {
+                execSync(`git clone "${resolved.url}" "${targetPath}"`, {
                   stdio: 'pipe'
                 });
               }

--- a/apps/cli/src/lib/agents/index.ts
+++ b/apps/cli/src/lib/agents/index.ts
@@ -9,6 +9,7 @@ import { styles } from '../styles.js';
 import { createDevcontainerConfig } from '../execution/devcontainer.js';
 import { getGitIdentity } from '../pr/index.js';
 import { pruneWorktrees } from '../branch/index.js';
+import { resolveRemoteUrl } from '../repos/git.js';
 
 export interface HQConfig {
   type: 'hq';
@@ -102,15 +103,14 @@ export interface CreateAgentOptions {
 }
 
 /**
- * Get the remote URL for a git repository
+ * Get the remote URL for a git repository, resolving local paths to GitHub remotes.
  */
 function getRemoteUrl(repoPath: string): string | null {
-  try {
-    const url = execSync('git remote get-url origin', { cwd: repoPath, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-    return url || null;
-  } catch {
-    return null;
+  const result = resolveRemoteUrl(repoPath);
+  if (result.warning) {
+    console.log(chalk.yellow(`  Warning: ${result.warning}`));
   }
+  return result.url;
 }
 
 /**

--- a/apps/cli/src/lib/repos/git.ts
+++ b/apps/cli/src/lib/repos/git.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
 
 /**
@@ -17,4 +18,140 @@ export function hasGitHubRemote(cwd?: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Check if a URL/path is a local filesystem path (not a remote URL).
+ */
+export function isLocalPath(urlOrPath: string): boolean {
+  return !urlOrPath.startsWith('http://') &&
+         !urlOrPath.startsWith('https://') &&
+         !urlOrPath.startsWith('git@') &&
+         !urlOrPath.startsWith('ssh://');
+}
+
+/**
+ * Get the origin remote URL for a git repository.
+ */
+export function getOriginUrl(repoPath: string): string | null {
+  try {
+    const url = execSync('git remote get-url origin', {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return url || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the actual GitHub/GitLab remote URL for a repository.
+ *
+ * When a repo is cloned from a local filesystem path, its origin points to that
+ * local path. This function detects that case and resolves the real remote URL
+ * by reading the source repo's remotes.
+ *
+ * Resolution strategy:
+ * 1. Get the repo's origin URL
+ * 2. If it's already a remote URL (https://, git@, ssh://), return it as-is
+ * 3. If it's a local path, read that source repo's remotes to find a remote URL
+ * 4. Prefer 'origin', then 'upstream', then any remote with a remote URL
+ * 5. If no remote URL found, return the local path as fallback
+ *
+ * @param repoPath - Path to the git repository
+ * @returns { url: string, isResolved: boolean, warning?: string }
+ */
+export function resolveRemoteUrl(repoPath: string): { url: string | null; isResolved: boolean; warning?: string } {
+  const originUrl = getOriginUrl(repoPath);
+  if (!originUrl) {
+    return { url: null, isResolved: false, warning: 'No origin remote configured' };
+  }
+
+  // Already a remote URL — no resolution needed
+  if (!isLocalPath(originUrl)) {
+    return { url: originUrl, isResolved: false };
+  }
+
+  // Origin is a local path — try to resolve from the source repo
+  const sourcePath = originUrl;
+
+  // Verify the source path exists and is a git repo
+  if (!fs.existsSync(sourcePath) || !isGitRepo(sourcePath)) {
+    return { url: originUrl, isResolved: false, warning: `Source path ${sourcePath} is not a valid git repo` };
+  }
+
+  // Read all remotes from the source repo
+  const remoteUrl = findRemoteUrl(sourcePath);
+  if (remoteUrl) {
+    return { url: remoteUrl, isResolved: true };
+  }
+
+  // No remote URL found in source — return local path with warning
+  return {
+    url: originUrl,
+    isResolved: false,
+    warning: `Source repo at ${sourcePath} has no remote URL configured (truly local-only repo)`,
+  };
+}
+
+/**
+ * Find the best remote URL from a git repository's configured remotes.
+ * Prefers origin > upstream > any other remote.
+ * Only returns actual remote URLs (not local paths).
+ */
+export function findRemoteUrl(repoPath: string): string | null {
+  try {
+    const output = execSync('git remote -v', {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    if (!output) return null;
+
+    // Parse remotes: "name\turl (fetch|push)"
+    const remotes = new Map<string, string>();
+    for (const line of output.split('\n')) {
+      const match = line.match(/^(\S+)\t(\S+)\s+\(fetch\)$/);
+      if (match) {
+        const [, name, url] = match;
+        if (!isLocalPath(url)) {
+          remotes.set(name, url);
+        }
+      }
+    }
+
+    // Prefer origin, then upstream, then any remote
+    return remotes.get('origin') ?? remotes.get('upstream') ?? remotes.values().next().value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a path is a git repository.
+ */
+export function isGitRepo(dir: string): boolean {
+  try {
+    execSync('git rev-parse --git-dir', {
+      cwd: dir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Update a git repository's origin URL to a new URL.
+ */
+export function setOriginUrl(repoPath: string, newUrl: string): void {
+  execSync(`git remote set-url origin "${newUrl}"`, {
+    cwd: repoPath,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
 }

--- a/apps/cli/src/lib/repos/index.ts
+++ b/apps/cli/src/lib/repos/index.ts
@@ -14,6 +14,7 @@ import {
 import { createDevcontainerConfig } from '../execution/devcontainer.js';
 import { getGitIdentity } from '../pr/index.js';
 import { findHQRoot } from '../workspace.js';
+import { isLocalPath, findRemoteUrl, setOriginUrl } from './git.js';
 
 export interface RepoToAdd {
   path: string;
@@ -254,8 +255,20 @@ export async function addRepositoriesToHQ(
         execSync(`git clone ${repo.path} ${targetPath}`, {
           stdio: 'inherit'
         });
+
+        // If cloned from a local path, resolve the GitHub remote and update origin
+        if (isLocalPath(repo.path)) {
+          const resolvedPath = path.resolve(repo.path);
+          const remoteUrl = findRemoteUrl(resolvedPath);
+          if (remoteUrl) {
+            setOriginUrl(targetPath, remoteUrl);
+            console.log(styles.muted(`  Updated origin to ${remoteUrl}`));
+          } else {
+            console.log(chalk.yellow(`  Warning: Source repo has no remote URL. Origin points to local path.`));
+          }
+        }
       }
-      
+
       addedRepos.push(repoName);
       console.log(chalk.green(`✅ Repository ${repoName} added successfully`));
     } catch (error) {
@@ -539,13 +552,33 @@ export async function addRepository(
     } else {
       console.log(styles.muted(`Cloning ${repoPath} to repos/${repoName}...`));
       execSync(`git clone "${repoPath}" "${targetPath}"`, { stdio: 'inherit' });
+
+      // If cloned from a local path, resolve the GitHub remote and update origin
+      if (isLocalPath(repoPath)) {
+        const resolvedPath = path.resolve(repoPath);
+        const remoteUrl = findRemoteUrl(resolvedPath);
+        if (remoteUrl) {
+          setOriginUrl(targetPath, remoteUrl);
+          console.log(styles.muted(`  Updated origin to ${remoteUrl}`));
+        } else {
+          console.log(chalk.yellow(`  Warning: Source repo has no remote URL. Origin points to local path.`));
+        }
+      }
     }
 
-    // Add to database
+    // Add to database (store the resolved remote URL if available)
+    let sourceUrl = repoPath;
+    if (isLocalPath(repoPath)) {
+      const resolvedPath = path.resolve(repoPath);
+      const remoteUrl = findRemoteUrl(resolvedPath);
+      if (remoteUrl) {
+        sourceUrl = remoteUrl;
+      }
+    }
     const dbRepoData = [{
       name: repoName,
       path: `repos/${repoName}`,
-      source_url: repoPath,
+      source_url: sourceUrl,
       action
     }];
     addRepositoriesToDatabase(hqPath, dbRepoData);


### PR DESCRIPTION
## Summary
- When `prlt repo add` uses a local filesystem path, agent clones now get the GitHub remote URL instead of the local path
- Resolves the source repo's `git remote -v` to find the real GitHub/GitLab origin
- Agents can now push and create PRs directly without manual intervention
- Fixes #678

## Test plan
- [ ] `prlt repo add /local/path` resolves to GitHub remote for agent clones
- [ ] Agent spawn creates clone with GitHub origin
- [ ] Agent can `git push` and `gh pr create` directly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)