### PR TITLE
TKT-123: Add prlt pr merge with auto-sync to Linear on merge

### DIFF
--- a/apps/cli/src/commands/pr/merge.ts
+++ b/apps/cli/src/commands/pr/merge.ts
@@ -10,6 +10,7 @@ import {
   getPRByNumber,
   listOpenPRs,
   mergePR,
+  getGitHubRepo,
 } from '../../lib/pr/index.js';
 import {
   shouldOutputJson,
@@ -18,6 +19,7 @@ import {
   createMetadata,
 } from '../../lib/prompt-json.js';
 import { FlagResolver } from '../../lib/flags/index.js';
+import { getEventBus } from '../../lib/events/event-bus.js';
 
 export default class PRMerge extends PMOCommand {
   static description = 'Merge a GitHub pull request by number';
@@ -140,7 +142,8 @@ export default class PRMerge extends PMOCommand {
       return handleError('MERGE_FAILED', `Failed to merge PR #${prNumber}: ${result.error}`);
     }
 
-    // Update ticket metadata if PR was linked
+    // Update ticket metadata if PR was linked and emit merge event for outbound sync
+    let linkedTicketId: string | undefined;
     if (this.hasPMO) {
       try {
         const allTickets = await this.storage.listTickets(flags.project);
@@ -148,6 +151,7 @@ export default class PRMerge extends PMOCommand {
           t.metadata?.pr_number === String(prNumber)
         );
         if (linkedTicket) {
+          linkedTicketId = linkedTicket.id;
           await this.storage.updateTicket(linkedTicket.id, {
             metadata: {
               ...linkedTicket.metadata,
@@ -160,6 +164,26 @@ export default class PRMerge extends PMOCommand {
       }
     }
 
+    // Emit work:pr_merged event for outbound sync (e.g., Linear auto-transition)
+    if (linkedTicketId) {
+      try {
+        const repo = getGitHubRepo();
+        const prUrl = repo ? `https://github.com/${repo}/pull/${prNumber}` : null;
+
+        getEventBus().emit('work:pr_merged', {
+          workItemId: linkedTicketId,
+          source: 'github',
+          prNumber,
+          prTitle: prInfo.title,
+          prUrl,
+          mergeMethod: method,
+          timestamp: new Date(),
+        });
+      } catch {
+        // Non-critical - don't fail the merge if event emission fails
+      }
+    }
+
     if (jsonMode) {
       outputSuccessAsJson(
         {
@@ -168,6 +192,8 @@ export default class PRMerge extends PMOCommand {
           title: prInfo.title,
           method,
           branchDeleted: flags['delete-branch'],
+          linkedTicket: linkedTicketId ?? null,
+          linearSyncEmitted: !!linkedTicketId,
         },
         createMetadata('pr merge', flags)
       );
@@ -180,6 +206,9 @@ export default class PRMerge extends PMOCommand {
     this.log(styles.muted(`   Method: ${method}`));
     if (flags['delete-branch']) {
       this.log(styles.muted(`   Branch ${prInfo.headBranch} deleted`));
+    }
+    if (linkedTicketId) {
+      this.log(styles.muted(`   Linear sync triggered for ${linkedTicketId}`));
     }
   }
 }

--- a/apps/cli/src/lib/events/events.ts
+++ b/apps/cli/src/lib/events/events.ts
@@ -12,6 +12,7 @@ import type {
   WorkStartedEvent,
   WorkStatusChangedEvent,
   WorkPRCreatedEvent,
+  WorkPRMergedEvent,
   WorkCompletedEvent,
 } from '../work-lifecycle/events.js'
 
@@ -119,6 +120,7 @@ export interface RuntimeEventMap {
   'work:started': WorkStartedEvent
   'work:status_changed': WorkStatusChangedEvent
   'work:pr_created': WorkPRCreatedEvent
+  'work:pr_merged': WorkPRMergedEvent
   'work:completed': WorkCompletedEvent
 }
 

--- a/apps/cli/src/lib/external-issues/outbound-sync.ts
+++ b/apps/cli/src/lib/external-issues/outbound-sync.ts
@@ -12,7 +12,7 @@
 
 import Database from 'better-sqlite3'
 import { getEventBus } from '../events/event-bus.js'
-import type { WorkStatusChangedEvent, WorkPRCreatedEvent } from '../work-lifecycle/events.js'
+import type { WorkStatusChangedEvent, WorkPRCreatedEvent, WorkPRMergedEvent } from '../work-lifecycle/events.js'
 import { LinearClient } from '../linear/client.js'
 import { LinearMapper } from '../linear/mapper.js'
 import { LinearSync } from '../linear/sync.js'
@@ -61,6 +61,12 @@ export class OutboundSyncHandler {
     this.unsubscribers.push(
       bus.on('work:pr_created', (event) => {
         void this.handlePRLinked(event)
+      }),
+    )
+
+    this.unsubscribers.push(
+      bus.on('work:pr_merged', (event) => {
+        void this.handlePRMerged(event)
       }),
     )
   }
@@ -128,6 +134,35 @@ export class OutboundSyncHandler {
     // Update provider-agnostic mapping with PR URL
     try {
       this.recordPRInMappings(event)
+    } catch {
+      // Non-fatal
+    }
+
+    return results
+  }
+
+  /**
+   * Handle a PR merge by syncing to all mapped external providers.
+   * Transitions the linked external issue to a completed state.
+   */
+  private async handlePRMerged(event: WorkPRMergedEvent): Promise<OutboundSyncResult[]> {
+    const results: OutboundSyncResult[] = []
+
+    // Try Linear sync (skip if event came from Linear)
+    if (event.source !== 'linear') {
+      try {
+        const linearResult = await this.syncMergeToLinear(event)
+        if (linearResult) {
+          results.push(linearResult)
+        }
+      } catch {
+        // Sync errors are non-fatal
+      }
+    }
+
+    // Update provider-agnostic mappings with merged state
+    try {
+      this.recordMergeInMappings(event)
     } catch {
       // Non-fatal
     }
@@ -232,6 +267,52 @@ export class OutboundSyncHandler {
     }
   }
 
+  /**
+   * Sync a PR merge to Linear if the work item has a Linear mapping.
+   * Transitions the issue to "completed" state and posts a merge comment.
+   */
+  private async syncMergeToLinear(event: WorkPRMergedEvent): Promise<OutboundSyncResult | null> {
+    if (!isLinearConfigured(this.db)) return null
+
+    const config = loadLinearConfig(this.db)
+    if (!config) return null
+
+    const mapper = new LinearMapper(this.db)
+    const mapping = mapper.getByTicketId(event.workItemId)
+    if (!mapping) return null
+
+    // Only sync outbound or bidirectional mappings
+    if (mapping.syncDirection === 'inbound') return null
+
+    try {
+      const client = new LinearClient(config.apiKey)
+
+      // Get Linear team's workflow states
+      const team = await client.getTeamByKey(mapping.linearTeamKey)
+      if (!team) {
+        return { provider: 'linear', success: false, error: `Team not found: ${mapping.linearTeamKey}` }
+      }
+
+      const states = await client.listStates(team.id)
+      const sync = new LinearSync(client, mapper)
+      const success = await sync.syncPRMerge(
+        event.workItemId,
+        states,
+        event.prTitle,
+        event.prUrl,
+        event.mergeMethod,
+      )
+
+      return { provider: 'linear', success }
+    } catch (err) {
+      return {
+        provider: 'linear',
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      }
+    }
+  }
+
   // ===========================================================================
   // Provider-Agnostic Sync
   // ===========================================================================
@@ -295,6 +376,34 @@ export class OutboundSyncHandler {
           provider: mapping.provider,
           externalId: mapping.externalId,
           prUrl: event.prUrl,
+          lastSyncedAt: new Date(),
+        })
+      } catch {
+        // Non-fatal
+      }
+    }
+  }
+
+  /**
+   * Record a PR merge in all external mappings for a work item.
+   */
+  private recordMergeInMappings(event: WorkPRMergedEvent): void {
+    const mappings = this.findMappingsForWorkItem(event.workItemId)
+
+    for (const mapping of mappings) {
+      // Skip the source provider to avoid sync loops
+      if (mapping.provider === event.source) continue
+
+      try {
+        this.mappingStore.upsertMapping({
+          provider: mapping.provider,
+          externalId: mapping.externalId,
+          latestStateSnapshot: {
+            ...((mapping.latestStateSnapshot as Record<string, unknown>) ?? {}),
+            prMerged: true,
+            prMergeMethod: event.mergeMethod,
+            lastOutboundSync: new Date().toISOString(),
+          },
           lastSyncedAt: new Date(),
         })
       } catch {

--- a/apps/cli/src/lib/linear/sync.ts
+++ b/apps/cli/src/lib/linear/sync.ts
@@ -71,6 +71,41 @@ export class LinearSync {
   }
 
   /**
+   * Sync a PR merge to the corresponding Linear issue.
+   * Transitions the issue to a "completed" state and posts a merge comment.
+   */
+  async syncPRMerge(
+    ticketId: string,
+    linearStates: LinearWorkflowState[],
+    prTitle?: string | null,
+    prUrl?: string | null,
+    mergeMethod?: string,
+  ): Promise<boolean> {
+    const mapping = this.mapper.getByTicketId(ticketId)
+    if (!mapping) return false
+
+    // Transition to completed state
+    const completedState = linearStates.find((s) => s.type === 'completed')
+    if (completedState) {
+      await this.client.updateIssueState(mapping.linearIssueId, completedState.id)
+    }
+
+    // Post merge comment
+    const parts: string[] = ['Pull request merged']
+    if (prTitle) parts[0] = `Pull request merged: **${prTitle}**`
+    if (mergeMethod) parts.push(`Method: ${mergeMethod}`)
+    if (prUrl) parts.push(`[View PR](${prUrl})`)
+
+    await this.client.addComment(
+      mapping.linearIssueId,
+      parts.join('\n'),
+    )
+
+    this.mapper.updateSyncTimestamp(ticketId)
+    return true
+  }
+
+  /**
    * Post a status update comment to the Linear issue.
    */
   async syncStatusComment(

--- a/apps/cli/src/lib/work-lifecycle/events.ts
+++ b/apps/cli/src/lib/work-lifecycle/events.ts
@@ -48,6 +48,18 @@ export interface WorkPRCreatedEvent {
   timestamp: Date
 }
 
+/** Emitted when a PR linked to a work item is merged. */
+export interface WorkPRMergedEvent {
+  workItemId: string
+  source: WorkEventSource
+  projectId?: string
+  prNumber: number
+  prTitle: string | null
+  prUrl: string | null
+  mergeMethod: string
+  timestamp: Date
+}
+
 /** Emitted when work on an item is completed (status moved to 'completed' category). */
 export interface WorkCompletedEvent {
   workItemId: string

--- a/apps/cli/test/e2e/pr-merge-linear-sync.test.ts
+++ b/apps/cli/test/e2e/pr-merge-linear-sync.test.ts
@@ -1,0 +1,362 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import {
+  createTestEnvironment,
+  cleanupTestEnvironment,
+  setupProductionSchema,
+  createHQConfig,
+  createPMODirectories,
+  type TestEnvironment,
+} from './test-helpers.js'
+import { LinearMapper } from '../../src/lib/linear/mapper.js'
+import { LinearSync } from '../../src/lib/linear/sync.js'
+import { EventBus } from '../../src/lib/events/event-bus.js'
+import { OutboundSyncHandler } from '../../src/lib/external-issues/outbound-sync.js'
+import {
+  saveLinearApiKey,
+  saveLinearDefaultTeam,
+} from '../../src/lib/linear/config.js'
+import type { LinearWorkflowState } from '../../src/lib/linear/types.js'
+import type { WorkPRMergedEvent } from '../../src/lib/work-lifecycle/events.js'
+
+/**
+ * PR Merge → Linear Sync Tests
+ *
+ * Verifies that when a PR is merged via `prlt pr merge`, the linked
+ * Linear issue is automatically transitioned to a "completed" state
+ * and a merge comment is posted.
+ */
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const mockLinearStates: LinearWorkflowState[] = [
+  { id: 'ls-backlog', name: 'Backlog', type: 'backlog', color: '#bbb', position: 0 },
+  { id: 'ls-todo', name: 'Todo', type: 'unstarted', color: '#eee', position: 1 },
+  { id: 'ls-progress', name: 'In Progress', type: 'started', color: '#f0ad4e', position: 2 },
+  { id: 'ls-done', name: 'Done', type: 'completed', color: '#5cb85c', position: 3 },
+  { id: 'ls-canceled', name: 'Canceled', type: 'canceled', color: '#999', position: 4 },
+]
+
+// =============================================================================
+// 1. LinearSync.syncPRMerge Unit Tests
+// =============================================================================
+
+describe('LinearSync – syncPRMerge', () => {
+  let env: TestEnvironment
+  let db: Database.Database
+  let mapper: LinearMapper
+  let clientCalls: Array<{ method: string; args: unknown[] }>
+
+  function createMockClient() {
+    clientCalls = []
+    return {
+      updateIssueState(issueId: string, stateId: string) {
+        clientCalls.push({ method: 'updateIssueState', args: [issueId, stateId] })
+        return Promise.resolve()
+      },
+      addComment(issueId: string, body: string) {
+        clientCalls.push({ method: 'addComment', args: [issueId, body] })
+        return Promise.resolve()
+      },
+      attachUrl(issueId: string, url: string, title: string) {
+        clientCalls.push({ method: 'attachUrl', args: [issueId, url, title] })
+        return Promise.resolve()
+      },
+    }
+  }
+
+  function insertStubTicket(ticketId: string): void {
+    db.exec(`INSERT OR IGNORE INTO pmo_projects (id, name, status) VALUES ('proj-merge', 'Merge Project', 'active')`)
+    db.exec(`INSERT OR IGNORE INTO pmo_tickets (id, project_id, title, status) VALUES ('${ticketId}', 'proj-merge', 'Stub ${ticketId}', 'In Progress')`)
+  }
+
+  beforeEach(() => {
+    env = createTestEnvironment('linear-merge-sync-')
+    createHQConfig(env.proletariatDir)
+    createPMODirectories(env.pmoPath)
+    db = setupProductionSchema(env.dbPath, env.pmoPath)
+    db.exec(`CREATE TABLE IF NOT EXISTS workspace_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+    mapper = new LinearMapper(db)
+  })
+
+  afterEach(() => {
+    if (db) db.close()
+    cleanupTestEnvironment(env)
+  })
+
+  it('should transition Linear issue to completed state on PR merge', async () => {
+    insertStubTicket('TKT-MERGE-1')
+
+    mapper.createMapping({
+      pmoTicketId: 'TKT-MERGE-1',
+      linearIssueId: 'lin-merge-1',
+      linearIdentifier: 'ENG-MERGE-1',
+      linearTeamKey: 'ENG',
+      linearUrl: 'https://linear.app/issue/ENG-MERGE-1',
+      syncDirection: 'inbound',
+      createdAt: new Date(),
+    })
+
+    const mockClient = createMockClient()
+    const sync = new LinearSync(mockClient as any, mapper)
+
+    const result = await sync.syncPRMerge(
+      'TKT-MERGE-1',
+      mockLinearStates,
+      'Fix login bug (#42)',
+      'https://github.com/acme/repo/pull/42',
+      'squash',
+    )
+
+    expect(result).to.be.true
+
+    // Should update state to completed
+    const stateCall = clientCalls.find(c => c.method === 'updateIssueState')
+    expect(stateCall).to.exist
+    expect(stateCall!.args[0]).to.equal('lin-merge-1')
+    expect(stateCall!.args[1]).to.equal('ls-done') // completed state
+
+    // Should add a merge comment
+    const commentCall = clientCalls.find(c => c.method === 'addComment')
+    expect(commentCall).to.exist
+    expect(commentCall!.args[1]).to.include('Pull request merged')
+    expect(commentCall!.args[1]).to.include('Fix login bug (#42)')
+    expect(commentCall!.args[1]).to.include('squash')
+    expect(commentCall!.args[1]).to.include('https://github.com/acme/repo/pull/42')
+  })
+
+  it('should post merge comment without URL when URL is null', async () => {
+    insertStubTicket('TKT-MERGE-2')
+
+    mapper.createMapping({
+      pmoTicketId: 'TKT-MERGE-2',
+      linearIssueId: 'lin-merge-2',
+      linearIdentifier: 'ENG-MERGE-2',
+      linearTeamKey: 'ENG',
+      linearUrl: 'https://linear.app/issue/ENG-MERGE-2',
+      syncDirection: 'inbound',
+      createdAt: new Date(),
+    })
+
+    const mockClient = createMockClient()
+    const sync = new LinearSync(mockClient as any, mapper)
+
+    const result = await sync.syncPRMerge(
+      'TKT-MERGE-2',
+      mockLinearStates,
+      'Some PR title',
+      null,
+      'merge',
+    )
+
+    expect(result).to.be.true
+
+    const commentCall = clientCalls.find(c => c.method === 'addComment')
+    expect(commentCall).to.exist
+    expect(commentCall!.args[1]).to.not.include('[View PR]')
+    expect(commentCall!.args[1]).to.include('merge')
+  })
+
+  it('should return false when ticket has no Linear mapping', async () => {
+    const mockClient = createMockClient()
+    const sync = new LinearSync(mockClient as any, mapper)
+
+    const result = await sync.syncPRMerge(
+      'TKT-NO-MAP',
+      mockLinearStates,
+      'PR title',
+      'https://github.com/acme/repo/pull/1',
+      'merge',
+    )
+
+    expect(result).to.be.false
+    expect(clientCalls).to.have.lengthOf(0)
+  })
+
+  it('should still post comment when no completed state exists', async () => {
+    insertStubTicket('TKT-MERGE-3')
+
+    mapper.createMapping({
+      pmoTicketId: 'TKT-MERGE-3',
+      linearIssueId: 'lin-merge-3',
+      linearIdentifier: 'ENG-MERGE-3',
+      linearTeamKey: 'ENG',
+      linearUrl: 'https://linear.app/issue/ENG-MERGE-3',
+      syncDirection: 'inbound',
+      createdAt: new Date(),
+    })
+
+    const mockClient = createMockClient()
+    const sync = new LinearSync(mockClient as any, mapper)
+
+    // Use states without a "completed" type
+    const statesWithoutCompleted = mockLinearStates.filter(s => s.type !== 'completed')
+
+    const result = await sync.syncPRMerge(
+      'TKT-MERGE-3',
+      statesWithoutCompleted,
+      'PR title',
+      null,
+      'merge',
+    )
+
+    expect(result).to.be.true
+
+    // Should NOT call updateIssueState
+    const stateCalls = clientCalls.filter(c => c.method === 'updateIssueState')
+    expect(stateCalls).to.have.lengthOf(0)
+
+    // Should still post comment
+    const commentCall = clientCalls.find(c => c.method === 'addComment')
+    expect(commentCall).to.exist
+    expect(commentCall!.args[1]).to.include('Pull request merged')
+  })
+
+  it('should call updateSyncTimestamp after merge sync', async () => {
+    insertStubTicket('TKT-MERGE-TS')
+
+    mapper.createMapping({
+      pmoTicketId: 'TKT-MERGE-TS',
+      linearIssueId: 'lin-merge-ts',
+      linearIdentifier: 'ENG-MERGE-TS',
+      linearTeamKey: 'ENG',
+      linearUrl: 'https://linear.app/issue/ENG-MERGE-TS',
+      syncDirection: 'inbound',
+      createdAt: new Date(),
+    })
+
+    const mockClient = createMockClient()
+    const sync = new LinearSync(mockClient as any, mapper)
+
+    const result = await sync.syncPRMerge(
+      'TKT-MERGE-TS',
+      mockLinearStates,
+      'PR',
+      null,
+      'merge',
+    )
+
+    // Sync succeeded and mapping still exists
+    expect(result).to.be.true
+    const mapping = mapper.getByTicketId('TKT-MERGE-TS')
+    expect(mapping).to.not.be.null
+    expect(mapping!.linearIssueId).to.equal('lin-merge-ts')
+  })
+})
+
+// =============================================================================
+// 2. WorkPRMergedEvent Type Tests
+// =============================================================================
+
+describe('WorkPRMergedEvent – Event Bus Integration', () => {
+  it('should emit and receive work:pr_merged events', () => {
+    const bus = new EventBus()
+    let receivedEvent: WorkPRMergedEvent | null = null
+
+    bus.on('work:pr_merged', (event) => {
+      receivedEvent = event
+    })
+
+    const emittedEvent: WorkPRMergedEvent = {
+      workItemId: 'TKT-001',
+      source: 'github',
+      prNumber: 42,
+      prTitle: 'Fix login bug',
+      prUrl: 'https://github.com/acme/repo/pull/42',
+      mergeMethod: 'squash',
+      timestamp: new Date(),
+    }
+
+    bus.emit('work:pr_merged', emittedEvent)
+
+    expect(receivedEvent).to.not.be.null
+    expect(receivedEvent!.workItemId).to.equal('TKT-001')
+    expect(receivedEvent!.prNumber).to.equal(42)
+    expect(receivedEvent!.prTitle).to.equal('Fix login bug')
+    expect(receivedEvent!.mergeMethod).to.equal('squash')
+    expect(receivedEvent!.source).to.equal('github')
+  })
+
+  it('should include projectId when provided', () => {
+    const bus = new EventBus()
+    let receivedEvent: WorkPRMergedEvent | null = null
+
+    bus.on('work:pr_merged', (event) => {
+      receivedEvent = event
+    })
+
+    bus.emit('work:pr_merged', {
+      workItemId: 'TKT-002',
+      source: 'github',
+      projectId: 'proj-1',
+      prNumber: 99,
+      prTitle: null,
+      prUrl: null,
+      mergeMethod: 'merge',
+      timestamp: new Date(),
+    })
+
+    expect(receivedEvent!.projectId).to.equal('proj-1')
+    expect(receivedEvent!.prTitle).to.be.null
+    expect(receivedEvent!.prUrl).to.be.null
+  })
+})
+
+// =============================================================================
+// 3. OutboundSyncHandler – work:pr_merged Subscription
+// =============================================================================
+
+describe('OutboundSyncHandler – work:pr_merged', () => {
+  let env: TestEnvironment
+  let db: Database.Database
+
+  beforeEach(() => {
+    env = createTestEnvironment('outbound-merge-')
+    createHQConfig(env.proletariatDir)
+    createPMODirectories(env.pmoPath)
+    db = setupProductionSchema(env.dbPath, env.pmoPath)
+    db.exec(`CREATE TABLE IF NOT EXISTS workspace_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+  })
+
+  afterEach(() => {
+    if (db) db.close()
+    cleanupTestEnvironment(env)
+  })
+
+  it('should subscribe to work:pr_merged events', () => {
+    const handler = new OutboundSyncHandler(db)
+    const bus = new EventBus()
+
+    // Verify the handler subscribes (by checking listener count on a fresh bus)
+    // We test this indirectly by verifying the handler can be started/stopped
+    handler.start()
+    handler.stop()
+
+    // No errors thrown = success
+  })
+
+  it('should not throw when handling a merge event without Linear config', () => {
+    const handler = new OutboundSyncHandler(db)
+    handler.start()
+
+    const bus = new EventBus()
+
+    // Emit a merge event - should not throw even without Linear config
+    // The handler silently skips sync when Linear is not configured
+    expect(() => {
+      bus.emit('work:pr_merged', {
+        workItemId: 'TKT-001',
+        source: 'github',
+        prNumber: 42,
+        prTitle: 'Test PR',
+        prUrl: 'https://github.com/test/repo/pull/42',
+        mergeMethod: 'merge',
+        timestamp: new Date(),
+      })
+    }).to.not.throw()
+
+    handler.stop()
+  })
+})


### PR DESCRIPTION
## Summary

Resolves TKT-123: Add prlt pr merge with auto-sync to Linear on merge

## Description

## External Issue Context

- Source: linear
- External key: PRLT-951
- External id: ec9c3cc7-25a1-4aec-a7e5-b0e9a80a28b1
- URL: https://linear.app/proletariat/issue/PRLT-951/add-prlt-pr-merge-with-auto-sync-to-linear-on-merge
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 0e61fed5 feat(TKT-123): add auto-sync to Linear on PR merge via work:pr_merged event

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
