### PR TITLE
release: bump @proletariat/cli to 0.3.57

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.56",
+  "version": "0.3.57",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
Version bump to 0.3.57. Includes everything merged since 0.3.56:

- **Asana end-to-end integration** (#703) — `prlt work start --source asana:<task-gid>`
- **TUI dashboard** (#701) — `prlt dashboard` terminal monitoring
- **Install fix** (#700) — better-sqlite3 error handling for bun/npm
- **Docker/prlt confusion fix** (#706) — agents get environment context in prompts
- **Orchestrator prompt overhaul** (#708) — dynamic command registry, anti-patterns
- **Local remote bug fix** (#709) — agent clones resolve GitHub origin from source repo

## Test plan
- [ ] CI passes
- [ ] `npm install -g @proletariat/cli@0.3.57` works after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)