### PR TITLE
PRLT-1043: Auto-move ticket to Done when prlt pr merge succeeds

### DIFF
--- a/apps/cli/src/commands/pr/merge.ts
+++ b/apps/cli/src/commands/pr/merge.ts
@@ -4,9 +4,6 @@ import {
   pmoBaseFlags,
 } from '../../lib/pmo/index.js';
 import { getWorkColumnSetting, findColumnByName } from '../../lib/pmo/utils.js';
-import Database from 'better-sqlite3';
-import * as path from 'node:path';
-import { getWorkspaceInfo } from '../../lib/agents/commands.js';
 import { styles } from '../../lib/styles.js';
 import {
   isGHInstalled,
@@ -24,6 +21,9 @@ import {
 } from '../../lib/prompt-json.js';
 import { FlagResolver } from '../../lib/flags/index.js';
 import { getEventBus } from '../../lib/events/event-bus.js';
+import { validateBranchName } from '../../lib/branch/index.js';
+import { PMO_TABLES } from '../../lib/pmo/schema.js';
+import type { Ticket } from '../../lib/pmo/types.js';
 
 export default class PRMerge extends PMOCommand {
   static description = 'Merge a GitHub pull request by number';
@@ -146,19 +146,17 @@ export default class PRMerge extends PMOCommand {
       return handleError('MERGE_FAILED', `Failed to merge PR #${prNumber}: ${result.error}`);
     }
 
-    // Update ticket metadata if PR was linked and emit merge event for outbound sync
+    // After successful merge, resolve the linked ticket and move it to Done
     let linkedTicketId: string | undefined;
+    let ticketMovedToDone = false;
+    let ticketTransitionProvider: string | undefined;
     if (this.hasPMO) {
       try {
-        const allTickets = await this.storage.listTickets(flags.project);
-        // Find linked ticket by pr_number or by extracting number from pr_url
-        const linkedTicket = allTickets.find(t =>
-          t.metadata?.pr_number === String(prNumber) ||
-          t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`) ||
-          t.metadata?.pr_url?.endsWith(`/${prNumber}`)
-        );
+        const linkedTicket = await this.resolveLinkedTicket(prNumber, prInfo.headBranch, flags.project);
         if (linkedTicket) {
           linkedTicketId = linkedTicket.id;
+
+          // Update PR state metadata
           await this.storage.updateTicket(linkedTicket.id, {
             metadata: {
               ...linkedTicket.metadata,
@@ -166,51 +164,36 @@ export default class PRMerge extends PMOCommand {
             },
           });
 
-          // Move ticket to Done column in local PMO and external provider
+          // Move ticket to Done column
           try {
-            let workspaceInfo;
-            try {
-              workspaceInfo = getWorkspaceInfo();
-            } catch {
-              workspaceInfo = null;
-            }
-            const dbPath = workspaceInfo
-              ? path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+            const db = this.storage.getDatabase();
+            const targetColumnName = getWorkColumnSetting(db, 'done');
+            const board = linkedTicket.projectId
+              ? await this.storage.getProjectBoard(linkedTicket.projectId)
               : null;
+            const columnNames = board ? board.columns.map(col => col.name) : [];
+            const doneColumn = findColumnByName(columnNames, targetColumnName);
 
-            if (dbPath) {
-              const db = new Database(dbPath);
-              try {
-                const targetColumnName = getWorkColumnSetting(db, 'done');
-                const board = linkedTicket.projectId
-                  ? await this.storage.getProjectBoard(linkedTicket.projectId)
-                  : null;
-                const columnNames = board ? board.columns.map(col => col.name) : [];
-                const doneColumn = findColumnByName(columnNames, targetColumnName);
+            if (doneColumn && linkedTicket.projectId) {
+              // Move in local PMO
+              await this.storage.moveTicket(linkedTicket.projectId, linkedTicket.id, doneColumn);
+              ticketMovedToDone = true;
 
-                if (doneColumn && linkedTicket.projectId) {
-                  // Move in local PMO
-                  await this.storage.moveTicket(linkedTicket.projectId, linkedTicket.id, doneColumn);
-
-                  // Sync to external provider (e.g., Linear)
-                  const provider = await this.resolveTicketProvider(linkedTicket.id, linkedTicket.projectId);
-                  if (provider.name !== 'pmo') {
-                    const moveResult = await provider.moveTicket(linkedTicket.id, doneColumn);
-                    if (moveResult.success) {
-                      this.log(styles.muted(`   Synced to ${moveResult.provider}: ${doneColumn}`));
-                    }
-                  }
+              // Sync to external provider (e.g., Linear)
+              const provider = await this.resolveTicketProvider(linkedTicket.id, linkedTicket.projectId);
+              if (provider.name !== 'pmo') {
+                const moveResult = await provider.moveTicket(linkedTicket.id, doneColumn);
+                if (moveResult.success) {
+                  ticketTransitionProvider = moveResult.provider;
                 }
-              } finally {
-                db.close();
               }
             }
-          } catch {
-            // Non-critical - don't fail the merge if ticket transition fails
+          } catch (err) {
+            this.warn(`Failed to move ticket ${linkedTicket.id} to Done: ${err instanceof Error ? err.message : err}`);
           }
         }
-      } catch {
-        // Non-critical - don't fail the merge if PMO update fails
+      } catch (err) {
+        this.warn(`Failed to resolve linked ticket: ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -243,7 +226,8 @@ export default class PRMerge extends PMOCommand {
           method,
           branchDeleted: flags['delete-branch'],
           linkedTicket: linkedTicketId ?? null,
-          linearSyncEmitted: !!linkedTicketId,
+          ticketMovedToDone,
+          ticketTransitionProvider: ticketTransitionProvider ?? null,
         },
         createMetadata('pr merge', flags)
       );
@@ -258,7 +242,65 @@ export default class PRMerge extends PMOCommand {
       this.log(styles.muted(`   Branch ${prInfo.headBranch} deleted`));
     }
     if (linkedTicketId) {
-      this.log(styles.muted(`   Linear sync triggered for ${linkedTicketId}`));
+      this.log(styles.muted(`   Ticket ${linkedTicketId} → Done`));
+      if (ticketTransitionProvider) {
+        this.log(styles.muted(`   Synced to ${ticketTransitionProvider}`));
+      }
     }
+  }
+
+  /**
+   * Resolve the linked ticket for a merged PR.
+   *
+   * Lookup order:
+   * 1. PR metadata (pr_number / pr_url) on tickets
+   * 2. agent_work table (branch → ticket_id)
+   * 3. PR branch name parsing (extract ticket ID from conventional branch format)
+   */
+  private async resolveLinkedTicket(
+    prNumber: number,
+    headBranch: string,
+    projectId: string | undefined,
+  ): Promise<Ticket | null> {
+    // 1. Find by PR metadata on tickets
+    const allTickets = await this.storage.listTickets(projectId);
+    const byMetadata = allTickets.find(t =>
+      t.metadata?.pr_number === String(prNumber) ||
+      t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`) ||
+      t.metadata?.pr_url?.endsWith(`/${prNumber}`)
+    );
+    if (byMetadata) return byMetadata;
+
+    // 2. Look up from agent_work table by branch name
+    try {
+      const db = this.storage.getDatabase();
+      const row = db.prepare(
+        `SELECT ticket_id FROM ${PMO_TABLES.agent_work} WHERE branch = ? LIMIT 1`
+      ).get(headBranch) as { ticket_id: string } | undefined;
+      if (row?.ticket_id) {
+        const ticket = await this.storage.getTicket(row.ticket_id);
+        if (ticket) return ticket;
+      }
+    } catch {
+      // agent_work lookup failed, continue to branch name parsing
+    }
+
+    // 3. Parse ticket ID from branch name (e.g., PRLT-1043/feat/owner/agent/desc)
+    const branchResult = validateBranchName(headBranch);
+    if (branchResult.valid && branchResult.parts?.ticketId) {
+      const ticketId = branchResult.parts.ticketId;
+
+      // Try direct lookup (works for TKT-xxx internal IDs)
+      const directTicket = await this.storage.getTicket(ticketId);
+      if (directTicket) return directTicket;
+
+      // Search by external_key metadata (works for PRLT-xxx, LINEAR-xxx, etc.)
+      const byExternalKey = allTickets.find(t =>
+        t.metadata?.external_key === ticketId
+      );
+      if (byExternalKey) return byExternalKey;
+    }
+
+    return null;
   }
 }

--- a/apps/cli/test/unit/pr-merge-ticket-resolution.test.ts
+++ b/apps/cli/test/unit/pr-merge-ticket-resolution.test.ts
@@ -1,0 +1,143 @@
+import { expect } from 'chai';
+import { validateBranchName } from '../../src/lib/branch/index.js';
+
+/**
+ * Unit tests for PR merge ticket resolution logic.
+ *
+ * Tests the resolveLinkedTicket lookup strategy used by `prlt pr merge`
+ * to find the linked ticket after a successful merge.
+ *
+ * Lookup order:
+ * 1. PR metadata (pr_number / pr_url) on tickets
+ * 2. agent_work table (branch → ticket_id)
+ * 3. PR branch name parsing (extract ticket ID from conventional branch format)
+ */
+describe('PR Merge - Ticket Resolution', () => {
+  describe('Branch name ticket extraction', () => {
+    it('should extract ticket ID from full format branch', () => {
+      const result = validateBranchName('PRLT-1043/feat/chrismcdermut/early-yang/auto-move-ticket-to');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.ticketId).to.equal('PRLT-1043');
+    });
+
+    it('should extract ticket ID from 4-part branch (no agent)', () => {
+      const result = validateBranchName('TKT-123/fix/chris/fix-login-bug');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.ticketId).to.equal('TKT-123');
+    });
+
+    it('should extract ticket ID from 3-part branch (minimal)', () => {
+      const result = validateBranchName('PRLT-42/feat/add-auth');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.ticketId).to.equal('PRLT-42');
+    });
+
+    it('should return no ticket for legacy branch without ticket', () => {
+      const result = validateBranchName('feat/chris/add-feature');
+      expect(result.valid).to.be.true;
+      expect(result.parts?.ticketId).to.be.undefined;
+    });
+
+    it('should return invalid for non-conventional branch names', () => {
+      const result = validateBranchName('main');
+      expect(result.valid).to.be.false;
+    });
+  });
+
+  describe('Metadata-based ticket matching', () => {
+    const mockTickets = [
+      {
+        id: 'TKT-100',
+        metadata: { pr_number: '42', pr_url: 'https://github.com/owner/repo/pull/42' },
+      },
+      {
+        id: 'TKT-200',
+        metadata: { external_key: 'PRLT-1043' },
+      },
+      {
+        id: 'TKT-300',
+        metadata: {},
+      },
+    ];
+
+    it('should match by pr_number', () => {
+      const prNumber = 42;
+      const found = mockTickets.find(t =>
+        t.metadata?.pr_number === String(prNumber)
+      );
+      expect(found?.id).to.equal('TKT-100');
+    });
+
+    it('should match by pr_url suffix /pull/N', () => {
+      const prNumber = 42;
+      const found = mockTickets.find(t =>
+        t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`)
+      );
+      expect(found?.id).to.equal('TKT-100');
+    });
+
+    it('should not match wrong pr_number', () => {
+      const prNumber = 99;
+      const found = mockTickets.find(t =>
+        t.metadata?.pr_number === String(prNumber) ||
+        t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`) ||
+        t.metadata?.pr_url?.endsWith(`/${prNumber}`)
+      );
+      expect(found).to.be.undefined;
+    });
+
+    it('should match by external_key from parsed branch', () => {
+      const branchResult = validateBranchName('PRLT-1043/feat/chrismcdermut/early-yang/auto-move');
+      const ticketId = branchResult.parts?.ticketId;
+
+      const found = mockTickets.find(t =>
+        t.metadata?.external_key === ticketId
+      );
+      expect(found?.id).to.equal('TKT-200');
+    });
+
+    it('should not match external_key when branch has no ticket ID', () => {
+      const branchResult = validateBranchName('feat/chris/add-feature');
+      const ticketId = branchResult.parts?.ticketId;
+
+      expect(ticketId).to.be.undefined;
+    });
+  });
+
+  describe('JSON output contract', () => {
+    it('should include ticket transition fields', () => {
+      // Verify the shape of the JSON output includes the transition result fields
+      const output = {
+        merged: true,
+        prNumber: 42,
+        title: 'Test PR',
+        method: 'squash',
+        branchDeleted: true,
+        linkedTicket: 'TKT-100',
+        ticketMovedToDone: true,
+        ticketTransitionProvider: 'linear',
+      };
+
+      expect(output).to.have.property('linkedTicket', 'TKT-100');
+      expect(output).to.have.property('ticketMovedToDone', true);
+      expect(output).to.have.property('ticketTransitionProvider', 'linear');
+    });
+
+    it('should have null values when no ticket linked', () => {
+      const output = {
+        merged: true,
+        prNumber: 42,
+        title: 'Test PR',
+        method: 'squash',
+        branchDeleted: true,
+        linkedTicket: null,
+        ticketMovedToDone: false,
+        ticketTransitionProvider: null,
+      };
+
+      expect(output.linkedTicket).to.be.null;
+      expect(output.ticketMovedToDone).to.be.false;
+      expect(output.ticketTransitionProvider).to.be.null;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves PRLT-1043: Auto-move ticket to Done when prlt pr merge succeeds

## Description

## Problem

Tickets stay stuck in "In Progress" after PRs merge. Need auto-move to Done.

## Approach — Event-driven, NOT polling

Do NOT poll on every command via the postrun hook. That's wasteful and adds latency to every prlt command for something that only matters when a PR merges.

Instead, trigger the ticket move **inside** `prlt pr merge`. When `prlt pr merge` succeeds:

1. Look up the linked ticket for the merged PR (from the agent_work table or PR branch name)
2. Move the ticket to Done via the configured PMO provider (Linear API, etc.)
3. Log the transition

That's it. Event-driven. The merge command already knows which PR and which ticket — just add the board move as a post-merge step.

## Implementation

1. In `apps/cli/src/commands/pr/merge.ts` — after successful merge, resolve the linked ticket and move it to Done
2. Use the existing ticket provider (Linear, etc.) to update the status
3. If the ticket move fails, log a warning but don't fail the merge command
4. Support --json output for the transition result
5. Do NOT add anything to the postrun hook
6. Do NOT poll GitHub for PR status on every command

## Notes

* Keep it simple — this is a one-liner after merge succeeds, not a separate sync system
* The `prlt pr sync` command from the previous attempt is NOT needed — delete it if it exists

## External Issue Context

- Source: linear
- External key: PRLT-1043
- External id: a81f8e3a-9ce3-45c4-a746-91911f0c501e
- URL: https://linear.app/proletariat/issue/PRLT-1043/auto-move-ticket-to-done-when-prlt-pr-merge-succeeds
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 0d52d096 feat(PRLT-1043): auto-move ticket to Done when pr merge succeeds

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
