### PR TITLE
release: bump @proletariat/cli to 0.3.58

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.57",
+  "version": "0.3.58",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Version bump from 0.3.57 to 0.3.58

## Changelog (11 commits since 0.3.57)
- TKT-080: Fix codex executor silent failure in host runner
- TKT-046: Rebalance e2e test shards (CI 12min -> 8min)
- TKT-076: Integration awareness in agent system prompts
- TKT-032: Shortcut integration fix
- TKT-050: Transaction rollback for test isolation
- TKT-081: Docker daemon detection — fail fast, fall back to host
- TKT-077: Media/video source type with preprocessing
- TKT-078: Slide deck from Kvia presentation
- TKT-051: Marketing plan + Asana task creation
- TKT-053: Disable plan mode for background agents
- TKT-040: --session-action flag for scripted conflict resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)