### PR TITLE
TKT-141: Use external source key for branch names and PR titles

### DIFF
--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -295,7 +295,7 @@ export default class WorkReady extends PMOCommand {
    * Handle PR creation for the ticket.
    */
   private async handlePRCreation(
-    ticket: { id: string; title: string; description?: string },
+    ticket: { id: string; title: string; description?: string; metadata?: Record<string, string> },
     draft: boolean,
     branchFromExecution?: string,
     worktreePath?: string
@@ -355,10 +355,12 @@ export default class WorkReady extends PMOCommand {
       }
 
       // Generate PR content
-      const prTitle = generatePRTitle(ticket.id, ticket.title);
+      // Use external key (e.g. PRLT-962) for PR title/body when ticket was imported
+      const displayTicketId = ticket.metadata?.external_key || ticket.id;
+      const prTitle = generatePRTitle(displayTicketId, ticket.title);
       const commits = getCommitLog(baseBranch);
       const prBody = generatePRBody({
-        ticketId: ticket.id,
+        ticketId: displayTicketId,
         ticketTitle: ticket.title,
         ticketDescription: ticket.description,
         commits: commits.slice(0, 10),

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -1233,8 +1233,12 @@ export default class WorkStart extends PMOCommand {
       const coderName = await getOrPromptCoderName(db)
 
       // Use ticket's existing branch or generate a new one
+      // When ticket was imported from an external source, use the external key
+      // (e.g. PRLT-962) instead of the internal PMO ID (e.g. TKT-134) for branch naming
+      const externalMeta = getTicketExternalMetadata(ticket)
+      const branchTicketId = externalMeta.key || ticket.id
       const branch = ticket.branch || generateBranchName(
-        ticket.id,
+        branchTicketId,
         ticket.title,
         coderName,
         assignedAgent,


### PR DESCRIPTION
## Summary
- When a ticket was imported from an external source (Linear, Jira, etc.), branch names and PR titles now use the external identifier (e.g. `PRLT-962`) instead of the internal PMO ID (e.g. `TKT-134`)
- This enables automatic linking in external systems like Linear and makes branch names meaningful to users

## Changes
- `apps/cli/src/commands/work/start.ts`: Use `external_key` from ticket metadata for branch name generation when available
- `apps/cli/src/commands/work/ready.ts`: Use `external_key` from ticket metadata for PR title and body generation when available

## Test plan
- [ ] Create a ticket imported from Linear with an external_key (e.g. PRLT-123)
- [ ] Run `prlt work start` on that ticket — branch should start with `PRLT-123/` not `TKT-XXX/`
- [ ] Run `prlt work ready --pr` — PR title should show `PRLT-123:` not `TKT-XXX:`
- [ ] Verify tickets without external sources still use `TKT-XXX` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)