### PR TITLE
chore: bump version to 0.3.74

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.73",
+  "version": "0.3.74",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump version to 0.3.74 to publish prompt delivery fix (PR #834) and other merged changes

Includes since 0.3.73:
- fix: write prompt file to agentDir so Docker containers can access it (#834)
- Previous merged fixes (provider routing, process.exit cleanup, bug fixes)