### PR TITLE
PRLT-931: Add prlt pr merge and prlt pr checks commands

### DIFF
--- a/apps/cli/src/commands/pr/checks.ts
+++ b/apps/cli/src/commands/pr/checks.ts
@@ -1,0 +1,193 @@
+import { Args } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles, divider } from '../../lib/styles.js';
+import {
+  isGHInstalled,
+  isGHAuthenticated,
+  getPRByNumber,
+  getPRForBranch,
+  getCurrentBranch,
+  listOpenPRs,
+  getPRChecks,
+} from '../../lib/pr/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { FlagResolver } from '../../lib/flags/index.js';
+
+export default class PRChecks extends PMOCommand {
+  static description = 'Show CI check status for a pull request';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> 123',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static args = {
+    prNumber: Args.integer({
+      description: 'PR number (defaults to PR for current branch)',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+  };
+
+  // Flag to track if PMO is available
+  private hasPMO = true;
+
+  async init(): Promise<void> {
+    try {
+      await super.init();
+    } catch {
+      this.hasPMO = false;
+    }
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(PRChecks);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('pr checks', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Check gh CLI
+    if (!isGHInstalled()) {
+      return handleError('GH_NOT_INSTALLED', 'GitHub CLI (gh) is not installed. Install it from https://cli.github.com/');
+    }
+
+    if (!isGHAuthenticated()) {
+      return handleError('GH_NOT_AUTHENTICATED', 'GitHub CLI is not authenticated. Run "gh auth login" first.');
+    }
+
+    let prNumber = args.prNumber;
+
+    // If no PR number, try to detect from current branch
+    if (!prNumber) {
+      const currentBranch = getCurrentBranch();
+      if (currentBranch) {
+        const branchPR = getPRForBranch(currentBranch);
+        if (branchPR) {
+          prNumber = branchPR.number;
+        }
+      }
+    }
+
+    // Still no PR number - prompt for selection
+    if (!prNumber) {
+      const openPRs = listOpenPRs();
+
+      if (openPRs.length === 0) {
+        return handleError('NO_OPEN_PRS', 'No open pull requests found.');
+      }
+
+      const resolver = new FlagResolver<{ pr?: string }>({
+        commandName: 'pr checks',
+        baseCommand: 'prlt pr checks',
+        jsonMode,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'pr',
+        type: 'list',
+        message: 'Select PR to view checks:',
+        choices: () => openPRs.map(pr => ({
+          name: `#${pr.number} - ${pr.title} (${pr.headBranch})`,
+          value: String(pr.number),
+        })),
+      });
+
+      const resolved = await resolver.resolve();
+      prNumber = parseInt(resolved.pr!, 10);
+    }
+
+    // Verify PR exists
+    const prInfo = getPRByNumber(prNumber);
+    if (!prInfo) {
+      return handleError('PR_NOT_FOUND', `PR #${prNumber} not found.`);
+    }
+
+    // Get checks
+    const checks = getPRChecks(prNumber);
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          prNumber,
+          title: prInfo.title,
+          url: prInfo.url,
+          checks: checks.map(c => ({
+            name: c.name,
+            status: c.status,
+            conclusion: c.conclusion,
+            url: c.url,
+          })),
+          summary: {
+            total: checks.length,
+            passing: checks.filter(c => c.conclusion === 'SUCCESS').length,
+            failing: checks.filter(c => c.conclusion === 'FAILURE').length,
+            pending: checks.filter(c => c.status === 'IN_PROGRESS' || c.status === 'QUEUED').length,
+          },
+        },
+        createMetadata('pr checks', flags)
+      );
+      return;
+    }
+
+    // Interactive output
+    this.log('');
+    this.log(styles.header(`CI Checks: PR #${prNumber}`));
+    this.log(styles.muted(`   ${prInfo.title}`));
+    this.log(styles.muted(`   ${prInfo.url}`));
+    this.log(divider(60));
+
+    if (checks.length === 0) {
+      this.log(styles.muted('   No CI checks found for this PR.'));
+      return;
+    }
+
+    for (const check of checks) {
+      const icon = this.getCheckIcon(check.status, check.conclusion);
+      const statusText = check.conclusion || check.status;
+      this.log(`${icon} ${check.name} ${styles.muted(`(${statusText})`)}`);
+    }
+
+    this.log('');
+    this.log(divider(60));
+
+    const passing = checks.filter(c => c.conclusion === 'SUCCESS').length;
+    const failing = checks.filter(c => c.conclusion === 'FAILURE').length;
+    const pending = checks.filter(c => c.status === 'IN_PROGRESS' || c.status === 'QUEUED').length;
+
+    const parts: string[] = [];
+    parts.push(`Total: ${checks.length}`);
+    if (passing > 0) parts.push(styles.success(`Passing: ${passing}`));
+    if (failing > 0) parts.push(styles.error(`Failing: ${failing}`));
+    if (pending > 0) parts.push(styles.warning(`Pending: ${pending}`));
+
+    this.log(parts.join(' | '));
+  }
+
+  private getCheckIcon(status: string, conclusion: string): string {
+    if (conclusion === 'SUCCESS') return styles.success('✓');
+    if (conclusion === 'FAILURE') return styles.error('✗');
+    if (conclusion === 'CANCELLED' || conclusion === 'SKIPPED') return styles.muted('○');
+    if (status === 'IN_PROGRESS' || status === 'QUEUED') return styles.warning('●');
+    return styles.muted('?');
+  }
+}

--- a/apps/cli/src/commands/pr/index.ts
+++ b/apps/cli/src/commands/pr/index.ts
@@ -21,8 +21,8 @@ export default class PR extends PMOCommand {
     ...pmoBaseFlags,
     action: Flags.string({
       char: 'a',
-      description: 'Action to perform (list, create, link, status)',
-      options: ['list', 'create', 'link', 'status'],
+      description: 'Action to perform (list, create, merge, checks, link, status)',
+      options: ['list', 'create', 'merge', 'checks', 'link', 'status'],
     }),
   };
 
@@ -61,6 +61,8 @@ export default class PR extends PMOCommand {
       choices: () => [
         { name: 'List all open PRs', value: 'list' },
         { name: 'Create PR from current branch', value: 'create' },
+        { name: 'Merge a PR', value: 'merge' },
+        { name: 'View CI check status', value: 'checks' },
         { name: 'Link existing PR to ticket', value: 'link' },
         { name: 'View PR status for ticket', value: 'status' },
         { name: 'Cancel', value: 'cancel' },
@@ -84,6 +86,12 @@ export default class PR extends PMOCommand {
         break;
       case 'link':
         await this.config.runCommand('pr:link', []);
+        break;
+      case 'merge':
+        await this.config.runCommand('pr:merge', []);
+        break;
+      case 'checks':
+        await this.config.runCommand('pr:checks', []);
         break;
       case 'status':
         await this.config.runCommand('pr:status', []);

--- a/apps/cli/src/commands/pr/merge.ts
+++ b/apps/cli/src/commands/pr/merge.ts
@@ -1,0 +1,185 @@
+import { Args, Flags } from '@oclif/core';
+import {
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  isGHInstalled,
+  isGHAuthenticated,
+  getPRByNumber,
+  listOpenPRs,
+  mergePR,
+} from '../../lib/pr/index.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { FlagResolver } from '../../lib/flags/index.js';
+
+export default class PRMerge extends PMOCommand {
+  static description = 'Merge a GitHub pull request by number';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> 123',
+    '<%= config.bin %> <%= command.id %> 123 --method squash',
+    '<%= config.bin %> <%= command.id %> 123 --no-delete-branch',
+    '<%= config.bin %> <%= command.id %> --json',
+  ];
+
+  static args = {
+    prNumber: Args.integer({
+      description: 'PR number to merge',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    method: Flags.string({
+      description: 'Merge method',
+      options: ['merge', 'squash', 'rebase'],
+      default: 'merge',
+    }),
+    'delete-branch': Flags.boolean({
+      description: 'Delete branch after merging',
+      default: true,
+      allowNo: true,
+    }),
+    admin: Flags.boolean({
+      description: 'Use admin privileges to bypass branch protections',
+      default: false,
+    }),
+  };
+
+  // Flag to track if PMO is available
+  private hasPMO = true;
+
+  async init(): Promise<void> {
+    try {
+      await super.init();
+    } catch {
+      this.hasPMO = false;
+    }
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(PRMerge);
+
+    const jsonMode = shouldOutputJson(flags);
+
+    const handleError = (code: string, message: string): never => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('pr merge', flags));
+        this.exit(1);
+      }
+      this.error(message);
+    };
+
+    // Check gh CLI
+    if (!isGHInstalled()) {
+      return handleError('GH_NOT_INSTALLED', 'GitHub CLI (gh) is not installed. Install it from https://cli.github.com/');
+    }
+
+    if (!isGHAuthenticated()) {
+      return handleError('GH_NOT_AUTHENTICATED', 'GitHub CLI is not authenticated. Run "gh auth login" first.');
+    }
+
+    let prNumber = args.prNumber;
+
+    // If no PR number provided, prompt for selection
+    if (!prNumber) {
+      const openPRs = listOpenPRs();
+
+      if (openPRs.length === 0) {
+        return handleError('NO_OPEN_PRS', 'No open pull requests found.');
+      }
+
+      const resolver = new FlagResolver<{ pr?: string }>({
+        commandName: 'pr merge',
+        baseCommand: 'prlt pr merge',
+        jsonMode,
+        flags: {},
+      });
+
+      resolver.addPrompt({
+        flagName: 'pr',
+        type: 'list',
+        message: 'Select PR to merge:',
+        choices: () => openPRs.map(pr => ({
+          name: `#${pr.number} - ${pr.title} (${pr.headBranch})`,
+          value: String(pr.number),
+        })),
+      });
+
+      const resolved = await resolver.resolve();
+      prNumber = parseInt(resolved.pr!, 10);
+    }
+
+    // Verify PR exists and is open
+    const prInfo = getPRByNumber(prNumber);
+    if (!prInfo) {
+      return handleError('PR_NOT_FOUND', `PR #${prNumber} not found.`);
+    }
+
+    if (prInfo.state !== 'OPEN') {
+      return handleError('PR_NOT_OPEN', `PR #${prNumber} is ${prInfo.state.toLowerCase()}, not open.`);
+    }
+
+    // Merge the PR
+    const method = flags.method as 'merge' | 'squash' | 'rebase';
+    const result = mergePR(prNumber, {
+      method,
+      deleteBranch: flags['delete-branch'],
+      admin: flags.admin,
+    });
+
+    if (!result.success) {
+      return handleError('MERGE_FAILED', `Failed to merge PR #${prNumber}: ${result.error}`);
+    }
+
+    // Update ticket metadata if PR was linked
+    if (this.hasPMO) {
+      try {
+        const allTickets = await this.storage.listTickets(flags.project);
+        const linkedTicket = allTickets.find(t =>
+          t.metadata?.pr_number === String(prNumber)
+        );
+        if (linkedTicket) {
+          await this.storage.updateTicket(linkedTicket.id, {
+            metadata: {
+              ...linkedTicket.metadata,
+              pr_state: 'MERGED',
+            },
+          });
+        }
+      } catch {
+        // Non-critical - don't fail the merge if PMO update fails
+      }
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          merged: true,
+          prNumber,
+          title: prInfo.title,
+          method,
+          branchDeleted: flags['delete-branch'],
+        },
+        createMetadata('pr merge', flags)
+      );
+      return;
+    }
+
+    this.log('');
+    this.log(styles.success(`PR #${prNumber} merged successfully!`));
+    this.log(styles.muted(`   Title: ${prInfo.title}`));
+    this.log(styles.muted(`   Method: ${method}`));
+    if (flags['delete-branch']) {
+      this.log(styles.muted(`   Branch ${prInfo.headBranch} deleted`));
+    }
+  }
+}

--- a/apps/cli/src/lib/pr/index.ts
+++ b/apps/cli/src/lib/pr/index.ts
@@ -668,6 +668,108 @@ export function hasPendingFeedback(feedback: PRFeedback): boolean {
 /**
  * Format PR feedback as markdown for agent prompt.
  */
+// =============================================================================
+// PR Merge
+// =============================================================================
+
+export interface MergePROptions {
+  /** Merge method: merge, squash, or rebase */
+  method?: 'merge' | 'squash' | 'rebase';
+  /** Delete branch after merging */
+  deleteBranch?: boolean;
+  /** Admin override to bypass branch protections */
+  admin?: boolean;
+  /** Working directory */
+  cwd?: string;
+}
+
+export interface MergePRResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Merge a pull request by number.
+ */
+export function mergePR(prNumber: number, options: MergePROptions = {}): MergePRResult {
+  const { method = 'merge', deleteBranch = true, admin = false, cwd } = options;
+
+  const args = ['pr', 'merge', String(prNumber), `--${method}`];
+
+  if (deleteBranch) {
+    args.push('--delete-branch');
+  }
+
+  if (admin) {
+    args.push('--admin');
+  }
+
+  try {
+    const result = spawnSync('gh', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if (result.status !== 0) {
+      return {
+        success: false,
+        error: result.stderr?.trim() || 'Failed to merge PR',
+      };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+// =============================================================================
+// PR Checks / CI Status
+// =============================================================================
+
+export interface PRCheck {
+  name: string;
+  status: string;
+  conclusion: string;
+  url: string;
+}
+
+/**
+ * Get CI check status for a PR.
+ */
+export function getPRChecks(prNumber: number, cwd?: string): PRCheck[] {
+  try {
+    const result = execSync(
+      `gh pr checks ${prNumber} --json name,state,conclusion,detailsUrl`,
+      {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    );
+
+    const data = JSON.parse(result) as Array<{
+      name: string;
+      state: string;
+      conclusion: string;
+      detailsUrl: string;
+    }>;
+
+    return data.map(check => ({
+      name: check.name,
+      status: check.state,
+      conclusion: check.conclusion,
+      url: check.detailsUrl || '',
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export function formatPRFeedbackForPrompt(feedback: PRFeedback): string {
   const lines: string[] = [];
 


### PR DESCRIPTION
## Summary
- Add `prlt pr merge [number]` command to merge PRs with configurable merge method (merge/squash/rebase), branch deletion control, and admin override support
- Add `prlt pr checks [number]` command to show CI check status with pass/fail/pending summary; auto-detects PR from current branch when no number is given
- Add `mergePR()` and `getPRChecks()` utility functions to `lib/pr/index.ts`
- Update `prlt pr` interactive menu to include the new merge and checks actions

## Test plan
- [ ] `prlt pr merge --help` shows correct usage
- [ ] `prlt pr checks --help` shows correct usage
- [ ] `prlt pr --help` lists merge and checks subcommands
- [ ] `prlt pr merge 123` merges a PR (with real repo)
- [ ] `prlt pr merge 123 --method squash` uses squash merge
- [ ] `prlt pr checks` auto-detects PR from current branch
- [ ] `prlt pr checks 123 --json` returns structured JSON output
- [ ] `prlt pr merge --json` returns JSON error/success output
- [ ] Build passes: `cd apps/cli && pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)