### PR TITLE
chore: bump version to 0.3.80

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.79",
+  "version": "0.3.80",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Bump version for release. Includes:
- PRLT-1005: Auto-cleanup Docker containers on agent completion (PR #866)
- PRLT-1013: Fix telemetry events never flushing to Statsig (PR #864)