### PR TITLE
TKT-040: Add --session-action flag for scripted session conflict resolution

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -340,6 +340,10 @@ export default class WorkStart extends PMOCommand {
       description: 'Use independent git clone instead of worktree (more isolation, no real-time sync)',
       default: false,
     }),
+    'session-action': Flags.string({
+      description: 'Action when existing session found (attach, spawn, kill, cancel). Skips interactive menu.',
+      options: ['attach', 'spawn', 'kill', 'cancel'],
+    }),
     yes: Flags.boolean({
       char: 'y',
       description: 'Skip confirmation prompt (for non-TTY/scripted execution)',
@@ -829,7 +833,7 @@ export default class WorkStart extends PMOCommand {
           commandName: 'work start',
           baseCommand: `prlt work start ${ticketId}`,
           jsonMode,
-          flags: {},
+          flags: flags['session-action'] ? { sessionAction: flags['session-action'] } : {},
         })
 
         sessionResolver.addPrompt({


### PR DESCRIPTION
## Summary

Resolves TKT-040: Add --session-action flag for scripted session conflict resolution

## Description

When prlt work start hits an existing session, it shows an interactive menu (attach/spawn/kill/cancel). There's no CLI flag to handle this non-interactively.

Add a --session-action flag accepting: attach, spawn, kill, cancel

Examples:
- prlt work start TKT-123 --session-action spawn  (spawn new agent alongside existing)
- prlt work start TKT-123 --session-action kill    (kill existing and respawn)
- prlt work start TKT-123 --session-action attach  (attach to existing)

This is needed for scripted/orchestrator use cases where interactive menus don't work.

## Changes

- f35feb65 feat(TKT-040): add --session-action flag for scripted session conflict resolution

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
