### PR TITLE
PRLT-1003: Auto-move ticket to Done in provider when agent work completes and PR merges

### DIFF
--- a/apps/cli/src/commands/pr/merge.ts
+++ b/apps/cli/src/commands/pr/merge.ts
@@ -3,6 +3,10 @@ import {
   PMOCommand,
   pmoBaseFlags,
 } from '../../lib/pmo/index.js';
+import { getWorkColumnSetting, findColumnByName } from '../../lib/pmo/utils.js';
+import Database from 'better-sqlite3';
+import * as path from 'node:path';
+import { getWorkspaceInfo } from '../../lib/agents/commands.js';
 import { styles } from '../../lib/styles.js';
 import {
   isGHInstalled,
@@ -147,8 +151,11 @@ export default class PRMerge extends PMOCommand {
     if (this.hasPMO) {
       try {
         const allTickets = await this.storage.listTickets(flags.project);
+        // Find linked ticket by pr_number or by extracting number from pr_url
         const linkedTicket = allTickets.find(t =>
-          t.metadata?.pr_number === String(prNumber)
+          t.metadata?.pr_number === String(prNumber) ||
+          t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`) ||
+          t.metadata?.pr_url?.endsWith(`/${prNumber}`)
         );
         if (linkedTicket) {
           linkedTicketId = linkedTicket.id;
@@ -158,6 +165,49 @@ export default class PRMerge extends PMOCommand {
               pr_state: 'MERGED',
             },
           });
+
+          // Move ticket to Done column in local PMO and external provider
+          try {
+            let workspaceInfo;
+            try {
+              workspaceInfo = getWorkspaceInfo();
+            } catch {
+              workspaceInfo = null;
+            }
+            const dbPath = workspaceInfo
+              ? path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+              : null;
+
+            if (dbPath) {
+              const db = new Database(dbPath);
+              try {
+                const targetColumnName = getWorkColumnSetting(db, 'done');
+                const board = linkedTicket.projectId
+                  ? await this.storage.getProjectBoard(linkedTicket.projectId)
+                  : null;
+                const columnNames = board ? board.columns.map(col => col.name) : [];
+                const doneColumn = findColumnByName(columnNames, targetColumnName);
+
+                if (doneColumn && linkedTicket.projectId) {
+                  // Move in local PMO
+                  await this.storage.moveTicket(linkedTicket.projectId, linkedTicket.id, doneColumn);
+
+                  // Sync to external provider (e.g., Linear)
+                  const provider = await this.resolveTicketProvider(linkedTicket.id, linkedTicket.projectId);
+                  if (provider.name !== 'pmo') {
+                    const moveResult = await provider.moveTicket(linkedTicket.id, doneColumn);
+                    if (moveResult.success) {
+                      this.log(styles.muted(`   Synced to ${moveResult.provider}: ${doneColumn}`));
+                    }
+                  }
+                }
+              } finally {
+                db.close();
+              }
+            }
+          } catch {
+            // Non-critical - don't fail the merge if ticket transition fails
+          }
         }
       } catch {
         // Non-critical - don't fail the merge if PMO update fails

--- a/apps/cli/src/commands/work/complete.ts
+++ b/apps/cli/src/commands/work/complete.ts
@@ -125,6 +125,19 @@ export default class WorkComplete extends PMOCommand {
       // Move to Done column (moveTicket also updates status_id)
       await this.storage.moveTicket(ticket.projectId!, ticketId!, doneColumn);
 
+      // Sync to external provider (e.g., Linear) if ticket was imported from one
+      try {
+        const provider = await this.resolveTicketProvider(ticketId!, ticket.projectId!);
+        if (provider.name !== 'pmo') {
+          const result = await provider.moveTicket(ticketId!, doneColumn);
+          if (result.success) {
+            this.log(styles.muted(`   Synced to ${result.provider}: ${doneColumn}`));
+          }
+        }
+      } catch {
+        // Non-fatal — don't block work complete for provider sync failures
+      }
+
       // Auto-export to board.md if configured
       await autoExportToBoard(this.pmoPath, this.storage);
 

--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -163,6 +163,19 @@ export default class WorkReady extends PMOCommand {
       // Move to Review column (moveTicket also updates status_id)
       await this.storage.moveTicket(ticket.projectId!, ticketId!, reviewColumn);
 
+      // Sync to external provider (e.g., Linear) if ticket was imported from one
+      try {
+        const provider = await this.resolveTicketProvider(ticketId!, ticket.projectId!);
+        if (provider.name !== 'pmo') {
+          const result = await provider.moveTicket(ticketId!, reviewColumn);
+          if (result.success) {
+            this.log(styles.muted(`   Synced to ${result.provider}: ${reviewColumn}`));
+          }
+        }
+      } catch {
+        // Non-fatal — don't block work ready for provider sync failures
+      }
+
       // Auto-export to board.md if configured
       await autoExportToBoard(this.pmoPath, this.storage);
 
@@ -251,14 +264,19 @@ export default class WorkReady extends PMOCommand {
           }
         }
 
-        prUrl = await this.handlePRCreation(ticket, flags['draft-pr'], branch, worktreePath);
-        if (prUrl) {
-          // Store PR URL in ticket metadata
+        const prResult = await this.handlePRCreation(ticket, flags['draft-pr'], branch, worktreePath);
+        if (prResult) {
+          prUrl = prResult.url;
+          // Store PR URL and number in ticket metadata
+          const prMetadata: Record<string, string> = {
+            ...ticket.metadata,
+            pr_url: prResult.url,
+          };
+          if (prResult.number) {
+            prMetadata.pr_number = String(prResult.number);
+          }
           await this.storage.updateTicket(ticketId!, {
-            metadata: {
-              ...ticket.metadata,
-              pr_url: prUrl,
-            },
+            metadata: prMetadata,
           });
         }
       }
@@ -324,13 +342,14 @@ export default class WorkReady extends PMOCommand {
 
   /**
    * Handle PR creation for the ticket.
+   * Returns the PR URL and number if created successfully.
    */
   private async handlePRCreation(
     ticket: { id: string; title: string; description?: string; metadata?: Record<string, string> },
     draft: boolean,
     branchFromExecution?: string,
     worktreePath?: string
-  ): Promise<string | undefined> {
+  ): Promise<{ url: string; number?: number } | undefined> {
     // Use branch from execution record if available, otherwise try to detect
     const currentBranch = branchFromExecution || getCurrentBranch();
     if (!currentBranch) {
@@ -357,7 +376,7 @@ export default class WorkReady extends PMOCommand {
       if (existingPR) {
         if (existingPR.state === 'MERGED') {
           this.log(styles.muted(`   PR #${existingPR.number} already merged: ${existingPR.url}`));
-          return existingPR.url;
+          return { url: existingPR.url, number: existingPR.number };
         }
         if (existingPR.state === 'OPEN') {
           // Push any unpushed commits so the existing PR is up to date
@@ -366,7 +385,7 @@ export default class WorkReady extends PMOCommand {
             pushBranch(currentBranch);
           }
           this.log(styles.muted(`   PR #${existingPR.number} already exists: ${existingPR.url}`));
-          return existingPR.url;
+          return { url: existingPR.url, number: existingPR.number };
         }
       }
 
@@ -418,7 +437,7 @@ export default class WorkReady extends PMOCommand {
       }
 
       this.log(styles.success(`   PR #${result.number} created`));
-      return result.url;
+      return { url: result.url!, number: result.number };
     } finally {
       // Restore original cwd
       if (worktreePath) {

--- a/apps/cli/test/e2e/auto-transition-provider.test.ts
+++ b/apps/cli/test/e2e/auto-transition-provider.test.ts
@@ -1,0 +1,209 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import {
+  createTestEnvironment,
+  cleanupTestEnvironment,
+  setupProductionSchema,
+  createHQConfig,
+  createPMODirectories,
+  type TestEnvironment,
+} from './test-helpers.js'
+import { LinearMapper } from '../../src/lib/linear/mapper.js'
+import { resolveTicketProvider } from '../../src/lib/providers/resolver.js'
+import type { ProviderStorage } from '../../src/lib/providers/types.js'
+import type { Ticket, TicketFilter, CreateTicketInput } from '../../src/lib/pmo/types.js'
+import {
+  saveLinearApiKey,
+  saveLinearDefaultTeam,
+} from '../../src/lib/linear/config.js'
+import { findMatchingLinearState } from '../../src/lib/external-issues/outbound-sync.js'
+
+/**
+ * Auto-Transition Provider Tests (PRLT-1003)
+ *
+ * Verifies that when work ready / work complete / pr merge runs,
+ * the ticket provider is resolved correctly so that status changes
+ * propagate to external providers (e.g., Linear).
+ */
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createMockStorage(overrides?: {
+  ticket?: Partial<Ticket> | null
+}): ProviderStorage {
+  return {
+    getTicket: async (id: string) => {
+      if (overrides?.ticket === null) return null
+      return {
+        id,
+        title: 'Test ticket',
+        projectId: 'test-project',
+        statusId: 'in-progress',
+        statusName: 'In Progress',
+        statusCategory: 'started',
+        subtasks: [],
+        labels: [],
+        metadata: {
+          external_source: 'linear',
+          external_key: 'ENG-123',
+          external_id: 'lin-123',
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides?.ticket,
+      } as Ticket
+    },
+    getProjectBoard: async () => ({
+      columns: [
+        { name: 'Backlog' },
+        { name: 'In Progress' },
+        { name: 'In Review' },
+        { name: 'Done' },
+      ],
+    }),
+    moveTicket: async (projectId: string, ticketId: string, columnName: string) => {
+      return {
+        id: ticketId,
+        title: 'Test ticket',
+        projectId,
+        statusId: columnName,
+        statusName: columnName,
+        subtasks: [],
+        labels: [],
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    deleteTicket: async () => {},
+    listTickets: async () => [],
+    createTicket: async (projectId: string, input: CreateTicketInput) => {
+      return {
+        id: 'TKT-NEW',
+        title: input.title,
+        projectId,
+        statusId: 'backlog',
+        statusName: 'Backlog',
+        subtasks: [],
+        labels: [],
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    getDatabase: () => null as any,
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Auto-Transition Provider Resolution (PRLT-1003)', () => {
+  let env: TestEnvironment
+  let db: Database.Database
+
+  beforeEach(() => {
+    env = createTestEnvironment('auto-transition-')
+    createHQConfig(env.proletariatDir)
+    createPMODirectories(env.pmoPath)
+    db = setupProductionSchema(env.dbPath, env.pmoPath)
+    db.exec(`CREATE TABLE IF NOT EXISTS workspace_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`)
+  })
+
+  afterEach(() => {
+    if (db) db.close()
+    cleanupTestEnvironment(env)
+  })
+
+  it('should resolve Linear provider for tickets imported from Linear', () => {
+    // Set up Linear config
+    saveLinearApiKey(db, 'test-api-key')
+    saveLinearDefaultTeam(db, 'team-eng-id', 'ENG')
+
+    // Create Linear mapping with inbound direction
+    const mapper = new LinearMapper(db)
+    db.exec(`INSERT OR IGNORE INTO pmo_projects (id, name, status) VALUES ('proj-1', 'Test Project', 'active')`)
+    db.exec(`INSERT OR IGNORE INTO pmo_tickets (id, project_id, title, status) VALUES ('TKT-001', 'proj-1', 'Test Ticket', 'In Progress')`)
+    mapper.createMapping({
+      pmoTicketId: 'TKT-001',
+      linearIssueId: 'lin-001',
+      linearIdentifier: 'ENG-001',
+      linearTeamKey: 'ENG',
+      linearUrl: 'https://linear.app/issue/ENG-001',
+      syncDirection: 'inbound',
+      createdAt: new Date(),
+    })
+
+    const storage = createMockStorage()
+    const provider = resolveTicketProvider(
+      'TKT-001',
+      'proj-1',
+      db,
+      storage,
+      { external_source: 'linear' },
+    )
+
+    expect(provider.name).to.equal('linear')
+  })
+
+  it('should resolve PMO provider for tickets without external source', () => {
+    const storage = createMockStorage()
+    const provider = resolveTicketProvider(
+      'TKT-002',
+      'proj-1',
+      db,
+      storage,
+      {},
+    )
+
+    expect(provider.name).to.equal('pmo')
+  })
+
+  it('should resolve PMO provider when Linear is not configured', () => {
+    const storage = createMockStorage()
+    const provider = resolveTicketProvider(
+      'TKT-003',
+      'proj-1',
+      db,
+      storage,
+      { external_source: 'linear' },
+    )
+
+    // No Linear config → falls back to PMO
+    expect(provider.name).to.equal('pmo')
+  })
+})
+
+describe('findMatchingLinearState – Review and Done mapping', () => {
+  const mockStates = [
+    { id: 'ls-backlog', name: 'Backlog', type: 'backlog' },
+    { id: 'ls-todo', name: 'Todo', type: 'unstarted' },
+    { id: 'ls-progress', name: 'In Progress', type: 'started' },
+    { id: 'ls-review', name: 'In Review', type: 'started' },
+    { id: 'ls-done', name: 'Done', type: 'completed' },
+  ]
+
+  it('should match "In Review" status by exact name', () => {
+    const match = findMatchingLinearState(mockStates, 'In Review', 'started')
+    expect(match).to.exist
+    expect(match!.name).to.equal('In Review')
+    expect(match!.id).to.equal('ls-review')
+  })
+
+  it('should match "Done" status by exact name', () => {
+    const match = findMatchingLinearState(mockStates, 'Done', 'completed')
+    expect(match).to.exist
+    expect(match!.name).to.equal('Done')
+    expect(match!.id).to.equal('ls-done')
+  })
+
+  it('should fall back to category match when name does not match', () => {
+    const match = findMatchingLinearState(mockStates, 'Completed', 'completed')
+    expect(match).to.exist
+    expect(match!.type).to.equal('completed')
+    expect(match!.id).to.equal('ls-done')
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-1003: Auto-move ticket to Done in provider when agent work completes and PR merges

## Description

## The missing piece of the core loop

When an agent finishes work and its PR merges, the ticket should automatically move to Done in Linear (or whatever provider is configured). Currently this never happens — tickets stay in 'In Progress' forever.

## Implementation

Two triggers:

1. When prlt work complete runs (agent finished) → move to Review
2. When the PR is merged → move to Done

For #2, options:

* GitHub webhook on PR merge → prlt detects and moves ticket
* Poll: prlt checks if PRs are merged periodically
* Manual: prlt pr merge command handles both merge + ticket update

The simplest first step: make prlt work complete and prlt work ready --pr call provider.moveTicket() to update the actual provider, not just local PMO. PR #809 (PRLT-975) added the provider interface but it needs to be verified end-to-end.

## Acceptance criteria

* After agent creates PR: ticket moves to Review in Linear
* After PR merges: ticket moves to Done in Linear
* No manual intervention needed

## External Issue Context

- Source: linear
- External key: PRLT-1003
- External id: aa5e09be-eb4c-45ad-b0ac-9a4c6e5e22a6
- URL: https://linear.app/proletariat/issue/PRLT-1003/auto-move-ticket-to-done-in-provider-when-agent-work-completes-and-pr
- Status: Ready
- Priority: Unset
- Labels: None

## Changes

- 4b363bf3 feat(PRLT-1003): auto-move ticket to provider (Linear) on work ready, work complete, and PR merge

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
