### PR TITLE
TKT-133: Pin CI/release workflows to Node 22 — better-sqlite3 fails on Node 24 LTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: '22'
 
       - name: Check if version already exists
         id: version-check


### PR DESCRIPTION
## Summary

Resolves TKT-133: Pin CI/release workflows to Node 22 — better-sqlite3 fails on Node 24 LTS

## Description

## Summary

The release workflow uses `node-version: lts/*` which now resolves to Node 24.14.0. better-sqlite3@12.6.2 fails to compile on Node 24 via node-gyp, causing release failures.

## Problem

* `node-gyp rebuild` fails for better-sqlite3 on Node 24
* The validate-better-sqlite3.cjs postinstall script catches it and exits 1
* Release workflow fails at "Generate oclif README" step
* This is intermittent — sometimes retries work, sometimes not
* Same Bus error / compile failure seen in test workflow (PR #795 needed 3 retries)

## Fix Options

1. **Pin to Node 22** in release.yml and test.yml — simplest, Node 22 is stable
2. **Upgrade better-sqlite3** — check if newer version supports Node 24
3. **Use prebuilt binaries** — prebuild-install instead of node-gyp compile

## Files

* .github/workflows/release.yml (line 18: `node-version: lts/*`)
* .github/workflows/test.yml
* apps/cli/package.json (better-sqlite3 version)

## Recommendation

Pin to Node 22 now, upgrade better-sqlite3 separately when a Node 24 compatible version is confirmed.

## External Issue Context

- Source: linear
- External key: PRLT-967
- External id: 1bfd28fc-48c0-49a2-811a-a79b03f4c117
- URL: https://linear.app/proletariat/issue/PRLT-967/pin-cirelease-workflows-to-node-22-better-sqlite3-fails-on-node-24-lts
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 382aff03 feat(TKT-133): pin release workflow to Node 22 to fix better-sqlite3 build failures

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
