### PR TITLE
TKT-110: Consolidate provider connect commands into provider-sources

### DIFF
--- a/apps/cli/src/commands/asana/connect.ts
+++ b/apps/cli/src/commands/asana/connect.ts
@@ -18,6 +18,7 @@ import {
   saveAsanaProject,
   saveAsanaWorkspace,
 } from '../../lib/asana/index.js'
+import { upsertProviderSource, removeProviderSourcesByProvider } from '../../lib/work-source/provider-sources.js'
 
 function isLikelyGid(value: string): boolean {
   return /^\d+$/.test(value)
@@ -62,6 +63,7 @@ export default class AsanaConnect extends PMOCommand {
 
     if (flags.disconnect) {
       clearAsanaConfig(db)
+      removeProviderSourcesByProvider(db, 'asana')
       if (jsonMode) {
         outputSuccessAsJson({ disconnected: true, message: 'Asana credentials removed.' }, createMetadata('asana connect', flags))
         return
@@ -282,6 +284,16 @@ export default class AsanaConnect extends PMOCommand {
       if (projectGid) {
         saveAsanaProject(db, projectGid, projectName ?? projectGid)
       }
+
+      // Register as provider source
+      upsertProviderSource(db, {
+        id: 'asana',
+        provider: 'asana',
+        apiKeyRef: 'asana.access_token',
+        teamProjectId: projectGid ?? workspaceGid ?? 'default',
+        prefix: 'ASANA-',
+        label: projectName ?? workspaceName ?? 'Asana',
+      })
 
       if (jsonMode) {
         outputSuccessAsJson({

--- a/apps/cli/src/commands/linear/connect.ts
+++ b/apps/cli/src/commands/linear/connect.ts
@@ -20,6 +20,7 @@ import {
   clearLinearConfig,
   getLinearApiKey,
 } from '../../lib/linear/index.js'
+import { upsertProviderSource, removeProviderSourcesByProvider } from '../../lib/work-source/provider-sources.js'
 
 export default class LinearConnect extends PMOCommand {
   static description = 'Connect to Linear workspace and configure authentication'
@@ -61,6 +62,7 @@ export default class LinearConnect extends PMOCommand {
     // Handle --disconnect
     if (flags.disconnect) {
       clearLinearConfig(db)
+      removeProviderSourcesByProvider(db, 'linear')
       if (jsonMode) {
         outputSuccessAsJson({
           disconnected: true,
@@ -266,6 +268,16 @@ export default class LinearConnect extends PMOCommand {
     const teams = await client.listTeams()
 
     if (teams.length === 0) {
+      // Register provider source even without a team
+      upsertProviderSource(db, {
+        id: 'linear',
+        provider: 'linear',
+        apiKeyRef: 'linear.api_key',
+        teamProjectId: 'default',
+        prefix: 'LIN-',
+        label: info.organizationName,
+      })
+
       if (jsonMode) {
         outputSuccessAsJson({
           authenticated: true,
@@ -297,6 +309,14 @@ export default class LinearConnect extends PMOCommand {
         this.error(message)
       }
       saveLinearDefaultTeam(db, matched!.id, matched!.key)
+      upsertProviderSource(db, {
+        id: 'linear',
+        provider: 'linear',
+        apiKeyRef: 'linear.api_key',
+        teamProjectId: matched!.key,
+        prefix: `${matched!.key}-`,
+        label: matched!.name,
+      })
       if (jsonMode) {
         outputSuccessAsJson({
           authenticated: true,
@@ -330,8 +350,12 @@ export default class LinearConnect extends PMOCommand {
 
     // Interactive team selection
     this.log('')
+    let selectedTeamKey: string
+    let selectedTeamName: string
     if (teams.length === 1) {
       saveLinearDefaultTeam(db, teams[0].id, teams[0].key)
+      selectedTeamKey = teams[0].key
+      selectedTeamName = teams[0].name
       this.log(colors.textMuted(`  Default team set to: ${teams[0].name} (${teams[0].key})`))
     } else {
       const teamChoices = teams.map((t) => ({
@@ -349,8 +373,20 @@ export default class LinearConnect extends PMOCommand {
 
       const selectedTeam = teams.find((t) => t.id === selectedTeamId)!
       saveLinearDefaultTeam(db, selectedTeam.id, selectedTeam.key)
+      selectedTeamKey = selectedTeam.key
+      selectedTeamName = selectedTeam.name
       this.log(colors.textMuted(`  Default team set to: ${selectedTeam.name} (${selectedTeam.key})`))
     }
+
+    // Register as provider source
+    upsertProviderSource(db, {
+      id: 'linear',
+      provider: 'linear',
+      apiKeyRef: 'linear.api_key',
+      teamProjectId: selectedTeamKey,
+      prefix: `${selectedTeamKey}-`,
+      label: selectedTeamName,
+    })
 
     this.log('')
     this.log(colors.success('Linear integration configured!'))

--- a/apps/cli/src/commands/monday/connect.ts
+++ b/apps/cli/src/commands/monday/connect.ts
@@ -19,6 +19,7 @@ import {
   getMondayApiToken,
   getMondayBoardId,
 } from '../../lib/monday/index.js'
+import { upsertProviderSource, removeProviderSourcesByProvider } from '../../lib/work-source/provider-sources.js'
 
 export default class MondayConnect extends PMOCommand {
   static description = 'Connect PRLT to Monday.com and store workspace credentials'
@@ -56,6 +57,7 @@ export default class MondayConnect extends PMOCommand {
 
     if (flags.disconnect) {
       clearMondayConfig(db)
+      removeProviderSourcesByProvider(db, 'monday')
       if (jsonMode) {
         outputSuccessAsJson({
           disconnected: true,
@@ -162,6 +164,16 @@ export default class MondayConnect extends PMOCommand {
         saveMondayBoard(db, board.id, board.name)
         boardId = board.id
       }
+
+      // Register as provider source
+      upsertProviderSource(db, {
+        id: 'monday',
+        provider: 'monday',
+        apiKeyRef: 'monday.api_token',
+        teamProjectId: boardId ?? 'default',
+        prefix: 'MON-',
+        label: boardName ?? info.accountName,
+      })
 
       if (jsonMode) {
         outputSuccessAsJson({

--- a/apps/cli/src/commands/shortcut/connect.ts
+++ b/apps/cli/src/commands/shortcut/connect.ts
@@ -18,6 +18,7 @@ import {
   clearShortcutConfig,
   getShortcutApiToken,
 } from '../../lib/shortcut/index.js'
+import { upsertProviderSource, removeProviderSourcesByProvider } from '../../lib/work-source/provider-sources.js'
 
 const SHORTCUT_API_URL = 'https://api.app.shortcut.com/api/v3'
 
@@ -94,6 +95,7 @@ export default class ShortcutConnect extends PMOCommand {
     // Handle --disconnect
     if (flags.disconnect) {
       clearShortcutConfig(db)
+      removeProviderSourcesByProvider(db, 'shortcut')
       if (jsonMode) {
         outputSuccessAsJson({
           disconnected: true,
@@ -184,6 +186,16 @@ export default class ShortcutConnect extends PMOCommand {
 
       // Save API token
       saveShortcutApiToken(db, apiToken!)
+
+      // Register as provider source
+      upsertProviderSource(db, {
+        id: 'shortcut',
+        provider: 'shortcut',
+        apiKeyRef: 'shortcut.api_token',
+        teamProjectId: 'default',
+        prefix: 'SC-',
+        label: 'Shortcut',
+      })
 
       if (!jsonMode) {
         this.log(colors.success('Connected to Shortcut'))

--- a/apps/cli/src/commands/trello/configure.ts
+++ b/apps/cli/src/commands/trello/configure.ts
@@ -19,6 +19,7 @@ import {
   saveTrelloApiToken,
   saveTrelloBoard,
 } from '../../lib/trello/index.js'
+import { upsertProviderSource, removeProviderSourcesByProvider } from '../../lib/work-source/provider-sources.js'
 
 export default class TrelloConfigure extends PMOCommand {
   static description = 'Connect to Trello and configure authentication'
@@ -59,6 +60,7 @@ export default class TrelloConfigure extends PMOCommand {
     // Handle --disconnect
     if (flags.disconnect) {
       clearTrelloConfig(db)
+      removeProviderSourcesByProvider(db, 'trello')
       if (jsonMode) {
         outputSuccessAsJson({
           disconnected: true,
@@ -229,6 +231,16 @@ export default class TrelloConfigure extends PMOCommand {
       if (boardId && boardName) {
         saveTrelloBoard(db, boardId, boardName)
       }
+
+      // Register as provider source
+      upsertProviderSource(db, {
+        id: 'trello',
+        provider: 'trello',
+        apiKeyRef: 'trello.api_key',
+        teamProjectId: boardId ?? 'default',
+        prefix: 'TRL-',
+        label: boardName ?? 'Trello',
+      })
 
       if (jsonMode) {
         outputSuccessAsJson({

--- a/apps/cli/src/lib/asana/config.ts
+++ b/apps/cli/src/lib/asana/config.ts
@@ -1,5 +1,6 @@
 import Database from 'better-sqlite3'
 import type { AsanaConfig } from './types.js'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 
@@ -68,8 +69,23 @@ export function clearAsanaConfig(db: Database.Database): void {
 }
 
 export function getAsanaAccessToken(db: Database.Database): string | null {
+  // 1. Try provider sources (supports custom apiKeyRef per source)
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'asana') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch {
+    // Provider sources may not exist in older databases
+  }
+
+  // 2. Legacy: environment variables
   const envToken = process.env.PRLT_ASANA_ACCESS_TOKEN || process.env.ASANA_ACCESS_TOKEN
   if (envToken) return envToken
 
+  // 3. Legacy: stored workspace setting
   return getSetting(db, ASANA_CONFIG_KEYS.accessToken)
 }

--- a/apps/cli/src/lib/jira/config.ts
+++ b/apps/cli/src/lib/jira/config.ts
@@ -6,6 +6,7 @@
  */
 
 import Database from 'better-sqlite3'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 
@@ -49,6 +50,19 @@ function deleteSetting(db: Database.Database, key: string): void {
  * - Environment variables PRLT_JIRA_BASE_URL/JIRA_BASE_URL and PRLT_JIRA_API_TOKEN/JIRA_API_TOKEN are set
  */
 export function isJiraConfigured(db: Database.Database): boolean {
+  // Check provider sources first
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'jira') {
+        const key = resolveApiKey(db, source)
+        if (key) return true
+      }
+    }
+  } catch {
+    // Provider sources may not exist in older databases
+  }
+
   const hasDbConfig = getSetting(db, JIRA_CONFIG_KEYS.baseUrl) !== null
     && getSetting(db, JIRA_CONFIG_KEYS.apiToken) !== null
 

--- a/apps/cli/src/lib/monday/config.ts
+++ b/apps/cli/src/lib/monday/config.ts
@@ -1,5 +1,6 @@
 import Database from 'better-sqlite3'
 import type { MondayConfig } from './types.js'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 
@@ -65,9 +66,24 @@ export function clearMondayConfig(db: Database.Database): void {
 }
 
 export function getMondayApiToken(db: Database.Database): string | null {
+  // 1. Try provider sources (supports custom apiKeyRef per source)
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'monday') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch {
+    // Provider sources may not exist in older databases
+  }
+
+  // 2. Legacy: environment variables
   const envToken = process.env.PRLT_MONDAY_API_TOKEN || process.env.MONDAY_API_TOKEN
   if (envToken) return envToken
 
+  // 3. Legacy: stored workspace setting
   return getSetting(db, MONDAY_CONFIG_KEYS.apiToken)
 }
 

--- a/apps/cli/src/lib/shortcut/config.ts
+++ b/apps/cli/src/lib/shortcut/config.ts
@@ -6,6 +6,7 @@
  */
 
 import Database from 'better-sqlite3'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 
@@ -110,8 +111,23 @@ export function clearShortcutConfig(db: Database.Database): void {
  * Also checks PRLT_SHORTCUT_API_TOKEN and SHORTCUT_API_TOKEN environment variables.
  */
 export function getShortcutApiToken(db: Database.Database): string | null {
+  // 1. Try provider sources (supports custom apiKeyRef per source)
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'shortcut') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch {
+    // Provider sources may not exist in older databases
+  }
+
+  // 2. Legacy: environment variables
   const envKey = process.env.PRLT_SHORTCUT_API_TOKEN || process.env.SHORTCUT_API_TOKEN
   if (envKey) return envKey
 
+  // 3. Legacy: stored workspace setting
   return getSetting(db, SHORTCUT_CONFIG_KEYS.apiToken)
 }

--- a/apps/cli/src/lib/trello/config.ts
+++ b/apps/cli/src/lib/trello/config.ts
@@ -6,6 +6,7 @@
  */
 
 import Database from 'better-sqlite3'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 
 const SETTINGS_TABLE = 'workspace_settings'
 
@@ -133,9 +134,24 @@ export function clearTrelloConfig(db: Database.Database): void {
  * Also checks PRLT_TRELLO_API_KEY and TRELLO_API_KEY environment variables.
  */
 export function getTrelloApiKey(db: Database.Database): string | null {
+  // 1. Try provider sources (resolves apiKeyRef → trello.api_key)
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'trello') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch {
+    // Provider sources may not exist in older databases
+  }
+
+  // 2. Legacy: environment variables
   const envKey = process.env.PRLT_TRELLO_API_KEY || process.env.TRELLO_API_KEY
   if (envKey) return envKey
 
+  // 3. Legacy: stored workspace setting
   return getSetting(db, TRELLO_CONFIG_KEYS.apiKey)
 }
 
@@ -144,8 +160,10 @@ export function getTrelloApiKey(db: Database.Database): string | null {
  * Also checks PRLT_TRELLO_API_TOKEN and TRELLO_API_TOKEN environment variables.
  */
 export function getTrelloApiToken(db: Database.Database): string | null {
+  // 1. Legacy: environment variables
   const envToken = process.env.PRLT_TRELLO_API_TOKEN || process.env.TRELLO_API_TOKEN
   if (envToken) return envToken
 
+  // 2. Legacy: stored workspace setting
   return getSetting(db, TRELLO_CONFIG_KEYS.apiToken)
 }

--- a/apps/cli/src/lib/work-source/index.ts
+++ b/apps/cli/src/lib/work-source/index.ts
@@ -29,4 +29,6 @@ export {
   resolveProviderByPrefixFromList,
   getRoutingTable,
   resolveApiKey,
+  upsertProviderSource,
+  removeProviderSourcesByProvider,
 } from './provider-sources.js'

--- a/apps/cli/src/lib/work-source/provider-sources.ts
+++ b/apps/cli/src/lib/work-source/provider-sources.ts
@@ -309,6 +309,55 @@ export function getRoutingTable(
 }
 
 // =============================================================================
+// Upsert (for connect commands)
+// =============================================================================
+
+/**
+ * Create or update a provider source entry by id.
+ * Used by connect commands to register the provider as a source after authentication.
+ * If an entry with the same id exists, it is replaced. Otherwise a new entry is added.
+ */
+export function upsertProviderSource(
+  db: Database.Database,
+  entry: ProviderSourceEntry,
+): ProviderSourceValidationError[] {
+  const errors = validateProviderSourceEntry(entry)
+  if (errors.length > 0) return errors
+
+  const existing = loadProviderSources(db)
+  const index = existing.findIndex((e) => e.id === entry.id)
+
+  if (index !== -1) {
+    // Check prefix uniqueness against other entries
+    if (existing.some((e, i) => i !== index && e.prefix.toUpperCase() === entry.prefix.toUpperCase())) {
+      return [{ field: 'prefix', message: `A provider source with prefix "${entry.prefix}" already exists` }]
+    }
+    existing[index] = entry
+    saveProviderSources(db, existing)
+    return []
+  }
+
+  // New entry – delegate to addProviderSource for uniqueness checks
+  return addProviderSource(db, entry)
+}
+
+/**
+ * Remove all provider source entries for a given provider type.
+ * Used by connect --disconnect to clean up provider sources.
+ * Returns the number of entries removed.
+ */
+export function removeProviderSourcesByProvider(
+  db: Database.Database,
+  provider: WorkSourceProvider,
+): number {
+  const sources = loadProviderSources(db)
+  const filtered = sources.filter((e) => e.provider !== provider)
+  const removedCount = sources.length - filtered.length
+  saveProviderSources(db, filtered)
+  return removedCount
+}
+
+// =============================================================================
 // API Key Resolution
 // =============================================================================
 

--- a/apps/cli/test/unit/provider-sources.test.ts
+++ b/apps/cli/test/unit/provider-sources.test.ts
@@ -12,6 +12,8 @@ import {
   resolveProviderByPrefixFromList,
   getRoutingTable,
   resolveApiKey,
+  upsertProviderSource,
+  removeProviderSourcesByProvider,
   type ProviderSourceEntry,
 } from '../../src/lib/work-source/provider-sources.js'
 
@@ -308,6 +310,104 @@ describe('provider-sources', () => {
       const db = setupDb()
       const key = resolveApiKey(db, makeEntry({ apiKeyRef: 'nonexistent.key' }))
       expect(key).to.be.null
+      db.close()
+    })
+  })
+
+  // ===========================================================================
+  // Upsert (for connect commands)
+  // ===========================================================================
+  describe('upsertProviderSource', () => {
+    it('inserts a new entry when id does not exist', () => {
+      const db = setupDb()
+      const errors = upsertProviderSource(db, makeEntry())
+      expect(errors).to.have.length(0)
+      expect(loadProviderSources(db)).to.have.length(1)
+      db.close()
+    })
+
+    it('replaces an existing entry with the same id', () => {
+      const db = setupDb()
+      upsertProviderSource(db, makeEntry({ label: 'Original' }))
+      const errors = upsertProviderSource(db, makeEntry({ label: 'Updated', teamProjectId: 'NEW' }))
+      expect(errors).to.have.length(0)
+
+      const sources = loadProviderSources(db)
+      expect(sources).to.have.length(1)
+      expect(sources[0].label).to.equal('Updated')
+      expect(sources[0].teamProjectId).to.equal('NEW')
+      db.close()
+    })
+
+    it('preserves other entries when upserting', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-' }))
+      upsertProviderSource(db, makeEntry())
+
+      const sources = loadProviderSources(db)
+      expect(sources).to.have.length(2)
+      db.close()
+    })
+
+    it('rejects duplicate prefix against other entries', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-' }))
+      const errors = upsertProviderSource(db, makeEntry({ prefix: 'PROD-' }))
+      expect(errors.some(e => e.field === 'prefix')).to.be.true
+      db.close()
+    })
+
+    it('allows updating prefix on same id without conflict', () => {
+      const db = setupDb()
+      upsertProviderSource(db, makeEntry())
+      const errors = upsertProviderSource(db, makeEntry({ prefix: 'NEW-' }))
+      expect(errors).to.have.length(0)
+
+      const sources = loadProviderSources(db)
+      expect(sources[0].prefix).to.equal('NEW-')
+      db.close()
+    })
+
+    it('returns validation errors for invalid entry', () => {
+      const db = setupDb()
+      const errors = upsertProviderSource(db, makeEntry({ id: '' }))
+      expect(errors.some(e => e.field === 'id')).to.be.true
+      db.close()
+    })
+  })
+
+  // ===========================================================================
+  // Remove by provider
+  // ===========================================================================
+  describe('removeProviderSourcesByProvider', () => {
+    it('removes all entries for a given provider', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      addProviderSource(db, makeEntry({ id: 'linear-design', prefix: 'DES-', teamProjectId: 'DES' }))
+      addProviderSource(db, makeEntry({ id: 'prod-asana', provider: 'asana', apiKeyRef: 'asana.access_token', teamProjectId: 'PROD', prefix: 'PROD-' }))
+
+      const removed = removeProviderSourcesByProvider(db, 'linear')
+      expect(removed).to.equal(2)
+
+      const remaining = loadProviderSources(db)
+      expect(remaining).to.have.length(1)
+      expect(remaining[0].provider).to.equal('asana')
+      db.close()
+    })
+
+    it('returns 0 when no entries match', () => {
+      const db = setupDb()
+      addProviderSource(db, makeEntry())
+      const removed = removeProviderSourcesByProvider(db, 'asana')
+      expect(removed).to.equal(0)
+      expect(loadProviderSources(db)).to.have.length(1)
+      db.close()
+    })
+
+    it('handles empty sources', () => {
+      const db = setupDb()
+      const removed = removeProviderSourcesByProvider(db, 'linear')
+      expect(removed).to.equal(0)
       db.close()
     })
   })


### PR DESCRIPTION
## Summary
- Connect commands (linear, asana, shortcut, monday, trello) now create a provider source entry with `apiKeyRef` pointing to the legacy workspace_settings key after authentication, making provider-sources the single system for API key resolution
- All provider config modules (`getXxxApiKey`) now check provider-sources first, then fall back to legacy env vars and workspace_settings for backwards compatibility
- `--disconnect` handlers clean up provider source entries alongside legacy config
- Added `upsertProviderSource` and `removeProviderSourcesByProvider` helpers with full test coverage (9 new tests, 40 total passing)

## Test plan
- [x] All 40 provider-sources unit tests pass (including 9 new)
- [x] TypeScript build passes with no errors
- [ ] Manual: `prlt linear connect` creates a provider source entry visible in `work.provider_sources`
- [ ] Manual: `prlt linear connect --disconnect` removes both legacy config and provider source
- [ ] Manual: Legacy env var fallback still works when no provider source exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)