### PR TITLE
TKT-099: Fix work start prompt delivery race condition

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -312,8 +312,20 @@ async function ensureTmuxServerHasKeychainAccess(): Promise<void> {
       // Keychain access is broken - restart tmux server
       // This happens silently - the next tmux session will have keychain access
       execSync('tmux kill-server', { stdio: 'pipe' })
-      // Brief delay to ensure server fully stops
-      await new Promise(resolve => setTimeout(resolve, 500))
+      // TKT-099: Wait for the tmux server to fully stop before returning.
+      // The old 500ms fixed delay was insufficient under load, causing the subsequent
+      // `tmux new-session` to occasionally create a session on the dying server.
+      // Poll for server shutdown with a reasonable timeout instead.
+      for (let i = 0; i < 10; i++) {
+        await new Promise(resolve => setTimeout(resolve, 300))
+        try {
+          execSync('tmux list-sessions 2>/dev/null', { stdio: 'pipe' })
+          // Server still alive, keep waiting
+        } catch {
+          // Server is gone — ready to proceed
+          break
+        }
+      }
     }
   } catch (_error) {
     // Test session failed - clean up if it exists
@@ -1102,6 +1114,22 @@ exec $SHELL
     finalInvocation = srtCmd
   }
 
+  // TKT-099: Build a fallback invocation WITHOUT the prompt argument.
+  // Used when prompt file is missing/empty — starts Claude in interactive mode
+  // so the agent at least gets a working session instead of silently failing.
+  let fallbackInvocation: string
+  if (isClaudeExecutor(executor)) {
+    const fbPermissions = skipPermissions ? '--dangerously-skip-permissions ' : ''
+    const fbEffort = skipPermissions ? '--effort high ' : ''
+    const fbPrint = config.outputMode === 'print' ? '-p ' : ''
+    const fbDisallowPlan = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
+    const fbSystemPrompt = systemPromptPath ? '--system-prompt "$(cat "$SYSTEM_PROMPT_PATH")" ' : ''
+    const fbMcpConfig = mcpConfigPath ? `--mcp-config "${mcpConfigPath}" ` : ''
+    fallbackInvocation = `${cmd} ${fbPermissions}${fbEffort}${fbPrint}${fbDisallowPlan}${fbSystemPrompt}${fbMcpConfig}`.trim()
+  } else {
+    fallbackInvocation = cmd
+  }
+
   const scriptContent = `#!/bin/bash
 # Auto-generated script for ticket ${context.ticketId}
 SCRIPT_PATH="${scriptPath}"
@@ -1111,8 +1139,25 @@ echo "🚀 Starting: ${sessionName}"
 ${context.executionEnvironment === 'sandbox' ? 'echo "🔒 Running in srt sandbox (filesystem + network isolation)"' : ''}
 echo ""
 cd "${context.worktreePath}"
-# Run executor in subshell with CLAUDECODE unset (prevents nested session error)
-(unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT; ${finalInvocation})
+
+# TKT-099: Robust prompt loading — wait for file and verify content before passing to executor.
+# Prevents race where the prompt file isn't flushed/synced yet (e.g., Docker file-sharing
+# delay, tmux server restart, or transient filesystem latency).
+PROMPT_WAIT=0
+while [ ! -s "$PROMPT_PATH" ] && [ $PROMPT_WAIT -lt 30 ]; do
+  sleep 0.5
+  PROMPT_WAIT=$((PROMPT_WAIT + 1))
+done
+
+if [ ! -s "$PROMPT_PATH" ]; then
+  echo "⚠️  Warning: Prompt file not available after 15s. Starting in interactive mode."
+  echo "   Expected: $PROMPT_PATH"
+  # Fallback: launch executor without prompt so the session isn't lost
+  (unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT; ${fallbackInvocation})
+else
+  # Run executor in subshell with CLAUDECODE unset (prevents nested session error)
+  (unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT; ${finalInvocation})
+fi
 
 # Clean up script and prompt files
 rm -f "$SCRIPT_PATH" "$PROMPT_PATH"${systemPromptPath ? ' "$SYSTEM_PROMPT_PATH"' : ''}
@@ -2236,7 +2281,7 @@ export async function runDevcontainer(
     if (sessionManager === 'tmux') {
       // Use tmux inside container - pass displayMode to control whether to open terminal tab
       // Pass containerId directly to avoid regex extraction issues with devcontainer exec commands
-      result = await runDevcontainerInTmux(context, devcontainerCmd, config, displayMode, containerId || undefined)
+      result = await runDevcontainerInTmux(context, devcontainerCmd, config, displayMode, containerId || undefined, promptFile)
     } else {
       switch (displayMode) {
         case 'background':
@@ -2554,7 +2599,8 @@ async function runDevcontainerInTmux(
   devcontainerCmd: string,
   config: ExecutionConfig,
   displayMode: DisplayMode = 'terminal',
-  containerId?: string
+  containerId?: string,
+  promptContainerPath?: string
 ): Promise<RunnerResult> {
   // Session name: {ticketId}-{action} (e.g., TKT-347-implement)
   const sessionName = buildTmuxWindowName(context)
@@ -2615,6 +2661,22 @@ exit 0`
 echo "✅ Agent work complete. Press Enter to close or run more commands."
 exec bash`
 
+    // TKT-099: Build a wait guard for the prompt file inside the container.
+    // Docker Desktop's file-sharing layer (grpcfuse/virtiofs) can lag behind host writes,
+    // so the prompt file may not be visible in the container the instant it was written on the host.
+    const promptWaitBlock = promptContainerPath
+      ? `# TKT-099: Wait for prompt file to sync from host into container
+PROMPT_WAIT=0
+while [ ! -s "${promptContainerPath}" ] && [ $PROMPT_WAIT -lt 30 ]; do
+  sleep 0.5
+  PROMPT_WAIT=$((PROMPT_WAIT + 1))
+done
+if [ ! -s "${promptContainerPath}" ]; then
+  echo "⚠️  Warning: Prompt file not available after 15s: ${promptContainerPath}"
+fi
+`
+      : ''
+
     const tmuxScript = `#!/bin/bash
 export TERM=xterm-256color
 export COLORTERM=truecolor
@@ -2622,15 +2684,12 @@ unset CI
 unset CLAUDECODE
 echo "🚀 Starting: ${sessionName}"
 echo ""
-${claudeCmd}
+${promptWaitBlock}${claudeCmd}
 ${containerPostExec}
 `
     const scriptPath = `/tmp/prlt-${sessionName}.sh`
 
     // Write script and start tmux session inside container
-    // IMPORTANT: We create the session with bash first, then send keys to run the script.
-    // This ensures bash is running interactively (required for Claude's TUI to render).
-    // If we pass the script as the session command, bash runs non-interactively and Claude won't show TUI.
     // -n sets the window name (shows in iTerm tab title with -CC mode)
     // sessionName is already ticket-action-agent format
     // Only enable mouse mode if NOT using control mode (control mode lets iTerm handle mouse natively)


### PR DESCRIPTION
## Summary

- **Fix race condition** where `prlt work start` spawns an agent but the task prompt never arrives — Claude Code sits idle at the `>` prompt
- **Root cause**: The prompt file (written on host, read via `$(cat "$PROMPT_PATH")` in tmux script) can be empty/missing due to Docker file-sharing sync delay (devcontainer), or tmux server restart timing (host)
- **Add wait-for-file loop** (up to 15s, 500ms poll) in both host and devcontainer startup scripts before reading the prompt
- **Graceful fallback**: if prompt file is still unavailable, launch Claude in interactive mode with a visible warning instead of silently passing an empty string
- **Fix tmux kill-server timing**: replace fixed 500ms delay with a poll loop that confirms the server has actually stopped, preventing the next `tmux new-session` from talking to a dying server

## Test plan

- [ ] Run `prlt work start TKT-XXX` on host — verify prompt arrives normally (no delay in common case since file is already written)
- [ ] Run `prlt work start TKT-XXX` with devcontainer — verify prompt arrives even under Docker file-sharing load
- [ ] Kill tmux server manually, then `prlt work start` — verify session creates cleanly without prompt loss
- [ ] If prompt file is manually deleted before script reads it, verify the warning message appears and Claude starts in interactive mode (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)