### PR TITLE
TKT-047: Cache initialized SQLite schema — eliminate per-test DB setup overhead

### DIFF
--- a/apps/cli/test/e2e/test-helpers.ts
+++ b/apps/cli/test/e2e/test-helpers.ts
@@ -22,6 +22,7 @@ import { runCommand } from '@oclif/test';
 import { initializePMOTables } from '../../src/lib/pmo/storage/base.js';
 import { PMO_TABLES } from '../../src/lib/pmo/schema.js';
 import { CREATE_TABLES_SQL } from '../../src/lib/database/index.js';
+import { setupProductionSchemaFromCache } from '../setup/schema-template-cache.js';
 
 /**
  * Error type for execSync failures, which include stdout/stderr from the child process.
@@ -179,17 +180,9 @@ const T = PMO_TABLES;
  * @returns Database instance with production schema initialized
  */
 export function setupProductionSchema(dbPath: string, pmoPath: string): Database.Database {
-  const db = new Database(dbPath);
-  db.pragma('foreign_keys = ON');
-
-  // Initialize PMO tables using production schema and seeding
-  // This runs migrations, creates tables, and seeds builtin data
-  initializePMOTables(db);
-
-  // Store PMO path in settings
-  db.prepare(`INSERT OR REPLACE INTO ${T.settings} (key, value) VALUES ('pmo_path', ?)`).run(pmoPath);
-
-  return db;
+  // Use cached template DB — copies a pre-initialized file (~1ms)
+  // instead of running full schema init + seeding (~100-200ms)
+  return setupProductionSchemaFromCache(dbPath, pmoPath);
 }
 
 /**

--- a/apps/cli/test/setup/schema-template-cache.ts
+++ b/apps/cli/test/setup/schema-template-cache.ts
@@ -1,0 +1,118 @@
+/**
+ * Schema Template Cache — eliminates per-test DB setup overhead.
+ *
+ * Instead of running full schema initialization (30+ tables, migrations, seeding)
+ * for every test (~100-200ms each), this module:
+ * 1. Creates a template database once with the full production schema + seed data
+ * 2. Caches it at /tmp/prlt-test-template-<hash>.db
+ * 3. For each test, copies the template via fs.copyFileSync (~1ms)
+ *
+ * The hash is computed from the source files that determine DB content
+ * (schema.ts, base.ts, templates-builtin.ts, utils.ts), so the template
+ * is automatically regenerated when schema or seed data changes.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import Database from 'better-sqlite3';
+import { initializePMOTables } from '../../src/lib/pmo/storage/base.js';
+import { PMO_TABLES } from '../../src/lib/pmo/schema.js';
+
+const T = PMO_TABLES;
+
+/**
+ * Source files that determine the template database contents.
+ * If any of these change, the cached template is invalidated.
+ */
+const SCHEMA_SOURCE_FILES = [
+  '../../src/lib/pmo/schema.ts',
+  '../../src/lib/pmo/storage/base.ts',
+  '../../src/lib/pmo/templates-builtin.ts',
+  '../../src/lib/pmo/utils.ts',
+  '../../src/lib/database/index.ts',
+];
+
+/** In-memory cached path to the template DB, so we don't recompute the hash repeatedly. */
+let cachedTemplatePath: string | null = null;
+
+/**
+ * Compute a SHA-256 hash of all schema source files.
+ * This is used to key the template DB so it's recreated when schema changes.
+ */
+function computeSchemaHash(): string {
+  const hasher = crypto.createHash('sha256');
+  const thisDir = path.dirname(new URL(import.meta.url).pathname);
+
+  for (const relPath of SCHEMA_SOURCE_FILES) {
+    const absPath = path.resolve(thisDir, relPath);
+    try {
+      hasher.update(fs.readFileSync(absPath));
+    } catch {
+      // File doesn't exist yet (e.g., during initial setup) — include path as fallback
+      hasher.update(relPath);
+    }
+  }
+
+  return hasher.digest('hex').slice(0, 16);
+}
+
+/**
+ * Get the path to the cached template database, creating it if needed.
+ * The template includes: full PMO schema, all seeded builtin data.
+ */
+function ensureTemplatePath(): string {
+  if (cachedTemplatePath && fs.existsSync(cachedTemplatePath)) {
+    return cachedTemplatePath;
+  }
+
+  const hash = computeSchemaHash();
+  const templatePath = path.join(os.tmpdir(), `prlt-test-template-${hash}.db`);
+
+  if (!fs.existsSync(templatePath)) {
+    // Create the template database with full schema + seed data
+    const db = new Database(templatePath);
+    try {
+      db.pragma('foreign_keys = ON');
+      initializePMOTables(db);
+      // Store a placeholder for pmo_path — tests will overwrite this per-test
+      db.prepare(`INSERT OR REPLACE INTO ${T.settings} (key, value) VALUES ('pmo_path', ?)`).run('__TEMPLATE__');
+    } finally {
+      db.close();
+    }
+  }
+
+  cachedTemplatePath = templatePath;
+  return templatePath;
+}
+
+/**
+ * Set up a test database by copying the cached template.
+ * This is ~100x faster than running full schema initialization.
+ *
+ * @param dbPath - Path where the test database should be created
+ * @param pmoPath - PMO directory path to store in settings
+ * @returns Database instance ready for use
+ */
+export function setupProductionSchemaFromCache(dbPath: string, pmoPath: string): Database.Database {
+  const templatePath = ensureTemplatePath();
+
+  // Copy template to test location (~1ms vs ~100-200ms for full init)
+  fs.copyFileSync(templatePath, dbPath);
+
+  // Open the copy and update the pmo_path setting
+  const db = new Database(dbPath);
+  db.pragma('foreign_keys = ON');
+  db.prepare(`UPDATE ${T.settings} SET value = ? WHERE key = 'pmo_path'`).run(pmoPath);
+
+  return db;
+}
+
+/**
+ * Invalidate the in-memory cache pointer.
+ * Useful if schema files are modified during a test run (unlikely in practice).
+ */
+export function invalidateTemplateCache(): void {
+  cachedTemplatePath = null;
+}


### PR DESCRIPTION
## Summary

Resolves TKT-047: Cache initialized SQLite schema — eliminate per-test DB setup overhead

## Description

Every test (unit + e2e) creates a fresh SQLite database and runs the full PMO schema initialization (30+ tables, workflows, statuses, phases, actions, templates). This costs ~100-200ms per test × 3,500+ tests = ~5-7 min of pure setup overhead.

Fix approach:
1. Create a 'template database' once per test suite run with the full schema initialized
2. For each test, copy the template file (fs.copyFileSync) instead of running all migrations — file copy is ~1ms vs ~100-200ms for schema init
3. Implement in test helpers (apps/cli/test/helpers/ or wherever createTestEnvironment/setupProductionSchema lives)

Implementation:
- Add a global beforeAll (or mocha root hook) that creates the template DB once
- Store it at a known temp path (e.g., /tmp/prlt-test-template-<hash>.db)
- In each test's beforeEach, copyFileSync the template to the test's temp dir
- The template should include: full schema, builtin data (workflows, statuses, default config)
- Hash the schema version so template is recreated when migrations change

Key files:
- apps/cli/test/helpers/test-helpers.ts (or similar — find the createTestEnvironment function)
- apps/cli/test/setup/ (native-sqlite-check.ts is here, add template setup)
- apps/cli/src/lib/pmo/storage/ (schema initialization functions)
- .mocharc.json (may need root hooks plugin for global setup)

Estimated savings: 100ms × 3500 tests = 350 seconds (~6 min total, but distributed across shards so ~1 min per shard wall clock reduction)

## Changes

- e7763bd2 feat(TKT-047): cache initialized SQLite schema to eliminate per-test DB setup overhead

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
