### PR TITLE
chore: bump version to 0.3.77

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.76",
+  "version": "0.3.77",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- engines + .nvmrc for Node 22 (#848), archived repos warning (#849), CLAUDE.md update (#846), orchestrator --json fix (#842)