### PR TITLE
TKT-049: Add smoke test tier — run subset on PRs, full suite on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,16 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      test_tier:
+        description: 'Test tier to run (smoke = @smoke tagged only, standard = scoped suite, full = everything)'
+        required: false
+        default: 'full'
+        type: choice
+        options:
+          - smoke
+          - standard
+          - full
 
 # Cancel in-progress runs when a new commit is pushed to the same branch/PR.
 # This prevents wasted CI minutes when iterating on a PR.
@@ -22,11 +32,16 @@ concurrency:
 # - A verification step runs `require('better-sqlite3')` before tests to fail fast with
 #   clear diagnostics if the native binding is missing or incompatible.
 
-# Change-detection scoping:
+# Test tier system:
+# - smoke: runs only @smoke-tagged tests (~13 test files, <3 min) — default for PRs
+# - standard: runs scoped test suite based on change detection — same as previous PR behavior
+# - full: runs all tests including slow integration tests — default for push to main
+#
+# Change-detection scoping (for standard/full tiers):
 # - docs-only PRs skip all test suites entirely
 # - Scoped source changes (pmo, execution) run only affected unit + e2e subsets
 # - Core/runtime changes (database, shared lib, config files) trigger the full suite
-# - push to main and workflow_dispatch always run the full suite
+# - push to main always runs the full suite
 # - The ci-status job serves as a single required check for branch protection
 
 jobs:
@@ -37,6 +52,7 @@ jobs:
       scope: ${{ steps.classify.outputs.scope }}
       reason: ${{ steps.classify.outputs.reason }}
       e2e_shards: ${{ steps.classify.outputs.e2e_shards }}
+      test_tier: ${{ steps.classify.outputs.test_tier }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +66,30 @@ jobs:
         id: classify
         shell: bash
         run: |
-          # For push to main and manual dispatch, always run full suite
+          # Determine test tier:
+          # - PRs default to smoke (fast feedback)
+          # - Push to main defaults to full
+          # - Manual dispatch uses the input value (default: full)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            TEST_TIER="smoke"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TEST_TIER="${{ github.event.inputs.test_tier || 'full' }}"
+          else
+            TEST_TIER="full"
+          fi
+          echo "test_tier=$TEST_TIER" >> "$GITHUB_OUTPUT"
+          echo "Test tier: $TEST_TIER"
+
+          # For smoke tier on PRs, we only run @smoke-tagged tests
+          if [[ "$TEST_TIER" == "smoke" ]]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            echo "scope=smoke" >> "$GITHUB_OUTPUT"
+            echo "reason=Smoke tier: running @smoke-tagged tests only (PR fast check)" >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=[]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # For push to main and manual dispatch (standard/full), determine scope
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
@@ -284,12 +323,94 @@ jobs:
           path: apps/cli/node_modules/.pnpm/**/better-sqlite3/build
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-better-sqlite3-${{ hashFiles('**/pnpm-lock.yaml') }}
 
+  # Smoke tests: fast subset of @smoke-tagged tests for PR feedback.
+  # Runs both unit and e2e @smoke tests in a single job via --grep @smoke.
+  # Target: <3 min total. Skipped when running standard/full tiers.
+  smoke-tests:
+    needs: [detect-changes, build]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.run_tests == 'true' &&
+      needs.detect-changes.outputs.test_tier == 'smoke' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: ['22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "store-path=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore better-sqlite3 native binding cache
+        id: sqlite-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: apps/cli/node_modules/.pnpm/**/better-sqlite3/build
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-better-sqlite3-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Rebuild better-sqlite3 native binding (cache miss)
+        if: steps.sqlite-cache.outputs.cache-hit != 'true'
+        run: npm rebuild better-sqlite3 || npm rebuild better-sqlite3
+        working-directory: apps/cli
+
+      - name: Verify better-sqlite3 native binding
+        run: |
+          node -e "
+            try {
+              require('better-sqlite3');
+              console.log('better-sqlite3 loaded successfully');
+            } catch (err) {
+              console.error('Failed to load better-sqlite3:', err.message);
+              process.exit(1);
+            }
+          "
+        working-directory: apps/cli
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output-node-${{ matrix.node-version }}
+          path: apps/cli/dist/
+
+      - name: Run smoke tests (@smoke tagged)
+        working-directory: apps/cli
+        env:
+          TEST_TIER: smoke
+        run: |
+          echo "Running @smoke-tagged tests (smoke tier)"
+          echo "Target: <3 min for fast PR feedback"
+          pnpm test:smoke
+
   # Unit tests run via ts-node directly (no compiled dist/ needed), so they
   # can start in parallel with the build job instead of waiting for it.
   # The postinstall script handles better-sqlite3 native binding rebuild.
+  # Skipped when test_tier is smoke (smoke-tests job handles those).
   unit-tests:
     needs: [detect-changes]
-    if: needs.detect-changes.outputs.run_tests == 'true'
+    if: |
+      needs.detect-changes.outputs.run_tests == 'true' &&
+      needs.detect-changes.outputs.test_tier != 'smoke'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -375,11 +496,13 @@ jobs:
           needs.detect-changes.outputs.scope == 'execution'
         run: pnpm --filter @proletariat/cli mocha --forbid-only "test/unit/codex-spawn-smoke.test.ts"
 
+  # Skipped when test_tier is smoke (smoke-tests job handles those).
   e2e-tests:
     needs: [detect-changes, build]
     if: |
       always() &&
       needs.detect-changes.outputs.run_tests == 'true' &&
+      needs.detect-changes.outputs.test_tier != 'smoke' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 35
@@ -525,19 +648,22 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [detect-changes, build, unit-tests, e2e-tests]
+    needs: [detect-changes, build, smoke-tests, unit-tests, e2e-tests]
     runs-on: ubuntu-latest
     steps:
       - name: CI Summary
         run: |
           SCOPE="${{ needs.detect-changes.outputs.scope }}"
           REASON="${{ needs.detect-changes.outputs.reason }}"
+          TIER="${{ needs.detect-changes.outputs.test_tier }}"
           BUILD="${{ needs.build.result }}"
+          SMOKE="${{ needs.smoke-tests.result }}"
           UNIT="${{ needs.unit-tests.result }}"
           E2E="${{ needs.e2e-tests.result }}"
 
           echo "## CI Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Test Tier:** \`$TIER\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Scope:** \`$SCOPE\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Reason:** $REASON" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -545,6 +671,7 @@ jobs:
           echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| detect-changes | ${{ needs.detect-changes.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| build | $BUILD |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| smoke-tests | $SMOKE |" >> "$GITHUB_STEP_SUMMARY"
           echo "| unit-tests | $UNIT |" >> "$GITHUB_STEP_SUMMARY"
           echo "| e2e-tests (all shards) | $E2E |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -552,11 +679,13 @@ jobs:
 
           echo ""
           echo "=== CI Results ==="
+          echo "Test tier: $TIER"
           echo "Scope: $SCOPE"
           echo "Reason: $REASON"
           echo "E2E shards: ${{ needs.detect-changes.outputs.e2e_shards }}"
           echo "detect-changes: ${{ needs.detect-changes.result }}"
           echo "build: $BUILD"
+          echo "smoke-tests: $SMOKE"
           echo "unit-tests: $UNIT"
           echo "e2e-tests: $E2E"
 
@@ -569,6 +698,10 @@ jobs:
           fi
           if [[ "${{ needs.build.result }}" == "failure" ]]; then
             echo "FAIL: build failed"
+            exit 1
+          fi
+          if [[ "${{ needs.smoke-tests.result }}" == "failure" ]]; then
+            echo "FAIL: smoke-tests failed"
             exit 1
           fi
           if [[ "${{ needs.unit-tests.result }}" == "failure" ]]; then

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -128,6 +128,7 @@
     "test:e2e": "mocha --forbid-only \"test/e2e/**/*.test.ts\"",
     "test:e2e:pmo": "mocha --forbid-only \"test/e2e/pmo-*.test.ts\"",
     "test:e2e:interactive": "mocha --forbid-only --timeout 120000 \"test/e2e/interactive-menu.test.ts\"",
+    "test:smoke": "mocha --forbid-only --grep @smoke \"test/**/*.test.ts\"",
     "test:commands": "mocha --forbid-only \"test/commands/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",
     "publish:npm": "pnpm build && pnpm publish --access public --no-git-checks && git tag v$(node -p \"require('./package.json').version\") && git push origin v$(node -p \"require('./package.json').version\") && gh release create v$(node -p \"require('./package.json').version\") --generate-notes --title \"v$(node -p \"require('./package.json').version\")\"",

--- a/apps/cli/test/e2e/commit-commands.test.ts
+++ b/apps/cli/test/e2e/commit-commands.test.ts
@@ -9,7 +9,7 @@ import { execInProcess } from './test-helpers.js';
  * End-to-end tests for Commit Command
  * Tests commit with various flags and options
  */
-describe('Commit Command E2E Tests', () => {
+describe('@smoke Commit Command E2E Tests', () => {
   let testDir: string;
   let originalCwd: string;
 

--- a/apps/cli/test/e2e/config-commands.test.ts
+++ b/apps/cli/test/e2e/config-commands.test.ts
@@ -12,7 +12,7 @@ import { execInProcess } from './test-helpers.js';
  * Validates that config commands work in both interactive (via flags) and
  * JSON/agent mode, exercising the full command flow end-to-end.
  */
-describe('Config Commands E2E Tests', () => {
+describe('@smoke Config Commands E2E Tests', () => {
   let testDir: string;
   let originalCwd: string;
   let dbPath: string;

--- a/apps/cli/test/e2e/pmo-init-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-init-commands.test.ts
@@ -21,7 +21,7 @@ import {
  * automatically. This is the expected behavior for testing agent flows.
  * All prompts must be bypassed with flags to avoid hanging.
  */
-describe('PMO Init Commands E2E Tests', () => {
+describe('@smoke PMO Init Commands E2E Tests', () => {
   let testDir: string;
   let originalCwd: string;
   let dbPath: string;

--- a/apps/cli/test/e2e/pmo-ticket-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-commands.test.ts
@@ -20,7 +20,7 @@ import { initializePMOTables } from '../../src/lib/pmo/storage/base.js';
  * Tests actual CLI usage as a user would interact with it
  * Spec: pmo-ticket-commands.md
  */
-describe('PMO Ticket Commands E2E Tests', () => {
+describe('@smoke PMO Ticket Commands E2E Tests', () => {
   let testDir: string;
   let originalCwd: string;
   let dbPath: string;

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -22,7 +22,7 @@ import {
  *
  * Each subcommand is tested through the interactive menu flow AND directly with flags.
  */
-describe('Session Commands E2E Tests', () => {
+describe('@smoke Session Commands E2E Tests', () => {
   let testDir: string;
   let originalCwd: string;
   let dbPath: string;

--- a/apps/cli/test/e2e/standalone-commands.test.ts
+++ b/apps/cli/test/e2e/standalone-commands.test.ts
@@ -23,7 +23,7 @@ import {
  * - Each choice includes command field for agent navigation
  * - Flag-based execution bypasses prompts correctly
  */
-describe('Standalone Commands E2E - this.prompt() Migration (TKT-764)', () => {
+describe('@smoke Standalone Commands E2E - this.prompt() Migration (TKT-764)', () => {
 
   // ================================================================
   // CLAUDE COMMAND TESTS

--- a/apps/cli/test/e2e/workspace-commands.test.ts
+++ b/apps/cli/test/e2e/workspace-commands.test.ts
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process';
  * End-to-end tests for workspace commands.
  * Tests: prlt workspace list, use, add, remove
  */
-describe('Workspace Commands E2E Tests', () => {
+describe('@smoke Workspace Commands E2E Tests', () => {
   let testDir: string;
   let originalCwd: string;
   let originalHome: string | undefined;

--- a/apps/cli/test/unit/codex-spawn-smoke.test.ts
+++ b/apps/cli/test/unit/codex-spawn-smoke.test.ts
@@ -21,7 +21,7 @@ const CODEX_SUPPORTED_FLAGS = ['--yolo'] as const
  *   - Autonomous mode uses --yolo
  *   - Only flags in CODEX_SUPPORTED_FLAGS are allowed
  */
-describe('Codex Spawn Smoke Tests (TKT-1169)', () => {
+describe('@smoke Codex Spawn Smoke Tests (TKT-1169)', () => {
   const makeContext = (overrides: Partial<ExecutionContext> = {}): ExecutionContext => ({
     ticketId: 'TKT-1169',
     ticketTitle: 'Codex spawn smoke test',

--- a/apps/cli/test/unit/json-envelope-contracts.test.ts
+++ b/apps/cli/test/unit/json-envelope-contracts.test.ts
@@ -35,7 +35,7 @@ const __dirname = path.dirname(__filename);
  * - Exit code constants
  * - Structural contracts for each output type
  */
-describe('JSON Envelope Contract Tests (TKT-1006)', () => {
+describe('@smoke JSON Envelope Contract Tests (TKT-1006)', () => {
 
   // ===========================================================================
   // Schema Stability: Type Discriminators

--- a/apps/cli/test/unit/native-validation.test.ts
+++ b/apps/cli/test/unit/native-validation.test.ts
@@ -5,7 +5,7 @@ import {
   validateBetterSqlite3NativeBinding,
 } from '../../src/lib/database/native-validation.js'
 
-describe('better-sqlite3 native validation', () => {
+describe('@smoke better-sqlite3 native validation', () => {
   it('formats actionable guidance with runtime details', () => {
     const message = buildBetterSqlite3ValidationMessage(
       new Error('not a mach-o file'),

--- a/apps/cli/test/unit/pmo-storage.test.ts
+++ b/apps/cli/test/unit/pmo-storage.test.ts
@@ -5,7 +5,7 @@ import * as os from 'node:os';
 import Database from 'better-sqlite3';
 import { SQLiteStorage } from '../../src/lib/pmo/storage-sqlite.js';
 
-describe('PMO SQLite Storage', () => {
+describe('@smoke PMO SQLite Storage', () => {
   let testDir: string;
   let storage: SQLiteStorage;
   const projectId = 'default';

--- a/apps/cli/test/unit/pmo-utils.test.ts
+++ b/apps/cli/test/unit/pmo-utils.test.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import Database from 'better-sqlite3';
 import { slugify, formatDate, formatTimestamp, parseDate, deepClone, arraysEqual, DEFAULT_WORK_COLUMNS, getWorkColumnSetting } from '../../src/lib/pmo/utils.js';
 
-describe('PMO Utils', () => {
+describe('@smoke PMO Utils', () => {
   describe('slugify', () => {
     it('converts string to lowercase', () => {
       expect(slugify('Hello World')).to.equal('hello-world');

--- a/apps/cli/test/unit/prompt-json.test.ts
+++ b/apps/cli/test/unit/prompt-json.test.ts
@@ -8,7 +8,7 @@ import {
   type JsonFlags,
 } from '../../src/lib/prompt-json.js';
 
-describe('prompt-json', () => {
+describe('@smoke prompt-json', () => {
   describe('isNonTTY', () => {
     it('returns true when stdout is not a TTY', () => {
       const originalIsTTY = process.stdout.isTTY;


### PR DESCRIPTION
## Summary

Resolves TKT-049: Add smoke test tier — run subset on PRs, full suite on main

## Description

Currently every PR runs the full test suite (~12 min). Most PRs only need a fast smoke check to catch obvious breakage.

Implementation:
1. Tag test files or describe blocks with tiers: smoke, standard, full
   - smoke: critical path tests that catch 80% of breakage (~50-100 tests, <2 min)
   - standard: current PR test set
   - full: everything including slow integration tests (main branch only)

2. Define smoke tests — pick the most important tests from each area:
   - Unit: core database operations, prompt-json, workspace detection
   - E2e: init/new basic flow, ticket CRUD, board view, work start (mocked), session list
   - Skip: docker-commands, mcp-server, agent-flow, heavy json-mode tests

3. Update .github/workflows/test.yml:
   - PR events: run smoke tier only (add grep/tag filter to mocha/vitest command)
   - Push to main: run full suite
   - Manual dispatch: choice of smoke/standard/full
   - Add a workflow input or env var: TEST_TIER=smoke|standard|full

4. Implementation options (pick one):
   a. Mocha grep: tag smoke tests with @smoke in describe, use --grep @smoke
   b. Vitest tags: if migrating to vitest, use test.tags
   c. File-based: create test/smoke/ directory with cherry-picked test files
   d. Environment variable: TEST_TIER env var checked in test helpers, skip non-matching

Key files:
- .github/workflows/test.yml (tier selection logic)
- apps/cli/test/ (tag or reorganize test files)
- apps/cli/package.json (add test:smoke script)

Target: PR smoke checks complete in <3 min. Full suite still runs on main.

## Changes

- 7626f339 feat(TKT-049): add smoke test tier with @smoke tags, test:smoke script, and CI workflow tier support

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
