### PR TITLE
PRLT-989: work ready --pr fails when branch already pushed — skips PR creation

### DIFF
--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -343,14 +343,20 @@ export default class WorkReady extends PMOCommand {
       if (!hasBranchBeenPushed(currentBranch)) {
         this.log(styles.muted(`   Pushing branch to origin...`));
         if (!pushBranch(currentBranch)) {
-          this.log(styles.warning('Failed to push branch. Skipping PR creation.'));
-          return undefined;
+          // Re-check: maybe the branch was pushed by another process (race condition)
+          if (!hasBranchBeenPushed(currentBranch)) {
+            this.log(styles.warning('Failed to push branch. Skipping PR creation.'));
+            return undefined;
+          }
+          this.log(styles.muted(`   Branch already exists on remote, continuing with PR creation...`));
         }
       } else if (hasUnpushedCommits(currentBranch)) {
         this.log(styles.muted(`   Pushing unpushed commits...`));
         if (!pushBranch(currentBranch)) {
-          this.log(styles.warning('Failed to push commits. Skipping PR creation.'));
-          return undefined;
+          // Branch is already on the remote — proceed with PR creation even if
+          // pushing latest commits failed (e.g. branch was already up-to-date
+          // and git push returned a non-zero exit code, or a concurrent push).
+          this.log(styles.warning('Could not push latest commits, but branch exists on remote. Continuing with PR creation.'));
         }
       }
 


### PR DESCRIPTION
## Summary

Resolves PRLT-989: work ready --pr fails when branch already pushed — skips PR creation

## Description

From GH#822 (@RShuken). 100% failure rate across 6 agents. Agent pushes branch manually, then work ready --pr tries to push again, fails, and skips PR creation entirely.

## External Issue Context

- Source: linear
- External key: PRLT-989
- External id: e3ba6779-2036-4bf1-9d1b-027177256d4e
- URL: https://linear.app/proletariat/issue/PRLT-989/work-ready-pr-fails-when-branch-already-pushed-skips-pr-creation
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 5a04784f feat(PRLT-989): fix: make push failures non-fatal when branch already exists on remote

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
