### PR TITLE
chore: bump version to 0.3.83

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.82",
+  "version": "0.3.83",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Bump version to 0.3.83. Includes PostHog telemetry, ORM migration validation, and Drizzle-first DB bootstrap.