### PR TITLE
PRLT-986: orchestrator start requires multiple undocumented flags with --json

### DIFF
--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -12,8 +12,6 @@ import {
   outputErrorAsJson,
   outputSuccessAsJson,
   createMetadata,
-  buildPromptConfig,
-  outputPromptAsJson,
 } from '../../lib/prompt-json.js'
 import { styles } from '../../lib/styles.js'
 import {
@@ -326,49 +324,46 @@ export default class OrchestratorStart extends PromptCommand {
         availableNames = buildAvailableOrchestratorNames(reservedNames)
       }
 
-      const nameChoices = [
-        ...availableNames.map(name => ({
-          name,
-          value: name,
-          command: `prlt orchestrator start --name ${name} --json`,
-        })),
-        { name: 'Custom...', value: '__custom__' },
-      ]
-      const nameMessage = 'Select orchestrator name:'
-
+      // JSON mode: auto-select first available name instead of prompting
       if (jsonMode) {
-        outputPromptAsJson(
-          buildPromptConfig('list', 'selectedName', nameMessage, nameChoices),
-          createMetadata('orchestrator start', flags),
-        )
-        return
-      }
-
-      const { selectedName } = await this.prompt<{ selectedName: string }>([{
-        type: 'list',
-        name: 'selectedName',
-        message: nameMessage,
-        choices: nameChoices,
-      }])
-
-      if (selectedName === '__custom__') {
-        const defaultCustomName = availableNames[0] || 'main'
-        const { customName } = await this.prompt<{ customName: string }>([{
-          type: 'input',
-          name: 'customName',
-          message: 'Enter orchestrator name:',
-          default: defaultCustomName,
-          validate: (input: unknown) => {
-            const normalized = resolveOrchestratorName(sanitizeName(String(input ?? '')).toLowerCase())
-            if (reservedNames.has(normalized)) {
-              return `Name "${normalized}" is already in use by an agent or orchestrator session.`
-            }
-            return true
-          },
-        }])
-        orchestratorName = resolveOrchestratorName(customName)
+        orchestratorName = resolveOrchestratorName(availableNames[0])
       } else {
-        orchestratorName = resolveOrchestratorName(selectedName)
+        const nameChoices = [
+          ...availableNames.map(name => ({
+            name,
+            value: name,
+            command: `prlt orchestrator start --name ${name} --json`,
+          })),
+          { name: 'Custom...', value: '__custom__' },
+        ]
+        const nameMessage = 'Select orchestrator name:'
+
+        const { selectedName } = await this.prompt<{ selectedName: string }>([{
+          type: 'list',
+          name: 'selectedName',
+          message: nameMessage,
+          choices: nameChoices,
+        }])
+
+        if (selectedName === '__custom__') {
+          const defaultCustomName = availableNames[0] || 'main'
+          const { customName } = await this.prompt<{ customName: string }>([{
+            type: 'input',
+            name: 'customName',
+            message: 'Enter orchestrator name:',
+            default: defaultCustomName,
+            validate: (input: unknown) => {
+              const normalized = resolveOrchestratorName(sanitizeName(String(input ?? '')).toLowerCase())
+              if (reservedNames.has(normalized)) {
+                return `Name "${normalized}" is already in use by an agent or orchestrator session.`
+              }
+              return true
+            },
+          }])
+          orchestratorName = resolveOrchestratorName(customName)
+        } else {
+          orchestratorName = resolveOrchestratorName(selectedName)
+        }
       }
     }
 
@@ -422,10 +417,12 @@ export default class OrchestratorStart extends PromptCommand {
       this.error(`Orchestrator name "${conflict}" is already in use by a staff/temp agent. Choose a different name.`)
     }
 
-    // Executor selection
+    // Executor selection (JSON mode defaults to claude-code)
     let selectedExecutor: ExecutorType
     if (flags.executor) {
       selectedExecutor = flags.executor as ExecutorType
+    } else if (jsonMode) {
+      selectedExecutor = 'claude-code'
     } else {
       const executorChoices = [
         { name: 'Claude Code', value: 'claude-code', command: 'prlt orchestrator start --executor claude-code --json' },
@@ -434,14 +431,6 @@ export default class OrchestratorStart extends PromptCommand {
         { name: 'Request executor support...', value: 'request-support' },
       ]
       const executorMessage = 'Select executor:'
-
-      if (jsonMode) {
-        outputPromptAsJson(
-          buildPromptConfig('list', 'executor', executorMessage, executorChoices),
-          createMetadata('orchestrator start', flags),
-        )
-        return
-      }
 
       const { executor } = await this.prompt<{ executor: string }>([{
         type: 'list',
@@ -526,26 +515,20 @@ export default class OrchestratorStart extends PromptCommand {
       return
     }
 
-    // Permission mode selection
+    // Permission mode selection (JSON mode defaults to danger)
     let permissionMode: PermissionMode
     if (flags['skip-permissions']) {
       permissionMode = 'danger'
     } else if (flags['permission-mode']) {
       permissionMode = flags['permission-mode'] as PermissionMode
+    } else if (jsonMode) {
+      permissionMode = 'danger'
     } else {
       const permissionChoices = [
         { name: '⚠️  danger - Skip permission checks (faster)', value: 'danger', command: 'prlt orchestrator start --permission-mode danger --json' },
         { name: '🔒 safe   - Requires approval for dangerous operations', value: 'safe', command: 'prlt orchestrator start --permission-mode safe --json' },
       ]
       const permissionMessage = 'Permission mode:'
-
-      if (jsonMode) {
-        outputPromptAsJson(
-          buildPromptConfig('list', 'permissionMode', permissionMessage, permissionChoices),
-          createMetadata('orchestrator start', flags),
-        )
-        return
-      }
 
       const { permissionMode: selectedMode } = await this.prompt<{ permissionMode: string }>([{
         type: 'list',
@@ -635,12 +618,14 @@ export default class OrchestratorStart extends PromptCommand {
       executionConfig.shell = detectShell() || 'zsh'
     }
 
-    // Determine display mode
+    // Determine display mode (JSON mode defaults to background)
     let displayMode: DisplayMode
     if (flags.background) {
       displayMode = 'background'
     } else if (flags.foreground) {
       displayMode = 'foreground'
+    } else if (jsonMode) {
+      displayMode = 'background'
     } else {
       const displayChoices = [
         { name: 'New terminal tab — opens attached to the tmux session', value: 'terminal', command: `prlt orchestrator start${orchestratorName !== 'main' ? ` --name ${orchestratorName}` : ''} --json` },
@@ -649,20 +634,12 @@ export default class OrchestratorStart extends PromptCommand {
       ]
       const displayMessage = 'How do you want to view the orchestrator?'
 
-      if (jsonMode) {
-        outputPromptAsJson(
-          buildPromptConfig('list', 'displayMode', displayMessage, displayChoices),
-          createMetadata('orchestrator start', flags),
-        )
-        return
-      }
-
       const { displayMode: selectedMode } = await this.prompt<{ displayMode: DisplayMode }>([{
         type: 'list',
         name: 'displayMode',
         message: displayMessage,
         choices: displayChoices,
-      }], jsonMode ? { flags, commandName: 'orchestrator start' } : null)
+      }])
       displayMode = selectedMode
     }
 

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -61,8 +61,27 @@ export type Runner = (
 /**
  * Build a unified name for tmux sessions, window names, and tab titles.
  * Format: "{ticketId}-{action}-{agentName}"
+ *
+ * Orchestrator sessions use HQ-scoped naming:
+ * Format: "prlt-orchestrator-{hqName}-{agentName}"
+ * This must match buildOrchestratorSessionName() in orchestrator/start.ts
+ * so that `orchestrator status` can find the running session.
  */
 export function buildSessionName(context: ExecutionContext): string {
+  // Orchestrator sessions use HQ-scoped naming for consistency with
+  // buildOrchestratorSessionName() used by status/start commands
+  if (context.isOrchestrator && context.hqName) {
+    const safeHqName = (context.hqName || 'default')
+      .replace(/[^a-zA-Z0-9._-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'default'
+    const safeName = (context.agentName || 'main')
+      .replace(/[^a-zA-Z0-9._-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'main'
+    return `prlt-orchestrator-${safeHqName}-${safeName}`
+  }
+
   const action = (context.actionName || 'work')
     .replace(/[^a-zA-Z0-9._-]/g, '-')
     .replace(/-+/g, '-')

--- a/apps/cli/test/unit/runner-shared.test.ts
+++ b/apps/cli/test/unit/runner-shared.test.ts
@@ -64,6 +64,48 @@ describe('Runner Shared Utilities (TKT-140)', () => {
       const result = buildSessionName(ctx)
       expect(result).to.equal('TKT-999-review-test-agent')
     })
+
+    it('should use HQ-scoped naming for orchestrator contexts', () => {
+      const ctx = makeContext({
+        ticketId: 'prlt',
+        actionName: 'orchestrator',
+        agentName: 'main',
+        isOrchestrator: true,
+        hqName: 'proletariat',
+      })
+      expect(buildSessionName(ctx)).to.equal('prlt-orchestrator-proletariat-main')
+    })
+
+    it('should use HQ-scoped naming for named orchestrator', () => {
+      const ctx = makeContext({
+        ticketId: 'prlt',
+        actionName: 'orchestrator',
+        agentName: 'ops',
+        isOrchestrator: true,
+        hqName: 'my-project',
+      })
+      expect(buildSessionName(ctx)).to.equal('prlt-orchestrator-my-project-ops')
+    })
+
+    it('should fall back to default hqName when hqName is empty', () => {
+      const ctx = makeContext({
+        ticketId: 'prlt',
+        actionName: 'orchestrator',
+        agentName: 'main',
+        isOrchestrator: true,
+        hqName: '',
+      })
+      // Empty hqName means isOrchestrator && context.hqName is falsy, falls back to standard format
+      expect(buildSessionName(ctx)).to.equal('prlt-orchestrator-main')
+    })
+
+    it('should use standard naming when not orchestrator even with hqName', () => {
+      const ctx = makeContext({
+        hqName: 'proletariat',
+        actionName: 'implement',
+      })
+      expect(buildSessionName(ctx)).to.equal('TKT-999-implement-test-agent')
+    })
   })
 
   describe('buildWindowTitle', () => {


### PR DESCRIPTION
## Summary

Resolves PRLT-986: orchestrator start requires multiple undocumented flags with --json

## Description

From GH#816 (@RShuken). prlt orchestrator start --json prompts interactively for name and executor type despite --json flag. Also orchestrator status reports not running while tmux session is active.

## External Issue Context

- Source: linear
- External key: PRLT-986
- External id: e2206e2e-bf22-476c-b3f9-68059acbfaf7
- URL: https://linear.app/proletariat/issue/PRLT-986/orchestrator-start-requires-multiple-undocumented-flags-with-json
- Status: Ready
- Priority: Unset
- Labels: None

## Changes

- 371847b9 feat(PRLT-986): fix orchestrator start --json to use sensible defaults instead of prompting, and fix session name mismatch between start/status and runner

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
