### PR TITLE
TKT-076: Add integration awareness to agent system prompts — agents should know about prlt asana/linear/jira/shortcut/trello commands

### DIFF
--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -43,6 +43,7 @@ import {
 } from '../../lib/execution/config.js'
 import { ensureBuiltinThemes } from '../../lib/themes.js'
 import { getActiveTheme, getAvailableThemeNames } from '../../lib/database/index.js'
+import { getConnectedIntegrations } from '../../lib/work-source/index.js'
 
 /**
  * Sanitize a name segment for use in tmux session names.
@@ -620,6 +621,11 @@ export default class OrchestratorStart extends PromptCommand {
       }
     } catch {
       // Ignore config loading errors, use defaults
+    }
+
+    // Inject connected integrations into context (must happen after db is opened)
+    if (db) {
+      context.connectedIntegrations = getConnectedIntegrations(db)
     }
 
     // Auto-detect shell (never prompt for orchestrator)

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -78,6 +78,7 @@ import {
   loadActiveWorkSource,
   saveActiveWorkSource,
   getRegisteredWorkSources,
+  getConnectedIntegrations,
 } from '../../lib/work-source/index.js'
 import { pruneWorktrees, checkoutBranchSafe } from '../../lib/branch/index.js'
 
@@ -1303,6 +1304,8 @@ export default class WorkStart extends PMOCommand {
         modifiesCode: customPrompt ? true : selectedAction?.modifiesCode ?? true,
         // Additional instructions from --message flag
         customMessage: externalIssueContextMessage ?? flags.message,
+        // Connected integrations for prompt injection
+        connectedIntegrations: getConnectedIntegrations(db),
       }
 
       // Check if agent has devcontainer config
@@ -2727,6 +2730,8 @@ export default class WorkStart extends PMOCommand {
       actionPrompt: defaultAction?.prompt,
       actionEndPrompt: defaultAction?.endPrompt,
       modifiesCode: defaultAction?.modifiesCode ?? true,
+      // Connected integrations for prompt injection
+      connectedIntegrations: getConnectedIntegrations(db),
     }
 
     // Use devcontainer by default if available

--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -457,6 +457,96 @@ export function runExecutorPreflight(
 }
 
 // =============================================================================
+// Integration Commands — Dynamic Prompt Section
+// =============================================================================
+
+/**
+ * Integration command definitions: commands available for each external integration.
+ * Only included in prompts when the integration is actually connected.
+ */
+interface IntegrationCommandSet {
+  provider: string       // e.g. 'asana', 'linear'
+  displayName: string    // e.g. 'Asana', 'Linear'
+  commands: string[]     // Command descriptions
+}
+
+const INTEGRATION_COMMANDS: IntegrationCommandSet[] = [
+  {
+    provider: 'asana',
+    displayName: 'Asana',
+    commands: [
+      'prlt asana connect — authenticate with Asana',
+      'prlt asana sync --ticket TKT-XXX --create-missing --project <gid> — sync a PMO ticket to Asana',
+      'prlt asana import — import Asana tasks into PMO',
+    ],
+  },
+  {
+    provider: 'linear',
+    displayName: 'Linear',
+    commands: [
+      'prlt linear connect — authenticate with Linear',
+      'prlt linear sync --ticket TKT-XXX --create-missing — sync a PMO ticket to Linear',
+      'prlt linear import — import Linear issues into PMO',
+    ],
+  },
+  {
+    provider: 'jira',
+    displayName: 'Jira',
+    commands: [
+      'prlt jira connect — authenticate with Jira',
+      'prlt jira sync --ticket TKT-XXX --create-missing — sync a PMO ticket to Jira',
+      'prlt jira import — import Jira issues into PMO',
+    ],
+  },
+  {
+    provider: 'shortcut',
+    displayName: 'Shortcut',
+    commands: [
+      'prlt shortcut connect — authenticate with Shortcut',
+      'prlt shortcut sync --ticket TKT-XXX --create-missing — sync a PMO ticket to Shortcut',
+      'prlt shortcut import — import Shortcut stories into PMO',
+    ],
+  },
+  {
+    provider: 'monday',
+    displayName: 'Monday.com',
+    commands: [
+      'prlt monday connect — authenticate with Monday.com',
+      'prlt monday sync --ticket TKT-XXX --create-missing — sync a PMO ticket to Monday.com',
+    ],
+  },
+]
+
+/**
+ * Build the integration commands section for agent prompts.
+ * Only includes integrations that are actually connected/configured.
+ * Returns empty string if no integrations are connected.
+ */
+function buildIntegrationCommandsSection(connectedIntegrations?: string[]): string {
+  if (!connectedIntegrations || connectedIntegrations.length === 0) return ''
+
+  const connected = INTEGRATION_COMMANDS.filter(ic =>
+    connectedIntegrations.includes(ic.provider)
+  )
+  if (connected.length === 0) return ''
+
+  let section = `## Integration Commands\n\n`
+  section += `The following external integrations are connected. Use these prlt commands to interact with them.\n\n`
+
+  for (const integration of connected) {
+    section += `### ${integration.displayName}\n`
+    for (const cmd of integration.commands) {
+      section += `- \`${cmd.split(' — ')[0]}\` — ${cmd.split(' — ')[1] || ''}\n`
+    }
+    section += '\n'
+  }
+
+  section += `**ANTI-PATTERN:** Never use curl, raw API calls, or shell scripts to interact with external services (Asana, Linear, Jira, Shortcut, Monday.com, etc.). Always use the corresponding \`prlt\` commands.\n\n`
+
+  return section
+}
+
+// =============================================================================
 // Orchestrator Prompt — Dynamic Command Registry
 // =============================================================================
 
@@ -620,6 +710,9 @@ function buildOrchestratorBody(hqName: string, context: ExecutionContext): strin
   // Anti-patterns (dynamically generated)
   prompt += buildOrchestratorAntiPatterns()
 
+  // Integration commands (only for connected integrations)
+  prompt += buildIntegrationCommandsSection(context.connectedIntegrations)
+
   // Workflow
   prompt += `## Workflow\n`
   prompt += `- Squash merge only: \`gh pr merge --squash\`\n`
@@ -732,6 +825,12 @@ function buildPrompt(context: ExecutionContext): string {
 
   // Note: Branch setup (fetch + checkout/create) is now handled programmatically
   // in work/start.ts before the agent spawns, so no prompt instructions needed
+
+  // Integration commands (only for connected integrations)
+  const integrationSection = buildIntegrationCommandsSection(context.connectedIntegrations)
+  if (integrationSection) {
+    prompt += `\n${integrationSection}`
+  }
 
   // Additional instructions from --message flag (appended to any action)
   if (context.customMessage) {

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -182,6 +182,8 @@ export interface ExecutionContext {
   hqName?: string // HQ workspace name (used in orchestrator prompt)
   // Execution environment (where the agent is running)
   executionEnvironment?: ExecutionEnvironment // 'devcontainer', 'host', 'docker', 'vm'
+  // Connected integrations (for prompt injection)
+  connectedIntegrations?: string[] // e.g. ['asana', 'linear'] — only integrations that are configured
 }
 
 // =============================================================================

--- a/apps/cli/src/lib/work-source/config.ts
+++ b/apps/cli/src/lib/work-source/config.ts
@@ -3,6 +3,7 @@ import { loadAsanaConfig } from '../asana/config.js'
 import { loadLinearConfig } from '../linear/config.js'
 import { loadJiraConfig } from '../jira/config.js'
 import { loadShortcutConfig } from '../shortcut/config.js'
+import { loadMondayConfig } from '../monday/config.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 const ACTIVE_SOURCE_KEY = 'work.active_source'
@@ -118,4 +119,20 @@ export function getRegisteredWorkSources(db: Database.Database): WorkSourceRef[]
   }
 
   return Array.from(providers.values())
+}
+
+/**
+ * Get a list of connected integration provider names (excluding 'pmo').
+ * Used to dynamically inject integration commands into agent prompts.
+ */
+export function getConnectedIntegrations(db: Database.Database): string[] {
+  const integrations: string[] = []
+
+  if (loadAsanaConfig(db)) integrations.push('asana')
+  if (loadLinearConfig(db)) integrations.push('linear')
+  if (loadJiraConfig(db)) integrations.push('jira')
+  if (loadShortcutConfig(db)) integrations.push('shortcut')
+  if (loadMondayConfig(db)) integrations.push('monday')
+
+  return integrations
 }

--- a/apps/cli/src/lib/work-source/index.ts
+++ b/apps/cli/src/lib/work-source/index.ts
@@ -9,6 +9,7 @@ export {
   clearActiveWorkSource,
   loadActiveWorkSource,
   getRegisteredWorkSources,
+  getConnectedIntegrations,
 } from './config.js'
 export {
   type WorkSourceClient,


### PR DESCRIPTION
## Summary

Resolves TKT-076: Add integration awareness to agent system prompts — agents should know about prlt asana/linear/jira/shortcut/trello commands

## Description

Problem: Agents don't know they can use prlt CLI to interact with integrations. When asked to create Asana tasks, an agent wrote a raw curl shell script instead of using prlt asana sync --create-missing. This is the same class of bug as agents using docker exec instead of prlt session commands.

Fix: Update the agent system prompt (the prompt injected into worker agent sessions) to include awareness of available prlt integration commands.

Add to the worker agent prompt (in runners.ts buildPromptBody or similar):

INTEGRATION COMMANDS:
- prlt asana connect — authenticate with Asana
- prlt asana sync --ticket TKT-XXX --create-missing --project <gid> — sync a PMO ticket to Asana
- prlt asana import — import Asana tasks into PMO
- prlt linear connect / prlt linear sync / prlt linear import — same for Linear
- prlt jira connect / prlt jira sync / prlt jira import — same for Jira
- prlt shortcut connect / prlt shortcut sync / prlt shortcut import — same for Shortcut (if merged)
- prlt trello connect / prlt trello sync / prlt trello import — same for Trello (if merged)

ANTI-PATTERN: Never use curl, raw API calls, or shell scripts to interact with external services. Always use prlt commands.

The prompt should be dynamic — only include integrations that are actually configured/connected. Check apps/cli/src/lib/execution/runners.ts for where prompts are built (buildPromptBody, buildOrchestratorBody).

Also add this to the orchestrator prompt (buildOrchestratorBody) so orchestrators know they can tell workers to use these commands.

Reference:
- apps/cli/src/lib/execution/runners.ts — prompt building
- apps/cli/src/commands/asana/ — Asana commands
- apps/cli/src/commands/linear/ — Linear commands  
- apps/cli/src/commands/jira/ — Jira commands

## Changes

- 0979c33b feat(TKT-076): add integration awareness to agent and orchestrator system prompts

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
