### PR TITLE
TKT-107: Fix work start --from linear: to read API key from workspace settings

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -77,6 +77,7 @@ import {
   getTrelloCardById,
 } from '../../lib/external-issues/trello.js'
 import { resolveMirrorToPmo } from '../../lib/external-issues/work-start.js'
+import { getLinearApiKey, loadLinearConfig } from '../../lib/linear/config.js'
 import { ExternalIssueAdapterError, type IssueSource, type NormalizedIssueEnvelope } from '../../lib/external-issues/types.js'
 import {
   parseWorkSourceRef,
@@ -411,13 +412,19 @@ export default class WorkStart extends PMOCommand {
   private async fetchExternalIssue(
     source: IssueSource,
     key: string,
+    db: Database.Database,
   ): Promise<NormalizedIssueEnvelope | null> {
     switch (source) {
       case 'jira': return getJiraIssueByKey({}, key)
       case 'asana': return getAsanaTaskByGid({}, key)
       case 'shortcut': return getShortcutStoryByKey({}, key)
       case 'trello': return getTrelloCardById({}, key)
-      default: return getLinearIssueByIdentifier({}, key)
+      default: {
+        const apiKey = getLinearApiKey(db) || undefined
+        const linearConfig = loadLinearConfig(db)
+        const team = linearConfig?.defaultTeamKey || undefined
+        return getLinearIssueByIdentifier({ apiKey, team }, key)
+      }
     }
   }
 
@@ -638,7 +645,7 @@ export default class WorkStart extends PMOCommand {
 
         let envelope: NormalizedIssueEnvelope | null = null
         try {
-          envelope = await this.fetchExternalIssue(sourceAndKey.source, sourceAndKey.key)
+          envelope = await this.fetchExternalIssue(sourceAndKey.source, sourceAndKey.key, db)
         } catch (error) {
           if (error instanceof ExternalIssueAdapterError) {
             db.close()


### PR DESCRIPTION
## Summary
- `work start --from linear:ISSUE-KEY` was failing with `EXTERNAL_ISSUE_MISSING_CONFIG` because `fetchExternalIssue` passed empty config `{}` to `getLinearIssueByIdentifier`, so it only checked environment variables for the API key
- Now uses `getLinearApiKey(db)` and `loadLinearConfig(db)` to resolve the API key and default team from workspace settings, matching how `ticket list` already works
- Users who connected Linear via `prlt linear connect` no longer need to also set `LINEAR_API_KEY` env var for `work start`

## Test plan
- [ ] Run `prlt linear connect` to store API key in workspace settings
- [ ] Run `prlt work start --from linear:ISSUE-KEY` without `LINEAR_API_KEY` env var — should succeed
- [ ] Run with `LINEAR_API_KEY` env var set — env var should still take precedence
- [ ] Run `prlt ticket list --source linear` — should continue working as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)