### PR TITLE
TKT-081: Fix Docker daemon detection — fail fast or fall back to host when Docker is unresponsive

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -1236,26 +1236,81 @@ export function isGitHubTokenAvailable(): boolean {
 // =============================================================================
 
 /**
- * Check if Docker daemon is running.
- * Returns true if Docker is available and responsive.
- * Uses retry logic to handle slow Docker Desktop startup.
+ * Docker daemon health check result (TKT-081).
+ * Provides diagnostic info about why Docker isn't available.
  */
-export function isDockerRunning(): boolean {
-  const maxRetries = 3
-  const timeout = 10000 // 10 seconds
+export type DockerDaemonStatus = {
+  available: boolean
+  /** 'ready' | 'not-installed' | 'daemon-not-ready' */
+  reason: 'ready' | 'not-installed' | 'daemon-not-ready'
+  /** Human-readable message for logging/display */
+  message: string
+}
 
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      execSync('docker info', { stdio: 'pipe', timeout })
-      return true
-    } catch {
-      if (attempt === maxRetries) {
-        return false
-      }
-      // Brief pause before retry
+/**
+ * Check Docker daemon health with fast detection (TKT-081).
+ *
+ * Uses `docker ps` with a 5-second timeout to quickly detect:
+ * - Docker not installed
+ * - Docker installed but daemon unresponsive (stuck on license, initializing, 500 errors)
+ * - Docker ready
+ *
+ * Total worst-case time: ~5 seconds (single attempt with timeout).
+ */
+export function checkDockerDaemon(): DockerDaemonStatus {
+  // First: is docker even installed?
+  try {
+    execSync('which docker', { stdio: 'pipe', timeout: 3000 })
+  } catch {
+    return {
+      available: false,
+      reason: 'not-installed',
+      message: 'Docker is not installed.',
     }
   }
-  return false
+
+  // Second: is the daemon responsive? Use `docker ps` — it's lightweight and
+  // fails fast when the daemon returns 500s or hangs on GUI prompts.
+  const timeout = 5000 // 5 seconds — enough for a healthy daemon, fast fail otherwise
+  try {
+    execSync('docker ps -q --no-trunc', { stdio: 'pipe', timeout })
+    return {
+      available: true,
+      reason: 'ready',
+      message: 'Docker daemon is ready.',
+    }
+  } catch (error: unknown) {
+    // Parse the error to give actionable feedback
+    const stderr = (error as { stderr?: Buffer })?.stderr?.toString() || ''
+    const isTimeout = (error as { killed?: boolean })?.killed === true
+
+    let message: string
+    if (isTimeout) {
+      message = 'Docker daemon is not responding (timed out after 5s). Docker Desktop may be initializing or stuck — check for license/login prompts.'
+    } else if (stderr.includes('500') || stderr.includes('Internal Server Error')) {
+      message = 'Docker daemon is returning errors (500). Docker Desktop needs attention — check for license/login prompts.'
+    } else if (stderr.includes('connect') || stderr.includes('Cannot connect') || stderr.includes('Is the docker daemon running')) {
+      message = 'Docker daemon is not running. Start Docker Desktop and try again.'
+    } else {
+      message = `Docker daemon is not ready: ${stderr.trim() || 'unknown error'}. Check Docker Desktop status.`
+    }
+
+    return {
+      available: false,
+      reason: 'daemon-not-ready',
+      message,
+    }
+  }
+}
+
+/**
+ * Check if Docker daemon is running.
+ * Returns true if Docker is available and responsive.
+ *
+ * For detailed diagnostics, use checkDockerDaemon() instead.
+ */
+export function isDockerRunning(): boolean {
+  return checkDockerDaemon().available
 }
 
 /**
@@ -1318,7 +1373,7 @@ function getImageName(agentName: string): string {
  */
 export function containerExists(containerName: string): boolean {
   try {
-    execSync(`docker container inspect ${containerName}`, { stdio: 'pipe' })
+    execSync(`docker container inspect ${containerName}`, { stdio: 'pipe', timeout: 5000 })
     return true
   } catch {
     return false
@@ -1332,7 +1387,7 @@ export function isContainerRunning(containerName: string): boolean {
   try {
     const status = execSync(
       `docker container inspect -f '{{.State.Running}}' ${containerName}`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
     ).trim()
     return status === 'true'
   } catch {
@@ -1347,7 +1402,7 @@ export function getContainerId(containerName: string): string | null {
   try {
     const containerId = execSync(
       `docker container inspect -f '{{.Id}}' ${containerName}`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
     ).trim()
     return containerId ? containerId.substring(0, 12) : null
   } catch {
@@ -1386,7 +1441,7 @@ function buildDockerImage(agentDir: string, imageName: string, buildArgs: Record
  */
 function imageExists(imageName: string): boolean {
   try {
-    execSync(`docker image inspect ${imageName}`, { stdio: 'pipe' })
+    execSync(`docker image inspect ${imageName}`, { stdio: 'pipe', timeout: 5000 })
     return true
   } catch {
     return false
@@ -1658,7 +1713,7 @@ function ensureDockerContainer(
     // Container exists but is stopped - remove and recreate for fresh mounts
     console.debug(`[runners:docker] Removing stopped container ${containerName} to create fresh one`)
     try {
-      execSync(`docker rm -f ${containerName}`, { stdio: 'pipe' })
+      execSync(`docker rm -f ${containerName}`, { stdio: 'pipe', timeout: 10000 })
     } catch {
       // Ignore removal errors
     }
@@ -1909,11 +1964,12 @@ export async function runDevcontainer(
   }
 
   try {
-    // Check if Docker is running
-    if (!isDockerRunning()) {
+    // Check if Docker is running (TKT-081: fast detection with diagnostic info)
+    const dockerStatus = checkDockerDaemon()
+    if (!dockerStatus.available) {
       return {
         success: false,
-        error: 'Docker is not running. Please start Docker Desktop and try again.',
+        error: `Docker daemon is not available. ${dockerStatus.message}`,
       }
     }
 
@@ -2672,14 +2728,12 @@ export async function runDocker(
   const containerName = `work-${context.ticketId}-${Date.now()}`
 
   try {
-    // Check if docker is available
-    execSync('which docker', { stdio: 'pipe' })
-
-    // Check if Docker is running
-    if (!isDockerRunning()) {
+    // Check if docker is available and daemon is responsive (TKT-081)
+    const dockerStatus = checkDockerDaemon()
+    if (!dockerStatus.available) {
       return {
         success: false,
-        error: 'Docker is not running. Please start Docker Desktop and try again.',
+        error: `Docker daemon is not available. ${dockerStatus.message}`,
       }
     }
 
@@ -2774,11 +2828,12 @@ export async function runOrchestratorInDocker(
   const imageName = `prlt-orchestrator-${(hqName).replace(/[^a-zA-Z0-9._-]/g, '-')}:latest`
 
   try {
-    // Check Docker is running
-    if (!isDockerRunning()) {
+    // Check Docker is running (TKT-081: fast detection with diagnostic info)
+    const dockerStatus = checkDockerDaemon()
+    if (!dockerStatus.available) {
       return {
         success: false,
-        error: 'Docker is not running. Please start Docker Desktop and try again.',
+        error: `Docker daemon is not available. ${dockerStatus.message}`,
       }
     }
 

--- a/apps/cli/src/lib/execution/spawner.ts
+++ b/apps/cli/src/lib/execution/spawner.ts
@@ -19,7 +19,7 @@ import { pruneWorktrees, checkoutBranchSafe } from '../branch/index.js'
 import { ExecutionStorage } from './storage.js'
 import { hasDevcontainerConfig } from './devcontainer.js'
 import { loadExecutionConfig, getOrPromptCoderName } from './config.js'
-import { runExecution, isDockerRunning, isGitHubTokenAvailable, isDevcontainerCliInstalled, runExecutorPreflight, getAgentContainerName, isContainerRunning, getContainerId, buildSessionName } from './runners.js'
+import { runExecution, isDockerRunning, checkDockerDaemon, isGitHubTokenAvailable, isDevcontainerCliInstalled, runExecutorPreflight, getAgentContainerName, isContainerRunning, getContainerId, buildSessionName } from './runners.js'
 import { detectRepoWorktrees, resolveWorktreePath } from './context.js'
 import { ExternalExecutionMappingStore } from '../external-issues/mapping-store.js'
 import { type ExternalMappingProvider } from '../external-issues/types.js'
@@ -382,33 +382,38 @@ export async function spawnAgentForTicket(
 
   // Determine execution environment and display mode
   const hasDevcontainer = hasDevcontainerConfig(agentDir)
-  const dockerRunning = isDockerRunning()
+  const dockerStatus = checkDockerDaemon()
 
-  // Security check: If devcontainer exists but Docker isn't running,
-  // require explicit --run-on-host flag to proceed (TKT-046)
+  // TKT-081: When Docker daemon is unresponsive (installed but not ready),
+  // fall back to host execution with a warning instead of hanging or hard-failing.
   let environment: ExecutionEnvironment
   if (options.environment) {
     environment = options.environment
-  } else if (hasDevcontainer && dockerRunning) {
+  } else if (hasDevcontainer && dockerStatus.available) {
     environment = 'devcontainer'
-  } else if (hasDevcontainer && !dockerRunning) {
-    // Devcontainer exists but Docker isn't running
-    if (options.runOnHost) {
-      // User explicitly opted to run on host
-      environment = 'host'
-      log('⚠️  Running on host (--run-on-host flag set). Agent has full host access.')
-    } else {
-      // Security: Don't silently fall back to host
-      return {
-        success: false,
-        ticketId: ticket.id,
-        agentName,
-        error: 'Docker is not running but devcontainer is configured.\n\n' +
-          'For security, agents should run in Docker containers.\n' +
-          'Options:\n' +
-          '  1. Start Docker Desktop and try again\n' +
-          '  2. Use --run-on-host flag to run directly on your machine (bypasses sandbox)',
+  } else if (hasDevcontainer && !dockerStatus.available) {
+    if (dockerStatus.reason === 'not-installed') {
+      // Docker not installed — require explicit opt-in to host (TKT-046 security check)
+      if (options.runOnHost) {
+        environment = 'host'
+        log('⚠️  Running on host (--run-on-host flag set). Agent has full host access.')
+      } else {
+        return {
+          success: false,
+          ticketId: ticket.id,
+          agentName,
+          error: 'Docker is not installed but devcontainer is configured.\n\n' +
+            'For security, agents should run in Docker containers.\n' +
+            'Options:\n' +
+            '  1. Install Docker Desktop and try again\n' +
+            '  2. Use --run-on-host flag to run directly on your machine (bypasses sandbox)',
+        }
       }
+    } else {
+      // TKT-081: Docker is installed but daemon is not ready (unresponsive, 500 errors,
+      // stuck on license/login prompt, still initializing). Fall back to host with a warning.
+      environment = 'host'
+      log(`⚠️  Docker daemon not ready, falling back to host. ${dockerStatus.message}`)
     }
   } else {
     // No devcontainer configured, host is the only option
@@ -912,4 +917,4 @@ export async function spawnForColumn(
 // Docker & GitHub Token Checks
 // =============================================================================
 
-export { isDockerRunning, isGitHubTokenAvailable, isDevcontainerCliInstalled }
+export { isDockerRunning, checkDockerDaemon, isGitHubTokenAvailable, isDevcontainerCliInstalled }

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process'
 
 import {
   isDockerRunning,
+  checkDockerDaemon,
   buildSessionName,
   shouldUseControlMode,
   buildTmuxMouseOption,
@@ -25,11 +26,11 @@ describe('Execution Utils', () => {
       expect(result).to.be.a('boolean')
     })
 
-    it('should match actual docker info command result', () => {
-      // Get the expected result by running docker info directly
+    it('should match actual docker ps command result', () => {
+      // Get the expected result by running docker ps directly
       let dockerAvailable: boolean
       try {
-        execSync('docker info', { stdio: 'pipe', timeout: 5000 })
+        execSync('docker ps -q --no-trunc', { stdio: 'pipe', timeout: 5000 })
         dockerAvailable = true
       } catch {
         dockerAvailable = false
@@ -42,6 +43,35 @@ describe('Execution Utils', () => {
     it('should not throw an error regardless of Docker state', () => {
       // The function should handle errors gracefully
       expect(() => isDockerRunning()).to.not.throw()
+    })
+  })
+
+  describe('checkDockerDaemon (TKT-081)', () => {
+    it('should return a status object with available, reason, and message', () => {
+      const result = checkDockerDaemon()
+      expect(result).to.have.property('available').that.is.a('boolean')
+      expect(result).to.have.property('reason').that.is.a('string')
+      expect(result).to.have.property('message').that.is.a('string')
+      expect(['ready', 'not-installed', 'daemon-not-ready']).to.include(result.reason)
+    })
+
+    it('should have available=true when reason is ready', () => {
+      const result = checkDockerDaemon()
+      if (result.reason === 'ready') {
+        expect(result.available).to.be.true
+      } else {
+        expect(result.available).to.be.false
+      }
+    })
+
+    it('should be consistent with isDockerRunning', () => {
+      const status = checkDockerDaemon()
+      const running = isDockerRunning()
+      expect(status.available).to.equal(running)
+    })
+
+    it('should not throw an error regardless of Docker state', () => {
+      expect(() => checkDockerDaemon()).to.not.throw()
     })
   })
 


### PR DESCRIPTION
## Summary

Resolves TKT-081: Fix Docker daemon detection — fail fast or fall back to host when Docker is unresponsive

## Description

Bug: When Docker Desktop is installed but not fully running (e.g. stuck on license agreement, still initializing, or daemon unresponsive), prlt hangs instead of gracefully handling the situation.

## Current behavior
- prlt detects Docker is installed but daemon returns 500 errors
- Commands that try to use Docker hang indefinitely
- No timeout or fallback

## Expected behavior
- Detect unresponsive Docker daemon within 5-10 seconds
- Fall back to host execution with a warning: 'Docker daemon not ready, falling back to host'
- Or fail fast with actionable error: 'Docker Desktop needs attention — check for license/login prompts'

## Where to fix
- apps/cli/src/lib/execution/spawner.ts — Docker readiness check before spawning
- apps/cli/src/lib/execution/runners.ts — Docker health check in runner setup
- Add a docker health check utility that does: docker ps with a timeout, and if it fails/hangs, returns false

## Additional context
Docker Desktop on macOS sometimes blocks on GUI prompts (license agreement, login, updates) that cant be accepted remotely. prlt should never hang waiting for Docker in these cases.

## Changes

- 43709e55 fix(TKT-081): fix docker daemon detection — fail fast with diagnostics, fall back to host when unresponsive

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
