### PR TITLE
PRLT-993: PR creation fails when GitHub repo transferred to new org

### DIFF
--- a/apps/cli/src/commands/pr/create.ts
+++ b/apps/cli/src/commands/pr/create.ts
@@ -17,6 +17,7 @@ import {
   getPRForBranch,
   generatePRTitle,
   generatePRBody,
+  ensureRemoteUpToDate,
 } from '../../lib/pr/index.js';
 import {
   shouldOutputJson,
@@ -220,6 +221,13 @@ export default class PRCreate extends PMOCommand {
         ticketDescription: ticket.description,
         commits: commits.slice(0, 10), // Limit to 10 commits
       });
+    }
+
+    // Detect and fix transferred repos before pushing
+    const remoteFixResult = ensureRemoteUpToDate();
+    if (remoteFixResult.fixed) {
+      this.log(styles.info(`Repository transferred: ${remoteFixResult.oldOwnerRepo} → ${remoteFixResult.newOwnerRepo}`));
+      this.log(styles.muted(`   Updated remote origin to new location.`));
     }
 
     // Push branch if not pushed

--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -20,6 +20,7 @@ import {
   getPRForBranch,
   generatePRTitle,
   generatePRBody,
+  ensureRemoteUpToDate,
 } from '../../lib/pr/index.js';
 import {
   shouldOutputJson,
@@ -369,6 +370,13 @@ export default class WorkReady extends PMOCommand {
     }
 
     try {
+      // Detect and fix transferred repos before pushing
+      const remoteFixResult = ensureRemoteUpToDate();
+      if (remoteFixResult.fixed) {
+        this.log(styles.info(`   Repository transferred: ${remoteFixResult.oldOwnerRepo} → ${remoteFixResult.newOwnerRepo}`));
+        this.log(styles.muted(`   Updated remote origin to new location.`));
+      }
+
       const baseBranch = getDefaultBaseBranch();
 
       // Check if PR already exists for this branch

--- a/apps/cli/src/lib/pr/index.ts
+++ b/apps/cli/src/lib/pr/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { execSync, spawnSync } from 'node:child_process';
+import { detectAndFixTransferredRepo } from '../repos/git.js';
 
 // =============================================================================
 // Types
@@ -264,8 +265,13 @@ export function hasBranchBeenPushed(branch: string, cwd?: string): boolean {
 
 /**
  * Push the current branch to origin.
+ *
+ * Automatically detects and fixes transferred repos before pushing.
  */
 export function pushBranch(branch: string, cwd?: string): boolean {
+  // Detect and fix transferred repos before pushing
+  ensureRemoteUpToDate(cwd);
+
   try {
     execSync(`git push -u origin ${branch}`, {
       cwd,
@@ -327,14 +333,45 @@ export function getCommitLog(base: string, cwd?: string): string[] {
 }
 
 // =============================================================================
+// Transferred Repo Detection
+// =============================================================================
+
+export interface RemoteFixResult {
+  fixed: boolean;
+  oldOwnerRepo?: string;
+  newOwnerRepo?: string;
+  message?: string;
+}
+
+/**
+ * Detect and fix a transferred GitHub repo before PR operations.
+ *
+ * When a repo is transferred on GitHub (e.g., from getCora/repo to getCoraAI/repo),
+ * the local remote still points to the old org. This causes `gh pr create` to fail
+ * with "No commits between" errors. This function detects the transfer via the
+ * GitHub API and updates the local remote URL.
+ *
+ * @param cwd - Working directory of the git repo
+ * @returns Fix result with details of any changes made
+ */
+export function ensureRemoteUpToDate(cwd?: string): RemoteFixResult {
+  return detectAndFixTransferredRepo(cwd);
+}
+
+// =============================================================================
 // PR Operations
 // =============================================================================
 
 /**
  * Create a GitHub pull request using `gh` CLI.
+ *
+ * Automatically detects and fixes transferred repos before creating the PR.
  */
 export function createPR(options: CreatePROptions): CreatePRResult {
   const { title, body, base, draft, cwd } = options;
+
+  // Detect and fix transferred repos before creating PR
+  ensureRemoteUpToDate(cwd);
 
   const args = ['pr', 'create', '--title', title];
 

--- a/apps/cli/src/lib/repos/git.ts
+++ b/apps/cli/src/lib/repos/git.ts
@@ -155,3 +155,145 @@ export function setOriginUrl(repoPath: string, newUrl: string): void {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 }
+
+// =============================================================================
+// Transferred Repo Detection
+// =============================================================================
+
+export interface TransferredRepoResult {
+  transferred: boolean;
+  oldOwnerRepo?: string;
+  newOwnerRepo?: string;
+  newUrl?: string;
+  error?: string;
+}
+
+/**
+ * Parse owner/repo from a GitHub remote URL.
+ *
+ * Handles formats:
+ * - https://github.com/owner/repo.git
+ * - https://github.com/owner/repo
+ * - git@github.com:owner/repo.git
+ * - git@github.com:owner/repo
+ * - ssh://git@github.com/owner/repo.git
+ */
+export function parseOwnerRepo(remoteUrl: string): string | null {
+  const httpsMatch = remoteUrl.match(/github\.com[/:]([^/]+)\/(.+?)(?:\.git)?$/);
+  const sshMatch = remoteUrl.match(/git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
+
+  const match = httpsMatch || sshMatch;
+  if (match) {
+    return `${match[1]}/${match[2]}`;
+  }
+  return null;
+}
+
+/**
+ * Detect if a GitHub repo has been transferred to a new org/owner.
+ *
+ * When a repo is transferred on GitHub, the API at the old owner/repo path
+ * automatically redirects to the new location. We detect this by comparing
+ * the local remote's owner/repo with what the GitHub API returns.
+ *
+ * @param cwd - Working directory of the git repo
+ * @returns Transfer detection result
+ */
+export function detectTransferredRepo(cwd?: string): TransferredRepoResult {
+  try {
+    const remoteUrl = execSync('git remote get-url origin', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    // Only works for GitHub remote URLs
+    if (!remoteUrl.includes('github.com')) {
+      return { transferred: false };
+    }
+
+    const localOwnerRepo = parseOwnerRepo(remoteUrl);
+    if (!localOwnerRepo) {
+      return { transferred: false };
+    }
+
+    // Query GitHub API — redirects are followed automatically
+    let apiResult: string;
+    try {
+      apiResult = execSync(`gh api repos/${localOwnerRepo} --jq .full_name`, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+    } catch {
+      // API call failed — repo may not exist or gh not authenticated
+      return { transferred: false, error: 'Could not query GitHub API' };
+    }
+
+    if (!apiResult) {
+      return { transferred: false };
+    }
+
+    // Compare: if the API returns a different owner/repo, the repo was transferred
+    if (apiResult.toLowerCase() !== localOwnerRepo.toLowerCase()) {
+      // Build the new URL in the same format as the old one
+      const newUrl = buildNewRemoteUrl(remoteUrl, localOwnerRepo, apiResult);
+      return {
+        transferred: true,
+        oldOwnerRepo: localOwnerRepo,
+        newOwnerRepo: apiResult,
+        newUrl,
+      };
+    }
+
+    return { transferred: false };
+  } catch {
+    return { transferred: false };
+  }
+}
+
+/**
+ * Build a new remote URL preserving the protocol format of the old URL.
+ */
+function buildNewRemoteUrl(oldUrl: string, oldOwnerRepo: string, newOwnerRepo: string): string {
+  // Replace owner/repo in the URL, preserving the protocol format
+  return oldUrl.replace(
+    oldOwnerRepo,
+    newOwnerRepo,
+  );
+}
+
+/**
+ * Detect and fix a transferred GitHub repo by updating the origin remote.
+ *
+ * @param cwd - Working directory of the git repo
+ * @returns Description of what was done, or null if no fix was needed
+ */
+export function detectAndFixTransferredRepo(cwd?: string): {
+  fixed: boolean;
+  oldOwnerRepo?: string;
+  newOwnerRepo?: string;
+  message?: string;
+} {
+  const result = detectTransferredRepo(cwd);
+
+  if (!result.transferred || !result.newUrl) {
+    return { fixed: false };
+  }
+
+  try {
+    const effectiveCwd = cwd || process.cwd();
+    setOriginUrl(effectiveCwd, result.newUrl);
+    return {
+      fixed: true,
+      oldOwnerRepo: result.oldOwnerRepo,
+      newOwnerRepo: result.newOwnerRepo,
+      message: `Repository transferred from ${result.oldOwnerRepo} to ${result.newOwnerRepo}. Updated remote origin.`,
+    };
+  } catch {
+    return {
+      fixed: false,
+      message: `Repository appears transferred from ${result.oldOwnerRepo} to ${result.newOwnerRepo}, but failed to update remote.`,
+    };
+  }
+}

--- a/apps/cli/test/unit/transferred-repo.test.ts
+++ b/apps/cli/test/unit/transferred-repo.test.ts
@@ -1,0 +1,139 @@
+import { expect } from 'chai';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  parseOwnerRepo,
+  detectTransferredRepo,
+  detectAndFixTransferredRepo,
+} from '../../src/lib/repos/git.js';
+
+/**
+ * Unit tests for transferred repo detection
+ * Ticket: PRLT-993 / TKT-160
+ *
+ * When a GitHub repo is transferred to a new org, the local remote still points
+ * to the old org. This causes PR creation to fail. These functions detect the
+ * transfer and update the remote URL.
+ */
+describe('Transferred Repo Detection', () => {
+  describe('parseOwnerRepo', () => {
+    it('should parse HTTPS URL with .git suffix', () => {
+      expect(parseOwnerRepo('https://github.com/getCora/myrepo.git')).to.equal('getCora/myrepo');
+    });
+
+    it('should parse HTTPS URL without .git suffix', () => {
+      expect(parseOwnerRepo('https://github.com/getCora/myrepo')).to.equal('getCora/myrepo');
+    });
+
+    it('should parse SSH URL with .git suffix', () => {
+      expect(parseOwnerRepo('git@github.com:getCora/myrepo.git')).to.equal('getCora/myrepo');
+    });
+
+    it('should parse SSH URL without .git suffix', () => {
+      expect(parseOwnerRepo('git@github.com:getCora/myrepo')).to.equal('getCora/myrepo');
+    });
+
+    it('should parse SSH protocol URL', () => {
+      expect(parseOwnerRepo('ssh://git@github.com/getCora/myrepo.git')).to.equal('getCora/myrepo');
+    });
+
+    it('should return null for non-GitHub URL', () => {
+      expect(parseOwnerRepo('https://gitlab.com/owner/repo.git')).to.be.null;
+    });
+
+    it('should return null for local path', () => {
+      expect(parseOwnerRepo('/home/user/repos/myrepo')).to.be.null;
+    });
+
+    it('should handle repos with dots in name', () => {
+      expect(parseOwnerRepo('https://github.com/owner/my.repo.git')).to.equal('owner/my.repo');
+    });
+
+    it('should handle orgs with hyphens and numbers', () => {
+      expect(parseOwnerRepo('https://github.com/my-org-123/repo-name.git')).to.equal('my-org-123/repo-name');
+    });
+  });
+
+  describe('detectTransferredRepo', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-test-transfer-'));
+      execSync('git init', { cwd: tmpDir, stdio: 'pipe' });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should return transferred: false for non-GitHub remote', () => {
+      execSync('git remote add origin https://gitlab.com/owner/repo.git', { cwd: tmpDir, stdio: 'pipe' });
+      const result = detectTransferredRepo(tmpDir);
+      expect(result.transferred).to.be.false;
+    });
+
+    it('should return transferred: false for local path remote', () => {
+      execSync('git remote add origin /some/local/path', { cwd: tmpDir, stdio: 'pipe' });
+      const result = detectTransferredRepo(tmpDir);
+      expect(result.transferred).to.be.false;
+    });
+
+    it('should return transferred: false when no remote configured', () => {
+      const result = detectTransferredRepo(tmpDir);
+      expect(result.transferred).to.be.false;
+    });
+  });
+
+  describe('detectAndFixTransferredRepo', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-test-transfer-'));
+      execSync('git init', { cwd: tmpDir, stdio: 'pipe' });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should return fixed: false when no remote is configured', () => {
+      const result = detectAndFixTransferredRepo(tmpDir);
+      expect(result.fixed).to.be.false;
+    });
+
+    it('should return fixed: false for non-GitHub remotes', () => {
+      execSync('git remote add origin https://gitlab.com/owner/repo.git', { cwd: tmpDir, stdio: 'pipe' });
+      const result = detectAndFixTransferredRepo(tmpDir);
+      expect(result.fixed).to.be.false;
+    });
+
+    it('should return fixed: false for local path remotes', () => {
+      execSync('git remote add origin /some/local/path', { cwd: tmpDir, stdio: 'pipe' });
+      const result = detectAndFixTransferredRepo(tmpDir);
+      expect(result.fixed).to.be.false;
+    });
+  });
+
+  describe('URL format preservation', () => {
+    it('should preserve HTTPS format when building new URL', () => {
+      const oldUrl = 'https://github.com/getCora/myrepo.git';
+      const newUrl = oldUrl.replace('getCora/myrepo', 'getCoraAI/myrepo');
+      expect(newUrl).to.equal('https://github.com/getCoraAI/myrepo.git');
+    });
+
+    it('should preserve SSH format when building new URL', () => {
+      const oldUrl = 'git@github.com:getCora/myrepo.git';
+      const newUrl = oldUrl.replace('getCora/myrepo', 'getCoraAI/myrepo');
+      expect(newUrl).to.equal('git@github.com:getCoraAI/myrepo.git');
+    });
+
+    it('should preserve HTTPS without .git suffix when building new URL', () => {
+      const oldUrl = 'https://github.com/getCora/myrepo';
+      const newUrl = oldUrl.replace('getCora/myrepo', 'getCoraAI/myrepo');
+      expect(newUrl).to.equal('https://github.com/getCoraAI/myrepo');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves PRLT-993: PR creation fails when GitHub repo transferred to new org

## Description

From GH#826 (@RShuken). Repo transferred from getCora to getCoraAI. Local remote still pointed to old org. gh pr create failed with 'No commits between' different orgs. Should detect transferred repos and update remote.

## External Issue Context

- Source: linear
- External key: PRLT-993
- External id: b199e805-0a38-49ce-9401-6420b9f03c2b
- URL: https://linear.app/proletariat/issue/PRLT-993/pr-creation-fails-when-github-repo-transferred-to-new-org
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- a48b596b feat(PRLT-993): detect and fix transferred GitHub repos before PR creation

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
