### PR TITLE
TKT-132: Fix Statsig telemetry — events never flush because init is not awaited and flush timeout is too short

### DIFF
--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -23,8 +23,8 @@ import { getMachineConfigDir, ensureMachineConfigDir } from '../machine-config.j
 // Statsig client SDK key (public — safe to embed in open source repos)
 const STATSIG_CLIENT_KEY = 'client-kvxMxRhn9NFSmH8orl7e2W9nYTfWVS7Kjf7yRTdIecc'
 
-// Flush timeout — don't let analytics delay CLI exit
-const FLUSH_TIMEOUT_MS = 2000
+// Max time to wait for init + flush during shutdown — keeps CLI exit snappy
+const SHUTDOWN_TIMEOUT_MS = 500
 
 /**
  * Telemetry configuration stored in ~/.proletariat/telemetry.json
@@ -63,6 +63,14 @@ let statsigClient: StatsigClientInstance | null = null
 let telemetryConfig: TelemetryConfig | null = null
 let cliVersion: string | null = null
 let initPromise: Promise<void> | null = null
+
+// Events logged before the Statsig client finishes initializing.
+// These are replayed once init completes (in shutdownAnalytics).
+let pendingEvents: Array<{
+  name: string
+  value?: string | number | null
+  metadata?: Record<string, string> | null
+}> = []
 
 // ─── Telemetry Config ────────────────────────────────────────────────────────
 
@@ -257,7 +265,7 @@ export function initAnalytics(version: string): Promise<void> {
  * @param metadata - Event-specific metadata
  */
 export function trackEvent(eventName: string, value?: string | number | null, metadata?: Record<string, unknown> | null): void {
-  if (!statsigClient || !isTelemetryEnabled()) return
+  if (!isTelemetryEnabled()) return
 
   try {
     // Convert metadata values to strings as required by the client SDK
@@ -268,7 +276,13 @@ export function trackEvent(eventName: string, value?: string | number | null, me
       : cliVersion
         ? { cli_version: cliVersion }
         : null
-    statsigClient.logEvent(eventName, value, stringMetadata)
+
+    if (statsigClient) {
+      statsigClient.logEvent(eventName, value, stringMetadata)
+    } else if (initPromise) {
+      // Client is still initializing — buffer the event for replay at shutdown
+      pendingEvents.push({ name: eventName, value, metadata: stringMetadata })
+    }
   } catch {
     // Never let analytics errors affect the CLI
   }
@@ -361,25 +375,46 @@ export function trackMCPToolCalled(options: {
 // ─── Shutdown ────────────────────────────────────────────────────────────────
 
 /**
+ * Replay events that were buffered while the Statsig client was initializing.
+ */
+function flushPendingEvents(): void {
+  if (!statsigClient || pendingEvents.length === 0) return
+  for (const event of pendingEvents) {
+    try {
+      statsigClient.logEvent(event.name, event.value, event.metadata)
+    } catch {
+      // Drop individual events silently
+    }
+  }
+  pendingEvents = []
+}
+
+/**
  * Flush pending events and shut down the Statsig client.
- * Called from the postrun hook. Times out to avoid blocking CLI exit.
+ * Called from the postrun hook. Caps total wait at SHUTDOWN_TIMEOUT_MS
+ * so analytics never adds more than 500ms to CLI exit time.
  */
 export async function shutdownAnalytics(): Promise<void> {
-  // Wait for init to complete so late-tracked events have a client
+  // Wait for init to complete so buffered events can be flushed,
+  // but cap the wait to avoid blocking CLI exit.
   if (initPromise) {
     try {
-      await initPromise
+      await Promise.race([
+        initPromise,
+        new Promise<void>((resolve) => setTimeout(resolve, SHUTDOWN_TIMEOUT_MS)),
+      ])
     } catch {
       // Init may have failed — continue to cleanup
     }
     initPromise = null
   }
 
+  // Replay any events that were buffered while init was in progress
+  flushPendingEvents()
+
   if (!statsigClient) return
 
   try {
-    // Give the client a moment to flush, but don't block the CLI
-    await new Promise<void>((resolve) => setTimeout(resolve, FLUSH_TIMEOUT_MS))
     statsigClient.shutdown()
   } catch {
     // Never let shutdown errors affect the CLI


### PR DESCRIPTION
## Summary

Resolves TKT-132: Fix Statsig telemetry — events never flush because init is not awaited and flush timeout is too short

## Description

## Problem

Statsig analytics events are being logged but never reach Statsig's servers. Two issues:

### 1\. Init is not awaited

In hooks/init.ts line 61:

```typescript
initAnalytics(config.version).catch(() => {})
```

This fires initializeAsync() as a floating promise. For fast commands (whoami, ticket list, etc.), the command finishes before Statsig's HTTP initialization completes. Events logged against an uninitialized client are silently dropped.

### 2\. Flush timeout too short

In analytics.ts line 27:

```typescript
const FLUSH_TIMEOUT_MS = 2000
```

The shutdown waits 2 seconds for events to flush. On slow networks or when init hasn't completed, this isn't enough.

## Fix Options

**Option A: Await init (adds \~200ms latency to first command)**

* Await initAnalytics in the init hook
* Trade-off: slightly slower CLI startup

**Option B: Batch and flush offline**

* Write events to a local file (\~/.proletariat/telemetry-queue.json)
* Flush the queue on next command (or in background)
* No latency impact, events are never lost

**Option C: Increase flush timeout + ensure init completes in postrun**

* In shutdownAnalytics, wait for initPromise with a longer timeout (5-10s)
* Less reliable than Option B but simplest change

## Acceptance Criteria

- [ ] Running `prlt whoami` results in a command_run event appearing in Statsig console
- [ ] Events are not dropped for fast-completing commands
- [ ] Analytics never adds more than 500ms to CLI exit time
- [ ] Verify by checking Statsig console for events from multiple machine IDs

## External Issue Context

- Source: linear
- External key: PRLT-961
- External id: dd9e8eab-b9a5-4dad-a2a1-1cb5176a37e6
- URL: https://linear.app/proletariat/issue/PRLT-961/fix-statsig-telemetry-events-never-flush-because-init-is-not-awaited
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 74815986 feat(TKT-132): fix Statsig telemetry: buffer events during init and cap shutdown at 500ms

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
