### PR TITLE
PRLT-948: Fix prompt delivery to agents on host execution

### DIFF
--- a/apps/cli/src/lib/execution/runners.ts
+++ b/apps/cli/src/lib/execution/runners.ts
@@ -1058,6 +1058,10 @@ export async function runHost(
   let executorInvocation: string
   if (isClaudeExecutor(executor)) {
     // Build flags based on config - Claude-specific flags
+    // PRLT-948: --permission-mode bypassPermissions skips the "trust this folder" dialog.
+    // Without it, Claude Code shows a workspace trust prompt in new worktrees and the
+    // agent sits idle waiting for user input that never comes in automated tmux sessions.
+    const bypassTrustFlag = skipPermissions ? '--permission-mode bypassPermissions ' : ''
     const permissionsFlag = skipPermissions ? '--dangerously-skip-permissions ' : ''
     // outputMode: 'print' adds -p flag (final result only), 'interactive' shows streaming UI
     const printFlag = config.outputMode === 'print' ? '-p ' : ''
@@ -1070,7 +1074,7 @@ export async function runHost(
     const disallowPlanFlag = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
     // Tool registry (TKT-083): pass MCP config to Claude Code via --mcp-config flag
     const mcpConfigFlag = mcpConfigPath ? `--mcp-config "${mcpConfigPath}" ` : ''
-    executorInvocation = `${cmd} ${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}${systemPromptFlag}${mcpConfigFlag}"$(cat "$PROMPT_PATH")"`
+    executorInvocation = `${cmd} ${bypassTrustFlag}${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}${systemPromptFlag}${mcpConfigFlag}"$(cat "$PROMPT_PATH")"`
   } else if (executor === 'codex') {
     // TKT-080: Use Codex adapter for deterministic command building.
     // Uses PLACEHOLDER pattern for reliable prompt replacement (same as devcontainer runner).
@@ -1121,13 +1125,14 @@ exec $SHELL
   // so the agent at least gets a working session instead of silently failing.
   let fallbackInvocation: string
   if (isClaudeExecutor(executor)) {
+    const fbBypassTrust = skipPermissions ? '--permission-mode bypassPermissions ' : ''
     const fbPermissions = skipPermissions ? '--dangerously-skip-permissions ' : ''
     const fbEffort = skipPermissions ? '--effort high ' : ''
     const fbPrint = config.outputMode === 'print' ? '-p ' : ''
     const fbDisallowPlan = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
     const fbSystemPrompt = systemPromptPath ? '--system-prompt "$(cat "$SYSTEM_PROMPT_PATH")" ' : ''
     const fbMcpConfig = mcpConfigPath ? `--mcp-config "${mcpConfigPath}" ` : ''
-    fallbackInvocation = `${cmd} ${fbPermissions}${fbEffort}${fbPrint}${fbDisallowPlan}${fbSystemPrompt}${fbMcpConfig}`.trim()
+    fallbackInvocation = `${cmd} ${fbBypassTrust}${fbPermissions}${fbEffort}${fbPrint}${fbDisallowPlan}${fbSystemPrompt}${fbMcpConfig}`.trim()
   } else {
     fallbackInvocation = cmd
   }


### PR DESCRIPTION
## Summary

- **Root cause**: The host runner's manually-built Claude Code invocation in `runHost()` was missing the `--permission-mode bypassPermissions` flag. Without it, Claude Code shows a workspace trust dialog ("Do you trust the files in this folder?") in new worktrees. In automated tmux sessions, nobody dismisses this dialog, so the agent sits idle at the welcome screen.
- The devcontainer runner (line 2137) and `getExecutorCommand()` (line 354) both correctly include this flag, but the host runner's manual flag construction omitted it when the invocation was refactored to build flags individually.
- Added `--permission-mode bypassPermissions` to both the main executor invocation and the fallback (interactive mode) invocation in the host runner.

## Test plan

- [ ] Run `prlt work start --run-on-host` with danger mode on a fresh worktree — agent should receive the prompt and begin working immediately instead of stalling at the trust dialog
- [ ] Verify the generated tmux script includes `--permission-mode bypassPermissions --dangerously-skip-permissions` flags
- [ ] Verify non-danger mode (safe) still launches without bypass flags (user manually handles trust dialog)
- [ ] Verify sandbox/srt path is unaffected (uses the same `executorInvocation` variable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)