### PR TITLE
PRLT-997: Telemetry STILL broken — process.on('exit') handler never fires in prlt commands

### DIFF
--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -16,10 +16,10 @@
  *
  * Write-ahead log:
  * - trackEvent() writes events to ~/.proletariat/telemetry-queue.json synchronously
- * - On the next command run (or during this run's shutdown if Statsig initialized in time),
- *   queued events are flushed to Statsig and the queue is cleared
+ * - On the next command run, queued events are flushed to Statsig and the queue is cleared
  * - Events are delayed by at most one command invocation — acceptable for analytics
  * - This adds zero latency and ensures no events are lost regardless of Statsig init timing
+ * - Shutdown never flushes the queue — events persist until the next run confirms delivery
  */
 
 import * as fs from 'node:fs'
@@ -80,6 +80,7 @@ let statsigClient: StatsigClientInstance | null = null
 let telemetryConfig: TelemetryConfig | null = null
 let cliVersion: string | null = null
 let initPromise: Promise<void> | null = null
+let analyticsShutdown = false
 
 // ─── Telemetry Config ────────────────────────────────────────────────────────
 
@@ -341,6 +342,14 @@ export function initAnalytics(version: string): void {
         { userID: getMachineId(), custom: { cli_version: version } },
       )
       await client.initializeAsync()
+
+      // If shutdown already ran while we were initializing, don't set state
+      // or flush — just clean up the client and bail out
+      if (analyticsShutdown) {
+        try { client.shutdown() } catch { /* ignore */ }
+        return
+      }
+
       statsigClient = client
 
       // Share Statsig client with feature-flags for synchronous gate checks
@@ -483,13 +492,20 @@ export function trackMCPToolCalled(options: {
  * didn't initialize in time, and will be flushed on the next command run.
  */
 export async function shutdownAnalytics(): Promise<void> {
+  // Mark as shut down so the in-progress async Statsig init (if any)
+  // won't set statsigClient or flush the queue after we're done
+  analyticsShutdown = true
+
   // Abandon any in-progress init — events are on disk, no need to wait
   initPromise = null
 
-  // If Statsig initialized during this run, flush queued events and shut down
+  // Shut down the Statsig client if it initialized during this run.
+  // Do NOT flush the queue here — events written during this command
+  // (by trackCommandRun in the postrun hook) are safely on disk and will
+  // be flushed on the next command run when Statsig is warm. Flushing
+  // here would delete events from disk before we can confirm they were
+  // actually sent, violating the write-ahead log guarantee.
   if (statsigClient) {
-    flushQueuedEvents()
-
     try {
       statsigClient.shutdown()
     } catch {

--- a/apps/cli/test/unit/analytics-queue.test.ts
+++ b/apps/cli/test/unit/analytics-queue.test.ts
@@ -1,0 +1,198 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Tests for the analytics write-ahead log (WAL) queue.
+ *
+ * The key invariant: events written by trackCommandRun() in the postrun hook
+ * MUST persist on disk after shutdownAnalytics() completes. Events are flushed
+ * to Statsig on the NEXT command run, not during the current run's shutdown.
+ *
+ * This prevents the race condition where shutdownAnalytics() would immediately
+ * clear the queue (via flushQueuedEvents), deleting events from disk before
+ * they could be confirmed as sent to Statsig.
+ */
+describe('Analytics queue persistence', () => {
+  let testDir: string
+  // Absolute path to the built analytics module
+  // Tests run from apps/cli/ so dist/ is directly under cwd
+  const analyticsPath = path.resolve(process.cwd(), 'dist/lib/telemetry/analytics.js')
+  // Convert to file:// URL for ESM imports in child scripts
+  const analyticsUrl = `file://${analyticsPath}`
+
+  beforeEach(() => {
+    testDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'analytics-queue-test-')))
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  /**
+   * Helper to run an ESM script in a child process with isolated HOME.
+   * The script receives analyticsUrl as a global so it can import the module.
+   */
+  function runAnalyticsScript(script: string): { queue: unknown[] | null; stdout: string; stderr: string } {
+    const configDir = path.join(testDir, '.proletariat')
+    fs.mkdirSync(configDir, { recursive: true })
+
+    // Create telemetry config so isTelemetryEnabled() returns true
+    fs.writeFileSync(
+      path.join(configDir, 'telemetry.json'),
+      JSON.stringify({
+        enabled: true,
+        noticeShown: true,
+        machineId: '00000000-0000-0000-0000-000000000000',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    )
+
+    // Prefix the script with the absolute import
+    const fullScript = `
+const ANALYTICS_URL = ${JSON.stringify(analyticsUrl)};
+const analytics = await import(ANALYTICS_URL);
+const { initAnalytics, trackCommandRun, trackEvent, shutdownAnalytics, flushQueuedEvents } = analytics;
+${script}
+`
+
+    const scriptPath = path.join(testDir, 'test-script.mjs')
+    fs.writeFileSync(scriptPath, fullScript, 'utf-8')
+
+    let stdout = ''
+    let stderr = ''
+    try {
+      stdout = execFileSync('node', [scriptPath], {
+        env: {
+          ...process.env,
+          HOME: testDir,
+          DO_NOT_TRACK: '',
+          PRLT_TELEMETRY_DISABLED: '',
+        },
+        timeout: 15000,
+      }).toString()
+    } catch (err: unknown) {
+      const e = err as { stdout?: Buffer; stderr?: Buffer }
+      stdout = e.stdout?.toString() ?? ''
+      stderr = e.stderr?.toString() ?? ''
+    }
+
+    const queuePath = path.join(configDir, 'telemetry-queue.json')
+    let queue: unknown[] | null = null
+    if (fs.existsSync(queuePath)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(queuePath, 'utf-8'))
+        queue = Array.isArray(parsed) ? parsed : null
+      } catch {
+        queue = null
+      }
+    }
+
+    return { queue, stdout, stderr }
+  }
+
+  it('events persist on disk after trackCommandRun + shutdownAnalytics', () => {
+    const { queue, stderr } = runAnalyticsScript(`
+      initAnalytics('0.0.0-test');
+      await new Promise(r => setTimeout(r, 200));
+      trackCommandRun({ command: 'test:persist', durationMs: 100, success: true, flags: ['--json'] });
+      await shutdownAnalytics();
+    `)
+
+    expect(queue, `queue should exist, stderr: ${stderr}`).to.not.be.null
+    expect(queue).to.have.length(1)
+    const event = queue![0] as Record<string, unknown>
+    expect(event.name).to.equal('command_run')
+    expect((event.metadata as Record<string, string>).command).to.equal('test:persist')
+  })
+
+  it('events persist even when Statsig client may have initialized', () => {
+    const { queue, stderr } = runAnalyticsScript(`
+      initAnalytics('0.0.0-test');
+      // Wait longer to give Statsig time to initialize
+      await new Promise(r => setTimeout(r, 3000));
+      trackCommandRun({ command: 'test:with-statsig', durationMs: 50, success: true, flags: [] });
+      await shutdownAnalytics();
+    `)
+
+    expect(queue, `queue should exist, stderr: ${stderr}`).to.not.be.null
+    expect(queue).to.have.length.greaterThanOrEqual(1)
+    const lastEvent = queue![queue!.length - 1] as Record<string, unknown>
+    expect(lastEvent.name).to.equal('command_run')
+    expect((lastEvent.metadata as Record<string, string>).command).to.equal('test:with-statsig')
+  })
+
+  it('multiple trackEvent calls accumulate in queue', () => {
+    const { queue, stderr } = runAnalyticsScript(`
+      initAnalytics('0.0.0-test');
+      trackEvent('event_one', 1, { key: 'val1' });
+      trackEvent('event_two', 2, { key: 'val2' });
+      trackEvent('event_three', 3, { key: 'val3' });
+      await shutdownAnalytics();
+    `)
+
+    expect(queue, `queue should exist, stderr: ${stderr}`).to.not.be.null
+    expect(queue).to.have.length(3)
+    expect((queue![0] as Record<string, unknown>).name).to.equal('event_one')
+    expect((queue![1] as Record<string, unknown>).name).to.equal('event_two')
+    expect((queue![2] as Record<string, unknown>).name).to.equal('event_three')
+  })
+
+  it('async Statsig init does not clear queue after shutdown', () => {
+    const { queue, stderr } = runAnalyticsScript(`
+      // Write event before init
+      trackEvent('pre_init_event', null, { source: 'previous-run' });
+
+      // Init starts async Statsig init
+      initAnalytics('0.0.0-test');
+
+      // Immediately shut down before Statsig can finish
+      await shutdownAnalytics();
+
+      // Wait to see if the async init completes and tries to flush
+      await new Promise(r => setTimeout(r, 3000));
+    `)
+
+    // Events should still be on disk
+    expect(queue, `queue should exist, stderr: ${stderr}`).to.not.be.null
+    expect(queue!.length).to.be.greaterThanOrEqual(1)
+  })
+
+  it('previous run events can be flushed by next initAnalytics call', () => {
+    const configDir = path.join(testDir, '.proletariat')
+    fs.mkdirSync(configDir, { recursive: true })
+
+    // Pre-populate queue with events from "previous run"
+    const previousEvents = [
+      { name: 'command_run', value: 50, metadata: { command: 'old:cmd' }, timestamp: new Date().toISOString() },
+    ]
+    fs.writeFileSync(
+      path.join(configDir, 'telemetry-queue.json'),
+      JSON.stringify(previousEvents),
+    )
+
+    const { queue, stderr } = runAnalyticsScript(`
+      initAnalytics('0.0.0-test');
+      // Wait for Statsig init + potential flush of previous events
+      await new Promise(r => setTimeout(r, 3000));
+
+      // Track current command
+      trackCommandRun({ command: 'new:cmd', durationMs: 25, success: true, flags: [] });
+      await shutdownAnalytics();
+    `)
+
+    // The current run's event should be on disk
+    expect(queue, `queue should exist, stderr: ${stderr}`).to.not.be.null
+    expect(queue!.length).to.be.greaterThanOrEqual(1)
+    const hasNewEvent = queue!.some(
+      (e: unknown) => (e as Record<string, unknown>).name === 'command_run' &&
+        ((e as Record<string, unknown>).metadata as Record<string, string>).command === 'new:cmd',
+    )
+    expect(hasNewEvent).to.be.true
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-997: Telemetry STILL broken — process.on('exit') handler never fires in prlt commands

## Description

## Bug

Despite PR #810 (postrun fallback) and PR #818 (process.exit cleanup), telemetry events are still never written to disk.

## Evidence

* prlt 0.3.73 installed
* isTelemetryEnabled() returns true
* Calling trackEvent() directly from Node writes to telemetry-queue.json correctly
* Running any prlt command (agent list, ticket list, etc.) produces NO queue file
* process.on('exit') handler is registered in init hook but never fires
* postrun hook has trackCommandRun but it also never writes to disk

## Debug needed

* Add console.error debug output to the exit handler to confirm it runs
* Check if oclif is doing something that prevents the exit handler from firing
* Check if shutdownAnalytics() in postrun is clearing state before trackCommandRun writes
* Maybe the issue is in writeEventToQueue itself when called from within the oclif lifecycle
* Test: does a minimal oclif command with process.on('exit') actually fire?

## The actual queue write works when called directly — the problem is purely in the oclif hook/exit lifecycle.

## External Issue Context

- Source: linear
- External key: PRLT-997
- External id: 35f2e249-6e0c-4d5c-9f07-f89772edeab6
- URL: https://linear.app/proletariat/issue/PRLT-997/telemetry-still-broken-processonexit-handler-never-fires-in-prlt
- Status: Ready
- Priority: Unset
- Labels: None

## Changes

- 6c7e6228 feat(PRLT-997): fix telemetry queue race: shutdownAnalytics no longer flushes queue, preventing events from being deleted before confirmed sent

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
