### PR TITLE
TKT-138: prlt workflow setup command — pull board states from provider and wire actions

### DIFF
--- a/apps/cli/src/commands/workflow/setup.ts
+++ b/apps/cli/src/commands/workflow/setup.ts
@@ -9,7 +9,6 @@ import {
   outputErrorAsJson,
   createMetadata,
   buildPromptConfig,
-  isMachineOutput,
   type PromptChoice,
 } from '../../lib/prompt-json.js';
 import {
@@ -22,7 +21,6 @@ import {
   isLinearConfigured,
   loadLinearConfig,
   getLinearApiKey,
-  type LinearWorkflowState,
 } from '../../lib/linear/index.js';
 import type { StateCategory, WorkAction } from '../../lib/pmo/types.js';
 
@@ -238,6 +236,27 @@ export default class WorkflowSetup extends PMOCommand {
     }
 
     // 6. Accept defaults or customize
+    if (jsonMode && !flags['accept-defaults']) {
+      // In JSON mode without --accept-defaults, output the plan for review
+      const plan = wirings.map(w => ({
+        state: w.stateName,
+        category: w.category,
+        action: w.actionId ?? 'none',
+        trigger: w.trigger,
+      }));
+
+      outputSuccessAsJson(
+        {
+          provider: provider,
+          providerLabel,
+          states: plan,
+          message: 'Default wiring plan. Re-run with --accept-defaults to apply, or run interactively to customize.',
+        },
+        createMetadata('workflow setup', flags),
+      );
+      return;
+    }
+
     if (!flags['accept-defaults'] && !jsonMode) {
       const { action } = await inquirer.prompt([{
         type: 'list',
@@ -252,54 +271,55 @@ export default class WorkflowSetup extends PMOCommand {
       if (action === 'customize') {
         await this.customizeWirings(wirings, allActions);
       }
-    } else if (jsonMode) {
-      // In JSON mode, output the default wiring plan for review
-      const plan = wirings.map(w => ({
-        state: w.stateName,
-        category: w.category,
-        action: w.actionId ?? 'none',
-        trigger: w.trigger,
-      }));
+    }
+
+    // 7. Save wiring to workflow_rules table (re-runnable: delete existing rules first)
+    await this.saveWirings(wirings);
+
+    if (jsonMode) {
+      const savedRules = wirings
+        .filter(w => w.actionId)
+        .map(w => ({
+          state: w.stateName,
+          category: w.category,
+          action: w.actionId,
+          trigger: w.trigger,
+        }));
 
       outputSuccessAsJson(
         {
           provider: provider,
           providerLabel,
-          states: plan,
-          message: 'Default wiring plan. Use --accept-defaults to apply, or run interactively to customize.',
+          rulesCreated: savedRules.length,
+          rules: savedRules,
         },
         createMetadata('workflow setup', flags),
       );
       return;
     }
 
-    // 7. Save wiring to workflow_rules table (re-runnable: delete existing rules first)
-    await this.saveWirings(wirings);
+    this.log('');
+    this.log(styles.success('Workflow rules saved successfully!'));
+    this.log('');
 
-    if (!jsonMode) {
-      this.log('');
-      this.log(styles.success('Workflow rules saved successfully!'));
-      this.log('');
-
-      // Show summary
-      const activeRules = wirings.filter(w => w.actionId);
-      if (activeRules.length > 0) {
-        this.log(styles.emphasis('Active rules:'));
-        for (const rule of activeRules) {
-          this.log(`  ${styles.muted(`${rule.stateName} \u2192 ${rule.actionId} (${rule.trigger})`)}`);
-        }
+    // Show summary
+    const activeRules = wirings.filter(w => w.actionId);
+    if (activeRules.length > 0) {
+      this.log(styles.emphasis('Active rules:'));
+      for (const rule of activeRules) {
+        this.log(`  ${styles.muted(`${rule.stateName} \u2192 ${rule.actionId} (${rule.trigger})`)}`);
       }
-
-      const skippedStates = wirings.filter(w => !w.actionId);
-      if (skippedStates.length > 0) {
-        this.log('');
-        this.log(styles.muted(`States with no action: ${skippedStates.map(s => s.stateName).join(', ')}`));
-      }
-
-      this.log('');
-      this.log(styles.muted('View rules: prlt workflow rules'));
-      this.log(styles.muted('Re-run setup: prlt workflow setup'));
     }
+
+    const skippedStates = wirings.filter(w => !w.actionId);
+    if (skippedStates.length > 0) {
+      this.log('');
+      this.log(styles.muted(`States with no action: ${skippedStates.map(s => s.stateName).join(', ')}`));
+    }
+
+    this.log('');
+    this.log(styles.muted('View rules: prlt workflow rules'));
+    this.log(styles.muted('Re-run setup: prlt workflow setup'));
   }
 
   /**


### PR DESCRIPTION
## Summary

Resolves TKT-138: prlt workflow setup command — pull board states from provider and wire actions

## Description

## Summary

Add a prlt workflow setup command that pulls the user's board states from their connected provider (Linear, Jira, etc.) and walks them through wiring actions to state transitions.

## Flow

1. Read connected provider (from work.default_source config)
2. Fetch all workflow states from provider API
3. Display states grouped by category (as a hint, not as the wiring mechanism)
4. For each state, suggest a default action based on category
5. Let user accept defaults or choose different actions
6. Save wiring to workflow_rules table

## CLI UX

```
$ prlt workflow setup

Connected to: Linear (PRLT team)

Your board states:
  Triage (backlog) ← No action (manual triage)
  Backlog (backlog) ← groom (Recommended)
  Ready (unstarted) ← No action
  In Progress (started) ← implement (Recommended)
  Review (started) ← No auto-action (implement moves here on PR)
  Done (completed) ← merge (Recommended)

Accept defaults? [Select to customize]
```

## Key Insight

Review doesn't need an on_enter action — the implement lifecycle hook moves tickets there when a PR is created. The merge action is the only one that fires on_enter for Review → Done.

## Requirements

* New command: apps/cli/src/commands/workflow/setup.ts
* Pull states from Linear/Jira/Asana provider adapters
* Use category as hint for suggesting defaults
* Store results in workflow_rules table
* Re-runnable (overwrites existing rules)
* Works with list selection (no Y/n prompts)

## Depends On

* PRLT-964 (workflow_rules table)
* PRLT-963 (merge action)

## External Issue Context

- Source: linear
- External key: PRLT-965
- External id: 4c246077-1c56-442e-92c1-b2d3f5667814
- URL: https://linear.app/proletariat/issue/PRLT-965/prlt-workflow-setup-command-pull-board-states-from-provider-and-wire
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 1a32354a feat(TKT-138): refine JSON mode flow — accept-defaults saves rules, remove unused imports
- 8b5f760c feat(TKT-138): implement workflow setup command — pull provider states and wire actions

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
