### PR TITLE
PRLT-987: Linear team key not persisted after linear connect --team

### DIFF
--- a/apps/cli/src/commands/linear/connect.ts
+++ b/apps/cli/src/commands/linear/connect.ts
@@ -86,6 +86,12 @@ export default class LinearConnect extends PMOCommand {
         const client = new LinearClient(existingConfig.apiKey)
         const info = await client.verify()
 
+        // If --team flag was provided, update the default team without re-auth
+        if (flags.team) {
+          await this.handleTeamSelection(client, flags, jsonMode, db, info)
+          return
+        }
+
         if (jsonMode) {
           outputSuccessAsJson({
             authenticated: true,


### PR DESCRIPTION
## Summary

Resolves PRLT-987: Linear team key not persisted after linear connect --team

## Description

From GH#817 (@RShuken). After prlt linear connect --team RSH, subsequent commands still require --team flag. Not saved as workspace default. Breaks orchestrator/agent workflows.

## External Issue Context

- Source: linear
- External key: PRLT-987
- External id: e6f916aa-06f7-4969-b67f-357d9b3f81cb
- URL: https://linear.app/proletariat/issue/PRLT-987/linear-team-key-not-persisted-after-linear-connect-team
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- bab2dc79 feat(PRLT-987): persist team key when using --team with existing connection

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
