### PR TITLE
feat(PRLT-1044): fix flaky better-sqlite3 postinstall in unit-tests CI

### DIFF
--- a/WORKFLOW_FIX.md
+++ b/WORKFLOW_FIX.md
@@ -1,0 +1,20 @@
+# Workflow Fix: better-sqlite3 CI flaky postinstall (PRLT-1044)
+
+## Problem
+The unit-tests CI job lacks the better-sqlite3 native binding cache restore and
+rebuild-with-retry pattern that the build and e2e-tests jobs already have.
+
+## How to apply
+A patch file is available at `fix-better-sqlite3.patch` in this branch.
+To apply it from the host machine (with a token that has `workflow` scope):
+
+```bash
+git checkout PRLT-1044/feat/chrismcdermut/sassy-horowitz/fix-flaky-better-sql
+git am < fix-better-sqlite3.patch
+git push origin HEAD
+```
+
+## Note
+The agent's GitHub OAuth token lacks the `workflow` scope required to push
+changes to `.github/workflows/` files. The patch must be applied by a human
+or a token with the `workflow` scope.

--- a/fix-better-sqlite3.patch
+++ b/fix-better-sqlite3.patch
@@ -1,0 +1,61 @@
+diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
+index fd58d184..a41b5fac 100644
+--- a/.github/workflows/test.yml
++++ b/.github/workflows/test.yml
+@@ -342,7 +342,7 @@ jobs:
+ 
+   # Unit tests run via ts-node directly (no compiled dist/ needed), so they
+   # can start in parallel with the build job instead of waiting for it.
+-  # The postinstall script handles better-sqlite3 native binding rebuild.
++  # The better-sqlite3 native binding is restored from cache or rebuilt with retry.
+   unit-tests:
+     needs: [detect-changes]
+     if: needs.detect-changes.outputs.run_tests == 'true'
+@@ -374,10 +374,29 @@ jobs:
+           restore-keys: |
+             ${{ runner.os }}-node-${{ matrix.node-version }}-pnpm-store-
+ 
+-      # pnpm install handles better-sqlite3 rebuild via postinstall script.
+       - name: Install dependencies
+         run: pnpm install --frozen-lockfile
+ 
++      # Restore better-sqlite3 native binding from cache (built by the build job).
++      # Falls back to a full rebuild if the cache is unavailable.
++      - name: Restore better-sqlite3 native binding cache
++        id: sqlite-cache
++        uses: actions/cache/restore@v4
++        with:
++          path: apps/cli/node_modules/.pnpm/**/better-sqlite3/build
++          key: ${{ runner.os }}-node-${{ matrix.node-version }}-better-sqlite3-${{ hashFiles('**/pnpm-lock.yaml') }}
++
++      - name: Rebuild better-sqlite3 native binding (cache miss)
++        if: steps.sqlite-cache.outputs.cache-hit != 'true'
++        run: |
++          if node -e "require('better-sqlite3')" 2>/dev/null; then
++            echo "better-sqlite3 binding already present, skipping rebuild"
++          else
++            echo "Rebuilding better-sqlite3 native binding..."
++            npm rebuild better-sqlite3 || npm rebuild better-sqlite3
++          fi
++        working-directory: apps/cli
++
+       # Fail fast if the native binding is missing or was compiled for a different ABI.
+       - name: Verify better-sqlite3 native binding
+         run: |
+@@ -385,8 +404,15 @@ jobs:
+             try {
+               require('better-sqlite3');
+               console.log('better-sqlite3 loaded successfully');
++              console.log('Node version:', process.version);
++              console.log('ABI version:', process.versions.modules);
++              console.log('Platform:', process.platform, process.arch);
+             } catch (err) {
+-              console.error('Failed to load better-sqlite3:', err.message);
++              console.error('Failed to load better-sqlite3:');
++              console.error(err.message);
++              console.error('Node version:', process.version);
++              console.error('ABI version:', process.versions.modules);
++              console.error('Platform:', process.platform, process.arch);
+               process.exit(1);
+             }
+           "


### PR DESCRIPTION
## Summary

Fix the flaky better-sqlite3 postinstall failures in the `unit-tests` CI job by adding:
- Native binding cache restore (matching the pattern used by `e2e-tests`)
- Explicit rebuild with retry on cache miss
- Enhanced verification diagnostics

## Problem

The `unit-tests` job frequently fails during `pnpm install` because better-sqlite3's postinstall script flakes when compiling native bindings (node-gyp EEXIST race condition). The `build` and `e2e-tests` jobs already handle this with caching and retry, but `unit-tests` was missing these safeguards. Re-running the failed job always succeeds.

## ⚠️ Action Required: Apply workflow patch

The agent's GitHub OAuth token lacks the `workflow` scope required to push `.github/workflows/` changes. The patch file (`fix-better-sqlite3.patch`) is included in this branch.

**To apply the actual fix:**
```bash
git checkout PRLT-1044/feat/chrismcdermut/sassy-horowitz/fix-flaky-better-sql
git apply fix-better-sqlite3.patch
git add .github/workflows/test.yml
git commit -m "feat(PRLT-1044): fix flaky better-sqlite3 postinstall in unit-tests CI job"
git push origin HEAD
```

Then remove the helper files:
```bash
git rm WORKFLOW_FIX.md fix-better-sqlite3.patch
git commit -m "chore: remove patch helper files"
git push origin HEAD
```

## Changes (in patch)

**File:** `.github/workflows/test.yml` — `unit-tests` job only

1. **Cache restore** — Restore the better-sqlite3 native binding from the cache saved by the `build` job (keyed on OS + Node version + lockfile hash)
2. **Rebuild with retry** — On cache miss, check if binding works (from postinstall), otherwise `npm rebuild better-sqlite3 || npm rebuild better-sqlite3`
3. **Better diagnostics** — Verification step now logs Node version, ABI version, and platform

## Test plan

- [ ] Apply the patch and verify the unit-tests job passes
- [ ] Verify cache hit path works (subsequent runs)
- [ ] Verify build and e2e-tests jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)