### PR TITLE
TKT-097: Audit test suite speed — rebalance CI shards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,44 +5,10 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "store-path=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm -r build
-
-      - name: Run unit tests
-        run: pnpm --filter @proletariat/cli test:unit
-
-      - name: Run e2e tests
-        run: pnpm --filter @proletariat/cli test:e2e
+  # Tests run in the parallel 'tests' workflow (test.yml) on every push to main.
+  # No need to duplicate them here — the release job proceeds independently.
 
   release:
-    # TODO: restore needs: [test] once CI tests are stabilized
-    # needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: push event" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","agent-flows","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -100,7 +100,7 @@ jobs:
             else
               echo "scope=full" >> "$GITHUB_OUTPUT"
               echo "reason=Full suite: manual dispatch with $TIER tier selected" >> "$GITHUB_OUTPUT"
-              echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
+              echo 'e2e_shards=["pmo","execution","agent-flows","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
             fi
             exit 0
           fi
@@ -111,7 +111,7 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: unable to compute merge-base with origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","agent-flows","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
@@ -228,13 +228,13 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: core/shared files changed (database, lib, config, CI, or unscoped source)" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","agent-flows","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
 
           elif [[ "$HAS_PMO" == "true" && "$HAS_EXECUTION" == "true" ]]; then
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
             echo "reason=Full suite: changes span multiple domains (pmo + execution)" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["pmo","execution","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["pmo","execution","agent-flows","json-mode","integrations","standalone","infrastructure"]' >> "$GITHUB_OUTPUT"
 
           elif [[ "$HAS_PMO" == "true" ]]; then
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
@@ -246,7 +246,7 @@ jobs:
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=execution" >> "$GITHUB_OUTPUT"
             echo "reason=Scoped run: only execution-related files changed (work/agent/docker orchestration)" >> "$GITHUB_OUTPUT"
-            echo 'e2e_shards=["execution"]' >> "$GITHUB_OUTPUT"
+            echo 'e2e_shards=["execution","agent-flows"]' >> "$GITHUB_OUTPUT"
 
           fi
 
@@ -533,16 +533,20 @@ jobs:
               ;;
             execution)
               echo "Running execution/work e2e tests"
-              npx mocha --forbid-only "test/e2e/work-*.test.ts" "test/e2e/*-agent-flow.test.ts"
+              npx mocha --forbid-only "test/e2e/work-*.test.ts"
+              ;;
+            agent-flows)
+              echo "Running agent flow e2e tests"
+              npx mocha --forbid-only "test/e2e/*-agent-flow.test.ts"
               ;;
             json-mode)
               echo "Running JSON/machine mode e2e tests"
               npx mocha --forbid-only \
                 --ignore "test/e2e/work-*.test.ts" \
-                --ignore "test/e2e/agent-json-mode.test.ts" \
                 "test/e2e/*-json-mode.test.ts" \
                 "test/e2e/json-mode-*.test.ts" \
-                "test/e2e/machine-mode-*.test.ts"
+                "test/e2e/machine-mode-*.test.ts" \
+                "test/e2e/agent-json-mode.test.ts"
               ;;
             integrations)
               echo "Running integration e2e tests"
@@ -562,8 +566,7 @@ jobs:
               npx mocha --forbid-only \
                 "test/e2e/docker-*.test.ts" \
                 "test/e2e/mcp-server.test.ts" \
-                "test/e2e/execution-*.test.ts" \
-                "test/e2e/agent-json-mode.test.ts"
+                "test/e2e/execution-*.test.ts"
               ;;
             standalone)
               echo "Running standalone e2e tests"

--- a/docs/audit-test-suite-speed.md
+++ b/docs/audit-test-suite-speed.md
@@ -1,0 +1,162 @@
+# Test Suite Speed Audit
+
+**Date:** 2026-03-13
+**Ticket:** TKT-097
+
+## Executive Summary
+
+CI pipeline wall-clock time on `main` averages **10-13 minutes** across 20 recent runs. The critical path is the **execution e2e shard at ~9m20s** — nearly 2x the next-slowest shard. A redundant serial test job in `release.yml` burns **~27 extra CI minutes** per push to main.
+
+### Changes Implemented
+
+| Change | Impact |
+|--------|--------|
+| Remove redundant test job from `release.yml` | **~27 min CI minutes saved** per push to main |
+| Split `execution` shard into `execution` + `agent-flows` | **~25-30% critical path reduction** (9m20s → ~6m) |
+| Move `agent-json-mode.test.ts` from infrastructure to json-mode | Balances infrastructure (6.3k → 4.4k lines) |
+
+**Estimated new CI wall-clock time:** ~7-8 minutes (down from 10-13 minutes).
+
+---
+
+## Benchmarks
+
+### CI Wall-Clock Times (20 Most Recent `main` Runs)
+
+| Run | Total | Critical Path Shard |
+|-----|-------|-------------------|
+| 23062373777 | 10m51s | execution (9m41s) |
+| 23038384381 | 10m27s | execution (9m19s) |
+| 23029258464 | 12m01s | execution (9m25s) |
+| Average (20 runs) | ~11m30s | ~9m20s |
+
+### Per-Shard Timing (Before Changes)
+
+| Shard | Files | Lines | Avg Runtime | Status |
+|-------|-------|-------|-------------|--------|
+| execution | 12 | 7,454 | **9m20s** | BOTTLENECK |
+| infrastructure | 4 | 6,329 | **7m40s** | Heavy |
+| json-mode | 8 | 5,944 | 4m50s | OK |
+| integrations | 10 | 5,321 | 3m55s | OK |
+| pmo | 14 | 7,237 | 2m30s | Light |
+| standalone | 18 | 7,287 | 1m45s | Light |
+
+### Per-Shard Timing (Expected After Changes)
+
+| Shard | Files | Lines | Est. Runtime |
+|-------|-------|-------|-------------|
+| agent-flows (NEW) | 9 | 5,429 | ~6-7m |
+| json-mode (+ agent-json-mode) | 9 | 7,837 | ~5-6m |
+| infrastructure (- agent-json-mode) | 3 | 4,436 | ~5-6m |
+| execution (work-*.test.ts only) | 3 | 2,025 | ~2-3m |
+| integrations | 10 | 5,321 | ~4m |
+| pmo | 14 | 7,237 | ~2m30s |
+| standalone | 18 | 7,287 | ~1m45s |
+
+### Step-Level Breakdown (e2e-tests execution shard)
+
+| Step | Duration |
+|------|----------|
+| Checkout + pnpm + Node setup | ~10s |
+| pnpm install (cached) | ~15s |
+| better-sqlite3 cache restore/rebuild | ~3s |
+| Download build artifacts | ~2s |
+| **Run e2e tests** | **~9m07s** |
+| Total | ~9m41s |
+
+Setup overhead is minimal (~30s). **The tests themselves are the bottleneck.**
+
+### PR Runs (Smoke Tier)
+
+PRs run only smoke-tagged tests and complete in **~4-5 minutes**. No changes needed.
+
+---
+
+## Findings
+
+### 1. Redundant Serial Test Job in `release.yml` (FIXED)
+
+The `release.yml` workflow contained a `test` job that ran ALL unit + e2e tests **serially** (~27 min) on every push to main. This was completely redundant with the parallelized `tests` workflow (`test.yml`) that also triggers on push to main.
+
+The release job didn't even depend on it — `needs: [test]` was commented out with a TODO. Removed the entire redundant job.
+
+### 2. Heavily Imbalanced E2E Shards (FIXED)
+
+The execution shard was a 5:1 outlier vs standalone:
+
+- execution: **9m20s** (12 files — `work-*.test.ts` + `*-agent-flow.test.ts`)
+- standalone: **1m45s** (18 files)
+
+**Root cause:** The `*-agent-flow.test.ts` tests are individually heavy — they test multi-step agent workflows with repeated CLI invocations and database operations. Bundling them with `work-*.test.ts` created the largest shard by far.
+
+**Fix:** Split into two shards: `execution` (work-\*.test.ts) and `agent-flows` (\*-agent-flow.test.ts).
+
+Also moved `agent-json-mode.test.ts` (1,893 lines — the single largest test file) from infrastructure to json-mode, where it logically belongs.
+
+### 3. Agent-Flow Tests Are Inherently Slow
+
+The 9 `*-agent-flow.test.ts` files (~5,429 lines) dominate runtime despite moderate line counts. Each test:
+- Creates a fresh test environment with temp dirs
+- Initializes a database from template
+- Runs multiple CLI commands via `execInProcess()` (full oclif command init per call)
+- Validates multi-step workflows (create project → create ticket → start work → etc.)
+
+This is by design — they test real workflows. Further optimization would require deeper refactoring (e.g., batch operations, shared test state between related tests).
+
+### 4. Mocha Parallel Mode Not Viable (Current Setup)
+
+Mocha `--parallel` runs files in worker processes, but the current setup uses `ts-node/esm` via `--node-option loader=ts-node/esm`. Mocha's `--node-option` is **not forwarded** to worker processes in parallel mode, so TypeScript compilation would fail.
+
+**Future option:** Migrate to vitest (native ESM + TypeScript + parallel by default) for a step-change improvement. This is a larger effort.
+
+### 5. Test Infrastructure Is Already Well-Optimized
+
+- **Template database caching** (`template-db.ts`): ~1ms copy vs ~100-200ms initialization
+- **In-process execution** (`execInProcess()`): ~5x faster than subprocess
+- **Test isolation**: Proper temp dirs, env var clearing, cleanup
+- **Build artifact reuse**: E2E tests download pre-built `dist/` instead of rebuilding
+
+### 6. Line Count ≠ Runtime
+
+| Shard | Lines | Runtime | Lines/Min |
+|-------|-------|---------|-----------|
+| standalone | 7,287 | 1m45s | 4,164 |
+| pmo | 7,237 | 2m30s | 2,895 |
+| execution | 7,454 | 9m20s | 799 |
+
+The execution shard processes lines 5x slower than standalone because agent-flow tests involve many multi-command sequences. Shard balancing should consider test complexity, not just file size.
+
+---
+
+## Optimization Opportunities (Future Work)
+
+### Medium Effort
+
+1. **Further shard rebalancing based on actual timing data**: After these changes land, measure new shard times and redistribute if needed. The `agent-flows` shard may still be the bottleneck at ~6-7m.
+
+2. **Move `work-json-mode.test.ts` from execution to json-mode**: This 1,193-line file is a json-mode test with a `work-` prefix. Moving it would lighten the execution shard further, but requires pattern adjustments.
+
+3. **Reduce per-test retries for fast tests**: `.mocharc.json` sets `retries: 1` globally. Flaky e2e tests benefit from retries, but fast unit tests don't need them. Consider setting retries only for e2e.
+
+### Larger Effort
+
+4. **Migrate to vitest**: Native ESM support, built-in TypeScript, parallel execution by default, faster test startup. Would likely cut test times by 30-50%.
+
+5. **Shared test fixtures between related agent-flow tests**: Instead of each test creating its own environment from scratch, tests in the same file could share a pre-populated database for read-only checks.
+
+6. **Mocha `--parallel` with pre-compiled tests**: Compile TypeScript to JS first (like the build step does), then run mocha in parallel mode against the compiled output. This bypasses the ts-node/esm worker limitation.
+
+---
+
+## Test Suite Overview
+
+| Category | Files | Lines |
+|----------|-------|-------|
+| Unit tests | 67 | 19,573 |
+| E2E tests | 69 | 37,779 |
+| Command tests | 13 | 1,960 |
+| **Total** | **149** | **59,312** |
+
+**Framework:** Mocha v10 + Chai + ts-node/esm
+**Database:** better-sqlite3 (native binding, cached template pattern)
+**CI:** GitHub Actions with 7 parallel e2e shards (after this PR)


### PR DESCRIPTION
## Summary

- **Remove redundant test job from `release.yml`** — was running ALL unit + e2e tests serially (~27 min) on every push to main, completely redundant with the parallel `tests` workflow
- **Split `execution` e2e shard into `execution` + `agent-flows`** — the execution shard was the critical path at ~9m20s (nearly 2x the next-slowest). Splitting agent-flow tests into their own shard cuts the critical path to ~6-7m
- **Move `agent-json-mode.test.ts` from infrastructure to json-mode** — rebalances infrastructure (6.3k → 4.4k lines) and groups this test with its logical domain
- **Add audit report** (`docs/audit-test-suite-speed.md`) with benchmarks, per-shard analysis, and future optimization recommendations

### Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| CI wall-clock (main) | 10-13 min | ~7-8 min |
| Critical path shard | execution (9m20s) | agent-flows (~6-7m) |
| CI minutes per main push (release.yml) | +27 min wasted | 0 (removed) |
| E2E shards | 6 | 7 |

## Test plan

- [ ] Verify `test.yml` YAML syntax is valid (validated locally)
- [ ] Verify `release.yml` YAML syntax is valid (validated locally)
- [ ] Smoke tests pass on this PR
- [ ] Full suite passes on merge to main with new 7-shard layout
- [ ] Release workflow still creates releases without the redundant test job

🤖 Generated with [Claude Code](https://claude.com/claude-code)