### PR TITLE
chore: bump version to 0.3.67

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.66",
+  "version": "0.3.67",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump version to 0.3.67
- Includes: work-lifecycle hooks system (#784), prlt pr merge with auto-sync (#783), Linear sync loop tests (#782)

🤖 Generated with [Claude Code](https://claude.com/claude-code)