### PR TITLE
TKT-046: Rebalance e2e test shards — add 6th shard to cut CI from 12 to 8 min

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: ${{ github.event_name }} event (not a pull request)" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -65,7 +65,7 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: unable to compute merge-base with origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
@@ -162,14 +162,14 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: core/shared files changed (database, lib, config, CI, or unscoped source)" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
 
           elif [[ "$HAS_PMO" == "true" && "$HAS_EXECUTION" == "true" ]]; then
             # Multiple domains changed, run full suite
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: changes span multiple domains (pmo + execution)" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
 
           elif [[ "$HAS_PMO" == "true" ]]; then
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
@@ -474,6 +474,7 @@ jobs:
               echo "Running JSON/machine mode e2e tests"
               npx mocha --forbid-only \
                 --ignore "test/e2e/work-*.test.ts" \
+                --ignore "test/e2e/agent-json-mode.test.ts" \
                 "test/e2e/*-json-mode.test.ts" \
                 "test/e2e/json-mode-*.test.ts" \
                 "test/e2e/machine-mode-*.test.ts"
@@ -488,10 +489,16 @@ jobs:
                 "test/e2e/branch-*.test.ts" \
                 "test/e2e/linear-*.test.ts" \
                 "test/e2e/monday-*.test.ts" \
-                "test/e2e/mcp-*.test.ts" \
+                "test/e2e/mcp-board-*.test.ts" \
+                "test/e2e/session-*.test.ts"
+              ;;
+            infrastructure)
+              echo "Running infrastructure e2e tests"
+              npx mocha --forbid-only \
                 "test/e2e/docker-*.test.ts" \
-                "test/e2e/session-*.test.ts" \
-                "test/e2e/execution-*.test.ts"
+                "test/e2e/mcp-server.test.ts" \
+                "test/e2e/execution-*.test.ts" \
+                "test/e2e/agent-json-mode.test.ts"
               ;;
             standalone)
               echo "Running standalone e2e tests"


### PR DESCRIPTION
## Summary

Resolves TKT-046: Rebalance e2e test shards — add 6th shard to cut CI from 12 to 8 min

## Description

The e2e test shards are severely imbalanced:
- integrations: 11 min (docker-commands 56KB, mcp-server 56KB, session-commands 30KB, execution-commands 52KB)
- execution: 10 min (project-agent-flow 56 tests, action-agent-flow 56 tests, work-json-mode 41 tests)
- json-mode: 8 min (agent-json-mode 70KB)
- pmo: 4.5 min
- standalone: 3 min

Fix:
1. Add a 6th shard called 'infrastructure' (or 'docker') to the matrix in .github/workflows/test.yml
2. Move docker-commands.test.ts and mcp-server.test.ts from integrations → new shard
3. Move agent-json-mode.test.ts from json-mode → standalone or new shard (it's 70KB, 100+ tests)
4. Consider moving execution-commands.test.ts from integrations → execution or new shard

The shard assignment is in .github/workflows/test.yml in the e2e-tests matrix and in the test run script that maps shard names to glob patterns.

Search for how shards are defined — likely a case/switch or mapping in the workflow that maps shard name to test file glob pattern. Each shard runs: npx mocha --grep or a specific test directory/glob.

Target: no shard exceeds 7 min. Current critical path is 12 min, target is 8 min.

Key files:
- .github/workflows/test.yml (matrix definition, shard→glob mapping)
- apps/cli/test/e2e/ (test files to redistribute)

## Changes

- fad167d0 feat(TKT-046): add 6th infrastructure shard and rebalance e2e test distribution

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
