### PR TITLE
chore: bump version to 0.3.59

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.58",
+  "version": "0.3.59",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.3.58 to 0.3.59
- Includes: TKT-005 (poke reliability fix), TKT-049 (smoke test tier), TKT-028 (dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)