### PR TITLE
PRLT-999: Update CLAUDE.md with current conventions and agent rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,18 +32,68 @@ specs/              # Specification files
 - **Database**: SQLite via better-sqlite3 in `apps/cli/src/lib/database/`
 - **Themes**: Optional agent naming themes in `apps/cli/src/lib/themes.ts`
 
-## Testing & Building
+## Testing
 
 ```bash
-cd apps/cli && pnpm build   # Build CLI (ALWAYS run after code changes)
-./test-cli.sh               # Run CLI tests
+pnpm test            # Run all tests (unit + e2e)
+pnpm test:unit       # Run unit tests only
+pnpm test:e2e        # Run e2e tests only
+pnpm test:smoke      # Run smoke tests
 ```
 
-**Important:** Always verify the build passes after modifying TypeScript files in `apps/cli/`.
+**Important:** Always verify the build passes after modifying TypeScript files in `apps/cli/`:
+
+```bash
+cd apps/cli && pnpm build
+```
+
+**Every bug fix PR MUST include a regression test** that fails if the fix is reverted.
+
+## Command Code Rules
+
+- **Never call `process.exit()` in command code** — let oclif handle lifecycle (use `return` instead).
+
+## Provider Architecture
+
+Commands route through a configured **ticket provider** (Linear, Jira, local PMO), not hardcoded to local PMO.
+
+- **Local PMO** is just the default provider for users without integrations — it is not a cache layer.
+- **Linear is the source of truth** when configured — prlt reads and writes directly to Linear.
+
+Provider implementations live in `apps/cli/src/lib/providers/`.
+
+## Branch Naming
+
+Branch names use the **source ticket ID** (e.g., `PRLT-xxx`), not the internal PMO ID (`TKT-xxx`).
+
+Format: `{ticketId}/{type}/{owner}/{agent}/{description}`
+
+Example: `PRLT-123/feat/chris/altman/implement-auth`
+
+## Workflow & Actions
+
+- Actions wire to **specific state names** (`from_state`/`to_state`), not categories.
+- The **workflow rules table** maps state transitions to actions with trigger types (`manual` | `on_enter`).
+
+## Non-Interactive Mode
+
+The `--yes` flag is being removed. Use the **`selection_needed` pattern** for non-interactive mode instead.
+
+## Execution Environment
+
+**Docker is the default execution environment** for agents.
+
+## Release Process
+
+**Version bumps should be PRs**, not direct pushes to main.
+
+## Issue Tracking
+
+**All GitHub issues should be tracked in Linear** with a comment linking back.
 
 ## UX Preferences
 
-- **Never use Y/n confirm prompts** - Always use list selection (Yes/No choices) instead of typing y/n. This provides better UX with arrow key navigation.
+- **Never use Y/n confirm prompts** — always use list selection (Yes/No choices) instead of typing y/n. This provides better UX with arrow key navigation.
 
 ```typescript
 // BAD - requires typing


### PR DESCRIPTION
## Summary

Resolves PRLT-999: Update CLAUDE.md with current conventions and agent rules

## Description

[CLAUDE.md](<http://CLAUDE.md>) is outdated. Update with all current conventions:

## Add:

* Every bug fix PR MUST include a regression test that fails if the fix is reverted
* Never call process.exit() in command code — let oclif handle lifecycle (return instead)
* Provider architecture: commands route through configured provider (Linear, Jira, local PMO), not hardcoded to local PMO
* Local PMO is just the default provider for users without integrations, not a cache layer
* Linear is the source of truth when configured — prlt reads and writes directly to Linear
* Branch naming uses source ticket ID (PRLT-xxx) not internal PMO ID (TKT-xxx)
* Actions wire to specific state names (from_state/to_state), not categories
* Workflow rules table maps state transitions to actions with trigger types
* \--yes flag is being removed — use selection_needed pattern for non-interactive mode
* Docker is the default execution environment for agents
* Version bumps should be PRs, not direct pushes to main
* Test commands: pnpm test, pnpm test:unit, pnpm test:e2e, pnpm test:smoke
* All GitHub issues should be tracked in Linear with a comment linking back

## Keep:

* pnpm not npm
* oclif framework
* Y/n prompt ban (use list selection)
* JSON mode pattern (outputPromptAsJson)
* Build verification after code changes

## External Issue Context

- Source: linear
- External key: PRLT-999
- External id: d086ef7c-edaf-4b41-b5dd-281c517605aa
- URL: https://linear.app/proletariat/issue/PRLT-999/update-claudemd-with-current-conventions-and-agent-rules
- Status: Ready
- Priority: Unset
- Labels: None

## Changes

- 14cb618e feat(PRLT-999): update CLAUDE.md with current conventions and agent rules

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
