### PR TITLE
PRLT-985: Version bump to 0.3.73 — includes postrun hook fix, provider write-back, PMO command routing

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.72",
+  "version": "0.3.73",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Resolves PRLT-985: Version bump to 0.3.73 — includes postrun hook fix, provider write-back, PMO command routing

## Description

Bump version to 0.3.73 and create PR. Includes: PR #810 (postrun hook telemetry fix), PR #809 (direct provider write-back), PR #811 (PMO command routing through configured provider).

## External Issue Context

- Source: linear
- External key: PRLT-985
- External id: cc26eef3-4572-4262-8e86-0ed9a53a1279
- URL: https://linear.app/proletariat/issue/PRLT-985/version-bump-to-0373-includes-postrun-hook-fix-provider-write-back-pmo
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 00353598 feat(PRLT-985): bump version to 0.3.73

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
