### PR TITLE
PRLT-991: No warning when adding archived GitHub repos — agents waste work

### DIFF
--- a/apps/cli/src/commands/repo/add.ts
+++ b/apps/cli/src/commands/repo/add.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { Args, Flags } from '@oclif/core';
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js';
 import { colors, format } from '../../lib/colors.js';
@@ -7,6 +8,7 @@ import {
   promptForRepositories,
   addRepository
 } from '../../lib/repos/index.js';
+import { parseGitHubOwnerRepo, checkGitHubRepoArchived, findRemoteUrl } from '../../lib/repos/git.js';
 import { getWorkspaceRepositories } from '../../lib/database/index.js';
 import {
   shouldOutputJson,
@@ -42,6 +44,11 @@ export default class Add extends PMOCommand {
     bulk: Flags.boolean({
       char: 'b',
       description: 'Add multiple repositories interactively',
+      default: false,
+    }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip archived repository warning',
       default: false,
     }),
   };
@@ -131,6 +138,35 @@ export default class Add extends PMOCommand {
       action = result.action;
     }
 
+    // Check if the GitHub repository is archived (before cloning)
+    if (!flags.force) {
+      const ownerRepo = this.resolveGitHubOwnerRepo(repoPath);
+      if (ownerRepo && checkGitHubRepoArchived(ownerRepo)) {
+        if (jsonMode) {
+          return handleError(
+            'REPO_ARCHIVED',
+            `Repository ${ownerRepo} is archived on GitHub. Pushing will fail. Use --force to add anyway.`
+          );
+        }
+
+        this.log(colors.warning(`Warning: ${ownerRepo} is archived on GitHub. You will not be able to push changes.`));
+        const { proceed } = await this.prompt<{ proceed: boolean }>([{
+          type: 'list',
+          name: 'proceed',
+          message: 'Add this archived repository anyway?',
+          choices: [
+            { name: 'No', value: false },
+            { name: 'Yes, add anyway', value: true },
+          ],
+        }], null);
+
+        if (!proceed) {
+          this.log(colors.textMuted('Operation cancelled.'));
+          return;
+        }
+      }
+    }
+
     // Add the repository
     const result = await addRepository(hqPath, repoPath, action);
 
@@ -185,5 +221,28 @@ export default class Add extends PMOCommand {
     if (failCount > 0) {
       this.log(format.error(`Failed to add ${failCount} repository(ies)`));
     }
+  }
+
+  /**
+   * Resolve a GitHub owner/repo from a URL or local path.
+   * For remote URLs, parses directly. For local paths, resolves the GitHub remote.
+   */
+  private resolveGitHubOwnerRepo(repoPath: string): string | null {
+    // Try parsing the URL directly (handles https://, git@, ssh:// GitHub URLs)
+    const fromUrl = parseGitHubOwnerRepo(repoPath);
+    if (fromUrl) return fromUrl;
+
+    // For local paths, try to resolve the GitHub remote from the source repo
+    try {
+      const resolvedPath = path.resolve(repoPath);
+      const remoteUrl = findRemoteUrl(resolvedPath);
+      if (remoteUrl) {
+        return parseGitHubOwnerRepo(remoteUrl);
+      }
+    } catch {
+      // Can't resolve — skip archived check
+    }
+
+    return null;
   }
 }

--- a/apps/cli/src/lib/repos/git.ts
+++ b/apps/cli/src/lib/repos/git.ts
@@ -155,3 +155,39 @@ export function setOriginUrl(repoPath: string, newUrl: string): void {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 }
+
+/**
+ * Parse a GitHub URL into owner/repo format.
+ * Supports:
+ *   https://github.com/owner/repo.git
+ *   git@github.com:owner/repo.git
+ *   ssh://git@github.com/owner/repo.git
+ *
+ * @returns "owner/repo" or null if not a GitHub URL
+ */
+export function parseGitHubOwnerRepo(url: string): string | null {
+  const httpsMatch = url.match(/github\.com[/:]([^/]+)\/([^/.]+?)(\.git)?$/);
+  if (httpsMatch) {
+    return `${httpsMatch[1]}/${httpsMatch[2]}`;
+  }
+  return null;
+}
+
+/**
+ * Check if a GitHub repository is archived using the `gh` CLI.
+ *
+ * @param ownerRepo - "owner/repo" format
+ * @returns true if archived, false if not archived or if the check fails
+ */
+export function checkGitHubRepoArchived(ownerRepo: string): boolean {
+  try {
+    const result = execSync(`gh api repos/${ownerRepo} -q .archived`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return result === 'true';
+  } catch {
+    // If gh CLI is not installed or API call fails, don't block the user
+    return false;
+  }
+}

--- a/apps/cli/src/lib/repos/index.ts
+++ b/apps/cli/src/lib/repos/index.ts
@@ -14,7 +14,7 @@ import {
 import { createDevcontainerConfig } from '../execution/devcontainer.js';
 import { getGitIdentity } from '../pr/index.js';
 import { findHQRoot } from '../workspace.js';
-import { isLocalPath, findRemoteUrl, setOriginUrl } from './git.js';
+import { isLocalPath, findRemoteUrl, setOriginUrl, parseGitHubOwnerRepo, checkGitHubRepoArchived } from './git.js';
 
 export interface RepoToAdd {
   path: string;

--- a/apps/cli/test/unit/repo-archived-check.test.ts
+++ b/apps/cli/test/unit/repo-archived-check.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { parseGitHubOwnerRepo, checkGitHubRepoArchived } from '../../src/lib/repos/git.js';
+
+describe('@smoke Archived Repository Detection', () => {
+  describe('parseGitHubOwnerRepo', () => {
+    it('parses HTTPS GitHub URL', () => {
+      expect(parseGitHubOwnerRepo('https://github.com/octocat/hello-world.git'))
+        .to.equal('octocat/hello-world');
+    });
+
+    it('parses HTTPS GitHub URL without .git suffix', () => {
+      expect(parseGitHubOwnerRepo('https://github.com/octocat/hello-world'))
+        .to.equal('octocat/hello-world');
+    });
+
+    it('parses SSH GitHub URL', () => {
+      expect(parseGitHubOwnerRepo('git@github.com:octocat/hello-world.git'))
+        .to.equal('octocat/hello-world');
+    });
+
+    it('parses SSH GitHub URL without .git suffix', () => {
+      expect(parseGitHubOwnerRepo('git@github.com:octocat/hello-world'))
+        .to.equal('octocat/hello-world');
+    });
+
+    it('parses ssh:// GitHub URL', () => {
+      expect(parseGitHubOwnerRepo('ssh://git@github.com/octocat/hello-world.git'))
+        .to.equal('octocat/hello-world');
+    });
+
+    it('returns null for non-GitHub URL', () => {
+      expect(parseGitHubOwnerRepo('https://gitlab.com/user/repo.git')).to.be.null;
+    });
+
+    it('returns null for local path', () => {
+      expect(parseGitHubOwnerRepo('/home/user/projects/repo')).to.be.null;
+    });
+
+    it('returns null for empty string', () => {
+      expect(parseGitHubOwnerRepo('')).to.be.null;
+    });
+
+    it('handles repos with hyphens and dots in name', () => {
+      expect(parseGitHubOwnerRepo('https://github.com/my-org/my-repo'))
+        .to.equal('my-org/my-repo');
+    });
+  });
+
+  describe('checkGitHubRepoArchived', () => {
+    it('returns false when gh CLI is not available or API call fails', () => {
+      // Using an invalid owner/repo should cause the API call to fail
+      // and the function should gracefully return false
+      expect(checkGitHubRepoArchived('__nonexistent__/__nonexistent__')).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves PRLT-991: No warning when adding archived GitHub repos — agents waste work

## Description

From GH#824 (@RShuken). prlt repo add cloned an archived repo without warning. Agent spent 4 min working then failed to push. Should detect archived repos and warn or block.

## External Issue Context

- Source: linear
- External key: PRLT-991
- External id: 2ed5080c-a4b8-4e21-b4ae-157a8a8282c3
- URL: https://linear.app/proletariat/issue/PRLT-991/no-warning-when-adding-archived-github-repos-agents-waste-work
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 5e4d78f9 feat(PRLT-991): detect archived GitHub repos in repo add and warn before cloning

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
