### PR TITLE
PRLT-1024: Switch Statsig from js-client (browser SDK) to node-server-sdk

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,7 @@
     "@oclif/plugin-help": "^6",
     "@oclif/plugin-plugins": "^5",
     "@sentry/node": "^10.42.0",
-    "@statsig/js-client": "^3.32.0",
+    "statsig-node": "^6.5.1",
     "better-sqlite3": "^12.6.2",
     "chalk": "^4.1.2",
     "chokidar": "^5.0.0",

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -27,8 +27,8 @@ import * as path from 'node:path'
 import * as crypto from 'node:crypto'
 import { getMachineConfigDir, ensureMachineConfigDir } from '../machine-config.js'
 
-// Statsig client SDK key (public — safe to embed in open source repos)
-const STATSIG_CLIENT_KEY = 'client-kvxMxRhn9NFSmH8orl7e2W9nYTfWVS7Kjf7yRTdIecc'
+// Statsig server secret key (private — this repo is private, will be replaced before merge)
+const STATSIG_SERVER_KEY = 'secret-placeholder'
 
 // PostHog API key (public — PostHog client keys are meant to be public)
 const POSTHOG_API_KEY = 'phc_ihCp4i3ZWlk2KQxFbcE6odylZGtISEaCNKAVklMwAk'
@@ -386,20 +386,37 @@ export function initAnalytics(version: string): void {
       posthogClient = null
     }
 
-    // Initialize Statsig
+    // Initialize Statsig (server SDK)
     try {
-      const { StatsigClient: StatsigClientClass } = await import('@statsig/js-client')
-      const client = new StatsigClientClass(
-        STATSIG_CLIENT_KEY,
-        { userID: getMachineId(), custom: { cli_version: version } },
-      )
-      await client.initializeAsync()
+      const { Statsig } = await import('statsig-node')
+      await Statsig.initialize(STATSIG_SERVER_KEY, {
+        environment: { tier: 'production' },
+      })
 
       // If shutdown already ran while we were initializing, don't set state
-      // or flush — just clean up the client and bail out
+      // or flush — just clean up and bail out
       if (analyticsShutdown) {
-        try { client.shutdown() } catch { /* ignore */ }
+        try { Statsig.shutdown() } catch { /* ignore */ }
         return
+      }
+
+      // Wrap the static Statsig API to match our StatsigClientInstance interface,
+      // binding the user for all calls so feature-flags.ts doesn't need to change
+      const user = { userID: getMachineId(), custom: { cli_version: version } }
+      const client: StatsigClientInstance = {
+        initializeAsync: () => Promise.resolve(),
+        logEvent(eventName, value, metadata) {
+          Statsig.logEvent(user, eventName, value, metadata)
+        },
+        checkGate(gateName) {
+          return Statsig.checkGate(user, gateName)
+        },
+        getDynamicConfig(configName) {
+          return Statsig.getConfig(user, configName)
+        },
+        shutdown() {
+          Statsig.shutdown()
+        },
       }
 
       statsigClient = client

--- a/apps/cli/test/unit/analytics-queue.test.ts
+++ b/apps/cli/test/unit/analytics-queue.test.ts
@@ -12,7 +12,7 @@ import { execFileSync } from 'node:child_process'
  * events from previous runs get flushed. If Statsig doesn't initialize in
  * time, events persist on disk for the next run.
  *
- * Tests use a mock @statsig/js-client to make Statsig initialization
+ * Tests use a mock statsig-node to make Statsig initialization
  * deterministic (no network dependency).
  */
 describe('Analytics queue persistence', () => {
@@ -50,29 +50,27 @@ describe('Analytics queue persistence', () => {
     const initDelay = opts?.initDelay ?? 0
     const initThrows = opts?.initThrows ?? false
 
-    // Mock @statsig/js-client module
+    // Mock statsig-node module (server SDK — static Statsig object)
     fs.writeFileSync(path.join(mockDir, 'statsig-mock.mjs'), `
 import * as fs from 'node:fs';
 const EVENTS_FILE = ${JSON.stringify(statsigEventsPath)};
-export class StatsigClient {
-  constructor(key, user) {
-    this._events = [];
-  }
-  async initializeAsync() {
+const _events = [];
+export const Statsig = {
+  async initialize(key, options) {
     ${initDelay > 0 ? `await new Promise(r => setTimeout(r, ${initDelay}));` : ''}
     ${initThrows ? `throw new Error('mock init failure');` : ''}
-  }
-  logEvent(name, value, metadata) {
-    this._events.push({ name, value, metadata });
-  }
-  checkGate() { return false; }
-  getDynamicConfig() { return { get: (k, d) => d }; }
+  },
+  logEvent(user, name, value, metadata) {
+    _events.push({ name, value, metadata });
+  },
+  checkGate() { return false; },
+  getConfig() { return { get: (k, d) => d }; },
   shutdown() {
     try {
-      fs.writeFileSync(EVENTS_FILE, JSON.stringify(this._events), 'utf-8');
+      fs.writeFileSync(EVENTS_FILE, JSON.stringify(_events), 'utf-8');
     } catch {}
-  }
-}
+  },
+};
 `, 'utf-8')
 
     // Mock posthog-node module
@@ -94,12 +92,12 @@ export class PostHog {
 }
 `, 'utf-8')
 
-    // Loader hook — resolves @statsig/js-client and posthog-node to our mocks
+    // Loader hook — resolves statsig-node and posthog-node to our mocks
     fs.writeFileSync(path.join(mockDir, 'mock-loader.mjs'), `
 const STATSIG_MOCK_URL = new URL('./statsig-mock.mjs', import.meta.url).href;
 const POSTHOG_MOCK_URL = new URL('./posthog-mock.mjs', import.meta.url).href;
 export async function resolve(specifier, context, nextResolve) {
-  if (specifier === '@statsig/js-client') {
+  if (specifier === 'statsig-node') {
     return { url: STATSIG_MOCK_URL, shortCircuit: true };
   }
   if (specifier === 'posthog-node') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ importers:
       '@sentry/node':
         specifier: ^10.42.0
         version: 10.42.0
-      '@statsig/js-client':
-        specifier: ^3.32.0
-        version: 3.32.0
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -70,6 +67,9 @@ importers:
       react:
         specifier: ^18.0.0
         version: 18.3.1
+      statsig-node:
+        specifier: ^6.5.1
+        version: 6.5.1
       string-width:
         specifier: ^8.1.1
         version: 8.1.1
@@ -1517,12 +1517,6 @@ packages:
   '@smithy/uuid@1.1.0':
     resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
     engines: {node: '>=18.0.0'}
-
-  '@statsig/client-core@3.32.0':
-    resolution: {integrity: sha512-/cVPhFt4uvbhK9pI0ju8Ko4ZiJqc5paG9DoYZCtdy79ChA5LJ2gEo6L8qAvOfXQ9huYSSrwaFpv/29oJfXlEiw==}
-
-  '@statsig/js-client@3.32.0':
-    resolution: {integrity: sha512-TNsVTThSKRaRTb1bI5ZxL6lL63TukB2pcYcl4arWUt+8vdzZMlTRgRDFOxe3+vNj1HLSeF1NINWEflGSg7CDzQ==}
 
   '@stylistic/eslint-plugin@3.1.0':
     resolution: {integrity: sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==}
@@ -3136,6 +3130,9 @@ packages:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
 
+  ip3country@5.0.0:
+    resolution: {integrity: sha512-lcFLMFU4eO1Z7tIpbVFZkaZ5ltqpeaRx7L9NsAbA9uA7/O/rj3RF8+evE5gDitooaTTIqjdzZrenFO/OOxQ2ew==}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3585,6 +3582,15 @@ packages:
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -4241,6 +4247,10 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  statsig-node@6.5.1:
+    resolution: {integrity: sha512-/rKvMMN9SWTK8+b7MyRP1wOsStsKf55Mdj8O2ffV/bCQ/38bXYCC/GVd3gVvBSwVCibAnkTz2v1gpRJSIKsBIg==}
+    engines: {pnpm: never}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4352,6 +4362,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -4446,6 +4459,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -4482,6 +4499,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -4498,6 +4519,12 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -6560,12 +6587,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@statsig/client-core@3.32.0': {}
-
-  '@statsig/js-client@3.32.0':
-    dependencies:
-      '@statsig/client-core': 3.32.0
-
   '@stylistic/eslint-plugin@3.1.0(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/utils': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
@@ -8405,6 +8426,8 @@ snapshots:
 
   ip-address@10.0.1: {}
 
+  ip3country@5.0.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
@@ -8811,6 +8834,10 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.3
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.27: {}
 
@@ -9485,6 +9512,15 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  statsig-node@6.5.1:
+    dependencies:
+      ip3country: 5.0.0
+      node-fetch: 2.7.0
+      ua-parser-js: 1.0.41
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+
   statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
@@ -9602,6 +9638,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9710,6 +9748,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  ua-parser-js@1.0.41: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -9767,6 +9807,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid@8.3.2: {}
+
   v8-compile-cache-lib@3.0.1: {}
 
   validate-npm-package-license@3.0.4:
@@ -9781,6 +9823,13 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves PRLT-1024: Switch Statsig from js-client (browser SDK) to node-server-sdk

## Description

## Problem

Statsig telemetry events are not showing up in the Statsig dashboard. The CLI uses `@statsig/js-client` (browser SDK) which likely has browser-specific network transport (navigator.sendBeacon, browser fetch) that doesn't work properly in Node.js. Events are queued and passed to `logEvent()` (WAL drains successfully), but the SDK never actually sends them to Statsig's servers.

Meanwhile, PostHog was added using `posthog-node` (server SDK) and works correctly — confirming the issue is the browser SDK, not the telemetry pipeline.

## Implementation

1. Replace `@statsig/js-client` with `@statsig/node-server-sdk` in `apps/cli/package.json`
2. Update `apps/cli/src/lib/telemetry/analytics.ts`:
   * Change the import from `@statsig/js-client` to `@statsig/node-server-sdk`
   * The server SDK uses a **server secret key** instead of a client key. Generate one in the Statsig console. For now, use the constant name `STATSIG_SERVER_KEY` and set it to: `secret-placeholder` (will be replaced before merge)
   * Update the initialization: server SDK uses `Statsig.initialize(serverKey, { environment: { tier: 'production' } })`
   * Update `logEvent()` calls to match server SDK API: `Statsig.logEvent({ userID }, eventName, value, metadata)`
   * Update `shutdown()` to use `Statsig.shutdown()`
   * The `StatsigClientInstance` interface will need to be updated to match the server SDK API
3. Keep PostHog running alongside — both backends should fire in parallel
4. Run tests and ensure build passes

## Notes

* Server secret keys are NOT safe to embed in open source — but this repo is private, so it's fine for now
* The existing WAL pattern should remain unchanged — only the SDK integration layer changes
* Do NOT remove or modify PostHog integration

## External Issue Context

- Source: linear
- External key: PRLT-1024
- External id: 20a9cdab-fad0-4474-a20a-9fc51312e85f
- URL: https://linear.app/proletariat/issue/PRLT-1024/switch-statsig-from-js-client-browser-sdk-to-node-server-sdk
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 8d706211 feat(PRLT-1024): switch Statsig from @statsig/js-client (browser SDK) to statsig-node (server SDK)

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
