### PR TITLE
PRLT-1005: Auto-cleanup Docker containers when agent completes — triggered GC, not TTL

### DIFF
--- a/apps/cli/src/commands/session/cleanup.ts
+++ b/apps/cli/src/commands/session/cleanup.ts
@@ -1,0 +1,259 @@
+/**
+ * prlt session cleanup — Clean up dead Docker containers
+ *
+ * Manually cleans up Docker containers that are no longer in use.
+ * Finds containers that are exited/stopped or idle (no active tmux sessions)
+ * and removes them.
+ *
+ * TKT-172 / PRLT-1005
+ */
+
+import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import Database from 'better-sqlite3'
+import { styles } from '../../lib/styles.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { ExecutionStorage, ContainerStorage } from '../../lib/execution/storage.js'
+import {
+  cleanupDeadContainers,
+  cleanupIdleContainers,
+  listDeadContainers,
+  listIdleContainers,
+  listAllProletariatContainers,
+  type ContainerCleanupResult,
+} from '../../lib/docker/container-cleanup.js'
+import {
+  getWorkspaceInfo,
+} from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+
+export default class SessionCleanup extends PMOCommand {
+  static description = 'Clean up dead Docker containers from completed agent work'
+
+  static examples = [
+    '<%= config.bin %> session cleanup',
+    '<%= config.bin %> session cleanup --dry-run',
+    '<%= config.bin %> session cleanup --include-idle',
+    '<%= config.bin %> session cleanup --json',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    'dry-run': Flags.boolean({
+      char: 'd',
+      description: 'Show what would be cleaned without actually doing it',
+      default: false,
+    }),
+    'include-idle': Flags.boolean({
+      description: 'Also stop and remove idle running containers (no active tmux sessions)',
+      default: false,
+    }),
+    yes: Flags.boolean({
+      char: 'y',
+      description: 'Skip confirmation prompt',
+      default: false,
+    }),
+  }
+
+  protected getPMOOptions() {
+    return { promptIfMultiple: false }
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(SessionCleanup)
+    const jsonMode = shouldOutputJson(flags)
+    const dryRun = flags['dry-run']
+    const includeIdle = flags['include-idle']
+    const skipConfirm = flags.yes
+
+    // Get workspace info
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run from a proletariat HQ directory.', createMetadata('session cleanup', flags))
+        return
+      }
+      this.log(styles.error('Not in a workspace. Run from a proletariat HQ directory.'))
+      return
+    }
+
+    // Open database to sync container records
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new Database(dbPath)
+
+    try {
+      const executionStorage = new ExecutionStorage(db)
+
+      // Also clean up stale execution records first
+      const staleCleaned = executionStorage.cleanupStaleExecutions()
+
+      // Discover containers to clean
+      const deadContainers = listDeadContainers()
+      const idleContainers = includeIdle ? listIdleContainers() : []
+      const totalContainers = deadContainers.length + idleContainers.length
+
+      if (totalContainers === 0 && staleCleaned === 0) {
+        if (jsonMode) {
+          outputSuccessAsJson({
+            message: 'No containers to clean up.',
+            staleExecutionsCleaned: 0,
+            containersRemoved: 0,
+          }, createMetadata('session cleanup', flags))
+          return
+        }
+        this.log('')
+        this.log(styles.success('No containers to clean up. Everything is clean.'))
+        this.log('')
+        return
+      }
+
+      // Show what will be cleaned
+      if (!jsonMode) {
+        this.log('')
+        this.log(styles.header(`${dryRun ? '[DRY RUN] ' : ''}Container Cleanup`))
+        this.log('═'.repeat(60))
+
+        if (staleCleaned > 0) {
+          this.log(styles.info(`  ${staleCleaned} stale execution record(s) cleaned`))
+        }
+
+        if (deadContainers.length > 0) {
+          this.log(styles.info(`  ${deadContainers.length} dead container(s) ${dryRun ? 'would be ' : 'to be '}removed:`))
+          for (const c of deadContainers) {
+            this.log(styles.muted(`    - ${c.id.substring(0, 12)} ${c.name} (${c.status})`))
+          }
+        }
+
+        if (idleContainers.length > 0) {
+          this.log(styles.info(`  ${idleContainers.length} idle container(s) ${dryRun ? 'would be ' : 'to be '}stopped and removed:`))
+          for (const c of idleContainers) {
+            this.log(styles.muted(`    - ${c.id.substring(0, 12)} ${c.name} (${c.status})`))
+          }
+        }
+        this.log('')
+      }
+
+      // Dry run: just report
+      if (dryRun) {
+        if (jsonMode) {
+          outputSuccessAsJson({
+            message: `Would remove ${totalContainers} container(s)`,
+            dryRun: true,
+            staleExecutionsCleaned: staleCleaned,
+            deadContainers: deadContainers.map(c => ({
+              id: c.id.substring(0, 12),
+              name: c.name,
+              status: c.status,
+            })),
+            idleContainers: idleContainers.map(c => ({
+              id: c.id.substring(0, 12),
+              name: c.name,
+              status: c.status,
+            })),
+          }, createMetadata('session cleanup', flags))
+        }
+        return
+      }
+
+      // Confirm unless --yes
+      if (!skipConfirm && totalContainers > 0) {
+        if (jsonMode) {
+          outputSuccessAsJson({
+            message: 'Confirmation required',
+            preview: {
+              deadContainers: deadContainers.length,
+              idleContainers: idleContainers.length,
+              staleExecutionsCleaned: staleCleaned,
+            },
+          }, createMetadata('session cleanup', flags))
+          return
+        }
+
+        const { confirm } = await this.prompt<{ confirm: boolean }>([
+          {
+            type: 'list',
+            name: 'confirm',
+            message: `Remove ${totalContainers} container(s)?`,
+            choices: [
+              { name: 'No, cancel', value: false },
+              { name: 'Yes, clean up', value: true },
+            ],
+            default: 0,
+          },
+        ], null)
+
+        if (!confirm) {
+          this.log(styles.muted('Operation cancelled.'))
+          return
+        }
+      }
+
+      // Perform cleanup
+      let result: ContainerCleanupResult
+      if (includeIdle) {
+        result = cleanupIdleContainers()
+      } else {
+        result = cleanupDeadContainers()
+      }
+
+      // Update container records in DB
+      try {
+        const containerStorage = new ContainerStorage(db)
+        for (const removedId of result.removed) {
+          containerStorage.markRemoved(removedId)
+        }
+      } catch {
+        // Non-fatal — DB sync failure shouldn't block cleanup reporting
+      }
+
+      // Output results
+      if (jsonMode) {
+        outputSuccessAsJson({
+          message: `Removed ${result.removed.length} container(s)`,
+          staleExecutionsCleaned: staleCleaned,
+          containersRemoved: result.removed.length,
+          containers: result.removed.map(id => id.substring(0, 12)),
+          errors: result.errors.map(e => ({
+            containerId: e.containerId.substring(0, 12),
+            error: e.error,
+          })),
+        }, createMetadata('session cleanup', flags))
+        return
+      }
+
+      // Summary
+      this.log('')
+      this.log(styles.header('Cleanup Summary'))
+      this.log('─'.repeat(40))
+
+      if (staleCleaned > 0) {
+        this.log(styles.success(`  ${staleCleaned} stale execution(s) cleaned`))
+      }
+
+      if (result.removed.length > 0) {
+        this.log(styles.success(`  ${result.removed.length} container(s) removed`))
+      }
+
+      if (result.errors.length > 0) {
+        for (const err of result.errors) {
+          this.log(styles.error(`  Failed: ${err.containerId.substring(0, 12)} - ${err.error}`))
+        }
+      }
+
+      if (result.removed.length === 0 && result.errors.length === 0) {
+        this.log(styles.success('  No containers needed cleanup'))
+      }
+
+      this.log('')
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/session/index.ts
+++ b/apps/cli/src/commands/session/index.ts
@@ -40,6 +40,7 @@ export default class Session extends PMOCommand {
         { name: 'Execute command in agent context', value: 'exec', command: 'prlt session exec --json' },
         { name: 'Restart an agent session', value: 'restart', command: 'prlt session restart --json' },
         { name: 'Prune stale sessions', value: 'prune', command: 'prlt session prune --json' },
+        { name: 'Clean up dead containers', value: 'cleanup', command: 'prlt session cleanup --json' },
         { name: 'Cancel', value: 'cancel' },
       ],
     }], jsonModeConfig)
@@ -79,6 +80,9 @@ export default class Session extends PMOCommand {
         break
       case 'prune':
         await this.config.runCommand('session:prune', [])
+        break
+      case 'cleanup':
+        await this.config.runCommand('session:cleanup', [])
         break
     }
   }

--- a/apps/cli/src/commands/work/complete.ts
+++ b/apps/cli/src/commands/work/complete.ts
@@ -15,6 +15,7 @@ import {
 import { trackWorkCompleted } from '../../lib/telemetry/analytics.js';
 import { tryValidateCommits } from '../../lib/execution/commit-validation.js';
 import { detectRepoWorktrees } from '../../lib/execution/context.js';
+import { cleanupExecutionContainer } from '../../lib/docker/container-cleanup.js';
 
 export default class WorkComplete extends PMOCommand {
   static description = 'Mark work as complete (moves ticket to Done column)';
@@ -152,6 +153,14 @@ export default class WorkComplete extends PMOCommand {
         trackWorkCompleted({ durationMs, prCreated: false });
 
         this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+
+        // TKT-172: Auto-cleanup Docker container when agent work is completed
+        if (runningExecution.containerId && runningExecution.environment === 'devcontainer') {
+          const cleanup = cleanupExecutionContainer(runningExecution.containerId);
+          if (cleanup.removed.length > 0) {
+            this.log(styles.muted(`   Container ${runningExecution.containerId.substring(0, 12)} cleaned up`));
+          }
+        }
 
         // PRLT-984: Commit validation — warn if no meaningful code was committed
         if (runningExecution.branch && runningExecution.agentName) {

--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -29,6 +29,7 @@ import {
 import { tryValidateCommits } from '../../lib/execution/commit-validation.js';
 import { detectRepoWorktrees } from '../../lib/execution/context.js';
 import { ensureRemoteUpToDate } from '../../lib/repos/git.js';
+import { cleanupExecutionContainer } from '../../lib/docker/container-cleanup.js';
 
 export default class WorkReady extends PMOCommand {
   static description = 'Mark work as ready for review (moves ticket to In Review column)';
@@ -185,6 +186,14 @@ export default class WorkReady extends PMOCommand {
       if (runningExecution) {
         executionStorage.updateStatus(runningExecution.id, 'completed');
         this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+
+        // TKT-172: Auto-cleanup Docker container when agent work is marked ready
+        if (runningExecution.containerId && runningExecution.environment === 'devcontainer') {
+          const cleanup = cleanupExecutionContainer(runningExecution.containerId);
+          if (cleanup.removed.length > 0) {
+            this.log(styles.muted(`   Container ${runningExecution.containerId.substring(0, 12)} cleaned up`));
+          }
+        }
       }
 
       // PRLT-984: Commit validation — warn if no meaningful code was committed

--- a/apps/cli/src/lib/docker/cleanup-listener.ts
+++ b/apps/cli/src/lib/docker/cleanup-listener.ts
@@ -1,0 +1,161 @@
+/**
+ * Container Cleanup Listener — Event-driven Docker container GC
+ *
+ * Subscribes to agent completion events on the EventBus and triggers
+ * container cleanup. Containers are removed when:
+ *
+ * 1. An agent is stopped (manual or completed)
+ * 2. An agent encounters an error
+ * 3. Work is completed (ticket moved to Done)
+ * 4. A PR is created (work ready for review)
+ *
+ * This is triggered GC, NOT TTL-based cleanup.
+ *
+ * TKT-172 / PRLT-1005
+ */
+
+import type { EventBus } from '../events/event-bus.js'
+import { getEventBus } from '../events/event-bus.js'
+import { cleanupExecutionContainer, type ContainerCleanupResult } from './container-cleanup.js'
+import type { ExecutionStorage } from '../execution/storage.js'
+
+export interface CleanupListenerOptions {
+  /** Optional logger for cleanup messages */
+  log?: (message: string) => void
+  /** EventBus instance (defaults to global singleton) */
+  eventBus?: EventBus
+  /** ExecutionStorage for looking up container IDs from execution records */
+  executionStorage?: ExecutionStorage
+}
+
+/**
+ * ContainerCleanupListener subscribes to agent lifecycle events
+ * and cleans up Docker containers when agents complete their work.
+ */
+export class ContainerCleanupListener {
+  private unsubscribers: Array<() => void> = []
+  private bus: EventBus
+  private log: (message: string) => void
+  private executionStorage?: ExecutionStorage
+
+  constructor(options?: CleanupListenerOptions) {
+    this.bus = options?.eventBus ?? getEventBus()
+    this.log = options?.log ?? (() => {})
+    this.executionStorage = options?.executionStorage
+  }
+
+  /**
+   * Start listening for agent completion events.
+   * Call stop() to unsubscribe.
+   */
+  start(): void {
+    // Listen for agent stopped events
+    this.unsubscribers.push(
+      this.bus.on('agent:stopped', (event) => {
+        this.handleAgentCompletion(event.sessionId, `agent stopped (${event.reason})`)
+      }),
+    )
+
+    // Listen for agent error events
+    this.unsubscribers.push(
+      this.bus.on('agent:error', (event) => {
+        this.handleAgentCompletion(event.sessionId, `agent error: ${event.error}`)
+      }),
+    )
+
+    // Listen for work completed events
+    this.unsubscribers.push(
+      this.bus.on('work:completed', (event) => {
+        this.handleWorkCompletion(event.workItemId, 'work completed')
+      }),
+    )
+
+    // Listen for PR created events (signals agent work is done)
+    this.unsubscribers.push(
+      this.bus.on('work:pr_created', (event) => {
+        this.handleWorkCompletion(event.workItemId, 'PR created')
+      }),
+    )
+  }
+
+  /**
+   * Stop listening and unsubscribe from all events.
+   */
+  stop(): void {
+    for (const unsub of this.unsubscribers) {
+      unsub()
+    }
+    this.unsubscribers = []
+  }
+
+  /**
+   * Handle agent completion by looking up the container ID from the session/execution.
+   */
+  private handleAgentCompletion(sessionId: string, reason: string): void {
+    if (!this.executionStorage) return
+
+    // Try to find the execution by session ID
+    const executions = this.executionStorage.listExecutions({ limit: 50 })
+    const execution = executions.find(e => e.sessionId === sessionId)
+
+    if (!execution?.containerId) return
+
+    this.log(`Container cleanup triggered: ${reason} (container: ${execution.containerId.substring(0, 12)})`)
+    const result = cleanupExecutionContainer(execution.containerId)
+    this.logCleanupResult(result)
+  }
+
+  /**
+   * Handle work completion by looking up the container from the ticket's execution.
+   */
+  private handleWorkCompletion(workItemId: string, reason: string): void {
+    if (!this.executionStorage) return
+
+    // Find the execution for this work item (ticket)
+    const execution = this.executionStorage.getRunningExecution(workItemId)
+    if (!execution?.containerId) return
+
+    this.log(`Container cleanup triggered: ${reason} for ${workItemId} (container: ${execution.containerId.substring(0, 12)})`)
+    const result = cleanupExecutionContainer(execution.containerId)
+    this.logCleanupResult(result)
+  }
+
+  private logCleanupResult(result: ContainerCleanupResult): void {
+    if (result.removed.length > 0) {
+      this.log(`  Removed ${result.removed.length} container(s)`)
+    }
+    for (const err of result.errors) {
+      this.log(`  Error cleaning ${err.containerId.substring(0, 12)}: ${err.error}`)
+    }
+  }
+}
+
+// =============================================================================
+// Singleton
+// =============================================================================
+
+let _listener: ContainerCleanupListener | undefined
+
+/**
+ * Initialize the container cleanup listener.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function initContainerCleanupListener(
+  options?: CleanupListenerOptions,
+): ContainerCleanupListener {
+  if (!_listener) {
+    _listener = new ContainerCleanupListener(options)
+    _listener.start()
+  }
+  return _listener
+}
+
+/**
+ * Stop the container cleanup listener (primarily for testing).
+ */
+export function stopContainerCleanupListener(): void {
+  if (_listener) {
+    _listener.stop()
+    _listener = undefined
+  }
+}

--- a/apps/cli/src/lib/docker/container-cleanup.ts
+++ b/apps/cli/src/lib/docker/container-cleanup.ts
@@ -1,0 +1,402 @@
+/**
+ * Container Cleanup — Triggered GC for Docker containers
+ *
+ * Provides event-driven and manual cleanup of Docker containers when agents
+ * complete their work. Containers are cleaned up on agent completion events
+ * (PR created, error, explicit stop), NOT on a TTL.
+ *
+ * TKT-172 / PRLT-1005
+ */
+
+import { execSync } from 'node:child_process'
+import { sanitizeContainerId } from './resolve.js'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ContainerCleanupResult {
+  /** Containers that were successfully stopped and removed */
+  removed: string[]
+  /** Containers that failed to be cleaned up, with error messages */
+  errors: Array<{ containerId: string; error: string }>
+  /** Containers that were already stopped/exited (just removed) */
+  alreadyStopped: string[]
+}
+
+export interface ContainerInfo {
+  id: string
+  name: string
+  status: string
+  image: string
+  /** Labels from the container */
+  labels: Record<string, string>
+}
+
+// =============================================================================
+// Core Cleanup Functions
+// =============================================================================
+
+/**
+ * Stop and remove a single Docker container.
+ * First attempts graceful stop (SIGTERM), then force-removes.
+ *
+ * @param containerId - Docker container ID or name
+ * @param gracefulTimeoutSecs - Seconds to wait for graceful stop before force-killing (default: 10)
+ * @returns true if container was removed, false on failure
+ */
+export function stopAndRemoveContainer(
+  containerId: string,
+  gracefulTimeoutSecs = 10,
+): boolean {
+  try {
+    const safeId = sanitizeContainerId(containerId)
+
+    // Check if container is running first
+    const running = isContainerRunningById(safeId)
+
+    if (running) {
+      // Graceful stop
+      execSync(`docker stop --time ${gracefulTimeoutSecs} ${safeId}`, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: (gracefulTimeoutSecs + 5) * 1000,
+      })
+    }
+
+    // Remove the container (whether it was running or already stopped)
+    execSync(`docker rm ${safeId}`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30_000,
+    })
+
+    return true
+  } catch {
+    // Try force remove as fallback
+    try {
+      const safeId = sanitizeContainerId(containerId)
+      execSync(`docker rm -f ${safeId}`, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 30_000,
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+/**
+ * Clean up containers for a specific execution.
+ * Called when an agent completes work (PR created, error, or stop).
+ *
+ * @param containerId - The container ID associated with the execution
+ * @returns Result with removed containers and any errors
+ */
+export function cleanupExecutionContainer(containerId: string): ContainerCleanupResult {
+  const result: ContainerCleanupResult = {
+    removed: [],
+    errors: [],
+    alreadyStopped: [],
+  }
+
+  if (!containerId) {
+    return result
+  }
+
+  try {
+    const safeId = sanitizeContainerId(containerId)
+    const running = isContainerRunningById(safeId)
+
+    if (!running) {
+      result.alreadyStopped.push(containerId)
+    }
+
+    const success = stopAndRemoveContainer(containerId)
+    if (success) {
+      result.removed.push(containerId)
+    } else {
+      result.errors.push({
+        containerId,
+        error: 'Failed to stop and remove container',
+      })
+    }
+  } catch (err) {
+    result.errors.push({
+      containerId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  return result
+}
+
+/**
+ * Find and clean up all dead containers (exited, not running) that belong
+ * to the proletariat system (identified by the devcontainer.local_folder label
+ * or prlt-agent- name prefix).
+ *
+ * This is the implementation behind `prlt session cleanup`.
+ *
+ * @returns Result with all removed containers and errors
+ */
+export function cleanupDeadContainers(): ContainerCleanupResult {
+  const result: ContainerCleanupResult = {
+    removed: [],
+    errors: [],
+    alreadyStopped: [],
+  }
+
+  const deadContainers = listDeadContainers()
+
+  for (const container of deadContainers) {
+    result.alreadyStopped.push(container.id)
+
+    try {
+      execSync(`docker rm ${container.id}`, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 30_000,
+      })
+      result.removed.push(container.id)
+    } catch (err) {
+      result.errors.push({
+        containerId: container.id,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return result
+}
+
+/**
+ * Find and clean up all idle containers (running at 0% CPU with no active
+ * tmux sessions) that belong to the proletariat system.
+ *
+ * More aggressive than cleanupDeadContainers — also stops running containers
+ * that have no active work.
+ *
+ * @returns Result with all removed containers and errors
+ */
+export function cleanupIdleContainers(): ContainerCleanupResult {
+  const result: ContainerCleanupResult = {
+    removed: [],
+    errors: [],
+    alreadyStopped: [],
+  }
+
+  // First, clean dead containers
+  const deadResult = cleanupDeadContainers()
+  result.removed.push(...deadResult.removed)
+  result.errors.push(...deadResult.errors)
+  result.alreadyStopped.push(...deadResult.alreadyStopped)
+
+  // Then find idle running containers
+  const idleContainers = listIdleContainers()
+
+  for (const container of idleContainers) {
+    const success = stopAndRemoveContainer(container.id)
+    if (success) {
+      result.removed.push(container.id)
+    } else {
+      result.errors.push({
+        containerId: container.id,
+        error: 'Failed to stop and remove idle container',
+      })
+    }
+  }
+
+  return result
+}
+
+// =============================================================================
+// Container Discovery
+// =============================================================================
+
+/**
+ * List all proletariat containers that are exited/dead.
+ */
+export function listDeadContainers(): ContainerInfo[] {
+  try {
+    const output = execSync(
+      'docker ps -a --filter "status=exited" --filter "label=devcontainer.local_folder" --format "{{.ID}}\\t{{.Names}}\\t{{.Status}}\\t{{.Image}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+
+    if (!output) {
+      // Also check for prlt-agent- named containers
+      return listDeadContainersByName()
+    }
+
+    const containers = parseContainerOutput(output)
+
+    // Also include prlt-agent- named containers
+    const namedContainers = listDeadContainersByName()
+    const existingIds = new Set(containers.map(c => c.id))
+    for (const c of namedContainers) {
+      if (!existingIds.has(c.id)) {
+        containers.push(c)
+      }
+    }
+
+    return containers
+  } catch {
+    return []
+  }
+}
+
+/**
+ * List dead containers by the prlt-agent- name prefix.
+ */
+function listDeadContainersByName(): ContainerInfo[] {
+  try {
+    const output = execSync(
+      'docker ps -a --filter "status=exited" --filter "name=prlt-agent-" --format "{{.ID}}\\t{{.Names}}\\t{{.Status}}\\t{{.Image}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+
+    if (!output) return []
+    return parseContainerOutput(output)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * List all proletariat containers that are running but idle
+ * (have no active tmux sessions inside them).
+ */
+export function listIdleContainers(): ContainerInfo[] {
+  try {
+    // Get all running prlt containers
+    const output = execSync(
+      'docker ps --filter "label=devcontainer.local_folder" --format "{{.ID}}\\t{{.Names}}\\t{{.Status}}\\t{{.Image}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+
+    if (!output) {
+      return listIdleContainersByName()
+    }
+
+    const containers = parseContainerOutput(output)
+
+    // Also include prlt-agent- named running containers
+    const namedContainers = listIdleContainersByName()
+    const existingIds = new Set(containers.map(c => c.id))
+    for (const c of namedContainers) {
+      if (!existingIds.has(c.id)) {
+        containers.push(c)
+      }
+    }
+
+    // Filter to only those with no tmux sessions (truly idle)
+    return containers.filter(c => !hasActiveTmuxSessions(c.id))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * List idle running containers by the prlt-agent- name prefix.
+ */
+function listIdleContainersByName(): ContainerInfo[] {
+  try {
+    const output = execSync(
+      'docker ps --filter "name=prlt-agent-" --format "{{.ID}}\\t{{.Names}}\\t{{.Status}}\\t{{.Image}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+
+    if (!output) return []
+    return parseContainerOutput(output)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * List all proletariat containers (running + stopped).
+ * Used by `prlt session cleanup --dry-run` to show what would be cleaned.
+ */
+export function listAllProletariatContainers(): ContainerInfo[] {
+  try {
+    const output = execSync(
+      'docker ps -a --filter "label=devcontainer.local_folder" --format "{{.ID}}\\t{{.Names}}\\t{{.Status}}\\t{{.Image}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+
+    const containers = output ? parseContainerOutput(output) : []
+
+    // Also include prlt-agent- named containers
+    const namedOutput = execSync(
+      'docker ps -a --filter "name=prlt-agent-" --format "{{.ID}}\\t{{.Names}}\\t{{.Status}}\\t{{.Image}}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+
+    if (namedOutput) {
+      const namedContainers = parseContainerOutput(namedOutput)
+      const existingIds = new Set(containers.map(c => c.id))
+      for (const c of namedContainers) {
+        if (!existingIds.has(c.id)) {
+          containers.push(c)
+        }
+      }
+    }
+
+    return containers
+  } catch {
+    return []
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Check if a container is currently running by its ID.
+ */
+function isContainerRunningById(containerId: string): boolean {
+  try {
+    const output = execSync(
+      `docker inspect -f '{{.State.Running}}' ${containerId}`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim()
+    return output === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if a container has active tmux sessions inside it.
+ */
+function hasActiveTmuxSessions(containerId: string): boolean {
+  try {
+    const output = execSync(
+      `docker exec ${containerId} tmux list-sessions 2>/dev/null`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 },
+    ).trim()
+    return output.length > 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse docker ps output into ContainerInfo array.
+ */
+function parseContainerOutput(output: string): ContainerInfo[] {
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const [id, name, status, image] = line.split('\t')
+      return {
+        id: id?.trim() || '',
+        name: name?.trim() || '',
+        status: status?.trim() || '',
+        image: image?.trim() || '',
+        labels: {},
+      }
+    })
+    .filter(c => c.id)
+}

--- a/apps/cli/src/lib/pmo/sync-manager.ts
+++ b/apps/cli/src/lib/pmo/sync-manager.ts
@@ -29,6 +29,8 @@ import { initHookManager } from '../work-lifecycle/hooks/index.js';
 import { initWorkflowRuleEvaluator } from '../work-lifecycle/rule-evaluator.js';
 import { initActionChaining } from '../work-lifecycle/action-chaining.js';
 import { initTriggerHandler } from '../providers/trigger-config.js';
+import { initContainerCleanupListener } from '../docker/cleanup-listener.js';
+import { ExecutionStorage } from '../execution/storage.js';
 
 /**
  * Get the board path for a project
@@ -303,6 +305,11 @@ export function getStorageWithAutoSync(
 
   // Initialize action chaining (auto-spawns next action on workflow rule matches)
   initActionChaining(storage.getDatabase(), storage, pmoPath);
+
+  // Initialize container cleanup listener (TKT-172: auto-cleanup Docker containers on agent completion)
+  initContainerCleanupListener({
+    executionStorage: new ExecutionStorage(storage.getDatabase()),
+  });
 
   // Initialize configurable trigger handler (agent_started, pr_created, etc. → target column)
   initTriggerHandler(storage.getDatabase(), async (ticketId, projectId, targetStatus) => {

--- a/apps/cli/test/unit/cleanup-listener.test.ts
+++ b/apps/cli/test/unit/cleanup-listener.test.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai'
+import { EventBus } from '../../src/lib/events/event-bus.js'
+import {
+  ContainerCleanupListener,
+  initContainerCleanupListener,
+  stopContainerCleanupListener,
+} from '../../src/lib/docker/cleanup-listener.js'
+
+/**
+ * Unit tests for the container cleanup event listener.
+ * TKT-172 / PRLT-1005: Container lifecycle tied to agent completion events.
+ *
+ * Tests the event subscription/unsubscription lifecycle and event routing
+ * without requiring Docker or a database.
+ */
+
+describe('ContainerCleanupListener (TKT-172)', () => {
+  let bus: EventBus
+  let logMessages: string[]
+
+  beforeEach(() => {
+    bus = new EventBus()
+    logMessages = []
+  })
+
+  afterEach(() => {
+    stopContainerCleanupListener()
+  })
+
+  // ===========================================================================
+  // Listener lifecycle — subscribes to correct events
+  // ===========================================================================
+  describe('start/stop lifecycle', () => {
+    it('should subscribe to all completion events on start', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+
+      listener.start()
+
+      expect(bus.listenerCount('agent:stopped')).to.equal(1)
+      expect(bus.listenerCount('agent:error')).to.equal(1)
+      expect(bus.listenerCount('work:completed')).to.equal(1)
+      expect(bus.listenerCount('work:pr_created')).to.equal(1)
+
+      listener.stop()
+    })
+
+    it('should unsubscribe from all events on stop', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+
+      listener.start()
+      listener.stop()
+
+      expect(bus.listenerCount('agent:stopped')).to.equal(0)
+      expect(bus.listenerCount('agent:error')).to.equal(0)
+      expect(bus.listenerCount('work:completed')).to.equal(0)
+      expect(bus.listenerCount('work:pr_created')).to.equal(0)
+    })
+
+    it('should not subscribe to unrelated events', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+
+      listener.start()
+
+      // These events should NOT have listeners from the cleanup listener
+      expect(bus.listenerCount('agent:spawned')).to.equal(0)
+      expect(bus.listenerCount('agent:poked')).to.equal(0)
+      expect(bus.listenerCount('agent:output')).to.equal(0)
+
+      listener.stop()
+    })
+  })
+
+  // ===========================================================================
+  // Event handling without execution storage (no-op path)
+  // ===========================================================================
+  describe('without execution storage', () => {
+    it('should handle agent:stopped gracefully (no crash)', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+      listener.start()
+
+      // Should not throw — just silently skip when no storage is available
+      bus.emit('agent:stopped', {
+        sessionId: 'ses-abc',
+        runner: 'claude-code',
+        reason: 'completed',
+        timestamp: new Date(),
+      })
+
+      expect(logMessages).to.have.length(0)
+
+      listener.stop()
+    })
+
+    it('should handle agent:error gracefully (no crash)', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+      listener.start()
+
+      bus.emit('agent:error', {
+        sessionId: 'ses-abc',
+        runner: 'claude-code',
+        error: 'something failed',
+        timestamp: new Date(),
+      })
+
+      expect(logMessages).to.have.length(0)
+
+      listener.stop()
+    })
+
+    it('should handle work:completed gracefully (no crash)', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+      listener.start()
+
+      bus.emit('work:completed', {
+        workItemId: 'TKT-001',
+        source: 'pmo',
+        status: 'Done',
+        timestamp: new Date(),
+      })
+
+      expect(logMessages).to.have.length(0)
+
+      listener.stop()
+    })
+
+    it('should handle work:pr_created gracefully (no crash)', () => {
+      const listener = new ContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+      listener.start()
+
+      bus.emit('work:pr_created', {
+        workItemId: 'TKT-002',
+        source: 'github',
+        prUrl: 'https://github.com/org/repo/pull/42',
+        prTitle: 'feat: add feature',
+        timestamp: new Date(),
+      })
+
+      expect(logMessages).to.have.length(0)
+
+      listener.stop()
+    })
+  })
+
+  // ===========================================================================
+  // Singleton management
+  // ===========================================================================
+  describe('singleton', () => {
+    it('should initialize and stop cleanly', () => {
+      const listener = initContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+
+      expect(listener).to.be.instanceOf(ContainerCleanupListener)
+      expect(bus.listenerCount('agent:stopped')).to.equal(1)
+
+      stopContainerCleanupListener()
+      expect(bus.listenerCount('agent:stopped')).to.equal(0)
+    })
+
+    it('should be idempotent on multiple init calls', () => {
+      const listener1 = initContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+
+      // Second call should return the same listener
+      const listener2 = initContainerCleanupListener({
+        eventBus: bus,
+        log: (msg) => logMessages.push(msg),
+      })
+
+      expect(listener1).to.equal(listener2)
+      // Should still have only 1 listener per event
+      expect(bus.listenerCount('agent:stopped')).to.equal(1)
+
+      stopContainerCleanupListener()
+    })
+  })
+})

--- a/apps/cli/test/unit/container-cleanup.test.ts
+++ b/apps/cli/test/unit/container-cleanup.test.ts
@@ -1,0 +1,150 @@
+import { expect } from 'chai'
+import { execSync } from 'node:child_process'
+import {
+  type ContainerCleanupResult,
+  cleanupExecutionContainer,
+  listDeadContainers,
+  listAllProletariatContainers,
+} from '../../src/lib/docker/container-cleanup.js'
+import { sanitizeContainerId } from '../../src/lib/docker/resolve.js'
+
+/**
+ * Unit tests for Docker container cleanup module.
+ * TKT-172 / PRLT-1005: Auto-cleanup Docker containers when agent completes.
+ *
+ * These tests validate the container cleanup logic without requiring Docker.
+ * Docker-dependent tests (actual container stop/remove) are in e2e tests.
+ */
+
+describe('Container Cleanup (TKT-172)', () => {
+  // ===========================================================================
+  // sanitizeContainerId (shared validation logic)
+  // ===========================================================================
+  describe('sanitizeContainerId (shell injection prevention)', () => {
+    it('should accept valid hex container IDs', () => {
+      expect(sanitizeContainerId('abc123def456')).to.equal('abc123def456')
+    })
+
+    it('should accept full-length SHA256 IDs', () => {
+      const fullId = 'a'.repeat(64)
+      expect(sanitizeContainerId(fullId)).to.equal(fullId)
+    })
+
+    it('should accept container names with hyphens and underscores', () => {
+      expect(sanitizeContainerId('prlt-agent-alice_1')).to.equal('prlt-agent-alice_1')
+    })
+
+    it('should accept container names with periods', () => {
+      expect(sanitizeContainerId('prlt.agent.alice')).to.equal('prlt.agent.alice')
+    })
+
+    it('should reject IDs with semicolons (command injection)', () => {
+      expect(() => sanitizeContainerId('abc; rm -rf /')).to.throw('Invalid container ID')
+    })
+
+    it('should reject IDs with pipe characters', () => {
+      expect(() => sanitizeContainerId('abc | cat /etc/passwd')).to.throw('Invalid container ID')
+    })
+
+    it('should reject IDs with backticks', () => {
+      expect(() => sanitizeContainerId('abc`whoami`')).to.throw('Invalid container ID')
+    })
+
+    it('should reject IDs with dollar signs', () => {
+      expect(() => sanitizeContainerId('abc$(whoami)')).to.throw('Invalid container ID')
+    })
+
+    it('should reject IDs that are too long', () => {
+      const longId = 'a'.repeat(200)
+      expect(() => sanitizeContainerId(longId)).to.throw('Invalid container ID')
+    })
+
+    it('should reject empty IDs', () => {
+      expect(() => sanitizeContainerId('')).to.throw('Invalid container ID')
+    })
+  })
+
+  // ===========================================================================
+  // ContainerCleanupResult type validation
+  // ===========================================================================
+  describe('ContainerCleanupResult structure', () => {
+    it('should have the expected shape for empty result', () => {
+      const result: ContainerCleanupResult = {
+        removed: [],
+        errors: [],
+        alreadyStopped: [],
+      }
+      expect(result.removed).to.be.an('array').that.is.empty
+      expect(result.errors).to.be.an('array').that.is.empty
+      expect(result.alreadyStopped).to.be.an('array').that.is.empty
+    })
+
+    it('should support error entries with container ID and message', () => {
+      const result: ContainerCleanupResult = {
+        removed: [],
+        errors: [
+          { containerId: 'abc123', error: 'permission denied' },
+        ],
+        alreadyStopped: [],
+      }
+      expect(result.errors[0].containerId).to.equal('abc123')
+      expect(result.errors[0].error).to.equal('permission denied')
+    })
+
+    it('should track already-stopped containers separately', () => {
+      const result: ContainerCleanupResult = {
+        removed: ['abc123'],
+        errors: [],
+        alreadyStopped: ['abc123'],
+      }
+      // A container can be both already-stopped and successfully removed
+      expect(result.removed).to.include('abc123')
+      expect(result.alreadyStopped).to.include('abc123')
+    })
+  })
+
+  // ===========================================================================
+  // Integration with Docker (requires Docker, gracefully skipped)
+  // ===========================================================================
+  describe('Docker integration (requires Docker)', () => {
+    let dockerAvailable = false
+
+    before(() => {
+      try {
+        execSync('docker ps -q', { stdio: 'pipe', timeout: 5000 })
+        dockerAvailable = true
+      } catch {
+        dockerAvailable = false
+      }
+    })
+
+    it('should list dead containers (or return empty if Docker unavailable)', () => {
+      if (!dockerAvailable) return
+
+      const result = listDeadContainers()
+      expect(result).to.be.an('array')
+    })
+
+    it('should list all proletariat containers (or return empty if Docker unavailable)', () => {
+      if (!dockerAvailable) return
+
+      const result = listAllProletariatContainers()
+      expect(result).to.be.an('array')
+    })
+
+    it('should handle cleanupExecutionContainer with non-existent container', () => {
+      if (!dockerAvailable) return
+
+      const result = cleanupExecutionContainer('nonexistent123abc')
+      // Should not crash — error is recorded in result
+      expect(result).to.have.property('removed')
+      expect(result).to.have.property('errors')
+    })
+
+    it('should handle cleanupExecutionContainer with empty string', () => {
+      const result = cleanupExecutionContainer('')
+      expect(result.removed).to.have.length(0)
+      expect(result.errors).to.have.length(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-1005: Auto-cleanup Docker containers when agent completes — triggered GC, not TTL

## Description

Docker containers sit idle at 0% CPU forever after agents finish. No cleanup mechanism exists.

Needs:

* Triggered cleanup when agent work completes (PR created, error, or explicit stop)
* `prlt session cleanup` command to clear dead containers manually
* Container lifecycle tied to agent completion events, NOT a TTL

Currently the orchestrator has to manually `docker stop` + `docker rm` after checking CPU usage.

## External Issue Context

- Source: linear
- External key: PRLT-1005
- External id: dee28963-6d77-4b7b-9c9b-70585f1a63ea
- URL: https://linear.app/proletariat/issue/PRLT-1005/auto-cleanup-docker-containers-when-agent-completes-triggered-gc-not
- Status: In Progress
- Priority: Unset
- Labels: None

## Changes

- 4d60ebe7 feat(PRLT-1005): feat: add auto-cleanup Docker containers on agent completion (TKT-172)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
