### PR TITLE
chore: bump version to 0.3.82

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.81",
+  "version": "0.3.82",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Bump version for release. Includes:
- PRLT-183: Migrate StatusStorage to Drizzle ORM (PR #872)
- PRLT-182: Migrate SpecStorage to Drizzle ORM (PR #876)
- PRLT-1008: prlt ticket move/cancel commands (PR #873)
- PRLT-1010: prlt pr merge/close/status commands (PR #874)
- PRLT-1016: prlt update command (PR #875)
- PRLT-1020: Remove ~100 unused PMO commands (PR #878)