### PR TITLE
chore: bump version to 0.3.71

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.70",
+  "version": "0.3.71",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump version to 0.3.71 after merging Statsig telemetry fix (#796)

🤖 Generated with [Claude Code](https://claude.com/claude-code)