### PR TITLE
chore: bump version to 0.3.72

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.71",
+  "version": "0.3.72",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Version bump to 0.3.72
- Includes PRs #803 (workflow setup), #804 (branch naming), #805 (real tests), #806 (action chaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)