### PR TITLE
TKT-100: Fix auto-update suggesting stale version

### DIFF
--- a/apps/cli/src/hooks/postrun.ts
+++ b/apps/cli/src/hooks/postrun.ts
@@ -1,12 +1,14 @@
 import { Hook } from '@oclif/core'
 import { flushSentry } from '../lib/telemetry.js'
 import { trackCommandRun, shutdownAnalytics } from '../lib/telemetry/analytics.js'
+import { flushPendingVersionCheck } from '../lib/update-check.js'
 
 /**
  * Postrun hook - runs after every command completes
  *
  * Tracks the command_run event with duration and success via Statsig,
- * then flushes pending analytics events and Sentry crash reports before CLI exit.
+ * then flushes pending analytics events, version check, and Sentry crash
+ * reports before CLI exit.
  */
 const hook: Hook<'postrun'> = async function ({ Command, argv }) {
   const startTime = (globalThis as Record<string, unknown>).__prlt_command_start as number | undefined
@@ -28,9 +30,12 @@ const hook: Hook<'postrun'> = async function ({ Command, argv }) {
     })
   }
 
-  // Flush pending events with timeout — don't delay CLI exit
-  await shutdownAnalytics()
-  await flushSentry()
+  // Flush pending events — don't delay CLI exit longer than necessary
+  await Promise.all([
+    flushPendingVersionCheck(),
+    shutdownAnalytics(),
+    flushSentry(),
+  ])
 }
 
 export default hook

--- a/apps/cli/src/lib/update-check.ts
+++ b/apps/cli/src/lib/update-check.ts
@@ -334,6 +334,13 @@ export function isNewerVersion(current: string, latest: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Pending check tracking
+// ---------------------------------------------------------------------------
+
+/** Module-level promise tracking so the check can be flushed before exit. */
+let pendingCheck: Promise<void> | null = null
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -382,8 +389,9 @@ export function getCachedUpdateInfo(currentVersion: string): UpdateInfo {
 
 /**
  * Perform a background version check and update the cache.
- * This is fire-and-forget — errors are silently ignored.
- * Does not block the calling process.
+ * The fetch runs without blocking startup, but the promise is tracked
+ * internally so it can be flushed before process exit via
+ * {@link flushPendingVersionCheck}.
  */
 export function triggerBackgroundCheck(pm: PackageManager): void {
   const cache = readCache()
@@ -392,8 +400,7 @@ export function triggerBackgroundCheck(pm: PackageManager): void {
     return
   }
 
-  // Fire and forget — don't await, don't block
-  fetchLatestVersion(pm)
+  pendingCheck = fetchLatestVersion(pm)
     .then((latest) => {
       if (latest) {
         const updatedCache = readCache() // Re-read to avoid races
@@ -405,6 +412,22 @@ export function triggerBackgroundCheck(pm: PackageManager): void {
     .catch(() => {
       // Silently ignore — never fail startup due to version check
     })
+    .finally(() => {
+      pendingCheck = null
+    })
+}
+
+/**
+ * Await the in-flight background version check (if any) so the result
+ * is written to disk before the process exits.  Called from the postrun
+ * hook — mirrors the flush pattern used by analytics and Sentry.
+ *
+ * No-op when no check is pending (the common case).
+ */
+export async function flushPendingVersionCheck(): Promise<void> {
+  if (pendingCheck) {
+    await pendingCheck
+  }
 }
 
 /**

--- a/apps/cli/test/unit/update-check.test.ts
+++ b/apps/cli/test/unit/update-check.test.ts
@@ -15,6 +15,8 @@ import {
   checkStaleTap,
   getBrewTapPath,
   getStaleTapCommands,
+  triggerBackgroundCheck,
+  flushPendingVersionCheck,
   type VersionCheckCache,
 } from '../../src/lib/update-check.js'
 
@@ -253,6 +255,39 @@ describe('Update Check', () => {
       // Result depends on whether Homebrew is actually installed on this machine.
       // We just verify it returns a string or null without throwing.
       expect(result === null || typeof result === 'string').to.be.true
+    })
+  })
+
+  describe('flushPendingVersionCheck', () => {
+    it('resolves immediately when no check is pending', async () => {
+      // Should be a no-op and resolve without error
+      await flushPendingVersionCheck()
+    })
+
+    it('waits for a pending background check to complete', async () => {
+      // Write a cache that is stale (last checked > 20 hours ago) so
+      // triggerBackgroundCheck actually fires a fetch
+      const staleCache: VersionCheckCache = {
+        latest_version: '0.1.0',
+        last_checked_at: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+        dismissed_version: null,
+      }
+      writeCache(staleCache)
+
+      // Trigger a background check. The npm fetch will either succeed
+      // (updating the cache) or fail (caught internally). Either way,
+      // flush should resolve without throwing.
+      triggerBackgroundCheck('npm')
+      await flushPendingVersionCheck()
+
+      // After flush, the cache should have been updated (last_checked_at
+      // should be more recent than our stale value — or unchanged if the
+      // network call failed, which is fine).
+      const cache = readCache()
+      expect(cache.last_checked_at).to.satisfy(
+        (v: string | null) => v === staleCache.last_checked_at || (v !== null && new Date(v).getTime() > new Date(staleCache.last_checked_at!).getTime()),
+        'last_checked_at should be updated or unchanged on network failure',
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

- **Root cause**: `triggerBackgroundCheck()` was fire-and-forget — the fetch promise was untracked, so `process.exit()` killed it before the result could be written to cache (`~/.proletariat/version-check.json`). The cached `latest_version` stayed stuck on whatever was last successfully fetched.
- **Fix**: Track the background check promise in a module-level variable and flush it in the postrun hook via `flushPendingVersionCheck()`, following the same pattern used by analytics (`shutdownAnalytics`) and Sentry (`flushSentry`). All three flushes run concurrently via `Promise.all` so there's no added latency.
- Added unit tests for `flushPendingVersionCheck` (no-op case + pending check case).

## Test plan

- [x] `pnpm build` passes
- [x] Unit tests pass (`flushPendingVersionCheck` resolves immediately when idle, waits for pending check when active)
- [ ] Manual: delete `~/.proletariat/version-check.json`, run any `prlt` command, verify the cache file is created with the correct latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)