### PR TITLE
chore: bump version to 0.3.64

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.62",
+  "version": "0.3.64",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Includes PRLT-945 (outbound sync fix), PRLT-947 (generic external_issue_map), PRLT-948 (host prompt delivery fix).