### PR TITLE
TKT-094: Add multi-source provider config with prefix-based routing

### DIFF
--- a/apps/cli/src/lib/work-source/config.ts
+++ b/apps/cli/src/lib/work-source/config.ts
@@ -5,6 +5,7 @@ import { loadJiraConfig } from '../jira/config.js'
 import { loadShortcutConfig } from '../shortcut/config.js'
 import { loadTrelloConfig } from '../trello/config.js'
 import { loadMondayConfig } from '../monday/config.js'
+import { loadProviderSources } from './provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 const ACTIVE_SOURCE_KEY = 'work.active_source'
@@ -124,6 +125,18 @@ export function getRegisteredWorkSources(db: Database.Database): WorkSourceRef[]
     providers.set('trello', {
       provider: 'trello',
       context: trelloConfig.boardName ?? trelloConfig.boardId ?? undefined,
+    })
+  }
+
+  // Append multi-source provider entries. These use a composite key
+  // (provider + ':' + prefix) so they don't overwrite single-provider
+  // entries already in the map.
+  const multiSources = loadProviderSources(db)
+  for (const source of multiSources) {
+    const key = `${source.provider}:${source.prefix}` as WorkSourceProvider
+    providers.set(key, {
+      provider: source.provider,
+      context: source.teamProjectId,
     })
   }
 

--- a/apps/cli/src/lib/work-source/index.ts
+++ b/apps/cli/src/lib/work-source/index.ts
@@ -15,3 +15,18 @@ export {
   type WorkSourceClient,
   getWorkSourceClient,
 } from './client.js'
+export {
+  type ProviderSourceEntry,
+  type ProviderSourceValidationError,
+  validateProviderSourceEntry,
+  loadProviderSources,
+  saveProviderSources,
+  addProviderSource,
+  updateProviderSource,
+  removeProviderSource,
+  getProviderSourceById,
+  resolveProviderByPrefix,
+  resolveProviderByPrefixFromList,
+  getRoutingTable,
+  resolveApiKey,
+} from './provider-sources.js'

--- a/apps/cli/src/lib/work-source/provider-sources.ts
+++ b/apps/cli/src/lib/work-source/provider-sources.ts
@@ -1,0 +1,336 @@
+/**
+ * Multi-Source Provider Configuration
+ *
+ * Allows a workspace to have multiple external ticket providers configured
+ * simultaneously (e.g. Linear for engineering, Asana for product, Shortcut
+ * for design). Each source entry includes a provider type, API key reference,
+ * team/project ID, and an identifier prefix used for routing ticket keys to
+ * the correct provider.
+ *
+ * Stored as a JSON array in workspace_settings under the key
+ * `work.provider_sources`.
+ */
+
+import Database from 'better-sqlite3'
+import type { WorkSourceProvider } from './config.js'
+import { WORK_SOURCE_PROVIDERS, isWorkSourceProvider } from './config.js'
+
+const SETTINGS_TABLE = 'workspace_settings'
+const PROVIDER_SOURCES_KEY = 'work.provider_sources'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A single provider source entry in the multi-source configuration.
+ *
+ * Example: { id: 'eng-linear', provider: 'linear', apiKeyRef: 'linear.api_key',
+ *            teamProjectId: 'ENG', prefix: 'ENG-', label: 'Engineering' }
+ */
+export interface ProviderSourceEntry {
+  /** Unique identifier for this source config (user-chosen, slug-like) */
+  id: string
+
+  /** Provider type (linear, jira, asana, shortcut, trello, monday) */
+  provider: WorkSourceProvider
+
+  /**
+   * Reference to the API key. Can be:
+   * - A workspace_settings key (e.g. 'linear.api_key')
+   * - An environment variable name (e.g. 'PRLT_LINEAR_API_KEY')
+   */
+  apiKeyRef: string
+
+  /**
+   * Team or project identifier in the external system.
+   * e.g. Linear team key 'ENG', Jira project key 'PROJ', Asana project GID.
+   */
+  teamProjectId: string
+
+  /**
+   * Prefix used for routing ticket keys to this provider.
+   * e.g. 'ENG-' means ticket keys starting with 'ENG-' route to this source.
+   * Must end with a separator character (typically '-').
+   */
+  prefix: string
+
+  /** Optional human-readable label for display purposes */
+  label?: string
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+export interface ProviderSourceValidationError {
+  field: string
+  message: string
+}
+
+export function validateProviderSourceEntry(
+  entry: Partial<ProviderSourceEntry>,
+): ProviderSourceValidationError[] {
+  const errors: ProviderSourceValidationError[] = []
+
+  if (!entry.id || entry.id.trim().length === 0) {
+    errors.push({ field: 'id', message: 'id is required' })
+  } else if (!/^[a-z0-9][a-z0-9_-]*$/.test(entry.id)) {
+    errors.push({
+      field: 'id',
+      message: 'id must be lowercase alphanumeric with hyphens/underscores, starting with a letter or digit',
+    })
+  }
+
+  if (!entry.provider) {
+    errors.push({ field: 'provider', message: 'provider is required' })
+  } else if (!isWorkSourceProvider(entry.provider)) {
+    errors.push({
+      field: 'provider',
+      message: `provider must be one of: ${WORK_SOURCE_PROVIDERS.join(', ')}`,
+    })
+  }
+
+  if (!entry.apiKeyRef || entry.apiKeyRef.trim().length === 0) {
+    errors.push({ field: 'apiKeyRef', message: 'apiKeyRef is required' })
+  }
+
+  if (!entry.teamProjectId || entry.teamProjectId.trim().length === 0) {
+    errors.push({ field: 'teamProjectId', message: 'teamProjectId is required' })
+  }
+
+  if (!entry.prefix || entry.prefix.trim().length === 0) {
+    errors.push({ field: 'prefix', message: 'prefix is required' })
+  }
+
+  return errors
+}
+
+// =============================================================================
+// Persistence
+// =============================================================================
+
+function getRawSetting(db: Database.Database, key: string): string | null {
+  const row = db
+    .prepare(`SELECT value FROM ${SETTINGS_TABLE} WHERE key = ?`)
+    .get(key) as { value: string } | undefined
+  return row?.value ?? null
+}
+
+function setRawSetting(db: Database.Database, key: string, value: string): void {
+  db.prepare(`
+    INSERT INTO ${SETTINGS_TABLE} (key, value)
+    VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(key, value)
+}
+
+function deleteRawSetting(db: Database.Database, key: string): void {
+  db.prepare(`DELETE FROM ${SETTINGS_TABLE} WHERE key = ?`).run(key)
+}
+
+/**
+ * Load all provider source entries from the database.
+ * Returns an empty array if none are configured.
+ */
+export function loadProviderSources(db: Database.Database): ProviderSourceEntry[] {
+  const raw = getRawSetting(db, PROVIDER_SOURCES_KEY)
+  if (!raw) return []
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (entry: unknown) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as ProviderSourceEntry).id === 'string' &&
+        typeof (entry as ProviderSourceEntry).provider === 'string',
+    ) as ProviderSourceEntry[]
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Save the full list of provider source entries to the database.
+ */
+export function saveProviderSources(db: Database.Database, sources: ProviderSourceEntry[]): void {
+  if (sources.length === 0) {
+    deleteRawSetting(db, PROVIDER_SOURCES_KEY)
+    return
+  }
+  setRawSetting(db, PROVIDER_SOURCES_KEY, JSON.stringify(sources))
+}
+
+/**
+ * Add a new provider source entry. Returns validation errors if invalid,
+ * or throws if an entry with the same id already exists.
+ */
+export function addProviderSource(
+  db: Database.Database,
+  entry: ProviderSourceEntry,
+): ProviderSourceValidationError[] {
+  const errors = validateProviderSourceEntry(entry)
+  if (errors.length > 0) return errors
+
+  const existing = loadProviderSources(db)
+
+  if (existing.some((e) => e.id === entry.id)) {
+    return [{ field: 'id', message: `A provider source with id "${entry.id}" already exists` }]
+  }
+
+  if (existing.some((e) => e.prefix.toUpperCase() === entry.prefix.toUpperCase())) {
+    return [{ field: 'prefix', message: `A provider source with prefix "${entry.prefix}" already exists` }]
+  }
+
+  existing.push(entry)
+  saveProviderSources(db, existing)
+  return []
+}
+
+/**
+ * Update an existing provider source entry by id.
+ * Returns validation errors if the update is invalid, or if the entry is not found.
+ */
+export function updateProviderSource(
+  db: Database.Database,
+  id: string,
+  updates: Partial<Omit<ProviderSourceEntry, 'id'>>,
+): ProviderSourceValidationError[] {
+  const sources = loadProviderSources(db)
+  const index = sources.findIndex((e) => e.id === id)
+
+  if (index === -1) {
+    return [{ field: 'id', message: `No provider source found with id "${id}"` }]
+  }
+
+  const merged = { ...sources[index], ...updates }
+  const errors = validateProviderSourceEntry(merged)
+  if (errors.length > 0) return errors
+
+  // Check prefix uniqueness against other entries
+  if (
+    updates.prefix &&
+    sources.some((e, i) => i !== index && e.prefix.toUpperCase() === updates.prefix!.toUpperCase())
+  ) {
+    return [{ field: 'prefix', message: `A provider source with prefix "${updates.prefix}" already exists` }]
+  }
+
+  sources[index] = merged
+  saveProviderSources(db, sources)
+  return []
+}
+
+/**
+ * Remove a provider source entry by id.
+ * Returns true if removed, false if not found.
+ */
+export function removeProviderSource(db: Database.Database, id: string): boolean {
+  const sources = loadProviderSources(db)
+  const filtered = sources.filter((e) => e.id !== id)
+
+  if (filtered.length === sources.length) return false
+
+  saveProviderSources(db, filtered)
+  return true
+}
+
+/**
+ * Get a single provider source entry by id.
+ */
+export function getProviderSourceById(
+  db: Database.Database,
+  id: string,
+): ProviderSourceEntry | null {
+  const sources = loadProviderSources(db)
+  return sources.find((e) => e.id === id) ?? null
+}
+
+// =============================================================================
+// Prefix-Based Routing
+// =============================================================================
+
+/**
+ * Resolve which provider source should handle a given ticket key based on
+ * its prefix. Matching is case-insensitive and selects the longest matching
+ * prefix (most specific match wins).
+ *
+ * Example: given sources with prefixes ['ENG-', 'PROD-', 'DES-'],
+ *   resolveProviderByPrefix(db, 'ENG-123') → source with prefix 'ENG-'
+ *   resolveProviderByPrefix(db, 'PROD-456') → source with prefix 'PROD-'
+ *   resolveProviderByPrefix(db, 'UNKNOWN-789') → null
+ */
+export function resolveProviderByPrefix(
+  db: Database.Database,
+  ticketKey: string,
+): ProviderSourceEntry | null {
+  const sources = loadProviderSources(db)
+  return resolveProviderByPrefixFromList(sources, ticketKey)
+}
+
+/**
+ * Pure function variant that operates on an in-memory list of sources.
+ * Useful for testing and batch operations.
+ */
+export function resolveProviderByPrefixFromList(
+  sources: ProviderSourceEntry[],
+  ticketKey: string,
+): ProviderSourceEntry | null {
+  const upperKey = ticketKey.toUpperCase()
+  let bestMatch: ProviderSourceEntry | null = null
+  let bestLength = 0
+
+  for (const source of sources) {
+    const upperPrefix = source.prefix.toUpperCase()
+    if (upperKey.startsWith(upperPrefix) && upperPrefix.length > bestLength) {
+      bestMatch = source
+      bestLength = upperPrefix.length
+    }
+  }
+
+  return bestMatch
+}
+
+/**
+ * Get all configured prefixes and their provider mappings.
+ * Useful for displaying the routing table to the user.
+ */
+export function getRoutingTable(
+  db: Database.Database,
+): Array<{ prefix: string; provider: WorkSourceProvider; label: string; id: string }> {
+  const sources = loadProviderSources(db)
+  return sources.map((s) => ({
+    prefix: s.prefix,
+    provider: s.provider,
+    label: s.label ?? s.id,
+    id: s.id,
+  }))
+}
+
+// =============================================================================
+// API Key Resolution
+// =============================================================================
+
+/**
+ * Resolve the actual API key value from a ProviderSourceEntry's apiKeyRef.
+ *
+ * Resolution order:
+ * 1. If apiKeyRef matches an environment variable name, use its value
+ * 2. If apiKeyRef matches a workspace_settings key, use its value
+ * 3. Return null if neither resolves
+ */
+export function resolveApiKey(
+  db: Database.Database,
+  entry: ProviderSourceEntry,
+): string | null {
+  // Try environment variable first
+  const envValue = process.env[entry.apiKeyRef]
+  if (envValue) return envValue
+
+  // Try workspace_settings key
+  const dbValue = getRawSetting(db, entry.apiKeyRef)
+  if (dbValue) return dbValue
+
+  return null
+}

--- a/apps/cli/test/unit/provider-sources.test.ts
+++ b/apps/cli/test/unit/provider-sources.test.ts
@@ -1,0 +1,314 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import {
+  validateProviderSourceEntry,
+  loadProviderSources,
+  saveProviderSources,
+  addProviderSource,
+  updateProviderSource,
+  removeProviderSource,
+  getProviderSourceById,
+  resolveProviderByPrefix,
+  resolveProviderByPrefixFromList,
+  getRoutingTable,
+  resolveApiKey,
+  type ProviderSourceEntry,
+} from '../../src/lib/work-source/provider-sources.js'
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workspace_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    )
+  `)
+  return db
+}
+
+function makeEntry(overrides: Partial<ProviderSourceEntry> = {}): ProviderSourceEntry {
+  return {
+    id: 'eng-linear',
+    provider: 'linear',
+    apiKeyRef: 'linear.api_key',
+    teamProjectId: 'ENG',
+    prefix: 'ENG-',
+    ...overrides,
+  }
+}
+
+describe('provider-sources', () => {
+  // ===========================================================================
+  // Validation
+  // ===========================================================================
+  describe('validateProviderSourceEntry', () => {
+    it('passes for a valid entry', () => {
+      const errors = validateProviderSourceEntry(makeEntry())
+      expect(errors).to.have.length(0)
+    })
+
+    it('rejects empty id', () => {
+      const errors = validateProviderSourceEntry(makeEntry({ id: '' }))
+      expect(errors.some(e => e.field === 'id')).to.be.true
+    })
+
+    it('rejects id with uppercase', () => {
+      const errors = validateProviderSourceEntry(makeEntry({ id: 'Eng-Linear' }))
+      expect(errors.some(e => e.field === 'id')).to.be.true
+    })
+
+    it('rejects missing provider', () => {
+      const errors = validateProviderSourceEntry({ ...makeEntry(), provider: undefined as unknown as 'linear' })
+      expect(errors.some(e => e.field === 'provider')).to.be.true
+    })
+
+    it('rejects invalid provider', () => {
+      const errors = validateProviderSourceEntry(makeEntry({ provider: 'github' as 'linear' }))
+      expect(errors.some(e => e.field === 'provider')).to.be.true
+    })
+
+    it('rejects empty apiKeyRef', () => {
+      const errors = validateProviderSourceEntry(makeEntry({ apiKeyRef: '' }))
+      expect(errors.some(e => e.field === 'apiKeyRef')).to.be.true
+    })
+
+    it('rejects empty teamProjectId', () => {
+      const errors = validateProviderSourceEntry(makeEntry({ teamProjectId: '' }))
+      expect(errors.some(e => e.field === 'teamProjectId')).to.be.true
+    })
+
+    it('rejects empty prefix', () => {
+      const errors = validateProviderSourceEntry(makeEntry({ prefix: '' }))
+      expect(errors.some(e => e.field === 'prefix')).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Persistence
+  // ===========================================================================
+  describe('loadProviderSources / saveProviderSources', () => {
+    it('returns empty array when nothing stored', () => {
+      const db = setupDb()
+      expect(loadProviderSources(db)).to.deep.equal([])
+      db.close()
+    })
+
+    it('round-trips a list of entries', () => {
+      const db = setupDb()
+      const entries = [
+        makeEntry(),
+        makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-' }),
+      ]
+      saveProviderSources(db, entries)
+      const loaded = loadProviderSources(db)
+      expect(loaded).to.have.length(2)
+      expect(loaded[0].id).to.equal('eng-linear')
+      expect(loaded[1].id).to.equal('prod-asana')
+      db.close()
+    })
+
+    it('clears storage when saving empty array', () => {
+      const db = setupDb()
+      saveProviderSources(db, [makeEntry()])
+      saveProviderSources(db, [])
+      expect(loadProviderSources(db)).to.deep.equal([])
+      db.close()
+    })
+
+    it('handles corrupted JSON gracefully', () => {
+      const db = setupDb()
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('work.provider_sources', '{broken')
+      expect(loadProviderSources(db)).to.deep.equal([])
+      db.close()
+    })
+  })
+
+  // ===========================================================================
+  // CRUD
+  // ===========================================================================
+  describe('addProviderSource', () => {
+    it('adds a valid entry', () => {
+      const db = setupDb()
+      const errors = addProviderSource(db, makeEntry())
+      expect(errors).to.have.length(0)
+      expect(loadProviderSources(db)).to.have.length(1)
+      db.close()
+    })
+
+    it('rejects duplicate id', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const errors = addProviderSource(db, makeEntry({ prefix: 'OTHER-' }))
+      expect(errors.some(e => e.field === 'id')).to.be.true
+      db.close()
+    })
+
+    it('rejects duplicate prefix (case-insensitive)', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const errors = addProviderSource(db, makeEntry({ id: 'eng2', prefix: 'eng-' }))
+      expect(errors.some(e => e.field === 'prefix')).to.be.true
+      db.close()
+    })
+  })
+
+  describe('updateProviderSource', () => {
+    it('updates an existing entry', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const errors = updateProviderSource(db, 'eng-linear', { label: 'Engineering Team' })
+      expect(errors).to.have.length(0)
+
+      const updated = getProviderSourceById(db, 'eng-linear')
+      expect(updated?.label).to.equal('Engineering Team')
+      db.close()
+    })
+
+    it('returns error for non-existent id', () => {
+      const db = setupDb()
+      const errors = updateProviderSource(db, 'nonexistent', { label: 'test' })
+      expect(errors.some(e => e.field === 'id')).to.be.true
+      db.close()
+    })
+
+    it('rejects prefix conflict with other entries', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      addProviderSource(db, makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-' }))
+      const errors = updateProviderSource(db, 'prod-asana', { prefix: 'ENG-' })
+      expect(errors.some(e => e.field === 'prefix')).to.be.true
+      db.close()
+    })
+  })
+
+  describe('removeProviderSource', () => {
+    it('removes an existing entry', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      expect(removeProviderSource(db, 'eng-linear')).to.be.true
+      expect(loadProviderSources(db)).to.have.length(0)
+      db.close()
+    })
+
+    it('returns false for non-existent id', () => {
+      const db = setupDb()
+      expect(removeProviderSource(db, 'nonexistent')).to.be.false
+      db.close()
+    })
+  })
+
+  describe('getProviderSourceById', () => {
+    it('finds an existing entry', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const entry = getProviderSourceById(db, 'eng-linear')
+      expect(entry).to.not.be.null
+      expect(entry?.provider).to.equal('linear')
+      db.close()
+    })
+
+    it('returns null for non-existent id', () => {
+      const db = setupDb()
+      expect(getProviderSourceById(db, 'nonexistent')).to.be.null
+      db.close()
+    })
+  })
+
+  // ===========================================================================
+  // Prefix Routing
+  // ===========================================================================
+  describe('resolveProviderByPrefix', () => {
+    it('routes ticket key to correct provider', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      addProviderSource(db, makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-' }))
+      addProviderSource(db, makeEntry({ id: 'des-shortcut', provider: 'shortcut', apiKeyRef: 'shortcut.api_token', teamProjectId: 'DES', prefix: 'DES-' }))
+
+      const linear = resolveProviderByPrefix(db, 'ENG-123')
+      expect(linear?.provider).to.equal('linear')
+
+      const asana = resolveProviderByPrefix(db, 'PROD-456')
+      expect(asana?.provider).to.equal('asana')
+
+      const shortcut = resolveProviderByPrefix(db, 'DES-789')
+      expect(shortcut?.provider).to.equal('shortcut')
+
+      db.close()
+    })
+
+    it('returns null for unmatched prefix', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      expect(resolveProviderByPrefix(db, 'UNKNOWN-123')).to.be.null
+      db.close()
+    })
+
+    it('matches case-insensitively', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const result = resolveProviderByPrefix(db, 'eng-123')
+      expect(result?.provider).to.equal('linear')
+      db.close()
+    })
+  })
+
+  describe('resolveProviderByPrefixFromList', () => {
+    it('selects longest matching prefix', () => {
+      const sources = [
+        makeEntry({ id: 'eng', prefix: 'ENG-' }),
+        makeEntry({ id: 'eng-core', provider: 'jira', prefix: 'ENG-CORE-' }),
+      ]
+      const result = resolveProviderByPrefixFromList(sources, 'ENG-CORE-42')
+      expect(result?.id).to.equal('eng-core')
+    })
+
+    it('returns null for empty list', () => {
+      expect(resolveProviderByPrefixFromList([], 'ENG-123')).to.be.null
+    })
+  })
+
+  // ===========================================================================
+  // Routing Table
+  // ===========================================================================
+  describe('getRoutingTable', () => {
+    it('returns all configured prefixes', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry({ label: 'Engineering' }))
+      addProviderSource(db, makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-', label: 'Product' }))
+
+      const table = getRoutingTable(db)
+      expect(table).to.have.length(2)
+      expect(table[0]).to.deep.equal({ prefix: 'ENG-', provider: 'linear', label: 'Engineering', id: 'eng-linear' })
+      expect(table[1]).to.deep.equal({ prefix: 'PROD-', provider: 'asana', label: 'Product', id: 'prod-asana' })
+      db.close()
+    })
+
+    it('uses id as label fallback', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const table = getRoutingTable(db)
+      expect(table[0].label).to.equal('eng-linear')
+      db.close()
+    })
+  })
+
+  // ===========================================================================
+  // API Key Resolution
+  // ===========================================================================
+  describe('resolveApiKey', () => {
+    it('resolves from workspace_settings key', () => {
+      const db = setupDb()
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('linear.api_key', 'lin_test_key')
+      const key = resolveApiKey(db, makeEntry())
+      expect(key).to.equal('lin_test_key')
+      db.close()
+    })
+
+    it('returns null when neither env nor db has the key', () => {
+      const db = setupDb()
+      const key = resolveApiKey(db, makeEntry({ apiKeyRef: 'nonexistent.key' }))
+      expect(key).to.be.null
+      db.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `ProviderSourceEntry` schema allowing multiple external ticket providers per workspace (e.g. Linear for engineering, Asana for product, Shortcut for design)
- Each entry includes provider type, API key reference, team/project ID, and a routing prefix (e.g. `ENG-` → Linear, `PROD-` → Asana)
- Prefix-based routing resolves ticket keys to the correct provider using longest-prefix matching (case-insensitive)
- Full CRUD with validation (unique id + prefix enforcement), API key resolution from env vars or workspace_settings, and routing table display helper
- Integrates with `getRegisteredWorkSources()` so multi-source entries appear alongside single-provider configs

## Test plan

- [x] 31 new unit tests covering validation, CRUD, persistence, prefix routing, routing table, and API key resolution
- [x] All existing `work-source-config` tests still pass (14/14)
- [x] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)