### PR TITLE
PRLT-1008: Add prlt ticket move and prlt ticket cancel commands

### DIFF
--- a/apps/cli/src/commands/ticket/cancel.ts
+++ b/apps/cli/src/commands/ticket/cancel.ts
@@ -1,0 +1,252 @@
+import { Args, Flags } from '@oclif/core';
+import {
+  autoExportToBoard,
+  PMOCommand,
+  pmoBaseFlags,
+} from '../../lib/pmo/index.js';
+import { styles } from '../../lib/styles.js';
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js';
+import { formatTicket } from '../../lib/mcp/helpers.js';
+
+export default class TicketCancel extends PMOCommand {
+  static description = 'Cancel ticket(s) (move to Canceled column)';
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> TKT-001',
+    '<%= config.bin %> <%= command.id %> --bulk',
+  ];
+
+  static args = {
+    ticketId: Args.string({
+      description: 'Ticket ID - prompts with dropdown if not provided',
+      required: false,
+    }),
+  };
+
+  static flags = {
+    ...pmoBaseFlags,
+    bulk: Flags.boolean({
+      char: 'b',
+      description: 'Enable bulk mode to cancel multiple tickets',
+      default: false,
+    }),
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt (bulk mode only)',
+      default: false,
+    }),
+  };
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(TicketCancel);
+    const projectId = (flags as { project?: string }).project;
+
+    // Check if JSON output mode is active
+    const jsonMode = shouldOutputJson(flags);
+
+    // Helper to handle errors in JSON mode
+    const handleError = (code: string, message: string): void => {
+      if (jsonMode) {
+        outputErrorAsJson(code, message, createMetadata('ticket cancel', flags));
+        return
+      }
+      this.error(message);
+    };
+
+    // Get all active tickets (not already canceled or done)
+    const allTickets = await this.storage.listTickets(projectId);
+    const activeTickets = allTickets.filter(t =>
+      t.statusName &&
+      !t.statusName.toLowerCase().includes('cancel') &&
+      !t.statusName.toLowerCase().includes('done')
+    );
+
+    if (activeTickets.length === 0) {
+      if (jsonMode) {
+        outputErrorAsJson('NO_ACTIVE_TICKETS', 'No active tickets found to cancel.', createMetadata('ticket cancel', flags));
+        return;
+      }
+      this.log(styles.info('No active tickets found to cancel.'));
+      return;
+    }
+
+    // Get board for columns (use the first active ticket's project)
+    const board = await this.storage.getProjectBoard(activeTickets[0].projectId!);
+    if (!board) {
+      return handleError('PROJECT_NOT_FOUND', `Project "${activeTickets[0].projectId}" not found. The ticket may belong to an orphaned project.`);
+    }
+
+    // Find the "Canceled" column (case-insensitive, match both "Canceled" and "Cancelled")
+    const canceledColumn = board.columns.find(col =>
+      col.name.toLowerCase().includes('cancel')
+    );
+
+    if (!canceledColumn) {
+      return handleError('NO_CANCELED_COLUMN', 'No "Canceled" column found in board configuration.');
+    }
+
+    // Bulk mode
+    if (flags.bulk) {
+      await this.executeBulk(activeTickets, canceledColumn.name, flags);
+      return;
+    }
+
+    // Single ticket mode
+    let ticketId = args.ticketId;
+
+    if (!ticketId) {
+      const selected = await this.selectFromList({
+        message: 'Select ticket to cancel:',
+        items: activeTickets,
+        getName: (t) => `${t.id} - ${t.title} (${t.statusName})`,
+        getValue: (t) => t.id,
+        getCommand: (t) => `prlt ticket cancel ${t.id}${projectId ? ` -P ${projectId}` : ''} --json`,
+        jsonMode: jsonMode ? { flags, commandName: 'ticket cancel' } : null,
+      });
+
+      if (!selected) {
+        return;
+      }
+      ticketId = selected;
+    }
+
+    // Get ticket
+    const ticket = await this.storage.getTicket(ticketId!);
+    if (!ticket) {
+      return handleError('TICKET_NOT_FOUND', `Ticket "${ticketId}" not found.`);
+    }
+
+    // Move to Canceled column through provider (routes to Linear/Jira/PMO as appropriate)
+    const provider = await this.resolveTicketProvider(ticketId!, ticket.projectId!);
+    const moveResult = await provider.moveTicket(ticketId!, canceledColumn.name);
+
+    if (!moveResult.success) {
+      return handleError('CANCEL_FAILED', `Failed to cancel ticket: ${moveResult.error}`);
+    }
+
+    // Refresh ticket to get updated status
+    const canceled = await this.storage.getTicket(ticketId!) || ticket;
+
+    // Auto-export to board.md if configured
+    await autoExportToBoard(this.pmoPath, this.storage, (msg) => this.log(styles.muted(msg)));
+
+    // JSON output mode
+    if (jsonMode) {
+      this.log(JSON.stringify({
+        success: true,
+        ticket: formatTicket(canceled),
+        provider: moveResult.provider,
+      }, null, 2));
+      return;
+    }
+
+    this.log(styles.success(`Canceled ${ticketId}`));
+    this.log(styles.muted(`   Title: ${ticket.title}`));
+    this.log(styles.muted(`   Moved to: ${canceled.statusName}`));
+    if (moveResult.provider !== 'pmo') {
+      this.log(styles.muted(`   Provider: ${moveResult.provider}`));
+    }
+  }
+
+  private async executeBulk(
+    activeTickets: Awaited<ReturnType<typeof this.storage.listTickets>>,
+    canceledColumnName: string,
+    flags: { force: boolean; json: boolean; machine: boolean; bulk: boolean; project?: string }
+  ): Promise<void> {
+    // Only show header in interactive mode
+    if (!shouldOutputJson(flags)) {
+      this.log(styles.emphasis('Cancel Multiple Tickets\n'));
+    }
+
+    // Agent mode config for prompts
+    const jsonModeConfig = shouldOutputJson(flags) ? { flags, commandName: 'ticket cancel --bulk' } : null;
+
+    // Select tickets to cancel
+    const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
+      type: 'checkbox',
+      name: 'selectedTickets',
+      message: 'Select tickets to cancel:',
+      choices: activeTickets.map(t => ({
+        name: `${t.id} - ${t.title} (${t.statusName})`,
+        value: t.id,
+        command: `prlt ticket cancel ${t.id}${flags.project ? ` -P ${flags.project}` : ''} --json`,
+      })),
+    }], jsonModeConfig);
+
+    if (selectedTickets.length === 0) {
+      this.log(styles.muted('No tickets selected.'));
+      return;
+    }
+
+    // Confirmation
+    if (!flags.force) {
+      this.log(styles.warning('\nWill cancel:'));
+      for (const ticketId of selectedTickets) {
+        const ticket = activeTickets.find(t => t.id === ticketId);
+        this.log(styles.primary(`  • ${ticketId}: ${ticket?.title}`));
+      }
+      this.log(styles.primary(`  → Move to: ${canceledColumnName}\n`));
+
+      const { confirm } = await this.prompt<{ confirm: boolean }>([{
+        type: 'list',
+        name: 'confirm',
+        message: 'Continue?',
+        choices: [
+          { name: 'No, keep tickets', value: 'false', command: '' },
+          { name: 'Yes, cancel tickets', value: 'true', command: `prlt ticket cancel ${selectedTickets.join(' ')}${flags.project ? ` -P ${flags.project}` : ''} --force --json` }
+        ],
+      }], jsonModeConfig);
+
+      if (!confirm) {
+        this.log(styles.muted('Operation cancelled.'));
+        return;
+      }
+    }
+
+    this.log('');
+
+    // Cancel each ticket
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const ticketId of selectedTickets) {
+      try {
+        const ticket = activeTickets.find(t => t.id === ticketId);
+        if (!ticket) {
+          throw new Error('Ticket not found in active tickets list');
+        }
+        // eslint-disable-next-line no-await-in-loop
+        const provider = await this.resolveTicketProvider(ticketId, ticket.projectId!);
+        // eslint-disable-next-line no-await-in-loop
+        const result = await provider.moveTicket(ticketId, canceledColumnName);
+        if (result.success) {
+          this.log(styles.success(`Canceled ${ticketId}`));
+          successCount++;
+        } else {
+          this.log(styles.error(`Failed to cancel ${ticketId}: ${result.error}`));
+          failCount++;
+        }
+      } catch (error) {
+        this.log(styles.error(`Failed to cancel ${ticketId}: ${error instanceof Error ? error.message : String(error)}`));
+        failCount++;
+      }
+    }
+
+    // Auto-export to board.md
+    await autoExportToBoard(this.pmoPath, this.storage, (msg) => this.log(styles.muted(msg)));
+
+    // Summary
+    this.log('');
+    if (successCount > 0) {
+      this.log(styles.success(`Canceled ${successCount} ticket(s)`));
+    }
+    if (failCount > 0) {
+      this.log(styles.error(`Failed to cancel ${failCount} ticket(s)`));
+    }
+  }
+}

--- a/apps/cli/src/commands/ticket/move.ts
+++ b/apps/cli/src/commands/ticket/move.ts
@@ -19,6 +19,7 @@ export default class TicketMove extends PMOCommand {
   static examples = [
     '<%= config.bin %> <%= command.id %> my-ticket "In Progress"',
     '<%= config.bin %> <%= command.id %> implement-auth Done',
+    '<%= config.bin %> <%= command.id %> TKT-123 --status "In Review"',
     '<%= config.bin %> <%= command.id %> fix-bug "In Review" --position 0',
     '<%= config.bin %> <%= command.id %> TKT-123 --to-project PROJ-002',
     '<%= config.bin %> <%= command.id %> --bulk',
@@ -37,6 +38,10 @@ export default class TicketMove extends PMOCommand {
 
   static flags = {
     ...pmoBaseFlags,
+    status: Flags.string({
+      char: 's',
+      description: 'Target status/column (alternative to positional column argument)',
+    }),
     position: Flags.integer({
       description: 'Position within the column (0 = top)',
     }),
@@ -70,6 +75,9 @@ export default class TicketMove extends PMOCommand {
       this.error(message);
     };
 
+    // --status flag takes precedence over positional column arg
+    const columnArg = flags.status || args.column;
+
     // Cross-project move: if ticketId and --to-project are provided, skip project context
     // The source project is determined from the ticket itself
     if (args.ticketId && flags['to-project']) {
@@ -77,7 +85,7 @@ export default class TicketMove extends PMOCommand {
       if (!ticket) {
         return handleError('TICKET_NOT_FOUND', `Ticket "${args.ticketId}" not found.`);
       }
-      await this.executeCrossProjectMove(ticket, flags['to-project'], args.column, jsonMode, flags);
+      await this.executeCrossProjectMove(ticket, flags['to-project'], columnArg, jsonMode, flags);
       return;
     }
 
@@ -131,12 +139,12 @@ export default class TicketMove extends PMOCommand {
 
     // Cross-project move (when --to-project flag is provided)
     if (flags['to-project']) {
-      await this.executeCrossProjectMove(ticket, flags['to-project'], args.column, jsonMode, flags);
+      await this.executeCrossProjectMove(ticket, flags['to-project'], columnArg, jsonMode, flags);
       return;
     }
 
     // Get target column - prompt if not provided
-    let targetColumn = args.column;
+    let targetColumn = columnArg;
 
     if (!targetColumn) {
       // Check if there are other projects to move to

--- a/apps/cli/test/e2e/pmo-ticket-commands.test.ts
+++ b/apps/cli/test/e2e/pmo-ticket-commands.test.ts
@@ -411,6 +411,77 @@ describe('@smoke PMO Ticket Commands E2E Tests', () => {
     });
   });
 
+  describe('prlt ticket cancel', () => {
+    it('should move ticket to Canceled column', async () => {
+      await execInProcess('ticket create --title "Cancel test" --column "Backlog"');
+      const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Cancel test') as { id: string };
+
+      await execInProcess(`ticket cancel ${ticket.id}`);
+
+      // Verify via workflow statuses
+      const status = db.prepare(`
+        SELECT s.name
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses s ON s.id = t.status_id
+        WHERE t.id = ?
+      `).get(ticket.id) as { name: string };
+
+      expect(status.name).to.equal('Canceled');
+    });
+
+    it('should display success message', async () => {
+      await execInProcess('ticket create --title "Cancel msg test" --column "In Progress"');
+      const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Cancel msg test') as { id: string };
+
+      const output = await execInProcess(`ticket cancel ${ticket.id}`);
+
+      expect(output).to.contain('Canceled');
+      expect(output).to.contain(ticket.id);
+    });
+
+    it('should error for non-existent ticket', async () => {
+      const output = await execInProcess('ticket cancel NON-EXISTENT');
+
+      expect(output.toLowerCase()).to.satisfy((s: string) =>
+        s.includes('not found') || s.includes('no active tickets')
+      );
+    });
+  });
+
+  describe('prlt ticket move --status', () => {
+    it('should move ticket using --status flag', async () => {
+      await execInProcess('ticket create --title "Status flag test" --column "Backlog"');
+      const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Status flag test') as { id: string };
+
+      await execInProcess(`ticket move ${ticket.id} --status "In Progress"`);
+
+      const status = db.prepare(`
+        SELECT s.name
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses s ON s.id = t.status_id
+        WHERE t.id = ?
+      `).get(ticket.id) as { name: string };
+
+      expect(status.name).to.equal('In Progress');
+    });
+
+    it('should move ticket using -s shorthand', async () => {
+      await execInProcess('ticket create --title "Short flag test" --column "Backlog"');
+      const ticket = db.prepare('SELECT id FROM pmo_tickets WHERE title = ?').get('Short flag test') as { id: string };
+
+      await execInProcess(`ticket move ${ticket.id} -s "Review"`);
+
+      const status = db.prepare(`
+        SELECT s.name
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses s ON s.id = t.status_id
+        WHERE t.id = ?
+      `).get(ticket.id) as { name: string };
+
+      expect(status.name).to.equal('Review');
+    });
+  });
+
   describe('prlt ticket link', () => {
     // Note: The old `ticket link TKT-XXX EPIC-XXX` syntax was replaced by
     // `ticket link` topic with subcommands (block, relates, duplicates).
@@ -580,6 +651,7 @@ function setupTestDatabase(db: Database.Database) {
     { id: 'ws-review', name: 'Review', category: 'started', position: 3 },
     { id: 'ws-done', name: 'Done', category: 'completed', position: 4 },
     { id: 'ws-merged', name: 'Merged', category: 'completed', position: 5 },
+    { id: 'ws-canceled', name: 'Canceled', category: 'canceled', position: 6 },
   ];
 
   for (const status of workflowStatuses) {


### PR DESCRIPTION
## Summary

Resolves PRLT-1008: Add prlt ticket move and prlt ticket cancel commands

## Description

Missing CLI commands for ticket state management:

* `prlt ticket move <id> --status <status>` — move to any workflow state (In Progress, Review, Done, etc.)
* `prlt ticket cancel <id>` — cancel/close a ticket

Currently the orchestrator has to curl the Linear API directly to move tickets between states. These should route through the configured provider (depends on PRLT-978 for provider routing).

## External Issue Context

- Source: linear
- External key: PRLT-1008
- External id: 0d55c08d-5bbb-423a-9672-f823ae436c9a
- URL: https://linear.app/proletariat/issue/PRLT-1008/add-prlt-ticket-move-and-prlt-ticket-cancel-commands
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 4c5ec343 feat(PRLT-1008): add ticket cancel command and --status flag for ticket move

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
