### PR TITLE
fix: write prompt file to agentDir so Docker containers can access it

### DIFF
--- a/apps/cli/src/lib/execution/context.ts
+++ b/apps/cli/src/lib/execution/context.ts
@@ -39,7 +39,7 @@ export function detectRepoWorktrees(agentDir: string): string[] {
  *
  * @param agentDir - The agent's working directory
  * @param repoWorktrees - Array of repository names (from detectRepoWorktrees)
- * @param fallbackPath - Path to use if no worktrees found (defaults to process.cwd())
+ * @param fallbackPath - Path to use if no worktrees found (defaults to agentDir)
  * @returns The resolved worktree path
  */
 export function resolveWorktreePath(
@@ -54,7 +54,9 @@ export function resolveWorktreePath(
     // Multiple repos - use agent directory, let user navigate between them
     return agentDir
   } else {
-    // No git worktrees found - use fallback
-    return fallbackPath ?? process.cwd()
+    // No git worktrees found - fall back to agentDir so the path stays
+    // inside the Docker mount (process.cwd() is on the host and won't
+    // resolve inside a container)
+    return fallbackPath ?? agentDir
   }
 }

--- a/apps/cli/src/lib/execution/runners/devcontainer.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer.ts
@@ -69,26 +69,40 @@ function cleanupOldPromptFiles(worktreePath: string, ticketId?: string): void {
 }
 
 /**
- * Write prompt to a file inside the worktree so the container can access it.
- * Returns the path to the prompt file (relative to worktree for container access).
+ * Write prompt to a file that's accessible inside the Docker container.
+ * Always writes to a path under agentDir (mounted at /workspace) so the
+ * container can read it — even when worktreePath is outside agentDir.
  * Cleans up old prompt files for the same ticket before writing.
  */
 function writePromptFile(context: ExecutionContext): { hostPath: string; containerPath: string } {
-  // Clean up old prompt files for this ticket before creating a new one
-  cleanupOldPromptFiles(context.worktreePath, context.ticketId)
-
   const prompt = buildPrompt(context)
   const filename = `.prlt-prompt-${context.ticketId}-${Date.now()}.txt`
-  const hostPath = path.join(context.worktreePath, filename)
 
-  fs.writeFileSync(hostPath, prompt, { mode: 0o644 })
-
-  // Container mounts agentDir at /workspace
-  // If worktreePath is a subdirectory of agentDir, we need the relative path
+  // Container mounts agentDir at /workspace.
+  // Determine if worktreePath is inside agentDir — if so, write the prompt
+  // file there alongside the code. If worktreePath is OUTSIDE agentDir
+  // (e.g., when resolveWorktreePath falls back to cwd), write to agentDir
+  // itself so the file is always under the /workspace mount.
   const relativePath = path.relative(context.agentDir, context.worktreePath)
-  const containerPath = relativePath
-    ? `/workspace/${relativePath}/${filename}`
-    : `/workspace/${filename}`
+  const isInsideAgentDir = relativePath && !relativePath.startsWith('..')
+
+  let hostWriteDir: string
+  let containerPath: string
+
+  if (isInsideAgentDir) {
+    hostWriteDir = context.worktreePath
+    containerPath = `/workspace/${relativePath}/${filename}`
+  } else {
+    // worktreePath is outside agentDir — write to agentDir root
+    hostWriteDir = context.agentDir
+    containerPath = `/workspace/${filename}`
+  }
+
+  // Clean up old prompt files before creating a new one
+  cleanupOldPromptFiles(hostWriteDir, context.ticketId)
+
+  const hostPath = path.join(hostWriteDir, filename)
+  fs.writeFileSync(hostPath, prompt, { mode: 0o644 })
 
   return { hostPath, containerPath }
 }
@@ -112,9 +126,12 @@ export function buildDevcontainerCommand(
   displayMode: DisplayMode = 'terminal',
   mcpConfigFile?: string
 ): string {
-  // Calculate the relative path from agentDir to worktreePath for cd
+  // Calculate the relative path from agentDir to worktreePath for cd.
+  // Only use the relative path if worktreePath is inside agentDir — if it
+  // traverses upward (starts with ..), the path won't exist inside Docker.
   const relativePath = path.relative(context.agentDir, context.worktreePath)
-  const cdCmd = relativePath ? `cd /workspace/${relativePath} && ` : ''
+  const isInsideAgentDir = relativePath && !relativePath.startsWith('..')
+  const cdCmd = isInsideAgentDir ? `cd /workspace/${relativePath} && ` : ''
 
   // Build executor command using the centralized getExecutorCommand()
   let executorCmd: string


### PR DESCRIPTION
## Summary

- **Bug**: Prompt files were written to `worktreePath` which could be outside the Docker mount (`agentDir → /workspace`). When `resolveWorktreePath` fell back to `process.cwd()`, `path.relative()` produced `../../..` traversals that don't resolve inside the container, leaving agents without their work prompt.
- **Fix `resolveWorktreePath`** (context.ts): Fall back to `agentDir` instead of `process.cwd()` when no repo worktrees are detected
- **Fix `writePromptFile`** (devcontainer.ts): Detect when worktreePath is outside agentDir and write to agentDir root instead
- **Fix `buildDevcontainerCommand`** (devcontainer.ts): Guard `cd` command against upward path traversal

Supersedes #833 (rebased onto current main after refactor)

Fixes PRLT-1004

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] Spawn a Docker agent and verify the prompt file is written inside the agent directory
- [ ] Verify the container path resolves to `/workspace/<filename>` (no `../` traversal)
- [ ] Verify agent receives and executes the prompt successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)