### PR TITLE
TKT-941: Fix agents spawning idle when Docker is unavailable

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -1089,7 +1089,9 @@ export async function runHost(
 
   // Build script that runs executor and keeps shell open after completion
   const setTitleCmds = getSetTitleCommands(windowTitle)
-  const systemPromptVar = systemPromptPath ? `\nSYSTEM_PROMPT_PATH="${systemPromptPath}"` : ''
+  // TKT-941: Export SYSTEM_PROMPT_PATH so it's available inside srt sandbox child processes.
+  // Without export, `bash -c '...'` inside srt can't access the variable.
+  const systemPromptVar = systemPromptPath ? `\nexport SYSTEM_PROMPT_PATH="${systemPromptPath}"` : ''
 
   // Ephemeral agents auto-close after completion instead of dropping to interactive shell
   const postExecBlock = context.isEphemeral
@@ -1133,7 +1135,12 @@ exec $SHELL
   const scriptContent = `#!/bin/bash
 # Auto-generated script for ticket ${context.ticketId}
 SCRIPT_PATH="${scriptPath}"
-PROMPT_PATH="${promptPath}"${systemPromptVar}
+# TKT-941: Export PROMPT_PATH so it's available inside srt sandbox child processes.
+# When running in sandbox mode, the executor is wrapped with:
+#   srt ... -- bash -c 'claude ... "$(cat "$PROMPT_PATH")"'
+# Without export, the inner bash started by srt cannot access PROMPT_PATH,
+# causing $(cat "$PROMPT_PATH") to expand to empty and the agent to start idle.
+export PROMPT_PATH="${promptPath}"${systemPromptVar}
 ${setTitleCmds}
 echo "🚀 Starting: ${sessionName}"
 ${context.executionEnvironment === 'sandbox' ? 'echo "🔒 Running in srt sandbox (filesystem + network isolation)"' : ''}


### PR DESCRIPTION
## Summary

- **Root cause**: When Docker is unavailable and srt (sandbox-runtime) is installed, the spawner falls back to sandbox execution. The host runner wraps the executor with `srt ... -- bash -c 'claude ... "$(cat "$PROMPT_PATH")"'`. Because `PROMPT_PATH` and `SYSTEM_PROMPT_PATH` were plain shell variables (not exported), the inner `bash -c` started by srt could not access them — `$PROMPT_PATH` expanded to empty, so Claude Code launched with no prompt and sat idle.
- **Fix**: `export` both `PROMPT_PATH` and `SYSTEM_PROMPT_PATH` in the generated script so they propagate through srt to child processes.

## Code path traced

1. `spawner.ts:371` — `checkDockerDaemon()` detects Docker unavailable
2. `spawner.ts:408` — falls back: `environment = isSrtInstalled() ? 'sandbox' : 'host'`
3. `runners.ts:3539-3544` — `runSandbox()` delegates to `runHost()` with `executionEnvironment: 'sandbox'`
4. `runners.ts:1110-1116` — `runHost()` wraps executor with srt: `srt ... -- bash -c '...'`
5. `runners.ts:1143` — script sets `PROMPT_PATH=...` (**was not exported**)
6. Inner `bash -c` expands `$PROMPT_PATH` → empty → `cat ""` → no prompt → idle agent

## Test plan

- [ ] Verify build passes (`cd apps/cli && pnpm build`)
- [ ] With Docker stopped and srt installed: `prlt work start <ticket>` → agent receives prompt
- [ ] Without srt: host fallback still works (no behavioral change — `export` is harmless for non-srt case)
- [ ] With Docker running: devcontainer path is unaffected (uses `writePromptFile()`, not this script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)