### PR TITLE
TKT-108: Wire apiKeyRef from provider-sources into API key resolution

### DIFF
--- a/apps/cli/src/commands/linear/auth.ts
+++ b/apps/cli/src/commands/linear/auth.ts
@@ -148,7 +148,7 @@ export default class LinearAuth extends PMOCommand {
       if (jsonMode) {
         outputErrorAsJson(
           'API_KEY_REQUIRED',
-          'Linear API key required. Set LINEAR_API_KEY or PRLT_LINEAR_API_KEY environment variable, or run interactively.',
+          'Linear API key required. Configure a Linear provider source, set PRLT_LINEAR_API_KEY, or run interactively.',
           createMetadata('linear auth', flags),
         )
         this.exit(1)

--- a/apps/cli/src/commands/linear/connect.ts
+++ b/apps/cli/src/commands/linear/connect.ts
@@ -116,7 +116,7 @@ export default class LinearConnect extends PMOCommand {
       if (jsonMode) {
         outputErrorAsJson(
           'API_KEY_REQUIRED',
-          'Linear API key required. Set LINEAR_API_KEY or PRLT_LINEAR_API_KEY environment variable, or run interactively.',
+          'Linear API key required. Configure a Linear provider source, set PRLT_LINEAR_API_KEY, or run interactively.',
           createMetadata('linear connect', flags),
         )
         this.exit(1)

--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -475,7 +475,7 @@ export default class TicketCreate extends PMOCommand {
     if (!apiKey) {
       return handleError(
         'LINEAR_NOT_CONFIGURED',
-        'Linear is not configured. Run "prlt linear setup" first, or set LINEAR_API_KEY.'
+        'Linear is not configured. Run "prlt linear setup" first, or configure a Linear provider source.'
       );
     }
 

--- a/apps/cli/src/lib/external-issues/linear.ts
+++ b/apps/cli/src/lib/external-issues/linear.ts
@@ -151,7 +151,7 @@ function ensureLinearConfig(
   if (!apiKey) {
     throw new ExternalIssueAdapterError(
       'MISSING_CONFIG',
-      'Missing Linear API key. Set LINEAR_API_KEY or PRLT_LINEAR_API_KEY.',
+      'Missing Linear API key. Configure a Linear provider source, or set PRLT_LINEAR_API_KEY.',
     )
   }
 
@@ -317,7 +317,7 @@ export async function getLinearIssueByIdentifier(
   if (response.status === 401 || response.status === 403) {
     throw new ExternalIssueAdapterError(
       'AUTH_FAILED',
-      'Linear authentication failed. Verify your LINEAR_API_KEY token.',
+      'Linear authentication failed. Verify your API key configuration.',
     )
   }
 
@@ -392,7 +392,7 @@ export async function listLinearIssues(
   if (response.status === 401 || response.status === 403) {
     throw new ExternalIssueAdapterError(
       'AUTH_FAILED',
-      'Linear authentication failed. Verify your LINEAR_API_KEY token.',
+      'Linear authentication failed. Verify your API key configuration.',
     )
   }
 

--- a/apps/cli/src/lib/linear/config.ts
+++ b/apps/cli/src/lib/linear/config.ts
@@ -6,6 +6,7 @@
 
 import Database from 'better-sqlite3'
 import type { LinearConfig } from './types.js'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 
@@ -104,13 +105,32 @@ export function clearLinearConfig(db: Database.Database): void {
 }
 
 /**
- * Get the stored Linear API key.
- * Also checks PRLT_LINEAR_API_KEY and LINEAR_API_KEY environment variables.
+ * Get the Linear API key using the provider-sources resolution chain.
+ *
+ * Resolution order:
+ * 1. If a Linear provider source is configured, resolve its apiKeyRef
+ *    (checks env var named apiKeyRef, then workspace_settings key named apiKeyRef)
+ * 2. Legacy fallback: PRLT_LINEAR_API_KEY or LINEAR_API_KEY environment variables
+ * 3. Legacy fallback: workspace_settings key 'linear.api_key'
  */
 export function getLinearApiKey(db: Database.Database): string | null {
-  // Environment variables take precedence
+  // 1. Try provider sources (supports custom apiKeyRef per source)
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'linear') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch {
+    // Provider sources table may not exist in older databases
+  }
+
+  // 2. Legacy: environment variables
   const envKey = process.env.PRLT_LINEAR_API_KEY || process.env.LINEAR_API_KEY
   if (envKey) return envKey
 
+  // 3. Legacy: stored workspace setting
   return getSetting(db, LINEAR_CONFIG_KEYS.apiKey)
 }

--- a/apps/cli/test/e2e/linear-integration.test.ts
+++ b/apps/cli/test/e2e/linear-integration.test.ts
@@ -123,6 +123,104 @@ describe('Linear Integration', () => {
       const key = getLinearApiKey(db)
       expect(key).to.equal('lin_api_stored')
     })
+
+    it('should resolve API key from provider source apiKeyRef', () => {
+      delete process.env.LINEAR_API_KEY
+      delete process.env.PRLT_LINEAR_API_KEY
+
+      // Configure a provider source with a custom apiKeyRef pointing to a workspace setting
+      const sources = [{
+        id: 'eng-linear',
+        provider: 'linear',
+        apiKeyRef: 'custom.linear_key',
+        teamProjectId: 'ENG',
+        prefix: 'ENG-',
+      }]
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run(
+        'work.provider_sources',
+        JSON.stringify(sources),
+      )
+      // Store the key under the custom apiKeyRef
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run(
+        'custom.linear_key',
+        'lin_api_from_provider_source',
+      )
+
+      const key = getLinearApiKey(db)
+      expect(key).to.equal('lin_api_from_provider_source')
+    })
+
+    it('should resolve API key from provider source env var apiKeyRef', () => {
+      delete process.env.LINEAR_API_KEY
+      delete process.env.PRLT_LINEAR_API_KEY
+
+      // Configure a provider source with apiKeyRef pointing to an env var
+      process.env.MY_CUSTOM_LINEAR_KEY = 'lin_api_custom_env'
+      const sources = [{
+        id: 'eng-linear',
+        provider: 'linear',
+        apiKeyRef: 'MY_CUSTOM_LINEAR_KEY',
+        teamProjectId: 'ENG',
+        prefix: 'ENG-',
+      }]
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run(
+        'work.provider_sources',
+        JSON.stringify(sources),
+      )
+
+      const key = getLinearApiKey(db)
+      expect(key).to.equal('lin_api_custom_env')
+
+      delete process.env.MY_CUSTOM_LINEAR_KEY
+    })
+
+    it('should prefer provider source over legacy env var', () => {
+      process.env.LINEAR_API_KEY = 'lin_api_legacy_env'
+
+      // Configure provider source with workspace setting
+      const sources = [{
+        id: 'eng-linear',
+        provider: 'linear',
+        apiKeyRef: 'custom.linear_key',
+        teamProjectId: 'ENG',
+        prefix: 'ENG-',
+      }]
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run(
+        'work.provider_sources',
+        JSON.stringify(sources),
+      )
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run(
+        'custom.linear_key',
+        'lin_api_provider_source',
+      )
+
+      const key = getLinearApiKey(db)
+      expect(key).to.equal('lin_api_provider_source')
+
+      delete process.env.LINEAR_API_KEY
+    })
+
+    it('should fall back to legacy env var when provider source has no key', () => {
+      process.env.PRLT_LINEAR_API_KEY = 'lin_api_legacy_fallback'
+
+      // Configure provider source with a ref that doesn't resolve
+      const sources = [{
+        id: 'eng-linear',
+        provider: 'linear',
+        apiKeyRef: 'nonexistent.key',
+        teamProjectId: 'ENG',
+        prefix: 'ENG-',
+      }]
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run(
+        'work.provider_sources',
+        JSON.stringify(sources),
+      )
+
+      const key = getLinearApiKey(db)
+      expect(key).to.equal('lin_api_legacy_fallback')
+
+      delete process.env.PRLT_LINEAR_API_KEY
+    })
   })
 
   // ===========================================================================

--- a/apps/cli/test/unit/external-issue-redaction.test.ts
+++ b/apps/cli/test/unit/external-issue-redaction.test.ts
@@ -290,7 +290,7 @@ describe('Redaction integration – adapter outputs are credential-free', () => 
     try {
       // The error message from ensureLinearConfig should mention the env var name,
       // not the value
-      const errorMsg = 'Missing Linear API key. Set LINEAR_API_KEY or PRLT_LINEAR_API_KEY.'
+      const errorMsg = 'Missing Linear API key. Configure a Linear provider source, or set PRLT_LINEAR_API_KEY.'
       assertNoCredentials(errorMsg, 'config error message')
     } finally {
       if (savedKey !== undefined) {


### PR DESCRIPTION
## Summary
- Refactored `getLinearApiKey()` to first check configured provider sources via `resolveApiKey()` before falling back to legacy hardcoded env var names (`LINEAR_API_KEY`/`PRLT_LINEAR_API_KEY`)
- Users can now configure custom `apiKeyRef` values per provider source (e.g. `MY_LINEAR_KEY` env var or `custom.linear_key` workspace setting) and all commands automatically resolve through the new chain
- Updated error messages across `linear auth`, `linear connect`, `ticket create`, and external-issues adapter to reference provider sources instead of hardcoded env var names

## Test plan
- [x] 4 new tests in `linear-integration.test.ts` covering provider source resolution: DB key, env var, precedence over legacy, and fallback when unresolved
- [x] All 125 existing tests pass (linear-integration, provider-sources, external-issue-redaction, external-issue-spawn)
- [x] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)