### PR TITLE
feat(TKT-126): fix ticket create --source auto-detection for Linear

### DIFF
--- a/apps/cli/src/commands/ticket/create.ts
+++ b/apps/cli/src/commands/ticket/create.ts
@@ -21,10 +21,10 @@ import { multiLineInput } from '../../lib/multiline-input.js';
 import { isLinearConfigured, loadLinearConfig, getLinearApiKey, LinearClient } from '../../lib/linear/index.js';
 import { LinearMapper } from '../../lib/linear/mapper.js';
 import { PMO_PRIORITY_TO_LINEAR, LINEAR_PRIORITY_TO_PMO } from '../../lib/linear/types.js';
-import { getRegisteredWorkSources } from '../../lib/work-source/config.js';
+import { getRegisteredWorkSources, loadDefaultWorkSource } from '../../lib/work-source/config.js';
 
 export default class TicketCreate extends PMOCommand {
-  static description = 'Create a new ticket on the PMO board';
+  static description = 'Create a new ticket (routes to Linear when configured, or local PMO)';
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
@@ -412,8 +412,13 @@ export default class TicketCreate extends PMOCommand {
 
   /**
    * Determine whether to route through Linear or PMO based on --source flag
-   * and workspace config. When multiple providers are configured and source is
-   * 'auto', prompts the user (or outputs JSON for agents) to choose.
+   * and workspace config.
+   *
+   * Resolution order for auto mode:
+   * 1. Explicit default work source (loadDefaultWorkSource) — user preference
+   * 2. Single external provider configured — auto-select it
+   * 3. Multiple external providers — prompt user to choose
+   * 4. No external providers — fall back to PMO
    */
   private async resolveSource(
     flags: { source?: string; json?: boolean },
@@ -424,44 +429,58 @@ export default class TicketCreate extends PMOCommand {
     if (source === 'pmo') return 'pmo';
     if (source === 'linear') return 'linear';
 
-    // auto: check configured providers
-    let providerTypes: string[];
+    // auto: resolve from workspace config
+    const db = this.storage.getDatabase();
+
     try {
-      const db = this.storage.getDatabase();
+      // 1. Respect explicit default work source if configured
+      const defaultSource = loadDefaultWorkSource(db);
+      if (defaultSource?.provider === 'linear') return 'linear';
+      if (defaultSource?.provider === 'pmo') return 'pmo';
+
+      // 2. Check registered providers (PMO is always implicitly registered)
       const registeredSources = getRegisteredWorkSources(db);
-      providerTypes = [...new Set(registeredSources.map(s => s.provider))];
+      const externalProviders = [...new Set(
+        registeredSources.map(s => s.provider).filter(p => p !== 'pmo')
+      )];
+
+      // No external providers — use PMO
+      if (externalProviders.length === 0) return 'pmo';
+
+      // Single external provider — auto-select it
+      if (externalProviders.length === 1) {
+        return externalProviders[0] === 'linear' ? 'linear' : 'pmo';
+      }
+
+      // Multiple external providers — prompt user to select
+      const allProviders = ['pmo', ...externalProviders];
+      const choices = allProviders.map(p => ({
+        name: p === 'pmo' ? 'PMO (local)' : `${p.charAt(0).toUpperCase() + p.slice(1)}`,
+        value: p,
+      }));
+      const message = 'Multiple ticket providers configured. Where should this ticket be created?';
+
+      if (jsonMode) {
+        outputPromptAsJson(
+          buildPromptConfig('list', 'source', message, choices),
+          createMetadata('ticket create', flags as Record<string, unknown>)
+        );
+        return 'pmo'
+      }
+
+      const { selectedSource } = await inquirer.prompt([{
+        type: 'list',
+        name: 'selectedSource',
+        message,
+        choices,
+      }]);
+
+      // Only 'linear' gets the special path; everything else falls through to PMO
+      return selectedSource === 'linear' ? 'linear' : 'pmo';
     } catch {
       // workspace_settings table may not exist in older/test databases
       return 'pmo';
     }
-
-    // If only PMO is available, use it directly
-    if (providerTypes.length <= 1) return 'pmo';
-
-    // Multiple providers configured — prompt user to select
-    const choices = providerTypes.map(p => ({
-      name: p === 'pmo' ? 'PMO (local)' : `${p.charAt(0).toUpperCase() + p.slice(1)}`,
-      value: p,
-    }));
-    const message = 'Multiple ticket providers configured. Where should this ticket be created?';
-
-    if (jsonMode) {
-      outputPromptAsJson(
-        buildPromptConfig('list', 'source', message, choices),
-        createMetadata('ticket create', flags as Record<string, unknown>)
-      );
-      return 'pmo'
-    }
-
-    const { selectedSource } = await inquirer.prompt([{
-      type: 'list',
-      name: 'selectedSource',
-      message,
-      choices,
-    }]);
-
-    // Only 'linear' gets the special path; everything else falls through to PMO
-    return selectedSource === 'linear' ? 'linear' : 'pmo';
   }
 
   /**

--- a/apps/cli/test/unit/ticket-create-source-resolution.test.ts
+++ b/apps/cli/test/unit/ticket-create-source-resolution.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import {
+  getRegisteredWorkSources,
+  loadDefaultWorkSource,
+  saveDefaultWorkSource,
+} from '../../src/lib/work-source/config.js'
+import { saveLinearApiKey, saveLinearDefaultTeam, isLinearConfigured } from '../../src/lib/linear/config.js'
+
+/**
+ * Tests for ticket create source resolution logic.
+ *
+ * The resolveSource() method in ticket/create.ts uses these functions
+ * to determine where to route ticket creation. These tests validate
+ * the resolution behavior:
+ *
+ * 1. loadDefaultWorkSource() — checked first (explicit user preference)
+ * 2. getRegisteredWorkSources() — auto-detect from configured providers
+ * 3. Fall back to PMO when nothing external is configured
+ */
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workspace_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    )
+  `)
+  return db
+}
+
+describe('ticket create source resolution', () => {
+  describe('loadDefaultWorkSource', () => {
+    it('returns null when no default is configured', () => {
+      const db = setupDb()
+      const result = loadDefaultWorkSource(db)
+      expect(result).to.be.null
+      db.close()
+    })
+
+    it('returns linear when default work source is set to linear', () => {
+      const db = setupDb()
+      saveDefaultWorkSource(db, { provider: 'linear' })
+      const result = loadDefaultWorkSource(db)
+      expect(result).to.not.be.null
+      expect(result!.provider).to.equal('linear')
+      db.close()
+    })
+
+    it('returns pmo when default work source is set to pmo', () => {
+      const db = setupDb()
+      saveDefaultWorkSource(db, { provider: 'pmo' })
+      const result = loadDefaultWorkSource(db)
+      expect(result).to.not.be.null
+      expect(result!.provider).to.equal('pmo')
+      db.close()
+    })
+  })
+
+  describe('getRegisteredWorkSources', () => {
+    it('returns only PMO when no external providers configured', () => {
+      const db = setupDb()
+      const sources = getRegisteredWorkSources(db)
+      const providers = sources.map(s => s.provider)
+      expect(providers).to.deep.equal(['pmo'])
+      db.close()
+    })
+
+    it('includes Linear when Linear API key is configured', () => {
+      const db = setupDb()
+      saveLinearApiKey(db, 'test-api-key')
+      const sources = getRegisteredWorkSources(db)
+      const providers = sources.map(s => s.provider)
+      expect(providers).to.include('pmo')
+      expect(providers).to.include('linear')
+      db.close()
+    })
+
+    it('includes Linear team context when default team is set', () => {
+      const db = setupDb()
+      saveLinearApiKey(db, 'test-api-key')
+      saveLinearDefaultTeam(db, 'team-uuid', 'ENG')
+      const sources = getRegisteredWorkSources(db)
+      const linearSource = sources.find(s => s.provider === 'linear')
+      expect(linearSource).to.exist
+      expect(linearSource!.context).to.equal('ENG')
+      db.close()
+    })
+  })
+
+  describe('auto-resolution logic (mirrors resolveSource behavior)', () => {
+    /**
+     * This test mirrors the resolveSource() logic in ticket/create.ts:
+     * 1. Check loadDefaultWorkSource() first
+     * 2. If not set, check external providers from getRegisteredWorkSources()
+     * 3. Single external → auto-select; Multiple → would prompt; None → PMO
+     */
+    function resolveSourceForTest(db: Database.Database): 'pmo' | 'linear' {
+      // Step 1: Check explicit default work source
+      const defaultSource = loadDefaultWorkSource(db)
+      if (defaultSource?.provider === 'linear') return 'linear'
+      if (defaultSource?.provider === 'pmo') return 'pmo'
+
+      // Step 2: Check registered providers
+      const registeredSources = getRegisteredWorkSources(db)
+      const externalProviders = [...new Set(
+        registeredSources.map(s => s.provider).filter(p => p !== 'pmo')
+      )]
+
+      // No external providers — use PMO
+      if (externalProviders.length === 0) return 'pmo'
+
+      // Single external provider — auto-select it
+      if (externalProviders.length === 1) {
+        return externalProviders[0] === 'linear' ? 'linear' : 'pmo'
+      }
+
+      // Multiple external — would prompt in real code, default to PMO for test
+      return 'pmo'
+    }
+
+    it('returns PMO when no providers configured', () => {
+      const db = setupDb()
+      expect(resolveSourceForTest(db)).to.equal('pmo')
+      db.close()
+    })
+
+    it('returns linear when Linear is the only external provider', () => {
+      const db = setupDb()
+      saveLinearApiKey(db, 'test-api-key')
+      expect(resolveSourceForTest(db)).to.equal('linear')
+      db.close()
+    })
+
+    it('returns linear when default work source is set to linear', () => {
+      const db = setupDb()
+      saveDefaultWorkSource(db, { provider: 'linear' })
+      expect(resolveSourceForTest(db)).to.equal('linear')
+      db.close()
+    })
+
+    it('respects explicit PMO default even when Linear is configured', () => {
+      const db = setupDb()
+      saveLinearApiKey(db, 'test-api-key')
+      saveDefaultWorkSource(db, { provider: 'pmo' })
+      expect(resolveSourceForTest(db)).to.equal('pmo')
+      db.close()
+    })
+
+    it('isLinearConfigured returns true when API key exists', () => {
+      const db = setupDb()
+      expect(isLinearConfigured(db)).to.be.false
+      saveLinearApiKey(db, 'test-api-key')
+      expect(isLinearConfigured(db)).to.be.true
+      db.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fix `resolveSource()` in `ticket create` to respect `loadDefaultWorkSource()` (user's default work source preference)
- Auto-select Linear when it's the only configured external provider (previously always prompted since PMO is implicitly registered)
- Update command description to reflect multi-source capability

## Changes
- **`apps/cli/src/commands/ticket/create.ts`**: Fixed auto-detection logic in `resolveSource()` — now checks default work source first, then auto-selects single external provider. Updated command description.
- **`apps/cli/test/unit/ticket-create-source-resolution.test.ts`**: New unit tests (11 tests) covering source resolution logic

## Test plan
- [x] Unit tests pass (11 new tests for source resolution)
- [x] Existing provider tests pass (31 tests)
- [x] E2E ticket command tests pass (32 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)