### PR TITLE
TKT-080: Fix Codex executor — work start with --executor codex fails silently before creating execution script

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -981,7 +981,8 @@ export async function runHost(
 
   // Build the executor command using getExecutorCommand() output
   // For Claude Code, we also support outputMode and additional flags
-  // For non-Claude executors, we use the command as-is from getExecutorCommand()
+  // For Codex, we use the codex adapter for deterministic command building (TKT-080)
+  // For other executors, we use the command as-is from getExecutorCommand()
   let executorInvocation: string
   if (isClaudeExecutor(executor)) {
     // Build flags based on config - Claude-specific flags
@@ -996,11 +997,20 @@ export async function runHost(
     // when there's no user to approve the plan mode transition
     const disallowPlanFlag = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
     executorInvocation = `${cmd} ${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}${systemPromptFlag}"$(cat "$PROMPT_PATH")"`
+  } else if (executor === 'codex') {
+    // TKT-080: Use Codex adapter for deterministic command building.
+    // Uses PLACEHOLDER pattern for reliable prompt replacement (same as devcontainer runner).
+    const codexPermission: PermissionMode = config.permissionMode
+    const codexContext = resolveCodexExecutionContext(displayMode, config.outputMode)
+    const codexResult = getCodexCommand('PLACEHOLDER', codexPermission, codexContext)
+    const argsStr = codexResult.args.map(a => a === 'PLACEHOLDER' ? '"$(cat "$PROMPT_PATH")"' : a).join(' ')
+    executorInvocation = `${codexResult.cmd} ${argsStr}`
   } else {
-    // Non-Claude executors: build command from getExecutorCommand() args
-    // Replace the prompt in args with a file read to avoid shell escaping
-    const argsWithFile = args.map(a => a === prompt ? '"$(cat "$PROMPT_PATH")"' : `"${a}"`)
-    executorInvocation = `${cmd} ${argsWithFile.join(' ')}`
+    // Non-Claude, non-Codex executors: build command from getExecutorCommand() args
+    // Use PLACEHOLDER for reliable prompt replacement instead of fragile string comparison
+    const { cmd: execCmd, args: execArgs } = getExecutorCommand(executor, 'PLACEHOLDER', skipPermissions)
+    const argsWithFile = execArgs.map(a => a === 'PLACEHOLDER' ? '"$(cat "$PROMPT_PATH")"' : `"${a}"`)
+    executorInvocation = `${execCmd} ${argsWithFile.join(' ')}`
   }
 
   // Build script that runs executor and keeps shell open after completion


### PR DESCRIPTION
## Summary

Resolves TKT-080: Fix Codex executor — work start with --executor codex fails silently before creating execution script

## Description

Bug: Running prlt work start with --executor codex fails silently. The branch and worktree are created successfully, but no execution script is generated and no tmux session is started. Status reports 'failed' with no error message.

## Reproduction

```bash
prlt work start TKT-079 --skip-permissions --display background --action implement --create-pr --yes --executor codex
```

Result: Branch created, worktree set up, but execution fails. No exec-TKT-079-*.sh script is created in .proletariat/scripts/. No tmux session is started.

## Expected
Should create an execution script that launches `codex` CLI (installed at /opt/homebrew/bin/codex, version 0.104.0) in a tmux session, similar to how claude-code executor works.

## Diagnosis needed
1. Check apps/cli/src/lib/execution/runners.ts for the codex runner implementation
2. The codex runner likely needs to build a command like: `codex --prompt 'ticket prompt here' --approval-mode full-auto` (or whatever codex's equivalent of dangerously-skip-permissions is)
3. Check if the codex runner is actually implemented or just stubbed out
4. Verify codex CLI flags/API — run `codex --help` to see available options
5. The runner needs to handle: prompt injection, working directory, permission mode, output mode

## Reference
- apps/cli/src/lib/execution/runners.ts — where executors are implemented
- apps/cli/src/lib/execution/types.ts — ExecutorType includes 'codex'
- Compare with claude-code runner implementation for pattern
- Codex CLI: /opt/homebrew/bin/codex v0.104.0

## Changes

- 93242972 fix(TKT-080): update codex tests to expect --dangerously-bypass-approvals-and-sandbox instead of --yolo
- 25c559c0 fix(TKT-080): fix codex adapter: replace invalid --yolo flag with --dangerously-bypass-approvals-and-sandbox, use exec subcommand for non-tty

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
