### PR TITLE
TKT-053: Disable Claude Code plan mode for background agents — prevents silent stalls

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -893,7 +893,10 @@ export async function runHost(
     const effortFlag = skipPermissions ? '--effort high ' : ''
     // Orchestrator sessions inject their role via --system-prompt
     const systemPromptFlag = systemPromptPath ? '--system-prompt "$(cat "$SYSTEM_PROMPT_PATH")" ' : ''
-    executorInvocation = `${cmd} ${permissionsFlag}${effortFlag}${printFlag}${systemPromptFlag}"$(cat "$PROMPT_PATH")"`
+    // TKT-053: Disable plan mode for background agents — prevents silent stalls
+    // when there's no user to approve the plan mode transition
+    const disallowPlanFlag = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
+    executorInvocation = `${cmd} ${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}${systemPromptFlag}"$(cat "$PROMPT_PATH")"`
   } else {
     // Non-Claude executors: build command from getExecutorCommand() args
     // Replace the prompt in args with a file read to avoid shell escaping
@@ -1846,7 +1849,9 @@ export function buildDevcontainerCommand(
     const permissionsFlag = skipPermissions ? '--dangerously-skip-permissions ' : ''
     // --effort high: skips the effort level prompt for automated agents (TKT-1134)
     const effortFlag = '--effort high '
-    executorCmd = `claude ${bypassTrustFlag}${permissionsFlag}${effortFlag}${printFlag}"$(cat ${promptFile})"`
+    // TKT-053: Disable plan mode for background agents — prevents silent stalls
+    const disallowPlanFlag = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
+    executorCmd = `claude ${bypassTrustFlag}${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}"$(cat ${promptFile})"`
   } else if (executor === 'codex') {
     // Use Codex adapter for mode validation and deterministic command building.
     // Validates that the permission/display combination is supported before building.
@@ -2716,7 +2721,8 @@ export async function runDocker(
     // Non-Claude executors use their native command format from getExecutorCommand()
     dockerCmd += ` ${config.docker.image}`
     if (isClaudeExecutor(executor)) {
-      dockerCmd += ` ${cmd} --print '${escapedPrompt}'`
+      // TKT-053: Disable plan mode — Docker runner is always detached (no user to approve)
+      dockerCmd += ` ${cmd} --print --disallowedTools EnterPlanMode '${escapedPrompt}'`
     } else {
       const argsStr = args.map(a => a === escapedPrompt ? `'${escapedPrompt}'` : a).join(' ')
       dockerCmd += ` ${cmd} ${argsStr}`
@@ -2959,8 +2965,10 @@ export async function runOrchestratorInDocker(
     const skipPermissions = config.permissionMode === 'danger'
     const permissionsFlag = skipPermissions ? '--dangerously-skip-permissions ' : ''
     const effortFlag = skipPermissions ? '--effort high ' : ''
+    // TKT-053: Disable plan mode for background agents — prevents silent stalls
+    const disallowPlanFlag = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
     const executorCmd = executor === 'claude-code'
-      ? `claude ${permissionsFlag}${effortFlag}"$(cat ${promptPath})"`
+      ? `claude ${permissionsFlag}${effortFlag}${disallowPlanFlag}"$(cat ${promptPath})"`
       : `claude ${permissionsFlag}${effortFlag}"$(cat ${promptPath})"`
 
     // Build tmux session name (reuses the same name as host tmux for consistency)
@@ -2982,7 +2990,7 @@ export async function runOrchestratorInDocker(
         const scriptContent = `#!/bin/bash
 cd /hq
 unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT
-${executor === 'claude-code' ? `claude ${permissionsFlag}${effortFlag}"$(cat ${promptPath})"` : `claude "$(cat ${promptPath})"`}
+${executor === 'claude-code' ? `claude ${permissionsFlag}${effortFlag}${disallowPlanFlag}"$(cat ${promptPath})"` : `claude "$(cat ${promptPath})"`}
 echo ""
 echo "Orchestrator complete. Press Enter to close."
 exec bash
@@ -3159,7 +3167,8 @@ export async function runVm(
     // Build the remote command based on executor type
     let remoteCmd: string
     if (isClaudeExecutor(executor)) {
-      remoteCmd = `cd ${remoteWorkspace} && ${executorCmd} --print '${escapedPrompt}'`
+      // TKT-053: Disable plan mode — VM runner is always nohup (no user to approve)
+      remoteCmd = `cd ${remoteWorkspace} && ${executorCmd} --print --disallowedTools EnterPlanMode '${escapedPrompt}'`
     } else {
       const argsStr = executorArgs.map(a => a === escapedPrompt ? `'${escapedPrompt}'` : a).join(' ')
       remoteCmd = `cd ${remoteWorkspace} && ${executorCmd} ${argsStr}`


### PR DESCRIPTION
## Summary

Resolves TKT-053: Disable Claude Code plan mode for background agents — prevents silent stalls

## Description

When agents are spawned with --skip-permissions --display background, they can still enter Claude Code's plan mode which requires manual approval. The agent sits waiting for input and silently stalls.

This happened with zero-knight (TKT-028) which was stuck for hours on a plan approval prompt while running in background mode.

Fix:
1. When spawning Claude Code with --dangerously-skip-permissions, also pass flags to disable plan mode
2. Check Claude Code CLI docs for how to disable plan mode (may be --no-plan or an environment variable)
3. If no flag exists, add a system prompt instruction: 'Do not use plan mode. Implement directly without asking for approval.'
4. This should only apply when display mode is 'background' — foreground/terminal agents may want plan mode

Key files:
- apps/cli/src/lib/execution/runners.ts (where claude CLI args are constructed)
- apps/cli/src/lib/execution/spawner.ts (where execution options are set)
- Check Claude Code docs for plan mode flags

## Changes

- c592a10c feat(TKT-053): disable Claude Code plan mode for background agents via --disallowedTools EnterPlanMode

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
