### PR TITLE
TKT-091: Route ticket list through external provider adapters

### DIFF
--- a/apps/cli/src/commands/ticket/list.ts
+++ b/apps/cli/src/commands/ticket/list.ts
@@ -281,7 +281,12 @@ export default class TicketList extends Command {
     if (source === 'linear') return true;
     if (source === 'pmo') return false;
     // auto: use Linear when it's configured in the workspace
-    return isLinearConfigured(db);
+    try {
+      return isLinearConfigured(db);
+    } catch {
+      // workspace_settings table may not exist in older/test databases
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- When a workspace has Linear configured, `prlt ticket list` now queries the Linear API via the `ExternalIssueAdapter` pattern instead of local PMO/SQLite
- Adds `--source` flag (`auto`/`pmo`/`linear`) for explicit control — `auto` (default) detects Linear config and routes accordingly
- Adds `--team` flag to specify Linear team key (with fallback to `PRLT_LINEAR_TEAM` env var)
- Converts `NormalizedIssueEnvelope` to PMO `Ticket` shape so all existing display methods (table, compact, JSON, group-by) work unchanged
- Client-side filtering (priority, status/column, category, search, label) and pagination applied after fetching

## Test plan
- [ ] Verify `prlt ticket list` still works with PMO-only workspaces (no Linear configured)
- [ ] Verify `prlt ticket list --source linear --team ENG` fetches from Linear API
- [ ] Verify `prlt ticket list --source pmo` forces local PMO even when Linear is configured
- [ ] Verify filters (`--priority`, `--column`, `--search`, `--label`) work with Linear source
- [ ] Verify JSON output (`--format json`) includes external metadata fields
- [ ] Verify existing e2e tests pass (no Linear configured in test HQ → auto-fallback to PMO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)