### PR TITLE
TKT-077: Add media/video source type to HQ — preprocess videos into frames + transcripts for agent consumption

### DIFF
--- a/apps/cli/src/commands/media/add.ts
+++ b/apps/cli/src/commands/media/add.ts
@@ -1,0 +1,112 @@
+import { Args, Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors, format } from '../../lib/colors.js';
+import { findHQRoot } from '../../lib/repos/index.js';
+import { addMedia, isFfmpegInstalled } from '../../lib/media/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+
+export default class Add extends PMOCommand {
+  static description = 'Add a video or audio file to the HQ for preprocessing';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> /path/to/video.mp4',
+    '<%= config.bin %> <%= command.id %> /path/to/video.mp4 --interval 60',
+    '<%= config.bin %> <%= command.id %> /path/to/audio.mp3 --no-transcribe',
+  ];
+
+  static args = {
+    path: Args.string({
+      description: 'Path to the media file (video or audio)',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    interval: Flags.integer({
+      char: 'i',
+      description: 'Frame extraction interval in seconds',
+      default: 30,
+    }),
+    transcribe: Flags.boolean({
+      description: 'Generate transcript using whisper',
+      default: true,
+      allowNo: true,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(Add);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('media add', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      return handleError('NOT_IN_HQ', 'Not in an HQ directory. Run "prlt new" first.');
+    }
+
+    if (!isFfmpegInstalled()) {
+      return handleError('FFMPEG_NOT_INSTALLED', 'ffmpeg is not installed. Install it with: brew install ffmpeg');
+    }
+
+    let filePath: string;
+
+    if (args.path) {
+      filePath = args.path;
+    } else {
+      if (jsonMode) {
+        const agentConfig = { flags, commandName: 'media add' };
+        await this.prompt<{ path: string }>([{
+          type: 'input',
+          name: 'path',
+          message: 'Enter path to media file:',
+        }], agentConfig);
+        return;
+      }
+
+      const { path: inputPath } = await this.prompt<{ path: string }>([{
+        type: 'input',
+        name: 'path',
+        message: 'Enter path to media file (video or audio):',
+      }]);
+
+      if (!inputPath || !inputPath.trim()) {
+        this.log(colors.textMuted('Operation cancelled.'));
+        return;
+      }
+      filePath = inputPath.trim();
+    }
+
+    this.log(colors.primary(`\n🎬 Adding media: ${filePath}\n`));
+
+    const result = await addMedia(hqPath, filePath, {
+      interval: flags.interval,
+      transcribe: flags.transcribe,
+    });
+
+    if (result.success) {
+      this.log('');
+      this.log(format.success(`Media "${result.name}" added and preprocessed`));
+      this.log(colors.textMuted(`  Location: media/${result.name}/`));
+      this.log(colors.textMuted(`  View details: prlt media show ${result.name}`));
+    } else {
+      this.error(`Failed to add media: ${result.error}`);
+    }
+  }
+}

--- a/apps/cli/src/commands/media/index.ts
+++ b/apps/cli/src/commands/media/index.ts
@@ -1,0 +1,97 @@
+
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors } from '../../lib/colors.js';
+import { shouldOutputJson } from '../../lib/prompt-json.js';
+
+export default class Media extends PMOCommand {
+  static description = 'Media management operations (videos, audio files)';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> add /path/to/video.mp4',
+    '<%= config.bin %> <%= command.id %> list',
+    '<%= config.bin %> <%= command.id %> show my-video',
+    '<%= config.bin %> <%= command.id %> remove my-video',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Media);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const menuChoices = [
+      { name: 'List all media', value: 'list', command: 'prlt media list --json' },
+      { name: 'Add media file', value: 'add', command: 'prlt media add --json' },
+      { name: 'Show media details', value: 'show', command: 'prlt media show --json' },
+      { name: 'Remove media', value: 'remove', command: 'prlt media remove --json' },
+      { name: 'Reprocess media', value: 'preprocess', command: 'prlt media preprocess --json' },
+    ];
+
+    if (!jsonMode) {
+      this.log(colors.primary('🎬 Media Operations'));
+      this.log('');
+    }
+
+    const agentConfig = jsonMode ? { flags, commandName: 'media' } : null;
+
+    const { action } = await this.prompt<{ action: string }>([{
+      type: 'list',
+      name: 'action',
+      message: 'What would you like to do?',
+      choices: menuChoices,
+    }], agentConfig);
+
+    if (!action || action === 'cancel') {
+      this.log(colors.textMuted('Operation cancelled.'));
+      return;
+    }
+
+    try {
+      this.log(colors.primary(`\nExecuting: media ${action}`));
+
+      switch (action) {
+        case 'list': {
+          const { default: ListCommand } = await import('./list.js');
+          const cmd = new ListCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'add': {
+          const { default: AddCommand } = await import('./add.js');
+          const cmd = new AddCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'show': {
+          const { default: ShowCommand } = await import('./show.js');
+          const cmd = new ShowCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'remove': {
+          const { default: RemoveCommand } = await import('./remove.js');
+          const cmd = new RemoveCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        case 'preprocess': {
+          const { default: PreprocessCommand } = await import('./preprocess.js');
+          const cmd = new PreprocessCommand([], this.config);
+          await cmd.run();
+          break;
+        }
+        default:
+          this.error(`Unknown action: ${action}`);
+      }
+    } catch (error) {
+      this.error(`Failed to execute media ${action}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}

--- a/apps/cli/src/commands/media/list.ts
+++ b/apps/cli/src/commands/media/list.ts
@@ -1,0 +1,109 @@
+import { Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors, format } from '../../lib/colors.js';
+import { findHQRoot } from '../../lib/repos/index.js';
+import { getWorkspaceMediaInfo, formatDuration } from '../../lib/media/index.js';
+import { isNonTTY } from '../../lib/prompt-json.js';
+import { visualPadEnd } from '../../lib/string-utils.js';
+
+export default class List extends PMOCommand {
+  static description = 'List all media files in the HQ';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ];
+
+  static flags = {
+    ...pmoBaseFlags,
+    format: Flags.string({
+      char: 'f',
+      description: 'Output format',
+      options: ['table', 'compact', 'json'],
+      default: 'table',
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(List);
+
+    if (flags.format === 'table' && isNonTTY()) {
+      flags.format = 'json';
+    }
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      this.error('Not in an HQ directory. Run "prlt new" first.');
+    }
+
+    const { media } = getWorkspaceMediaInfo();
+
+    if (media.length === 0) {
+      this.log(colors.warning('No media found. Add some with "prlt media add <path>"'));
+      return;
+    }
+
+    if (flags.format === 'json') {
+      this.log(JSON.stringify(media, null, 2));
+      return;
+    }
+
+    if (flags.format === 'compact') {
+      for (const item of media) {
+        const icon = item.mediaType === 'video' ? '🎬' : '🎵';
+        const duration = item.durationSeconds ? formatDuration(item.durationSeconds) : 'unknown';
+        this.log(`${icon} ${item.name} (${item.status}, ${duration}, ${item.frameCount} frames)`);
+      }
+      return;
+    }
+
+    // Table format
+    this.log(format.title(`🎬 Media (${media.length})`));
+    this.log('');
+
+    this.log(colors.textMuted(
+      visualPadEnd('Name', 25) +
+      visualPadEnd('Type', 8) +
+      visualPadEnd('Status', 12) +
+      visualPadEnd('Duration', 12) +
+      visualPadEnd('Frames', 8) +
+      'Transcript'
+    ));
+    this.log(colors.textMuted('─'.repeat(75)));
+
+    for (const item of media) {
+      const statusColor = item.status === 'ready' ? colors.success :
+                          item.status === 'error' ? colors.error :
+                          item.status === 'processing' ? colors.warning :
+                          colors.textMuted;
+      const duration = item.durationSeconds ? formatDuration(item.durationSeconds) : '-';
+      const transcript = item.hasTranscript ? '✓' : '-';
+
+      this.log(
+        colors.text(visualPadEnd(item.name, 25)) +
+        colors.textMuted(visualPadEnd(item.mediaType, 8)) +
+        statusColor(visualPadEnd(item.status, 12)) +
+        colors.text(visualPadEnd(duration, 12)) +
+        colors.text(visualPadEnd(String(item.frameCount), 8)) +
+        colors.text(transcript)
+      );
+    }
+
+    this.log('');
+    const readyCount = media.filter(m => m.status === 'ready').length;
+    const errorCount = media.filter(m => m.status === 'error').length;
+
+    this.log(format.subtitle('Summary:'));
+    this.log(colors.text(`  ${media.length} media item(s)`));
+    if (readyCount > 0) {
+      this.log(colors.success(`  ${readyCount} ready`));
+    }
+    if (errorCount > 0) {
+      this.log(colors.error(`  ${errorCount} with errors`));
+    }
+  }
+}

--- a/apps/cli/src/commands/media/preprocess.ts
+++ b/apps/cli/src/commands/media/preprocess.ts
@@ -1,0 +1,110 @@
+import { Args, Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors, format } from '../../lib/colors.js';
+import { findHQRoot } from '../../lib/repos/index.js';
+import { preprocessMedia, getWorkspaceMediaInfo, isFfmpegInstalled } from '../../lib/media/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+
+export default class Preprocess extends PMOCommand {
+  static description = 'Re-run preprocessing on a media item with different settings';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-video',
+    '<%= config.bin %> <%= command.id %> my-video --interval 60',
+    '<%= config.bin %> <%= command.id %> my-video --no-transcribe',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Media item name to preprocess',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    interval: Flags.integer({
+      char: 'i',
+      description: 'Frame extraction interval in seconds',
+      default: 30,
+    }),
+    transcribe: Flags.boolean({
+      description: 'Generate transcript using whisper',
+      default: true,
+      allowNo: true,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(Preprocess);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('media preprocess', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      return handleError('NOT_IN_HQ', 'Not in an HQ directory. Run "prlt new" first.');
+    }
+
+    if (!isFfmpegInstalled()) {
+      return handleError('FFMPEG_NOT_INSTALLED', 'ffmpeg is not installed. Install it with: brew install ffmpeg');
+    }
+
+    let mediaName: string | null = args.name || null;
+
+    if (!mediaName) {
+      const { media } = getWorkspaceMediaInfo();
+      if (media.length === 0) {
+        return handleError('NO_MEDIA', 'No media found. Add some with "prlt media add <path>"');
+      }
+
+      const selected = await this.selectFromList({
+        message: 'Select media to preprocess:',
+        items: media,
+        getName: (m) => `${m.name} (${m.status})`,
+        getValue: (m) => m.name,
+        getCommand: (m) => `prlt media preprocess ${m.name} --json`,
+        jsonMode: jsonMode ? { flags, commandName: 'media preprocess' } : null,
+        allowCancel: true,
+      });
+
+      if (!selected) {
+        this.log(colors.textMuted('Operation cancelled.'));
+        return;
+      }
+      mediaName = selected;
+    }
+
+    this.log(colors.primary(`\n🔄 Preprocessing "${mediaName}"...`));
+    this.log(colors.textMuted(`  Interval: ${flags.interval}s, Transcribe: ${flags.transcribe}\n`));
+
+    const result = await preprocessMedia(hqPath, mediaName, {
+      interval: flags.interval,
+      transcribe: flags.transcribe,
+    });
+
+    if (result.success) {
+      this.log('');
+      this.log(format.success(`Preprocessing complete for "${mediaName}"`));
+      this.log(colors.textMuted(`  View details: prlt media show ${mediaName}`));
+    } else {
+      this.log('');
+      this.log(format.error(`Preprocessing had issues: ${result.error}`));
+    }
+  }
+}

--- a/apps/cli/src/commands/media/remove.ts
+++ b/apps/cli/src/commands/media/remove.ts
@@ -1,0 +1,124 @@
+import { Args, Flags } from '@oclif/core';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors, format } from '../../lib/colors.js';
+import { findHQRoot } from '../../lib/repos/index.js';
+import { removeMedia, getWorkspaceMediaInfo, showMedia } from '../../lib/media/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+
+export default class Remove extends PMOCommand {
+  static description = 'Remove a media item from the HQ';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-video',
+    '<%= config.bin %> <%= command.id %> my-video --force',
+    '<%= config.bin %> <%= command.id %>',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Media item name to remove',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt',
+      default: false,
+    }),
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(Remove);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('media remove', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      return handleError('NOT_IN_HQ', 'Not in an HQ directory. Run "prlt new" first.');
+    }
+
+    let mediaName: string | null = args.name || null;
+
+    if (!mediaName) {
+      const { media } = getWorkspaceMediaInfo();
+      if (media.length === 0) {
+        return handleError('NO_MEDIA', 'No media found.');
+      }
+
+      const selected = await this.selectFromList({
+        message: 'Select media to remove:',
+        items: media,
+        getName: (m) => m.name,
+        getValue: (m) => m.name,
+        getCommand: (m) => `prlt media remove ${m.name} --json`,
+        jsonMode: jsonMode ? { flags, commandName: 'media remove' } : null,
+        allowCancel: true,
+      });
+
+      if (!selected) {
+        this.log(colors.textMuted('Operation cancelled.'));
+        return;
+      }
+      mediaName = selected;
+    }
+
+    // Validate media exists
+    const item = showMedia(hqPath, mediaName);
+    if (!item) {
+      return handleError('MEDIA_NOT_FOUND', `Media "${mediaName}" not found.`);
+    }
+
+    // Confirmation unless --force
+    if (!flags.force) {
+      const agentConfig = jsonMode ? { flags, commandName: 'media remove' } : null;
+
+      this.log(colors.warning('\n⚠️  This will:'));
+      this.log(colors.text(`  • Remove media/${mediaName}/ directory (source + preprocessed assets)`));
+      this.log(colors.text('  • Update database\n'));
+
+      const { confirm } = await this.prompt<{ confirm: string }>([{
+        type: 'list',
+        name: 'confirm',
+        message: `Are you sure you want to remove "${mediaName}"?`,
+        choices: [
+          { name: 'No, cancel', value: 'false', command: '' },
+          { name: 'Yes, remove media', value: 'true', command: `prlt media remove ${mediaName} --force --json` },
+        ],
+      }], agentConfig);
+
+      if (confirm !== 'true') {
+        this.log(colors.textMuted('Removal cancelled.'));
+        return;
+      }
+    }
+
+    this.log(colors.primary(`\nRemoving media "${mediaName}"...`));
+
+    const result = removeMedia(hqPath, mediaName);
+
+    if (result.success) {
+      this.log(format.success(`Media ${mediaName} removed`));
+    } else {
+      this.error(`Failed to remove media: ${result.error}`);
+    }
+  }
+}

--- a/apps/cli/src/commands/media/show.ts
+++ b/apps/cli/src/commands/media/show.ts
@@ -1,0 +1,149 @@
+import { Args } from '@oclif/core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
+import { colors, format } from '../../lib/colors.js';
+import { findHQRoot } from '../../lib/repos/index.js';
+import { showMedia, getWorkspaceMediaInfo, formatDuration, getMediaDir } from '../../lib/media/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+
+export default class Show extends PMOCommand {
+  static description = 'Show detailed information about a media item';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-video',
+    '<%= config.bin %> <%= command.id %>',
+  ];
+
+  static args = {
+    name: Args.string({
+      description: 'Media item name',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false };
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(Show);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('media show', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    const hqPath = findHQRoot();
+    if (!hqPath) {
+      return handleError('NOT_IN_HQ', 'Not in an HQ directory. Run "prlt new" first.');
+    }
+
+    let mediaName: string | null = args.name || null;
+
+    if (!mediaName) {
+      const { media } = getWorkspaceMediaInfo();
+      if (media.length === 0) {
+        return handleError('NO_MEDIA', 'No media found. Add some with "prlt media add <path>"');
+      }
+
+      const selected = await this.selectFromList({
+        message: 'Select media to view:',
+        items: media,
+        getName: (m) => `${m.name} (${m.status}${m.frameCount > 0 ? `, ${m.frameCount} frames` : ''})`,
+        getValue: (m) => m.name,
+        getCommand: (m) => `prlt media show ${m.name} --json`,
+        jsonMode: jsonMode ? { flags, commandName: 'media show' } : null,
+        allowCancel: true,
+      });
+
+      if (!selected) {
+        this.log(colors.textMuted('Operation cancelled.'));
+        return;
+      }
+      mediaName = selected;
+    }
+
+    const item = showMedia(hqPath, mediaName);
+    if (!item) {
+      return handleError('MEDIA_NOT_FOUND', `Media "${mediaName}" not found.`);
+    }
+
+    if (jsonMode) {
+      this.log(JSON.stringify(item, null, 2));
+      return;
+    }
+
+    // Display details
+    const icon = item.media_type === 'video' ? '🎬' : '🎵';
+    this.log(format.title(`${icon} Media: ${item.name}`));
+    this.log('');
+
+    this.log(`Path:        ${colors.path(item.path)}`);
+    if (item.source_path) {
+      this.log(`Source:      ${colors.text(item.source_path)}`);
+    }
+    this.log(`Type:        ${colors.text(item.media_type)}`);
+    this.log(`Added:       ${colors.text(new Date(item.added_at).toLocaleString())}`);
+
+    const statusColor = item.status === 'ready' ? colors.success :
+                        item.status === 'error' ? colors.error :
+                        item.status === 'processing' ? colors.warning :
+                        colors.textMuted;
+    this.log(`Status:      ${statusColor(item.status)}`);
+
+    if (item.error_message) {
+      this.log(`Error:       ${colors.error(item.error_message)}`);
+    }
+
+    if (item.duration_seconds) {
+      this.log(`Duration:    ${colors.text(formatDuration(item.duration_seconds))}`);
+    }
+    if (item.resolution) {
+      this.log(`Resolution:  ${colors.text(item.resolution)}`);
+    }
+
+    this.log(format.subtitle('\n📊 Preprocessed Assets:'));
+    this.log(`  Frames:      ${colors.text(String(item.frame_count))} (every ${item.frame_interval}s)`);
+    this.log(`  Transcript:  ${item.has_transcript ? colors.success('✓ Available') : colors.textMuted('Not generated')}`);
+
+    // Show frames info
+    const framesDir = path.join(getMediaDir(hqPath), item.name, 'frames');
+    if (fs.existsSync(framesDir)) {
+      const frameFiles = fs.readdirSync(framesDir).filter(f => f.endsWith('.jpg'));
+      if (frameFiles.length > 0) {
+        this.log(format.subtitle('\n🖼️  Frames:'));
+        const maxShow = Math.min(frameFiles.length, 10);
+        for (let i = 0; i < maxShow; i++) {
+          this.log(colors.textMuted(`  • ${frameFiles[i]}`));
+        }
+        if (frameFiles.length > maxShow) {
+          this.log(colors.textMuted(`  ... and ${frameFiles.length - maxShow} more`));
+        }
+      }
+    }
+
+    // Show manifest info
+    const manifestPath = path.join(getMediaDir(hqPath), item.name, 'manifest.json');
+    if (fs.existsSync(manifestPath)) {
+      this.log(colors.textMuted(`\nManifest:    media/${item.name}/manifest.json`));
+    }
+
+    if (item.processed_at) {
+      this.log(colors.textMuted(`Processed:   ${new Date(item.processed_at).toLocaleString()}`));
+    }
+  }
+}

--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -141,6 +141,23 @@ CREATE TABLE IF NOT EXISTS workspace_settings (
   value TEXT NOT NULL
 );
 
+-- Media items (videos, audio files with preprocessed assets)
+CREATE TABLE IF NOT EXISTS media_items (
+  name TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
+  source_path TEXT,
+  media_type TEXT NOT NULL DEFAULT 'video' CHECK (media_type IN ('video', 'audio')),
+  duration_seconds REAL,
+  resolution TEXT,
+  frame_count INTEGER NOT NULL DEFAULT 0,
+  has_transcript INTEGER NOT NULL DEFAULT 0,
+  frame_interval INTEGER NOT NULL DEFAULT 30,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'ready', 'error')),
+  error_message TEXT,
+  added_at TEXT NOT NULL,
+  processed_at TEXT
+);
+
 -- =============================================================================
 -- Indexes
 -- =============================================================================
@@ -294,6 +311,32 @@ export function openWorkspaceDatabase(workspacePath: string): Database.Database 
     }
   } catch {
     // Ignore migration errors - table might not exist yet or column already exists
+  }
+
+  // Migration: create media_items table (TKT-077)
+  try {
+    const mediaTableExists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='media_items'").get();
+    if (!mediaTableExists) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS media_items (
+          name TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          source_path TEXT,
+          media_type TEXT NOT NULL DEFAULT 'video' CHECK (media_type IN ('video', 'audio')),
+          duration_seconds REAL,
+          resolution TEXT,
+          frame_count INTEGER NOT NULL DEFAULT 0,
+          has_transcript INTEGER NOT NULL DEFAULT 0,
+          frame_interval INTEGER NOT NULL DEFAULT 30,
+          status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'ready', 'error')),
+          error_message TEXT,
+          added_at TEXT NOT NULL,
+          processed_at TEXT
+        )
+      `);
+    }
+  } catch {
+    // Ignore migration errors
   }
 
   // Migration: add position column to pmo_tickets table (TKT-965)
@@ -1205,5 +1248,158 @@ export function addThemeNames(workspacePath: string, themeId: string, names: str
   });
 
   transaction();
+  db.close();
+}
+
+// =============================================================================
+// Media Item Operations (TKT-077)
+// =============================================================================
+
+export interface MediaItem {
+  name: string;
+  path: string;
+  source_path: string | null;
+  media_type: 'video' | 'audio';
+  duration_seconds: number | null;
+  resolution: string | null;
+  frame_count: number;
+  has_transcript: boolean;
+  frame_interval: number;
+  status: 'pending' | 'processing' | 'ready' | 'error';
+  error_message: string | null;
+  added_at: string;
+  processed_at: string | null;
+}
+
+/**
+ * Add a media item to the database
+ */
+export function addMediaItemToDatabase(
+  workspacePath: string,
+  item: { name: string; path: string; source_path?: string; media_type: 'video' | 'audio'; frame_interval?: number }
+): void {
+  const db = openWorkspaceDatabase(workspacePath);
+  db.prepare(`
+    INSERT OR REPLACE INTO media_items (name, path, source_path, media_type, frame_interval, added_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(item.name, item.path, item.source_path || null, item.media_type, item.frame_interval || 30, new Date().toISOString());
+  db.close();
+}
+
+/**
+ * Update media item after preprocessing
+ */
+export function updateMediaItemStatus(
+  workspacePath: string,
+  name: string,
+  updates: {
+    status: 'pending' | 'processing' | 'ready' | 'error';
+    duration_seconds?: number;
+    resolution?: string;
+    frame_count?: number;
+    has_transcript?: boolean;
+    error_message?: string;
+  }
+): void {
+  const db = openWorkspaceDatabase(workspacePath);
+
+  const sets: string[] = ['status = ?'];
+  const values: (string | number | null)[] = [updates.status];
+
+  if (updates.duration_seconds !== undefined) {
+    sets.push('duration_seconds = ?');
+    values.push(updates.duration_seconds);
+  }
+  if (updates.resolution !== undefined) {
+    sets.push('resolution = ?');
+    values.push(updates.resolution);
+  }
+  if (updates.frame_count !== undefined) {
+    sets.push('frame_count = ?');
+    values.push(updates.frame_count);
+  }
+  if (updates.has_transcript !== undefined) {
+    sets.push('has_transcript = ?');
+    values.push(updates.has_transcript ? 1 : 0);
+  }
+  if (updates.error_message !== undefined) {
+    sets.push('error_message = ?');
+    values.push(updates.error_message);
+  }
+  if (updates.status === 'ready' || updates.status === 'error') {
+    sets.push('processed_at = ?');
+    values.push(new Date().toISOString());
+  }
+
+  values.push(name);
+  db.prepare(`UPDATE media_items SET ${sets.join(', ')} WHERE name = ?`).run(...values);
+  db.close();
+}
+
+/**
+ * Get all media items in workspace
+ */
+export function getWorkspaceMediaItems(workspacePath: string): MediaItem[] {
+  const db = openWorkspaceDatabase(workspacePath);
+  const rows = db.prepare('SELECT * FROM media_items ORDER BY added_at').all() as Array<{
+    name: string;
+    path: string;
+    source_path: string | null;
+    media_type: string;
+    duration_seconds: number | null;
+    resolution: string | null;
+    frame_count: number;
+    has_transcript: number;
+    frame_interval: number;
+    status: string;
+    error_message: string | null;
+    added_at: string;
+    processed_at: string | null;
+  }>;
+  db.close();
+  return rows.map(row => ({
+    ...row,
+    media_type: row.media_type as 'video' | 'audio',
+    has_transcript: Boolean(row.has_transcript),
+    status: row.status as MediaItem['status'],
+  }));
+}
+
+/**
+ * Get a single media item by name
+ */
+export function getMediaItem(workspacePath: string, name: string): MediaItem | null {
+  const db = openWorkspaceDatabase(workspacePath);
+  const row = db.prepare('SELECT * FROM media_items WHERE name = ?').get(name) as {
+    name: string;
+    path: string;
+    source_path: string | null;
+    media_type: string;
+    duration_seconds: number | null;
+    resolution: string | null;
+    frame_count: number;
+    has_transcript: number;
+    frame_interval: number;
+    status: string;
+    error_message: string | null;
+    added_at: string;
+    processed_at: string | null;
+  } | undefined;
+  db.close();
+  if (!row) return null;
+  return {
+    ...row,
+    media_type: row.media_type as 'video' | 'audio',
+    has_transcript: Boolean(row.has_transcript),
+    status: row.status as MediaItem['status'],
+  };
+}
+
+/**
+ * Remove a media item from the database
+ */
+export function removeMediaItemFromDatabase(workspacePath: string, name: string): void {
+  const db = openWorkspaceDatabase(workspacePath);
+  db.prepare('DELETE FROM media_items WHERE name = ?').run(name);
   db.close();
 }

--- a/apps/cli/src/lib/execution/spawner.ts
+++ b/apps/cli/src/lib/execution/spawner.ts
@@ -23,6 +23,7 @@ import { runExecution, isDockerRunning, isGitHubTokenAvailable, isDevcontainerCl
 import { detectRepoWorktrees, resolveWorktreePath } from './context.js'
 import { ExternalExecutionMappingStore } from '../external-issues/mapping-store.js'
 import { type ExternalMappingProvider } from '../external-issues/types.js'
+import { copyMediaToAgentWorkspace } from '../media/index.js'
 import {
   DisplayMode,
   SessionManager,
@@ -567,6 +568,15 @@ export async function spawnAgentForTicket(
         }
       }
     }
+  }
+
+  // TKT-077: Copy preprocessed media assets into agent workspace
+  // Copies frames/, transcript.md, manifest.json (not raw source video)
+  try {
+    copyMediaToAgentWorkspace(hqPath, agentDir)
+  } catch {
+    // Non-fatal: media copy failure shouldn't block agent spawn
+    log('Warning: Could not copy media assets to agent workspace')
   }
 
   // TKT-1028: Clean up orphaned execution records before creating a new one.

--- a/apps/cli/src/lib/media/index.ts
+++ b/apps/cli/src/lib/media/index.ts
@@ -1,0 +1,632 @@
+/**
+ * Media Library
+ *
+ * Manages media files (videos, audio) in HQ workspaces.
+ * Preprocesses media into frames + transcripts for agent consumption.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import chalk from 'chalk';
+import { styles } from '../styles.js';
+import { findHQRoot } from '../workspace.js';
+import {
+  addMediaItemToDatabase,
+  updateMediaItemStatus,
+  getWorkspaceMediaItems,
+  getMediaItem,
+  removeMediaItemFromDatabase,
+  type MediaItem,
+} from '../database/index.js';
+
+export type { MediaItem } from '../database/index.js';
+
+// =============================================================================
+// Dependency Detection
+// =============================================================================
+
+/**
+ * Check if ffmpeg is installed
+ */
+export function isFfmpegInstalled(): boolean {
+  try {
+    execSync('ffmpeg -version', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if whisper (or whisper.cpp) is available for transcription
+ */
+export function isWhisperInstalled(): boolean {
+  try {
+    execSync('whisper --help', { stdio: 'pipe' });
+    return true;
+  } catch {
+    try {
+      execSync('whisper-cpp --help', { stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Get the whisper command name (whisper or whisper-cpp)
+ */
+function getWhisperCommand(): string | null {
+  try {
+    execSync('whisper --help', { stdio: 'pipe' });
+    return 'whisper';
+  } catch {
+    try {
+      execSync('whisper-cpp --help', { stdio: 'pipe' });
+      return 'whisper-cpp';
+    } catch {
+      return null;
+    }
+  }
+}
+
+// =============================================================================
+// Media Info
+// =============================================================================
+
+interface MediaProbeResult {
+  duration: number | null;
+  width: number | null;
+  height: number | null;
+  hasAudio: boolean;
+  hasVideo: boolean;
+}
+
+/**
+ * Probe a media file to get its metadata using ffprobe
+ */
+function probeMedia(filePath: string): MediaProbeResult {
+  const result: MediaProbeResult = {
+    duration: null,
+    width: null,
+    height: null,
+    hasAudio: false,
+    hasVideo: false,
+  };
+
+  try {
+    const output = execSync(
+      `ffprobe -v quiet -print_format json -show_format -show_streams "${filePath}"`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    const data = JSON.parse(output);
+
+    if (data.format?.duration) {
+      result.duration = parseFloat(data.format.duration);
+    }
+
+    for (const stream of data.streams || []) {
+      if (stream.codec_type === 'video') {
+        result.hasVideo = true;
+        result.width = stream.width;
+        result.height = stream.height;
+      }
+      if (stream.codec_type === 'audio') {
+        result.hasAudio = true;
+      }
+    }
+  } catch {
+    // ffprobe failed - file might not be a valid media file
+  }
+
+  return result;
+}
+
+// =============================================================================
+// Media CRUD Operations
+// =============================================================================
+
+/**
+ * Supported media file extensions
+ */
+const VIDEO_EXTENSIONS = new Set(['.mp4', '.mkv', '.avi', '.mov', '.webm', '.flv', '.wmv']);
+const AUDIO_EXTENSIONS = new Set(['.mp3', '.wav', '.flac', '.aac', '.ogg', '.m4a', '.wma']);
+
+/**
+ * Detect if a file is video or audio based on extension
+ */
+export function detectMediaType(filePath: string): 'video' | 'audio' | null {
+  const ext = path.extname(filePath).toLowerCase();
+  if (VIDEO_EXTENSIONS.has(ext)) return 'video';
+  if (AUDIO_EXTENSIONS.has(ext)) return 'audio';
+  return null;
+}
+
+/**
+ * Get the media directory path within the HQ
+ */
+export function getMediaDir(hqPath: string): string {
+  return path.join(hqPath, 'media');
+}
+
+/**
+ * Add a media file to the HQ
+ */
+export async function addMedia(
+  hqPath: string,
+  sourcePath: string,
+  options: { interval?: number; transcribe?: boolean } = {}
+): Promise<{ success: boolean; name: string; error?: string }> {
+  const resolvedSource = path.resolve(sourcePath);
+
+  if (!fs.existsSync(resolvedSource)) {
+    return { success: false, name: '', error: `File not found: ${resolvedSource}` };
+  }
+
+  const mediaType = detectMediaType(resolvedSource);
+  if (!mediaType) {
+    return { success: false, name: '', error: `Unsupported file type: ${path.extname(resolvedSource)}` };
+  }
+
+  if (!isFfmpegInstalled()) {
+    return { success: false, name: '', error: 'ffmpeg is not installed. Install it with: brew install ffmpeg' };
+  }
+
+  const baseName = path.basename(resolvedSource, path.extname(resolvedSource));
+  // Sanitize name: lowercase, replace spaces/special chars with hyphens
+  const name = baseName.toLowerCase().replace(/[^a-z0-9-_]/g, '-').replace(/-+/g, '-');
+
+  const mediaDir = getMediaDir(hqPath);
+  const itemDir = path.join(mediaDir, name);
+
+  if (fs.existsSync(itemDir)) {
+    return { success: false, name, error: `Media "${name}" already exists. Remove it first or use a different name.` };
+  }
+
+  // Create directory structure
+  fs.mkdirSync(itemDir, { recursive: true });
+  fs.mkdirSync(path.join(itemDir, 'frames'), { recursive: true });
+
+  // Copy source file
+  const ext = path.extname(resolvedSource);
+  const destFile = path.join(itemDir, `source${ext}`);
+  console.log(styles.muted(`Copying ${resolvedSource} to media/${name}/...`));
+  fs.copyFileSync(resolvedSource, destFile);
+
+  // Add to database
+  addMediaItemToDatabase(hqPath, {
+    name,
+    path: `media/${name}`,
+    source_path: resolvedSource,
+    media_type: mediaType,
+    frame_interval: options.interval || 30,
+  });
+
+  // Run preprocessing
+  console.log(styles.muted('Starting preprocessing...'));
+  const preprocessResult = await preprocessMedia(hqPath, name, {
+    interval: options.interval || 30,
+    transcribe: options.transcribe ?? true,
+  });
+
+  if (!preprocessResult.success) {
+    console.log(chalk.yellow(`Warning: Preprocessing had issues: ${preprocessResult.error}`));
+    console.log(chalk.yellow('You can retry with: prlt media preprocess ' + name));
+  }
+
+  return { success: true, name };
+}
+
+/**
+ * Remove a media item from the HQ
+ */
+export function removeMedia(
+  hqPath: string,
+  name: string
+): { success: boolean; error?: string } {
+  const itemDir = path.join(getMediaDir(hqPath), name);
+
+  // Remove from file system
+  if (fs.existsSync(itemDir)) {
+    fs.rmSync(itemDir, { recursive: true, force: true });
+  }
+
+  // Remove from database
+  removeMediaItemFromDatabase(hqPath, name);
+
+  return { success: true };
+}
+
+/**
+ * List all media items in the workspace
+ */
+export function listMedia(hqPath: string): MediaItem[] {
+  return getWorkspaceMediaItems(hqPath);
+}
+
+/**
+ * Get details for a specific media item
+ */
+export function showMedia(hqPath: string, name: string): MediaItem | null {
+  return getMediaItem(hqPath, name);
+}
+
+// =============================================================================
+// Preprocessing Pipeline
+// =============================================================================
+
+/**
+ * Format seconds into a timestamp string (e.g., "01m30s")
+ */
+function formatTimestamp(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${String(m).padStart(2, '0')}m${String(s).padStart(2, '0')}s`;
+}
+
+/**
+ * Preprocess a media file: extract frames and generate transcript
+ */
+export async function preprocessMedia(
+  hqPath: string,
+  name: string,
+  options: { interval?: number; transcribe?: boolean } = {}
+): Promise<{ success: boolean; error?: string }> {
+  const interval = options.interval || 30;
+  const transcribe = options.transcribe ?? true;
+
+  const item = getMediaItem(hqPath, name);
+  if (!item) {
+    return { success: false, error: `Media "${name}" not found` };
+  }
+
+  const itemDir = path.join(getMediaDir(hqPath), name);
+  if (!fs.existsSync(itemDir)) {
+    return { success: false, error: `Media directory not found: ${itemDir}` };
+  }
+
+  // Find source file
+  const sourceFile = findSourceFile(itemDir);
+  if (!sourceFile) {
+    return { success: false, error: 'Source media file not found in media directory' };
+  }
+
+  // Mark as processing
+  updateMediaItemStatus(hqPath, name, { status: 'processing' });
+
+  // Probe media info
+  const probe = probeMedia(sourceFile);
+  const resolution = probe.width && probe.height ? `${probe.width}x${probe.height}` : undefined;
+
+  // Clean previous frames
+  const framesDir = path.join(itemDir, 'frames');
+  if (fs.existsSync(framesDir)) {
+    fs.rmSync(framesDir, { recursive: true });
+  }
+  fs.mkdirSync(framesDir, { recursive: true });
+
+  let frameCount = 0;
+  let hasTranscript = false;
+  const errors: string[] = [];
+
+  // Extract frames (only for video)
+  if (probe.hasVideo) {
+    try {
+      console.log(styles.muted(`Extracting frames every ${interval}s...`));
+
+      // Use ffmpeg to extract frames at the specified interval
+      // Output as frame_NNNN_XXmYYs.jpg for easy reference
+      execSync(
+        `ffmpeg -i "${sourceFile}" -vf "fps=1/${interval}" -q:v 2 "${path.join(framesDir, 'frame_%04d.jpg')}" -y`,
+        { stdio: 'pipe' }
+      );
+
+      // Rename frames with timestamps
+      const frameFiles = fs.readdirSync(framesDir).filter(f => f.endsWith('.jpg')).sort();
+      for (let i = 0; i < frameFiles.length; i++) {
+        const oldPath = path.join(framesDir, frameFiles[i]);
+        const timestamp = formatTimestamp(i * interval);
+        const newName = `frame_${String(i).padStart(4, '0')}_${timestamp}.jpg`;
+        const newPath = path.join(framesDir, newName);
+        fs.renameSync(oldPath, newPath);
+      }
+
+      frameCount = frameFiles.length;
+      console.log(styles.muted(`Extracted ${frameCount} frames`));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      errors.push(`Frame extraction failed: ${msg}`);
+      console.log(chalk.yellow(`Warning: Frame extraction failed: ${msg}`));
+    }
+  }
+
+  // Generate transcript
+  if (transcribe && probe.hasAudio) {
+    const whisperCmd = getWhisperCommand();
+    if (whisperCmd) {
+      try {
+        console.log(styles.muted('Generating transcript...'));
+
+        // Extract audio to WAV for whisper compatibility
+        const wavPath = path.join(itemDir, 'audio.wav');
+        execSync(
+          `ffmpeg -i "${sourceFile}" -ar 16000 -ac 1 -c:a pcm_s16le "${wavPath}" -y`,
+          { stdio: 'pipe' }
+        );
+
+        // Run whisper
+        execSync(
+          `${whisperCmd} "${wavPath}" --output_format txt,json --output_dir "${itemDir}"`,
+          { stdio: 'pipe', timeout: 600000 } // 10 min timeout
+        );
+
+        // Clean up WAV
+        if (fs.existsSync(wavPath)) {
+          fs.unlinkSync(wavPath);
+        }
+
+        // Look for generated transcript files and rename them
+        const txtFiles = fs.readdirSync(itemDir).filter(f => f.endsWith('.txt') && f !== 'transcript.md');
+        const jsonFiles = fs.readdirSync(itemDir).filter(f => f.endsWith('.json') && f !== 'manifest.json');
+
+        if (txtFiles.length > 0) {
+          const txtContent = fs.readFileSync(path.join(itemDir, txtFiles[0]), 'utf-8');
+          fs.writeFileSync(path.join(itemDir, 'transcript.md'), `# Transcript: ${name}\n\n${txtContent}`);
+          // Clean up original
+          fs.unlinkSync(path.join(itemDir, txtFiles[0]));
+          hasTranscript = true;
+        }
+
+        if (jsonFiles.length > 0) {
+          fs.renameSync(path.join(itemDir, jsonFiles[0]), path.join(itemDir, 'transcript.json'));
+        }
+
+        console.log(styles.muted('Transcript generated'));
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        errors.push(`Transcription failed: ${msg}`);
+        console.log(chalk.yellow(`Warning: Transcription failed: ${msg}`));
+      }
+    } else {
+      console.log(chalk.yellow('Whisper not installed. Skipping transcription.'));
+      console.log(chalk.yellow('Install with: pip install openai-whisper'));
+    }
+  } else if (transcribe && !probe.hasAudio) {
+    console.log(styles.muted('No audio stream found. Skipping transcription.'));
+  }
+
+  // Generate manifest
+  const manifest = generateManifest(name, itemDir, probe, frameCount, hasTranscript, interval);
+  fs.writeFileSync(path.join(itemDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+  // Update database
+  const status = errors.length > 0 ? 'error' as const : 'ready' as const;
+  updateMediaItemStatus(hqPath, name, {
+    status,
+    duration_seconds: probe.duration ?? undefined,
+    resolution,
+    frame_count: frameCount,
+    has_transcript: hasTranscript,
+    error_message: errors.length > 0 ? errors.join('; ') : undefined,
+  });
+
+  if (errors.length > 0) {
+    return { success: false, error: errors.join('; ') };
+  }
+
+  return { success: true };
+}
+
+// =============================================================================
+// Manifest Generation
+// =============================================================================
+
+interface MediaManifest {
+  name: string;
+  media_type: 'video' | 'audio';
+  duration_seconds: number | null;
+  resolution: string | null;
+  frame_interval_seconds: number;
+  frame_count: number;
+  has_transcript: boolean;
+  frames: Array<{
+    filename: string;
+    timestamp_seconds: number;
+    timestamp_display: string;
+  }>;
+  transcript_file: string | null;
+  transcript_json_file: string | null;
+  processed_at: string;
+}
+
+/**
+ * Generate a manifest.json with metadata about the preprocessed media
+ */
+function generateManifest(
+  name: string,
+  itemDir: string,
+  probe: MediaProbeResult,
+  frameCount: number,
+  hasTranscript: boolean,
+  interval: number
+): MediaManifest {
+  const framesDir = path.join(itemDir, 'frames');
+  const frameFiles = fs.existsSync(framesDir)
+    ? fs.readdirSync(framesDir).filter(f => f.endsWith('.jpg')).sort()
+    : [];
+
+  return {
+    name,
+    media_type: probe.hasVideo ? 'video' : 'audio',
+    duration_seconds: probe.duration,
+    resolution: probe.width && probe.height ? `${probe.width}x${probe.height}` : null,
+    frame_interval_seconds: interval,
+    frame_count: frameCount,
+    has_transcript: hasTranscript,
+    frames: frameFiles.map((filename, i) => ({
+      filename,
+      timestamp_seconds: i * interval,
+      timestamp_display: formatTimestamp(i * interval),
+    })),
+    transcript_file: hasTranscript ? 'transcript.md' : null,
+    transcript_json_file: fs.existsSync(path.join(itemDir, 'transcript.json')) ? 'transcript.json' : null,
+    processed_at: new Date().toISOString(),
+  };
+}
+
+// =============================================================================
+// Workspace Info
+// =============================================================================
+
+export interface MediaInfo {
+  name: string;
+  mediaType: 'video' | 'audio';
+  status: 'pending' | 'processing' | 'ready' | 'error';
+  frameCount: number;
+  hasTranscript: boolean;
+  durationSeconds: number | null;
+  resolution: string | null;
+  addedAt: string;
+}
+
+/**
+ * Get workspace media information
+ */
+export function getWorkspaceMediaInfo(): { hqPath: string; mediaPath: string; media: MediaInfo[] } {
+  const hqPath = findHQRoot();
+  if (!hqPath) {
+    throw new Error('Not in an HQ directory. Run "prlt new" first.');
+  }
+
+  const mediaPath = getMediaDir(hqPath);
+  const items = getWorkspaceMediaItems(hqPath);
+
+  const media: MediaInfo[] = items.map(item => ({
+    name: item.name,
+    mediaType: item.media_type,
+    status: item.status,
+    frameCount: item.frame_count,
+    hasTranscript: item.has_transcript,
+    durationSeconds: item.duration_seconds,
+    resolution: item.resolution,
+    addedAt: item.added_at,
+  }));
+
+  return { hqPath, mediaPath, media };
+}
+
+// =============================================================================
+// Agent Workspace Mounting (TKT-077)
+// =============================================================================
+
+/**
+ * Copy preprocessed media assets into an agent's workspace directory.
+ * Only copies lightweight preprocessed assets (frames/, transcript.md, manifest.json).
+ * Does NOT copy the raw source video (too large).
+ *
+ * @param hqPath - The HQ root path
+ * @param agentDir - The agent's working directory (e.g., agents/temp/thick-spiegel)
+ */
+export function copyMediaToAgentWorkspace(hqPath: string, agentDir: string): void {
+  const mediaDir = getMediaDir(hqPath);
+  if (!fs.existsSync(mediaDir)) {
+    return;
+  }
+
+  const items = getWorkspaceMediaItems(hqPath);
+  const readyItems = items.filter(item => item.status === 'ready');
+
+  if (readyItems.length === 0) {
+    return;
+  }
+
+  const agentMediaDir = path.join(agentDir, 'media');
+  fs.mkdirSync(agentMediaDir, { recursive: true });
+
+  for (const item of readyItems) {
+    const sourceItemDir = path.join(hqPath, item.path);
+    const destItemDir = path.join(agentMediaDir, item.name);
+
+    if (!fs.existsSync(sourceItemDir)) {
+      continue;
+    }
+
+    fs.mkdirSync(destItemDir, { recursive: true });
+
+    // Copy manifest.json
+    const manifestSrc = path.join(sourceItemDir, 'manifest.json');
+    if (fs.existsSync(manifestSrc)) {
+      fs.copyFileSync(manifestSrc, path.join(destItemDir, 'manifest.json'));
+    }
+
+    // Copy transcript.md
+    const transcriptSrc = path.join(sourceItemDir, 'transcript.md');
+    if (fs.existsSync(transcriptSrc)) {
+      fs.copyFileSync(transcriptSrc, path.join(destItemDir, 'transcript.md'));
+    }
+
+    // Copy transcript.json
+    const transcriptJsonSrc = path.join(sourceItemDir, 'transcript.json');
+    if (fs.existsSync(transcriptJsonSrc)) {
+      fs.copyFileSync(transcriptJsonSrc, path.join(destItemDir, 'transcript.json'));
+    }
+
+    // Copy frames directory
+    const framesSrc = path.join(sourceItemDir, 'frames');
+    if (fs.existsSync(framesSrc)) {
+      const framesDest = path.join(destItemDir, 'frames');
+      fs.mkdirSync(framesDest, { recursive: true });
+      const frameFiles = fs.readdirSync(framesSrc);
+      for (const file of frameFiles) {
+        fs.copyFileSync(path.join(framesSrc, file), path.join(framesDest, file));
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Utility
+// =============================================================================
+
+/**
+ * Find the source media file in a media item directory
+ */
+function findSourceFile(itemDir: string): string | null {
+  const allExtensions = [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS];
+  for (const ext of allExtensions) {
+    const sourceFile = path.join(itemDir, `source${ext}`);
+    if (fs.existsSync(sourceFile)) {
+      return sourceFile;
+    }
+  }
+
+  // Also check for files with 'source' prefix or just any media file
+  const files = fs.readdirSync(itemDir);
+  for (const file of files) {
+    const ext = path.extname(file).toLowerCase();
+    if (allExtensions.includes(ext as typeof allExtensions[number])) {
+      return path.join(itemDir, file);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Format duration in seconds to human-readable string
+ */
+export function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+
+  if (h > 0) {
+    return `${h}h ${m}m ${s}s`;
+  }
+  if (m > 0) {
+    return `${m}m ${s}s`;
+  }
+  return `${s}s`;
+}


### PR DESCRIPTION
## Summary

Resolves TKT-077: Add media/video source type to HQ — preprocess videos into frames + transcripts for agent consumption

## Description

Add a new source type to HQ workspaces for media files (videos, audio). Similar to how repos/ contains git repositories that get worktree'd into agent environments, media/ (or videos/) would contain media files that get preprocessed and mounted into agent workspaces.

## Flow

1. User adds videos: prlt media add <path-to-video> or drops files into media/ directory in HQ
2. prlt preprocesses on add:
   - Extract keyframes at intervals (e.g. every 30s, scene changes) using ffmpeg
   - Generate transcript using whisper (or similar) 
   - Create a manifest.json with metadata (duration, resolution, timestamps of keyframes, transcript segments)
   - Store preprocessed assets in media/<video-name>/frames/, media/<video-name>/transcript.md
3. When an agent workspace is created, preprocessed media assets are mounted/copied in
4. Agent can view frame images (Claude Code supports images) and read transcripts
5. Agent can reference specific timestamps for clip suggestions

## Commands to add

- prlt media add <path> — Add a video/audio file, trigger preprocessing
- prlt media list — List all media in workspace
- prlt media show <name> — Show metadata, transcript, frame count
- prlt media remove <name> — Remove media and preprocessed assets
- prlt media preprocess <name> [--interval 30] [--transcribe] — Re-run preprocessing with different settings

## Preprocessing pipeline

Dependencies: ffmpeg (frame extraction), whisper or whisper.cpp (transcription)
- Detect if ffmpeg is installed, prompt to install if missing
- Detect if whisper is available for transcription
- Frame extraction: ffmpeg -i video.mp4 -vf 'fps=1/30' frames/frame_%04d.jpg
- Transcription: whisper video.mp4 --output_format txt,json
- Generate manifest with timestamps mapped to frames and transcript segments

## Directory structure in HQ

```
media/
  anthropic-demo/
    source.mp4              # Original video
    manifest.json           # Metadata + frame timestamps + transcript index
    frames/
      frame_0000_00m00s.jpg # Keyframe at 0:00
      frame_0001_00m30s.jpg # Keyframe at 0:30
      ...
    transcript.md           # Full transcript with timestamps
    transcript.json         # Structured transcript (word-level timestamps)
  boulder-netech/
    ...
  kvia-cowork/
    ...
```

## Agent workspace mounting

When spawning an agent, mount the preprocessed media directory (not the raw video — too large) into the agent workspace. The agent gets:
- Frame images it can view (Claude Code reads images)
- Transcript text it can read and search
- Manifest for navigating the content

## Integration with marketing workflow

This directly enables the marketing use case: agents can review video content, suggest clips/highlights with timestamps, write descriptions, and create social media posts — all by examining frames and reading transcripts.

Reference:
- apps/cli/src/lib/repos/ — how repos source type works
- apps/cli/src/lib/execution/spawner.ts — how workspaces are set up for agents
- apps/cli/src/commands/repo/ — repo commands pattern to follow

## Changes

- dc97f80d feat(TKT-077): feat(TKT-077): add media/video source type with preprocessing pipeline

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
