### PR TITLE
PRLT-976: oclif postrun hook never fires — telemetry events never tracked

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -5,7 +5,7 @@ import { findHQRoot } from '../lib/workspace.js'
 import { getCachedUpdateInfo, triggerBackgroundCheck } from '../lib/update-check.js'
 import { handleUpdatePrompt } from '../lib/update-prompt.js'
 import { initSentry } from '../lib/telemetry.js'
-import { initAnalytics, shutdownAnalytics } from '../lib/telemetry/analytics.js'
+import { initAnalytics, shutdownAnalytics, trackCommandRun } from '../lib/telemetry/analytics.js'
 
 /**
  * Init hook - runs before every command
@@ -55,10 +55,37 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
   }
 
   // Initialize analytics — fire-and-forget, events go to disk queue
-  // Store command start time for duration tracking in postrun hook
-  ;(globalThis as Record<string, unknown>).__prlt_command_start = Date.now()
+  // Store command start time for duration tracking
+  const commandStart = Date.now()
+  ;(globalThis as Record<string, unknown>).__prlt_command_start = commandStart
   ;(globalThis as Record<string, unknown>).__prlt_command_id = id
   initAnalytics(config.version)
+
+  // Register a process.on('exit') handler to track the command_run event.
+  // This is more reliable than the oclif postrun hook because process.exit()
+  // calls (from JSON output helpers, signal handlers, etc.) bypass postrun
+  // but still fire 'exit' listeners. trackCommandRun → writeEventToQueue
+  // uses fs.writeFileSync, so it works in synchronous exit handlers.
+  if (id) {
+    const cmdArgv = argv ?? []
+    process.on('exit', (code) => {
+      // Guard against double-tracking if postrun already ran
+      if ((globalThis as Record<string, unknown>).__prlt_telemetry_tracked) return
+      ;(globalThis as Record<string, unknown>).__prlt_telemetry_tracked = true
+
+      const durationMs = Date.now() - commandStart
+      const flagsUsed = cmdArgv
+        .filter((arg: string) => arg.startsWith('-'))
+        .map((arg: string) => arg.replace(/=.*/, ''))
+
+      trackCommandRun({
+        command: id,
+        durationMs,
+        success: code === 0,
+        flags: flagsUsed,
+      })
+    })
+  }
 
   if (shouldValidateNativeModules(id)) {
     await validateBetterSqlite3NativeBinding({ context: `command "${id}"` })

--- a/apps/cli/src/hooks/postrun.ts
+++ b/apps/cli/src/hooks/postrun.ts
@@ -4,30 +4,38 @@ import { trackCommandRun, shutdownAnalytics } from '../lib/telemetry/analytics.j
 import { flushPendingVersionCheck } from '../lib/update-check.js'
 
 /**
- * Postrun hook - runs after every command completes
+ * Postrun hook - runs after every command completes (when not bypassed by process.exit)
  *
- * Tracks the command_run event with duration and success via Statsig,
- * then flushes pending analytics events, version check, and Sentry crash
- * reports before CLI exit.
+ * Tracks the command_run event and flushes pending analytics, version check,
+ * and Sentry crash reports. The init hook also registers a process.on('exit')
+ * handler as a fallback for telemetry tracking, since many code paths call
+ * process.exit() directly (JSON output helpers, signal handlers) which
+ * bypasses the oclif postrun lifecycle. The __prlt_telemetry_tracked flag
+ * prevents double-counting between the two mechanisms.
  */
 const hook: Hook<'postrun'> = async function ({ Command, argv }) {
-  const startTime = (globalThis as Record<string, unknown>).__prlt_command_start as number | undefined
-  const commandId = (globalThis as Record<string, unknown>).__prlt_command_id as string | undefined
+  // Mark as tracked so the process.on('exit') fallback in init.ts skips
+  if (!(globalThis as Record<string, unknown>).__prlt_telemetry_tracked) {
+    ;(globalThis as Record<string, unknown>).__prlt_telemetry_tracked = true
 
-  if (commandId && startTime) {
-    const durationMs = Date.now() - startTime
+    const startTime = (globalThis as Record<string, unknown>).__prlt_command_start as number | undefined
+    const commandId = (globalThis as Record<string, unknown>).__prlt_command_id as string | undefined
 
-    // Extract flag names (not values) from argv for privacy
-    const flagsUsed = (argv ?? [])
-      .filter((arg: string) => arg.startsWith('-'))
-      .map((arg: string) => arg.replace(/=.*/, ''))
+    if (commandId && startTime) {
+      const durationMs = Date.now() - startTime
 
-    trackCommandRun({
-      command: commandId,
-      durationMs,
-      success: true,
-      flags: flagsUsed,
-    })
+      // Extract flag names (not values) from argv for privacy
+      const flagsUsed = (argv ?? [])
+        .filter((arg: string) => arg.startsWith('-'))
+        .map((arg: string) => arg.replace(/=.*/, ''))
+
+      trackCommandRun({
+        command: commandId,
+        durationMs,
+        success: true,
+        flags: flagsUsed,
+      })
+    }
   }
 
   // Flush pending events — don't delay CLI exit longer than necessary

--- a/apps/cli/test/unit/telemetry-exit-handler.test.ts
+++ b/apps/cli/test/unit/telemetry-exit-handler.test.ts
@@ -1,0 +1,216 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Tests for the process.on('exit') telemetry handler registered in init.ts.
+ *
+ * The core fix: the oclif postrun hook never fires when commands call
+ * process.exit() directly (JSON output helpers, signal handlers, etc.).
+ * The init hook now registers a synchronous process.on('exit') handler
+ * that calls trackCommandRun → writeEventToQueue (fs.writeFileSync),
+ * ensuring telemetry events are always written to disk.
+ *
+ * A __prlt_telemetry_tracked flag on globalThis prevents double-counting
+ * when both the postrun hook and exit handler execute.
+ */
+describe('Telemetry exit handler', () => {
+  let testDir: string
+  let originalHome: string | undefined
+
+  beforeEach(() => {
+    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'telemetry-exit-test-')))
+    originalHome = process.env.HOME
+
+    // Reset the tracking flag between tests
+    delete (globalThis as Record<string, unknown>).__prlt_telemetry_tracked
+  })
+
+  afterEach(() => {
+    if (originalHome) {
+      process.env.HOME = originalHome
+    } else {
+      delete process.env.HOME
+    }
+
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('__prlt_telemetry_tracked guard', () => {
+    it('prevents double-tracking when postrun sets the flag first', () => {
+      // Simulate postrun hook setting the flag
+      ;(globalThis as Record<string, unknown>).__prlt_telemetry_tracked = true
+
+      // The exit handler checks this flag and should skip
+      let exitHandlerRan = false
+      const handler = () => {
+        if ((globalThis as Record<string, unknown>).__prlt_telemetry_tracked) return
+        exitHandlerRan = true
+      }
+      handler()
+
+      expect(exitHandlerRan).to.be.false
+    })
+
+    it('allows tracking when flag is not set', () => {
+      let exitHandlerRan = false
+      const handler = () => {
+        if ((globalThis as Record<string, unknown>).__prlt_telemetry_tracked) return
+        ;(globalThis as Record<string, unknown>).__prlt_telemetry_tracked = true
+        exitHandlerRan = true
+      }
+      handler()
+
+      expect(exitHandlerRan).to.be.true
+      expect((globalThis as Record<string, unknown>).__prlt_telemetry_tracked).to.be.true
+    })
+  })
+
+  describe('writeEventToQueue is synchronous (exit-handler compatible)', () => {
+    it('writes events using fs.writeFileSync', () => {
+      // Set up a temporary telemetry config directory
+      const configDir = path.join(testDir, '.proletariat')
+      fs.mkdirSync(configDir, { recursive: true })
+
+      // Write a minimal telemetry config so isTelemetryEnabled returns true
+      fs.writeFileSync(
+        path.join(configDir, 'config.json'),
+        JSON.stringify({
+          telemetry: true,
+          telemetryNoticeShown: true,
+          headquarters: [],
+        })
+      )
+
+      // Verify the queue file can be created synchronously
+      const queuePath = path.join(configDir, 'telemetry-queue.json')
+      const event = {
+        name: 'command_run',
+        value: 42,
+        metadata: { command: 'test', cli_version: '0.0.0' },
+        timestamp: new Date().toISOString(),
+      }
+
+      // Simulate what writeEventToQueue does (synchronous write)
+      fs.writeFileSync(queuePath, JSON.stringify([event]), 'utf-8')
+
+      expect(fs.existsSync(queuePath)).to.be.true
+      const queue = JSON.parse(fs.readFileSync(queuePath, 'utf-8'))
+      expect(queue).to.have.length(1)
+      expect(queue[0].name).to.equal('command_run')
+      expect(queue[0].metadata.command).to.equal('test')
+    })
+  })
+
+  describe('end-to-end: exit handler fires on process.exit()', () => {
+    it('writes telemetry event even when process.exit() is called', () => {
+      // This test spawns a child process that simulates the init hook's
+      // exit handler behavior + calls process.exit() to verify telemetry
+      // is written to disk.
+      const configDir = path.join(testDir, '.proletariat')
+      fs.mkdirSync(configDir, { recursive: true })
+
+      // Pre-create telemetry config
+      fs.writeFileSync(
+        path.join(configDir, 'config.json'),
+        JSON.stringify({
+          telemetry: true,
+          telemetryNoticeShown: true,
+          headquarters: [],
+        })
+      )
+
+      const queuePath = path.join(configDir, 'telemetry-queue.json')
+
+      // Script that simulates the exit handler + process.exit()
+      const script = `
+        const fs = require('fs');
+        const path = require('path');
+
+        const queuePath = ${JSON.stringify(queuePath)};
+        const startTime = Date.now();
+
+        // Simulate the init hook registering a process.on('exit') handler
+        process.on('exit', (code) => {
+          if (globalThis.__prlt_telemetry_tracked) return;
+          globalThis.__prlt_telemetry_tracked = true;
+
+          const event = {
+            name: 'command_run',
+            value: Date.now() - startTime,
+            metadata: { command: 'test-cmd', success: String(code === 0) },
+            timestamp: new Date().toISOString(),
+          };
+
+          // This is what writeEventToQueue does — synchronous fs write
+          fs.writeFileSync(queuePath, JSON.stringify([event]), 'utf-8');
+        });
+
+        // Simulate a command calling process.exit() directly
+        // (like outputPromptAsJson does)
+        process.exit(0);
+      `
+
+      try {
+        execFileSync('node', ['-e', script], {
+          env: { ...process.env, HOME: testDir },
+          timeout: 5000,
+        })
+      } catch {
+        // execFileSync may throw if child exits non-zero, ignore
+      }
+
+      // Verify the telemetry event was written despite process.exit()
+      expect(fs.existsSync(queuePath)).to.be.true
+      const queue = JSON.parse(fs.readFileSync(queuePath, 'utf-8'))
+      expect(queue).to.have.length(1)
+      expect(queue[0].name).to.equal('command_run')
+      expect(queue[0].metadata.command).to.equal('test-cmd')
+      expect(queue[0].metadata.success).to.equal('true')
+    })
+
+    it('records success=false for non-zero exit codes', () => {
+      const configDir = path.join(testDir, '.proletariat')
+      fs.mkdirSync(configDir, { recursive: true })
+
+      const queuePath = path.join(configDir, 'telemetry-queue.json')
+
+      const script = `
+        const fs = require('fs');
+        const queuePath = ${JSON.stringify(queuePath)};
+
+        process.on('exit', (code) => {
+          if (globalThis.__prlt_telemetry_tracked) return;
+          globalThis.__prlt_telemetry_tracked = true;
+
+          const event = {
+            name: 'command_run',
+            value: 10,
+            metadata: { command: 'fail-cmd', success: String(code === 0) },
+            timestamp: new Date().toISOString(),
+          };
+          fs.writeFileSync(queuePath, JSON.stringify([event]), 'utf-8');
+        });
+
+        process.exit(1);
+      `
+
+      try {
+        execFileSync('node', ['-e', script], {
+          env: { ...process.env, HOME: testDir },
+          timeout: 5000,
+        })
+      } catch {
+        // Expected — child exits with code 1
+      }
+
+      expect(fs.existsSync(queuePath)).to.be.true
+      const queue = JSON.parse(fs.readFileSync(queuePath, 'utf-8'))
+      expect(queue[0].metadata.success).to.equal('false')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-976: oclif postrun hook never fires — telemetry events never tracked

## Description

## Bug

The oclif postrun hook (apps/cli/src/hooks/postrun.ts) never executes. This means trackCommandRun() is never called, so no telemetry events are ever written to the disk queue or sent to Statsig.

## Evidence

* telemetry-queue.json is never created after running any prlt command
* Calling trackEvent() directly from Node DOES create the queue file — the write-to-disk code works
* The init hook fires correctly (sets globals, calls initAnalytics)
* The postrun hook is registered in package.json oclif.hooks.postrun = './dist/hooks/postrun'
* The hook file exists and has the correct export default format
* No events appear in Statsig dashboard

## Root cause investigation needed

* Is oclif v4 actually calling postrun hooks? Check oclif source/docs
* Does the command need to extend a specific base class for postrun to fire?
* Are certain command types (e.g., commands that output JSON) bypassing the hook lifecycle?
* Is there an error being swallowed during hook dispatch?

## Fix

Make the postrun hook actually fire after every command, or move telemetry tracking to a location that reliably executes (e.g., end of each command's run method, or a process.on('exit') handler in the init hook).

## Files

* apps/cli/src/hooks/postrun.ts — the hook that should fire but doesn't
* apps/cli/src/hooks/init.ts — the init hook that DOES fire
* apps/cli/src/lib/telemetry/analytics.ts — trackCommandRun, writeEventToQueue
* apps/cli/package.json — oclif.hooks config

## External Issue Context

- Source: linear
- External key: PRLT-976
- External id: c3dcf8bf-5662-4a92-8ffe-669fc102c3ae
- URL: https://linear.app/proletariat/issue/PRLT-976/oclif-postrun-hook-never-fires-telemetry-events-never-tracked
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 0d57330e feat(PRLT-976): fix telemetry tracking: use process.on('exit') handler to ensure events are always written even when process.exit() bypasses oclif postrun hook

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
