### PR TITLE
chore: bump version to 0.3.78

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.77",
+  "version": "0.3.78",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Bump version for release. Includes:
- PRLT-954: Auto-detect external issue identifiers (PR #856)
- PRLT-946: Move event triggers to adapter layer (PR #858)
- PRLT-993: Fix PR creation for transferred repos (PR #859)