### PR TITLE
PRLT-990: Agents fail on git push — upstream set to main instead of feature branch

### DIFF
--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -545,6 +545,12 @@ else
     echo "Warning: No GitHub token found, git push will require manual auth"
 fi
 
+# Configure git push to automatically set upstream tracking branch
+# Without this, 'git push' fails on new branches created with 'git checkout -b'
+# because no upstream is configured. This makes 'git push' equivalent to
+# 'git push -u origin <current-branch>' on first push. (TKT-157 / GH#823)
+git config --global push.autoSetupRemote true
+
 # Configure git user identity for commit attribution
 # Uses env vars set by host (from gh/git config), with fallback detection
 configure_git_identity() {

--- a/apps/cli/src/lib/execution/runners/prompt-builder.ts
+++ b/apps/cli/src/lib/execution/runners/prompt-builder.ts
@@ -363,7 +363,7 @@ export function buildPrompt(context: ExecutionContext): string {
   if (context.isRevision) {
     prompt += `After addressing the feedback:\n`
     prompt += `1. Commit your changes using \`prlt commit "your message"\`\n`
-    prompt += `2. Push your changes: \`git push\`\n`
+    prompt += `2. Push your changes: \`git push origin HEAD\`\n`
     prompt += `\nThe PR will be updated automatically.`
   } else if (context.actionEndPrompt) {
     let endPrompt = context.actionEndPrompt.replace(/\{\{TICKET_ID\}\}/g, context.ticketId)
@@ -380,7 +380,7 @@ export function buildPrompt(context: ExecutionContext): string {
       prompt += `   cd /workspace/<repo-name>\n`
       prompt += `   git add -A\n`
       prompt += `   prlt commit "describe your change"\n`
-      prompt += `   git push\n`
+      prompt += `   git push origin HEAD\n`
       prompt += `   \`\`\`\n`
       prompt += `   This formats your commit as a conventional commit with the ticket ID.\n`
       prompt += `\n2. **Mark work as ready** by running:\n`

--- a/apps/cli/src/lib/pmo/storage/base.ts
+++ b/apps/cli/src/lib/pmo/storage/base.ts
@@ -913,7 +913,7 @@ Example workflow:
 # After completing a piece of work
 git add -A
 prlt commit "implement user validation"
-git push
+git push origin HEAD
 \`\`\`
 
 When complete, the ticket should be ready for code review.
@@ -926,7 +926,7 @@ ${PRLT_COMMANDS_CODE}`,
    cd /workspace/<repo-name>
    git add -A
    prlt commit "describe your change"
-   git push
+   git push origin HEAD
    \`\`\`
    This formats your commit as a conventional commit with the ticket ID.
 
@@ -968,7 +968,7 @@ Continue working on this ticket from where you left off.
 - Don't wait until the end to commit - your work could be lost!
 
 \`\`\`bash
-git add -A && prlt commit "your change" && git push
+git add -A && prlt commit "your change" && git push origin HEAD
 \`\`\`
 
 ${PRLT_COMMANDS_COMMON}
@@ -979,7 +979,7 @@ ${PRLT_COMMANDS_CODE}`,
    cd /workspace/<repo-name>
    git add -A
    prlt commit "describe your change"
-   git push
+   git push origin HEAD
    \`\`\`
 
 2. **Mark work as ready** by running:
@@ -1198,7 +1198,7 @@ Review this ticket's implementation thoroughly and fix any issues found:
 - Push after every 1-2 commits to save your work
 
 \`\`\`bash
-git add -A && prlt commit "fix: address code review findings" && git push
+git add -A && prlt commit "fix: address code review findings" && git push origin HEAD
 \`\`\`
 
 ${PRLT_COMMANDS_COMMON}
@@ -1220,7 +1220,7 @@ ${PRLT_COMMANDS_REVIEW}`,
    - ...
    "
    prlt commit "fix: address code review findings"
-   git push
+   git push origin HEAD
    \`\`\`
 
 2. **If no issues were found**, approve the PR:
@@ -1277,7 +1277,7 @@ Address the feedback on this ticket's pull request:
 - Push after every 1-2 commits to save your work
 
 \`\`\`bash
-git add -A && prlt commit "fix: address PR review feedback" && git push
+git add -A && prlt commit "fix: address PR review feedback" && git push origin HEAD
 \`\`\`
 
 ${PRLT_COMMANDS_COMMON}
@@ -1292,7 +1292,7 @@ ${PRLT_COMMANDS_CODE}`,
 
 2. **Push your changes**:
    \`\`\`bash
-   git push
+   git push origin HEAD
    \`\`\`
 
 3. **Optionally reply to resolved review threads** using the GitHub API:
@@ -1561,7 +1561,7 @@ Write comprehensive tests for this ticket's implementation:
 - Push after every 1-2 commits to save your work
 
 \`\`\`bash
-git add -A && prlt commit "add tests for X" && git push
+git add -A && prlt commit "add tests for X" && git push origin HEAD
 \`\`\`
 
 ${PRLT_COMMANDS_COMMON}
@@ -1571,7 +1571,7 @@ ${PRLT_COMMANDS_CODE}`,
    \`\`\`bash
    git add -A
    prlt commit "add tests for {{TICKET_ID}}"
-   git push
+   git push origin HEAD
    \`\`\`
 
 2. **Mark work as ready** by running:


### PR DESCRIPTION
## Summary

Resolves PRLT-990: Agents fail on git push — upstream set to main instead of feature branch

## Description

From GH#823 (@RShuken). 4 of 6 agents failed git push — upstream set to main, not the feature branch. Agents must discover git push origin HEAD workaround.

## External Issue Context

- Source: linear
- External key: PRLT-990
- External id: f298f33b-34a3-412a-b138-de91e17bae7d
- URL: https://linear.app/proletariat/issue/PRLT-990/agents-fail-on-git-push-upstream-set-to-main-instead-of-feature-branch
- Status: Ready
- Priority: Unset
- Labels: None

## Changes

- 421f9ef1 feat(PRLT-990): fix agent git push failures by configuring push.autoSetupRemote and using git push origin HEAD

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
