### PR TITLE
PRLT-939: Add Drizzle migration system for SQLite schema upgrades

### DIFF
--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -2,8 +2,12 @@ import Database from 'better-sqlite3';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { getThemePersistentDir, isEphemeralAgentName } from '../themes.js';
-import { PMO_SCHEMA_SQL } from '../pmo/schema.js';
 import { throwIfNativeBindingError } from './native-validation.js';
+import { runDrizzleMigrations } from './migrator.js';
+import { ALL_MIGRATIONS } from './migrations/index.js';
+
+// Re-export CREATE_TABLES_SQL from its canonical location
+export { CREATE_TABLES_SQL } from './workspace-schema.js';
 
 export interface WorkspaceConfig {
   id: number;
@@ -65,108 +69,7 @@ export interface AgentWorktree {
   last_checked?: string;
 }
 
-export const CREATE_TABLES_SQL = `
--- Core workspace metadata
-CREATE TABLE IF NOT EXISTS workspace (
-  id INTEGER PRIMARY KEY CHECK (id = 1),
-  type TEXT NOT NULL CHECK (type IN ('hq', 'workspace')),
-  workspace_name TEXT NOT NULL,
-  has_pmo BOOLEAN DEFAULT FALSE,
-  active_theme_id TEXT,
-  created_at TEXT NOT NULL,
-  FOREIGN KEY (active_theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
-);
-
--- Repository management
-CREATE TABLE IF NOT EXISTS repositories (
-  name TEXT PRIMARY KEY,
-  path TEXT NOT NULL,
-  type TEXT DEFAULT 'main' CHECK (type IN ('main', 'dependency')),
-  source_url TEXT,
-  action TEXT CHECK (action IN ('clone', 'move', 'link')),
-  added_at TEXT NOT NULL
-);
-
--- Agent naming themes (optional)
-CREATE TABLE IF NOT EXISTS agent_themes (
-  id TEXT PRIMARY KEY,
-  name TEXT NOT NULL UNIQUE,
-  display_name TEXT NOT NULL,
-  description TEXT,
-  builtin BOOLEAN DEFAULT FALSE,
-  created_at TEXT NOT NULL
-);
-
--- Names available within each theme
-CREATE TABLE IF NOT EXISTS agent_theme_names (
-  theme_id TEXT NOT NULL,
-  name TEXT NOT NULL,
-  PRIMARY KEY (theme_id, name),
-  FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE CASCADE
-);
-
--- Agent instances in workspace
-CREATE TABLE IF NOT EXISTS agents (
-  name TEXT PRIMARY KEY,
-  type TEXT NOT NULL DEFAULT 'persistent' CHECK (type IN ('persistent', 'ephemeral')),
-  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'cleaned')),
-  base_name TEXT,
-  theme_id TEXT,
-  worktree_path TEXT,
-  mount_mode TEXT NOT NULL DEFAULT 'worktree' CHECK (mount_mode IN ('worktree', 'clone')),
-  created_at TEXT NOT NULL,
-  cleaned_at TEXT,
-  FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
-);
-
--- Agent-owned worktrees
-CREATE TABLE IF NOT EXISTS agent_worktrees (
-  agent_name TEXT NOT NULL,
-  repo_name TEXT NOT NULL,
-  worktree_path TEXT NOT NULL,
-  branch TEXT NOT NULL,
-  created_at TEXT NOT NULL,
-  last_commit_hash TEXT,
-  commits_ahead INTEGER NOT NULL DEFAULT 0,
-  is_clean INTEGER NOT NULL DEFAULT 1,
-  last_checked TEXT,
-  PRIMARY KEY (agent_name, repo_name),
-  FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
-  FOREIGN KEY (repo_name) REFERENCES repositories(name) ON DELETE CASCADE
-);
-
--- Workspace-level settings (key-value store)
-CREATE TABLE IF NOT EXISTS workspace_settings (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL
-);
-
--- Media items (videos, audio files with preprocessed assets)
-CREATE TABLE IF NOT EXISTS media_items (
-  name TEXT PRIMARY KEY,
-  path TEXT NOT NULL,
-  source_path TEXT,
-  media_type TEXT NOT NULL DEFAULT 'video' CHECK (media_type IN ('video', 'audio')),
-  duration_seconds REAL,
-  resolution TEXT,
-  frame_count INTEGER NOT NULL DEFAULT 0,
-  has_transcript INTEGER NOT NULL DEFAULT 0,
-  frame_interval INTEGER NOT NULL DEFAULT 30,
-  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'ready', 'error')),
-  error_message TEXT,
-  added_at TEXT NOT NULL,
-  processed_at TEXT
-);
-
--- =============================================================================
--- Indexes
--- =============================================================================
-
-CREATE INDEX IF NOT EXISTS idx_worktrees_agent ON agent_worktrees(agent_name);
-CREATE INDEX IF NOT EXISTS idx_worktrees_repo ON agent_worktrees(repo_name);
-CREATE INDEX IF NOT EXISTS idx_theme_names_theme ON agent_theme_names(theme_id);
-CREATE INDEX IF NOT EXISTS idx_agents_theme ON agents(theme_id);
-`;
+// CREATE_TABLES_SQL is now in workspace-schema.ts and re-exported above
 
 /**
  * Ensure ephemeral agents are correctly typed based on their worktree path or naming pattern
@@ -239,6 +142,9 @@ export function openWorkspaceDatabase(workspacePath: string): Database.Database 
   }
   db.pragma('foreign_keys = ON');
   db.pragma('busy_timeout = 5000');  // Wait up to 5 seconds if database is locked
+
+  // Run Drizzle migrations (creates tracking table, applies pending migrations)
+  runDrizzleMigrations(db, ALL_MIGRATIONS);
 
   // Ensure ephemeral agents are correctly typed
   ensureEphemeralAgentTypes(db);
@@ -423,11 +329,8 @@ export function createWorkspaceDatabase(
   // Enable foreign keys
   db.pragma('foreign_keys = ON');
 
-  // Create core workspace tables (agents, repos, etc)
-  db.exec(CREATE_TABLES_SQL);
-
-  // Create PMO tables (from shared schema)
-  db.exec(PMO_SCHEMA_SQL);
+  // Run all migrations (baseline creates core workspace + PMO tables)
+  runDrizzleMigrations(db, ALL_MIGRATIONS);
 
   // Insert workspace data (convert boolean to number for SQLite)
   db.prepare(`

--- a/apps/cli/src/lib/database/migrations/0001_baseline.ts
+++ b/apps/cli/src/lib/database/migrations/0001_baseline.ts
@@ -1,0 +1,21 @@
+/**
+ * Migration 0001 — Baseline
+ *
+ * Creates all core workspace tables and PMO tables that represent
+ * the current schema. Every statement uses CREATE TABLE IF NOT EXISTS
+ * so this migration is safe on both new and existing databases.
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+import { CREATE_TABLES_SQL } from '../workspace-schema.js'
+import { PMO_SCHEMA_SQL } from '../../pmo/schema.js'
+
+export const baseline: Migration = {
+  id: '0001',
+  name: 'baseline',
+  up: (db: Database.Database) => {
+    db.exec(CREATE_TABLES_SQL)
+    db.exec(PMO_SCHEMA_SQL)
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Migration registry.
+ *
+ * All migrations must be imported here and added to ALL_MIGRATIONS
+ * in chronological order. The migrator applies them in array order.
+ */
+
+import type { Migration } from '../migrator.js'
+import { baseline } from './0001_baseline.js'
+
+/**
+ * Ordered list of all migrations.
+ * New migrations should be appended to the end of this array.
+ */
+export const ALL_MIGRATIONS: Migration[] = [
+  baseline,
+]

--- a/apps/cli/src/lib/database/migrator.ts
+++ b/apps/cli/src/lib/database/migrator.ts
@@ -1,0 +1,59 @@
+/**
+ * Database migration runner for Proletariat workspace databases.
+ *
+ * Tracks applied migrations in a `prlt_migrations` table and runs
+ * pending migrations on startup. Handles the initial state where
+ * existing databases have no migrations table yet.
+ */
+
+import Database from 'better-sqlite3'
+
+export interface Migration {
+  /** Unique, sortable migration ID (e.g. "0001") */
+  id: string
+  /** Human-readable name (e.g. "baseline") */
+  name: string
+  /** Apply the migration to the database */
+  up: (db: Database.Database) => void
+}
+
+/**
+ * Run all pending migrations against the database.
+ *
+ * - Creates the `prlt_migrations` tracking table if it doesn't exist.
+ * - Skips migrations that have already been applied.
+ * - Each migration runs in its own transaction so partial failures
+ *   don't leave the tracking table out of sync.
+ *
+ * Safe to call on both brand-new and existing databases.
+ */
+export function runDrizzleMigrations(db: Database.Database, migrations: Migration[]): void {
+  // Ensure the tracking table exists
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS prlt_migrations (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `)
+
+  // Collect already-applied IDs
+  const applied = db.prepare('SELECT id FROM prlt_migrations').all() as { id: string }[]
+  const appliedSet = new Set(applied.map(m => m.id))
+
+  // Apply pending migrations in order
+  for (const migration of migrations) {
+    if (appliedSet.has(migration.id)) {
+      continue
+    }
+
+    const applyMigration = db.transaction(() => {
+      migration.up(db)
+      db.prepare(
+        'INSERT INTO prlt_migrations (id, name, applied_at) VALUES (?, ?, ?)'
+      ).run(migration.id, migration.name, new Date().toISOString())
+    })
+
+    applyMigration()
+  }
+}

--- a/apps/cli/src/lib/database/workspace-schema.ts
+++ b/apps/cli/src/lib/database/workspace-schema.ts
@@ -1,0 +1,109 @@
+/**
+ * Core workspace table definitions.
+ *
+ * Extracted so migration files can reference the SQL without
+ * creating a circular import through database/index.ts.
+ */
+
+export const CREATE_TABLES_SQL = `
+-- Core workspace metadata
+CREATE TABLE IF NOT EXISTS workspace (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  type TEXT NOT NULL CHECK (type IN ('hq', 'workspace')),
+  workspace_name TEXT NOT NULL,
+  has_pmo BOOLEAN DEFAULT FALSE,
+  active_theme_id TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (active_theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
+);
+
+-- Repository management
+CREATE TABLE IF NOT EXISTS repositories (
+  name TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
+  type TEXT DEFAULT 'main' CHECK (type IN ('main', 'dependency')),
+  source_url TEXT,
+  action TEXT CHECK (action IN ('clone', 'move', 'link')),
+  added_at TEXT NOT NULL
+);
+
+-- Agent naming themes (optional)
+CREATE TABLE IF NOT EXISTS agent_themes (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  builtin BOOLEAN DEFAULT FALSE,
+  created_at TEXT NOT NULL
+);
+
+-- Names available within each theme
+CREATE TABLE IF NOT EXISTS agent_theme_names (
+  theme_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  PRIMARY KEY (theme_id, name),
+  FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE CASCADE
+);
+
+-- Agent instances in workspace
+CREATE TABLE IF NOT EXISTS agents (
+  name TEXT PRIMARY KEY,
+  type TEXT NOT NULL DEFAULT 'persistent' CHECK (type IN ('persistent', 'ephemeral')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'cleaned')),
+  base_name TEXT,
+  theme_id TEXT,
+  worktree_path TEXT,
+  mount_mode TEXT NOT NULL DEFAULT 'worktree' CHECK (mount_mode IN ('worktree', 'clone')),
+  created_at TEXT NOT NULL,
+  cleaned_at TEXT,
+  FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
+);
+
+-- Agent-owned worktrees
+CREATE TABLE IF NOT EXISTS agent_worktrees (
+  agent_name TEXT NOT NULL,
+  repo_name TEXT NOT NULL,
+  worktree_path TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  last_commit_hash TEXT,
+  commits_ahead INTEGER NOT NULL DEFAULT 0,
+  is_clean INTEGER NOT NULL DEFAULT 1,
+  last_checked TEXT,
+  PRIMARY KEY (agent_name, repo_name),
+  FOREIGN KEY (agent_name) REFERENCES agents(name) ON DELETE CASCADE,
+  FOREIGN KEY (repo_name) REFERENCES repositories(name) ON DELETE CASCADE
+);
+
+-- Workspace-level settings (key-value store)
+CREATE TABLE IF NOT EXISTS workspace_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+-- Media items (videos, audio files with preprocessed assets)
+CREATE TABLE IF NOT EXISTS media_items (
+  name TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
+  source_path TEXT,
+  media_type TEXT NOT NULL DEFAULT 'video' CHECK (media_type IN ('video', 'audio')),
+  duration_seconds REAL,
+  resolution TEXT,
+  frame_count INTEGER NOT NULL DEFAULT 0,
+  has_transcript INTEGER NOT NULL DEFAULT 0,
+  frame_interval INTEGER NOT NULL DEFAULT 30,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'ready', 'error')),
+  error_message TEXT,
+  added_at TEXT NOT NULL,
+  processed_at TEXT
+);
+
+-- =============================================================================
+-- Indexes
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_worktrees_agent ON agent_worktrees(agent_name);
+CREATE INDEX IF NOT EXISTS idx_worktrees_repo ON agent_worktrees(repo_name);
+CREATE INDEX IF NOT EXISTS idx_theme_names_theme ON agent_theme_names(theme_id);
+CREATE INDEX IF NOT EXISTS idx_agents_theme ON agents(theme_id);
+`;


### PR DESCRIPTION
## Summary
- Adds a tracked migration system (`prlt_migrations` table) so SQLite schema changes between versions upgrade cleanly
- Extracts `CREATE_TABLES_SQL` to `workspace-schema.ts` and creates a migration runner (`migrator.ts`) that applies pending migrations on startup
- Baseline migration (`0001_baseline`) captures the full current schema using `CREATE TABLE IF NOT EXISTS`, safe for both new and existing databases
- Existing inline ALTER TABLE migrations are preserved for backward compatibility with older databases

## How it works
1. On startup (`openWorkspaceDatabase` / `createWorkspaceDatabase`), `runDrizzleMigrations()` creates the `prlt_migrations` tracking table if missing
2. Each registered migration is checked against applied records and run once
3. Future schema changes are added as new migration files in `migrations/` and appended to `ALL_MIGRATIONS`

## Test plan
- [x] Verified build passes (`pnpm build`)
- [x] Tested new DB creation: baseline applied, all tables created, migration tracked
- [x] Tested idempotency: re-running migrations is a no-op
- [x] Tested existing DB upgrade: `prlt_migrations` table created, baseline marked applied, existing data preserved
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)