### PR TITLE
PRLT-866: Fix work start blocking on Docker OAuth prompt in non-interactive mode

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -1604,8 +1604,8 @@ export default class WorkStart extends PMOCommand {
           this.log(styles.warning('Docker daemon is not running. Start Docker Desktop or use --run-on-host.'))
           this.log('')
 
-          if (jsonMode && flags.yes) {
-            // In JSON mode with --yes, auto-switch to host
+          if (flags.yes || !process.stdout.isTTY) {
+            // Non-interactive mode: auto-switch to host
             environment = 'host'
             this.log(styles.muted('Switched to host environment (Docker not running).'))
           } else {
@@ -1663,11 +1663,18 @@ export default class WorkStart extends PMOCommand {
           // Saved preference: OAuth — validate credentials exist
           const hasCredentials = dockerCredentialsExist()
           if (!hasCredentials) {
-            this.log('')
-            this.log(styles.warning('⚠️  Saved auth method is "oauth" but no OAuth credentials found.'))
-            this.log(styles.muted('   Run "' + this.config.bin + ' agent auth" to authenticate.'))
-            db.close()
-            return
+            if (flags.yes || !process.stdout.isTTY) {
+              // Non-interactive mode: auto-fallback to host
+              this.log(styles.warning('⚠️  Saved auth method is "oauth" but no OAuth credentials found.'))
+              environment = 'host'
+              this.log(styles.muted('Switched to host environment (OAuth credentials missing).'))
+            } else {
+              this.log('')
+              this.log(styles.warning('⚠️  Saved auth method is "oauth" but no OAuth credentials found.'))
+              this.log(styles.muted('   Run "' + this.config.bin + ' agent auth" to authenticate.'))
+              db.close()
+              return
+            }
           }
           // OAuth credentials valid — continue (useApiKey stays false)
         } else {
@@ -1679,9 +1686,10 @@ export default class WorkStart extends PMOCommand {
             // useApiKey stays false
           } else {
             // No saved preference and no OAuth credentials — prompt user
-            // In JSON mode with --yes, continue anyway (agent can run /login)
-            if (jsonMode && flags.yes) {
-              // Continue without prompting - agent will need to handle auth
+            if (flags.yes || !process.stdout.isTTY) {
+              // Non-interactive mode: auto-fallback to host
+              environment = 'host'
+              this.log(styles.warning('⚠️  No OAuth credentials found. Switched to host environment.'))
             } else {
               this.log('')
               this.log(styles.warning('⚠️  No Claude Code OAuth credentials found for Docker containers'))
@@ -2495,126 +2503,138 @@ export default class WorkStart extends PMOCommand {
         this.log(styles.warning('Docker daemon is not running. Start Docker Desktop or use --run-on-host.'))
         this.log('')
 
-        const { dockerAction } = await this.prompt<{ dockerAction: string }>([
-          {
-            type: 'list',
-            name: 'dockerAction',
-            message: 'Docker is not running. What would you like to do?',
-            choices: [
-              { name: '💻 Run all agents on host instead (--run-on-host)', value: 'host', command: 'prlt work start --all --run-on-host --json' },
-              { name: '✗  Cancel', value: 'cancel', command: '' },
-            ],
-          },
-        ], batchJsonModeConfig)
+        if (!process.stdout.isTTY) {
+          // Non-interactive mode: auto-switch to host
+          flags['run-on-host'] = true
+          this.log(styles.muted('All agents will run on host (Docker not running).'))
+        } else {
+          const { dockerAction } = await this.prompt<{ dockerAction: string }>([
+            {
+              type: 'list',
+              name: 'dockerAction',
+              message: 'Docker is not running. What would you like to do?',
+              choices: [
+                { name: '💻 Run all agents on host instead (--run-on-host)', value: 'host', command: 'prlt work start --all --run-on-host --json' },
+                { name: '✗  Cancel', value: 'cancel', command: '' },
+              ],
+            },
+          ], batchJsonModeConfig)
 
-        if (dockerAction === 'cancel') {
-          db.close()
-          this.log(styles.muted('Cancelled.'))
-          return
+          if (dockerAction === 'cancel') {
+            db.close()
+            this.log(styles.muted('Cancelled.'))
+            return
+          }
+
+          flags['run-on-host'] = true
+          this.log(styles.muted('All agents will run on host.'))
         }
-
-        flags['run-on-host'] = true
-        this.log(styles.muted('All agents will run on host.'))
       }
 
       if (!flags['run-on-host']) {
       const hasCredentials = dockerCredentialsExist()
       if (!hasCredentials) {
-        const hasApiKey = !!process.env.ANTHROPIC_API_KEY
-
-        this.log('')
-        this.log(styles.warning('⚠️  No Claude Code OAuth credentials found for Docker containers'))
-        this.log(styles.muted('   Agents need credentials to authenticate with Claude.'))
-        this.log('')
-
-        // Build choices based on available options
-        const batchAuthChoices: Array<{ name: string; value: string; command?: string }> = [
-          { name: `🔐 Run ${this.config.bin} agent auth now (recommended — uses Max subscription)`, value: 'auth', command: `${this.config.bin} agent auth` },
-        ]
-        if (hasApiKey) {
-          batchAuthChoices.push({ name: '🔑 Use ANTHROPIC_API_KEY (⚠️  uses API credits, not Max subscription)', value: 'apikey', command: '' })
-        }
-        batchAuthChoices.push(
-          { name: '💻 Run all agents on host instead (--run-on-host)', value: 'host', command: 'prlt work start --all --run-on-host --json' },
-          { name: '✗  Cancel', value: 'cancel', command: '' },
-        )
-
-        const { authAction } = await this.prompt<{ authAction: string }>([
-          {
-            type: 'list',
-            name: 'authAction',
-            message: 'What would you like to do?',
-            choices: batchAuthChoices,
-          },
-        ], batchJsonModeConfig)
-
-        if (authAction === 'cancel') {
-          db.close()
-          this.log(styles.muted('Cancelled.'))
-          return
-        }
-
-        if (authAction === 'host') {
+        if (!process.stdout.isTTY) {
+          // Non-interactive mode: auto-fallback to host
+          this.log(styles.warning('⚠️  No OAuth credentials found. Switched to host environment.'))
           flags['run-on-host'] = true
-          this.log(styles.muted('All agents will run on host.'))
-        } else if (authAction === 'apikey') {
-          batchUseApiKey = true
-          this.log(styles.warning('Using ANTHROPIC_API_KEY — this will consume API credits.'))
-          this.log(styles.muted(`Run "${this.config.bin} agent auth" to set up OAuth and use your Max subscription instead.`))
+        } else {
+          const hasApiKey = !!process.env.ANTHROPIC_API_KEY
+
           this.log('')
-        } else if (authAction === 'auth') {
-          this.log('')
-          this.log(styles.primary(`Opening ${this.config.bin} agent auth in new tab...`))
+          this.log(styles.warning('⚠️  No Claude Code OAuth credentials found for Docker containers'))
+          this.log(styles.muted('   Agents need credentials to authenticate with Claude.'))
           this.log('')
 
-          // Open auth in a new terminal tab
-          const authCmd = `${process.argv[1]} agent auth`
-          try {
-            execSync(`osascript -e '
-              tell application "iTerm"
-                tell current window
-                  create tab with default profile
-                  tell current session
-                    write text "${authCmd}"
-                  end tell
-                end tell
-              end tell
-            '`)
-          } catch {
-            // Fallback: try Terminal.app
-            try {
-              execSync(`osascript -e 'tell application "Terminal" to do script "${authCmd}"'`)
-            } catch {
-              this.log(styles.warning('Could not open new terminal tab.'))
-              this.log(styles.muted(`Please run manually: ${authCmd}`))
-            }
+          // Build choices based on available options
+          const batchAuthChoices: Array<{ name: string; value: string; command?: string }> = [
+            { name: `🔐 Run ${this.config.bin} agent auth now (recommended — uses Max subscription)`, value: 'auth', command: `${this.config.bin} agent auth` },
+          ]
+          if (hasApiKey) {
+            batchAuthChoices.push({ name: '🔑 Use ANTHROPIC_API_KEY (⚠️  uses API credits, not Max subscription)', value: 'apikey', command: '' })
           }
+          batchAuthChoices.push(
+            { name: '💻 Run all agents on host instead (--run-on-host)', value: 'host', command: 'prlt work start --all --run-on-host --json' },
+            { name: '✗  Cancel', value: 'cancel', command: '' },
+          )
 
-          this.log(styles.muted('Complete the /login flow in the new tab, then press Enter here...'))
-          this.log('')
+          const { authAction } = await this.prompt<{ authAction: string }>([
+            {
+              type: 'list',
+              name: 'authAction',
+              message: 'What would you like to do?',
+              choices: batchAuthChoices,
+            },
+          ], batchJsonModeConfig)
 
-          // Wait for user to complete auth
-          await this.prompt<{ done: string }>([{
-            type: 'input',
-            name: 'done',
-            message: 'Press Enter when authentication is complete:',
-          }], batchJsonModeConfig)
-
-          // Check if credentials now exist
-          if (!dockerCredentialsExist()) {
-            this.log('')
-            this.log(styles.warning('Authentication did not complete. No credentials found.'))
+          if (authAction === 'cancel') {
             db.close()
+            this.log(styles.muted('Cancelled.'))
             return
           }
-          const info = getDockerCredentialInfo()
-          this.log('')
-          this.log(styles.success('✓ Credentials configured'))
-          if (info) {
-            this.log(styles.muted(`   Subscription: ${info.subscriptionType || 'unknown'}`))
-            this.log(styles.muted(`   Expires: ${info.expiresAt.toLocaleDateString()}`))
+
+          if (authAction === 'host') {
+            flags['run-on-host'] = true
+            this.log(styles.muted('All agents will run on host.'))
+          } else if (authAction === 'apikey') {
+            batchUseApiKey = true
+            this.log(styles.warning('Using ANTHROPIC_API_KEY — this will consume API credits.'))
+            this.log(styles.muted(`Run "${this.config.bin} agent auth" to set up OAuth and use your Max subscription instead.`))
+            this.log('')
+          } else if (authAction === 'auth') {
+            this.log('')
+            this.log(styles.primary(`Opening ${this.config.bin} agent auth in new tab...`))
+            this.log('')
+
+            // Open auth in a new terminal tab
+            const authCmd = `${process.argv[1]} agent auth`
+            try {
+              execSync(`osascript -e '
+                tell application "iTerm"
+                  tell current window
+                    create tab with default profile
+                    tell current session
+                      write text "${authCmd}"
+                    end tell
+                  end tell
+                end tell
+              '`)
+            } catch {
+              // Fallback: try Terminal.app
+              try {
+                execSync(`osascript -e 'tell application "Terminal" to do script "${authCmd}"'`)
+              } catch {
+                this.log(styles.warning('Could not open new terminal tab.'))
+                this.log(styles.muted(`Please run manually: ${authCmd}`))
+              }
+            }
+
+            this.log(styles.muted('Complete the /login flow in the new tab, then press Enter here...'))
+            this.log('')
+
+            // Wait for user to complete auth
+            await this.prompt<{ done: string }>([{
+              type: 'input',
+              name: 'done',
+              message: 'Press Enter when authentication is complete:',
+            }], batchJsonModeConfig)
+
+            // Check if credentials now exist
+            if (!dockerCredentialsExist()) {
+              this.log('')
+              this.log(styles.warning('Authentication did not complete. No credentials found.'))
+              db.close()
+              return
+            }
+            const info = getDockerCredentialInfo()
+            this.log('')
+            this.log(styles.success('✓ Credentials configured'))
+            if (info) {
+              this.log(styles.muted(`   Subscription: ${info.subscriptionType || 'unknown'}`))
+              this.log(styles.muted(`   Expires: ${info.expiresAt.toLocaleDateString()}`))
+            }
+            this.log('')
           }
-          this.log('')
         }
       }
       }


### PR DESCRIPTION
## Summary
- When Docker OAuth credentials are missing during `work start`, interactive prompts (auth method selection, Docker-not-running fallback) would block execution in `--yes` or non-TTY mode
- Now auto-falls back to host execution (`--run-on-host`) when running non-interactively instead of hanging on prompts
- Fixes both single-ticket mode and batch (`--all`) mode credential checks

## Changes
All changes in `apps/cli/src/commands/work/start.ts`:

**Single-ticket mode:**
- Docker-not-running check: broadened `jsonMode && flags.yes` guard to `flags.yes || !process.stdout.isTTY` so it covers all non-interactive scenarios
- Saved auth method is `oauth` but credentials missing: auto-fallback to host instead of returning error in non-interactive mode
- No saved preference + no credentials: auto-fallback to host instead of only handling `jsonMode && flags.yes` (which left plain `--yes` unhandled)

**Batch mode (`--all`):**
- Docker-not-running check: added `!process.stdout.isTTY` guard before interactive prompt
- OAuth credentials missing: added `!process.stdout.isTTY` guard before interactive prompt, auto-switches to host

## Test plan
- [ ] Run `prlt work start <ticket> --yes` with Docker stopped → should auto-switch to host, not prompt
- [ ] Run `prlt work start <ticket> --yes` with saved auth=oauth but no credentials → should auto-switch to host
- [ ] Run `prlt work start <ticket>` interactively with no credentials → should still show auth menu as before
- [ ] Run `prlt work start --all` in non-TTY pipe → should auto-switch to host when Docker/credentials missing
- [ ] Build passes: `cd apps/cli && pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)