### PR TITLE
PRLT-945: Fix outbound sync — create Linear mapping on work start --from

### DIFF
--- a/apps/cli/src/commands/work/linear.ts
+++ b/apps/cli/src/commands/work/linear.ts
@@ -21,6 +21,7 @@ import {
   buildLinearSpawnContextMessage,
 } from '../../lib/external-issues/linear.js'
 import { getLinearApiKey, loadLinearConfig } from '../../lib/linear/index.js'
+import { LinearMapper } from '../../lib/linear/mapper.js'
 
 function buildWorkStartArgs(options: {
   ticketId: string
@@ -129,8 +130,9 @@ export default class WorkLinear extends PMOCommand {
     const description = buildLinearTicketDescription(envelope)
     const metadata = buildLinearMetadata(envelope)
 
+    let ticket: Ticket
     if (existing) {
-      const updated = await this.storage.updateTicket(existing.id, {
+      ticket = await this.storage.updateTicket(existing.id, {
         title: envelope.title,
         description,
         priority: envelope.priority ?? undefined,
@@ -141,17 +143,34 @@ export default class WorkLinear extends PMOCommand {
           ...metadata,
         },
       })
-      return updated
+    } else {
+      ticket = await this.storage.createTicket(projectId, {
+        title: envelope.title,
+        description,
+        priority: envelope.priority ?? undefined,
+        category: envelope.category ?? undefined,
+        labels: envelope.labels,
+        metadata,
+      })
     }
 
-    return this.storage.createTicket(projectId, {
-      title: envelope.title,
-      description,
-      priority: envelope.priority ?? undefined,
-      category: envelope.category ?? undefined,
-      labels: envelope.labels,
-      metadata,
-    })
+    // Create Linear mapping so OutboundSyncHandler can push status/PR changes back
+    const db = this.storage.getDatabase()
+    const mapper = new LinearMapper(db)
+    const existingMapping = mapper.getByTicketId(ticket.id)
+    if (!existingMapping) {
+      mapper.createMapping({
+        pmoTicketId: ticket.id,
+        linearIssueId: envelope.source.externalId,
+        linearIdentifier: envelope.source.externalKey,
+        linearTeamKey: envelope.projectKey,
+        linearUrl: envelope.source.url,
+        syncDirection: 'outbound',
+        createdAt: new Date(),
+      })
+    }
+
+    return ticket
   }
 
   async execute(): Promise<void> {

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -78,6 +78,7 @@ import {
 } from '../../lib/external-issues/trello.js'
 import { resolveMirrorToPmo } from '../../lib/external-issues/work-start.js'
 import { getLinearApiKey, loadLinearConfig } from '../../lib/linear/config.js'
+import { LinearMapper } from '../../lib/linear/mapper.js'
 import { ExternalIssueAdapterError, type IssueSource, type NormalizedIssueEnvelope } from '../../lib/external-issues/types.js'
 import {
   parseWorkSourceRef,
@@ -380,13 +381,14 @@ export default class WorkStart extends PMOCommand {
     })
   }
 
-  private async createOrUpdateLinkedTicket(projectId: string, envelope: NormalizedIssueEnvelope): Promise<Ticket> {
+  private async createOrUpdateLinkedTicket(projectId: string, envelope: NormalizedIssueEnvelope, db: Database.Database): Promise<Ticket> {
     const existing = await this.findLinkedTicketByEnvelope(projectId, envelope)
     const description = buildExternalTicketDescription(envelope)
     const metadata = buildExternalMetadata(envelope)
 
+    let ticket: Ticket
     if (existing) {
-      return this.storage.updateTicket(existing.id, {
+      ticket = await this.storage.updateTicket(existing.id, {
         title: envelope.title,
         description,
         priority: envelope.priority ?? undefined,
@@ -397,16 +399,35 @@ export default class WorkStart extends PMOCommand {
           ...metadata,
         },
       })
+    } else {
+      ticket = await this.storage.createTicket(projectId, {
+        title: envelope.title,
+        description,
+        priority: envelope.priority ?? undefined,
+        category: envelope.category ?? undefined,
+        labels: envelope.labels,
+        metadata,
+      })
     }
 
-    return this.storage.createTicket(projectId, {
-      title: envelope.title,
-      description,
-      priority: envelope.priority ?? undefined,
-      category: envelope.category ?? undefined,
-      labels: envelope.labels,
-      metadata,
-    })
+    // Create Linear mapping so OutboundSyncHandler can push status/PR changes back
+    if (envelope.source.name === 'linear') {
+      const mapper = new LinearMapper(db)
+      const existingMapping = mapper.getByTicketId(ticket.id)
+      if (!existingMapping) {
+        mapper.createMapping({
+          pmoTicketId: ticket.id,
+          linearIssueId: envelope.source.externalId,
+          linearIdentifier: envelope.source.externalKey,
+          linearTeamKey: envelope.projectKey,
+          linearUrl: envelope.source.url,
+          syncDirection: 'outbound',
+          createdAt: new Date(),
+        })
+      }
+    }
+
+    return ticket
   }
 
   private async fetchExternalIssue(
@@ -671,7 +692,7 @@ export default class WorkStart extends PMOCommand {
         let linkedTicket: Ticket
 
         if (mirrorToPmo) {
-          linkedTicket = await this.createOrUpdateLinkedTicket(projectId, envelope)
+          linkedTicket = await this.createOrUpdateLinkedTicket(projectId, envelope, db)
           await autoExportToBoard(this.pmoPath, this.storage)
         } else {
           if (!existingLinkedTicket) {


### PR DESCRIPTION
## Summary

- **Root cause**: `work start --from linear:` and `work linear` create a PMO ticket with external metadata (`external_source`, `external_id`, etc.) but never insert a row into `pmo_linear_issue_map`. When `OutboundSyncHandler.syncStatusToLinear()` looks up the mapping via `mapper.getByTicketId()`, it finds nothing and silently skips the sync. The provider-agnostic fallback path also can't help because it explicitly skips `linear` provider entries (expecting the Linear-specific path to handle them).
- **Fix**: After creating/updating the linked PMO ticket, insert a `pmo_linear_issue_map` entry with `syncDirection: 'outbound'` so the outbound sync handler can find the Linear issue to update when ticket status changes or PRs are linked.
- Applied to both `work start --from linear:` (unified command) and `work linear` (legacy command).

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Existing outbound-sync unit tests pass (11/11)
- [ ] Manual: run `prlt work start --from linear:ENG-XXX`, verify `pmo_linear_issue_map` row created with `sync_direction = 'outbound'`
- [ ] Manual: complete the ticket, verify Linear issue status updates
- [ ] Manual: create a PR via `prlt pr create`, verify PR link appears on Linear issue


🤖 Generated with [Claude Code](https://claude.com/claude-code)