### PR TITLE
PRLT-1050: Remove Statsig — use PostHog only

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,6 @@
     "@oclif/plugin-help": "^6",
     "@oclif/plugin-plugins": "^5",
     "@sentry/node": "^10.42.0",
-    "statsig-node": "^6.5.1",
     "better-sqlite3": "^12.6.2",
     "chalk": "^4.1.2",
     "chokidar": "^5.0.0",

--- a/apps/cli/src/commands/telemetry/disable.ts
+++ b/apps/cli/src/commands/telemetry/disable.ts
@@ -20,7 +20,7 @@ export default class TelemetryDisable extends Command {
     const { flags } = await this.parse(TelemetryDisable)
     const jsonMode = shouldOutputJson(flags)
 
-    // Disable both Statsig analytics and Sentry crash reporting
+    // Disable PostHog analytics and Sentry crash reporting
     disableTelemetry()
     writeTelemetryConfig({ enabled: false })
 

--- a/apps/cli/src/commands/telemetry/enable.ts
+++ b/apps/cli/src/commands/telemetry/enable.ts
@@ -20,7 +20,7 @@ export default class TelemetryEnable extends Command {
     const { flags } = await this.parse(TelemetryEnable)
     const jsonMode = shouldOutputJson(flags)
 
-    // Enable both Statsig analytics and Sentry crash reporting
+    // Enable PostHog analytics and Sentry crash reporting
     enableTelemetry()
     writeTelemetryConfig({ enabled: true })
 

--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -18,7 +18,7 @@ import { initAnalytics, shutdownAnalytics, trackCommandRun } from '../lib/teleme
  * - No workspaces are registered in machine config (~/.proletariat/config.json)
  * - AND they're not currently inside a valid HQ directory
  *
- * Also initializes analytics (Statsig) for telemetry and feature flags.
+ * Also initializes analytics (PostHog) for telemetry.
  */
 const hook: Hook<'init'> = async function ({ id, argv, config }) {
   // Initialize Sentry as early as possible for crash reporting

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -365,7 +365,6 @@ add_domain "console.anthropic.com"
 ${executor === 'codex' ? `# Codex API domains
 add_domain "api.openai.com"
 add_domain "openai.com"` : ''}
-add_domain "statsigapi.net"
 add_domain "sentry.io"
 add_domain "registry.npmjs.org"
 add_domain "npmjs.com"

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -1,7 +1,7 @@
 /**
- * Product Analytics (Statsig + PostHog) & Event Tracking
+ * Product Analytics (PostHog) & Event Tracking
  *
- * Provides anonymous usage analytics for the CLI using Statsig and PostHog.
+ * Provides anonymous usage analytics for the CLI using PostHog.
  * All data is anonymous — identified by a machine UUID only, no PII is ever sent.
  *
  * Telemetry can be disabled via:
@@ -16,7 +16,7 @@
  *
  * Write-ahead log:
  * - trackEvent() writes events to ~/.proletariat/telemetry-queue.json synchronously
- * - On the next command run, queued events are flushed to both backends and the queue is cleared
+ * - On the next command run, queued events are flushed to PostHog and the queue is cleared
  * - Events are delayed by at most one command invocation — acceptable for analytics
  * - This adds zero latency and ensures no events are lost regardless of backend init timing
  * - Shutdown never flushes the queue — events persist until the next run confirms delivery
@@ -26,9 +26,6 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as crypto from 'node:crypto'
 import { getMachineConfigDir, ensureMachineConfigDir } from '../machine-config.js'
-
-// Statsig server secret key (private — this repo is private, will be replaced before merge)
-const STATSIG_SERVER_KEY = 'secret-placeholder'
 
 // PostHog API key (public — PostHog client keys are meant to be public)
 const POSTHOG_API_KEY = 'phc_ihCp4i3ZWlk2KQxFbcE6odylZGtISEaCNKAVklMwAkV'
@@ -53,22 +50,6 @@ interface TelemetryConfig {
 }
 
 /**
- * Minimal interface for the Statsig client instance methods we use.
- * Uses loose return types to avoid coupling to SDK internals.
- */
-interface StatsigClientInstance {
-  initializeAsync(): Promise<unknown>
-  logEvent(
-    eventName: string,
-    value?: string | number | null,
-    metadata?: Record<string, string> | null,
-  ): void
-  checkGate(gateName: string): boolean
-  getDynamicConfig(configName: string): { get(key: string, defaultValue: unknown): unknown }
-  shutdown(): void
-}
-
-/**
  * Minimal interface for the PostHog client instance methods we use.
  */
 interface PostHogClientInstance {
@@ -87,7 +68,6 @@ interface QueuedEvent {
 }
 
 // Module-level state
-let statsigClient: StatsigClientInstance | null = null
 let posthogClient: PostHogClientInstance | null = null
 let telemetryConfig: TelemetryConfig | null = null
 let cliVersion: string | null = null
@@ -311,50 +291,37 @@ function readAndClearQueue(): QueuedEvent[] {
 }
 
 /**
- * Flush queued events to Statsig and PostHog. Requires at least one initialized client.
+ * Flush queued events to PostHog. Requires an initialized PostHog client.
  * Called during shutdown or at the start of the next command run.
  */
 export function flushQueuedEvents(): void {
-  if (!statsigClient && !posthogClient) return
+  if (!posthogClient) return
 
   const events = readAndClearQueue()
   const machineId = getMachineId()
   for (const event of events) {
-    // Send to Statsig
-    if (statsigClient) {
-      try {
-        statsigClient.logEvent(event.name, event.value, event.metadata)
-      } catch {
-        // Drop individual events silently
-      }
-    }
-
-    // Send to PostHog
-    if (posthogClient) {
-      try {
-        posthogClient.capture({
-          distinctId: machineId,
-          event: event.name,
-          properties: {
-            ...event.metadata,
-            ...(event.value != null ? { value: event.value } : {}),
-            timestamp: event.timestamp,
-          },
-        })
-      } catch {
-        // Drop individual events silently
-      }
+    try {
+      posthogClient.capture({
+        distinctId: machineId,
+        event: event.name,
+        properties: {
+          ...event.metadata,
+          ...(event.value != null ? { value: event.value } : {}),
+          timestamp: event.timestamp,
+        },
+      })
+    } catch {
+      // Drop individual events silently
     }
   }
 }
 
-// ─── Statsig Client ──────────────────────────────────────────────────────────
+// ─── PostHog Client ──────────────────────────────────────────────────────────
 
 /**
- * Initialize the Statsig SDK and flush any queued events from previous runs.
- * Called from the init hook. The Statsig init is fire-and-forget — event
+ * Initialize PostHog and flush any queued events from previous runs.
+ * Called from the init hook. The PostHog init is fire-and-forget — event
  * tracking does not depend on it (events go to the disk queue instead).
- * Statsig is still needed for feature flags.
  *
  * No-op if telemetry is disabled.
  */
@@ -365,10 +332,9 @@ export function initAnalytics(version: string): void {
 
   showTelemetryNotice()
 
-  // Start Statsig + PostHog init in background — not needed for event logging,
-  // but enables feature flags and allows queue flush if init completes in time
+  // Start PostHog init in background — not needed for event logging,
+  // but allows queue flush if init completes in time
   initPromise = (async () => {
-    // Initialize PostHog (fire-and-forget, independent of Statsig)
     try {
       const { PostHog } = await import('posthog-node')
       const ph = new PostHog(POSTHOG_API_KEY, {
@@ -386,55 +352,9 @@ export function initAnalytics(version: string): void {
       posthogClient = null
     }
 
-    // Initialize Statsig (server SDK)
-    try {
-      const { Statsig } = await import('statsig-node')
-      await Statsig.initialize(STATSIG_SERVER_KEY, {
-        environment: { tier: 'production' },
-      })
-
-      // If shutdown already ran while we were initializing, don't set state
-      // or flush — just clean up and bail out
-      if (analyticsShutdown) {
-        try { Statsig.shutdown() } catch { /* ignore */ }
-        return
-      }
-
-      // Wrap the static Statsig API to match our StatsigClientInstance interface,
-      // binding the user for all calls so feature-flags.ts doesn't need to change
-      const user = { userID: getMachineId(), custom: { cli_version: version } }
-      const client: StatsigClientInstance = {
-        initializeAsync: () => Promise.resolve(),
-        logEvent(eventName, value, metadata) {
-          Statsig.logEvent(user, eventName, value, metadata)
-        },
-        checkGate(gateName) {
-          return Statsig.checkGate(user, gateName)
-        },
-        getDynamicConfig(configName) {
-          return Statsig.getConfig(user, configName)
-        },
-        shutdown() {
-          Statsig.shutdown()
-        },
-      }
-
-      statsigClient = client
-
-      // Share Statsig client with feature-flags for synchronous gate checks
-      const { setStatsigClient } = await import('./feature-flags.js')
-      setStatsigClient(client)
-
-      // Backends are ready — flush any events queued from previous runs
+    // Backend is ready — flush any events queued from previous runs
+    if (posthogClient && !analyticsShutdown) {
       flushQueuedEvents()
-    } catch {
-      // If Statsig can't initialize, fail silently — analytics should never break the CLI
-      statsigClient = null
-
-      // Even if Statsig failed, PostHog may be ready — try flushing
-      if (posthogClient && !analyticsShutdown) {
-        flushQueuedEvents()
-      }
     }
   })()
 }
@@ -443,8 +363,8 @@ export function initAnalytics(version: string): void {
 
 /**
  * Track an analytics event. Writes to a local disk queue synchronously —
- * never blocks on network I/O. Events are flushed to Statsig on the next
- * command run (or during this run's shutdown if Statsig initialized in time).
+ * never blocks on network I/O. Events are flushed to PostHog on the next
+ * command run (or during this run's shutdown if PostHog initialized in time).
  *
  * @param eventName - Event name (e.g., 'command_run')
  * @param value - Optional numeric or string value
@@ -560,25 +480,19 @@ export function trackMCPToolCalled(options: {
 
 // ─── Shutdown ────────────────────────────────────────────────────────────────
 
-/** Maximum time (ms) to wait for Statsig init before giving up during shutdown. */
+/** Maximum time (ms) to wait for PostHog init before giving up during shutdown. */
 const SHUTDOWN_INIT_TIMEOUT_MS = 3000
 
 /**
- * Wait for Statsig init to complete (so queued events get flushed), then
+ * Wait for PostHog init to complete (so queued events get flushed), then
  * shut down the client. Uses a timeout to avoid blocking CLI exit if
- * Statsig is slow (e.g., first run with no cache). After the first
- * successful init, Statsig caches its config locally so subsequent
- * initializations resolve in < 100 ms.
+ * PostHog is slow.
  *
  * Events written during this command run (e.g., by trackCommandRun in
  * postrun) will be on disk and flushed on the next run — this is by
  * design (WAL guarantee: one-command delay for current-run events).
  */
 export async function shutdownAnalytics(): Promise<void> {
-  // Await the in-progress Statsig init so it can flush queued events from
-  // previous runs. Without this, the init promise sees analyticsShutdown=true
-  // and bails before calling flushQueuedEvents(), causing the queue to grow
-  // indefinitely (see PRLT-1013).
   if (initPromise) {
     try {
       await Promise.race([
@@ -590,43 +504,21 @@ export async function shutdownAnalytics(): Promise<void> {
     }
   }
 
-  // Now mark as shut down so any late-resolving init promise (after timeout)
-  // won't set statsigClient or flush the queue
   analyticsShutdown = true
   initPromise = null
 
-  if (statsigClient || posthogClient) {
+  if (posthogClient) {
     try {
-      // Flush events written during this run that arrived after the init
-      // promise's own flush (e.g., the command_run event from postrun).
-      // statsigClient.logEvent() buffers in memory; shutdown() sends them.
       flushQueuedEvents()
     } catch {
       // Never let flush errors affect the CLI
     }
 
-    if (statsigClient) {
-      try {
-        statsigClient.shutdown()
-      } catch {
-        // Never let shutdown errors affect the CLI
-      }
-      statsigClient = null
-      try {
-        const { setStatsigClient } = await import('./feature-flags.js')
-        setStatsigClient(null)
-      } catch {
-        // Ignore
-      }
+    try {
+      posthogClient.shutdown()
+    } catch {
+      // Never let shutdown errors affect the CLI
     }
-
-    if (posthogClient) {
-      try {
-        posthogClient.shutdown()
-      } catch {
-        // Never let shutdown errors affect the CLI
-      }
-      posthogClient = null
-    }
+    posthogClient = null
   }
 }

--- a/apps/cli/src/lib/telemetry/feature-flags.ts
+++ b/apps/cli/src/lib/telemetry/feature-flags.ts
@@ -1,93 +1,37 @@
 /**
- * Feature Flags (Statsig Feature Gates)
+ * Feature Flags (stub)
  *
- * Wraps Statsig feature gate checks with a simple API for the CLI.
- * Feature flags are evaluated locally after SDK initialization,
- * so checks are near-instant after the initial fetch.
+ * Previously backed by Statsig feature gates. Statsig has been removed
+ * (PRLT-1050) so all flags now return their default values.
+ *
+ * The API surface is preserved so callers don't need to change.
  *
  * Usage:
  *   import { isEnabled } from '../lib/telemetry/feature-flags.js'
  *   if (isEnabled('new_board_view')) { ... }
- *
- * Feature flags require Statsig to be initialized (via initAnalytics).
- * If Statsig is unavailable or telemetry is disabled, all flags return false.
  */
 
-import { isTelemetryEnabled } from './analytics.js'
-
-// Cache for flag values — populated on check, persists for the process lifetime
-const flagCache = new Map<string, boolean>()
-
-// Statsig client instance reference — set after initialization in initAnalytics
-let statsigClient: StatsigClientRef | null = null
-
-interface StatsigClientRef {
-  checkGate(gateName: string): boolean
-  getDynamicConfig(configName: string): { get(key: string, defaultValue: unknown): unknown }
+/**
+ * Check if a feature gate is enabled.
+ *
+ * Always returns false now that Statsig has been removed.
+ */
+export function isEnabled(_gateName: string): boolean {
+  return false
 }
 
 /**
- * Set the Statsig client reference (called from analytics.ts after init).
- * @internal
+ * Get a dynamic config value.
+ *
+ * Always returns the default value now that Statsig has been removed.
  */
-export function setStatsigClient(client: StatsigClientRef | null): void {
-  statsigClient = client
+export function getConfigValue<T>(_configName: string, _key: string, defaultValue: T): T {
+  return defaultValue
 }
 
 /**
- * Check if a feature gate is enabled for the current machine.
- *
- * Uses Statsig's local evaluation (near-zero latency after init).
- * Returns false if Statsig is not initialized or telemetry is disabled.
- *
- * @param gateName - The feature gate name (e.g., 'new_board_view')
- * @returns Whether the gate is enabled
- */
-export function isEnabled(gateName: string): boolean {
-  if (!isTelemetryEnabled() || !statsigClient) return false
-
-  // Return cached value if available
-  if (flagCache.has(gateName)) {
-    return flagCache.get(gateName)!
-  }
-
-  try {
-    const result = statsigClient.checkGate(gateName)
-    flagCache.set(gateName, result)
-    return result
-  } catch {
-    // Statsig not initialized or gate check failed — default to false
-    flagCache.set(gateName, false)
-    return false
-  }
-}
-
-/**
- * Get a dynamic config value from Statsig.
- *
- * Useful for remote configuration (not just boolean flags).
- * Returns the default value if Statsig is unavailable.
- *
- * @param configName - The dynamic config name
- * @param key - The key within the config
- * @param defaultValue - Default value if unavailable
- * @returns The config value, or the default
- */
-export function getConfigValue<T>(configName: string, key: string, defaultValue: T): T {
-  if (!isTelemetryEnabled() || !statsigClient) return defaultValue
-
-  try {
-    const config = statsigClient.getDynamicConfig(configName)
-    return config.get(key, defaultValue) as T
-  } catch {
-    return defaultValue
-  }
-}
-
-/**
- * Clear the local flag cache.
- * Useful for testing or when you want to force re-evaluation.
+ * Clear the local flag cache (no-op without Statsig).
  */
 export function clearFlagCache(): void {
-  flagCache.clear()
+  // No-op
 }

--- a/apps/cli/test/unit/analytics-queue.test.ts
+++ b/apps/cli/test/unit/analytics-queue.test.ts
@@ -8,11 +8,11 @@ import { execFileSync } from 'node:child_process'
  * Tests for the analytics write-ahead log (WAL) queue.
  *
  * Design: events are written synchronously to a disk queue via trackEvent().
- * On shutdown, the Statsig init promise is awaited (with timeout) so queued
- * events from previous runs get flushed. If Statsig doesn't initialize in
+ * On shutdown, the PostHog init promise is awaited (with timeout) so queued
+ * events from previous runs get flushed. If PostHog doesn't initialize in
  * time, events persist on disk for the next run.
  *
- * Tests use a mock statsig-node to make Statsig initialization
+ * Tests use a mock posthog-node to make PostHog initialization
  * deterministic (no network dependency).
  */
 describe('Analytics queue persistence', () => {
@@ -34,44 +34,19 @@ describe('Analytics queue persistence', () => {
   })
 
   /**
-   * Create mock @statsig/js-client and posthog-node files in the test directory.
+   * Create mock posthog-node files in the test directory.
    * Uses Node.js module resolution hooks to intercept the imports.
    *
-   * @param opts.initDelay - ms to delay initializeAsync (default: 0)
-   * @param opts.initThrows - if true, initializeAsync rejects
+   * @param opts.initDelay - ms to delay PostHog constructor (default: 0)
+   * @param opts.initThrows - if true, PostHog constructor throws
    * @returns path to the file where mock writes logged events on shutdown
    */
-  function createMockStatsig(opts?: { initDelay?: number; initThrows?: boolean }): string {
+  function createMockPostHog(opts?: { initDelay?: number; initThrows?: boolean }): string {
     const mockDir = path.join(testDir, 'mock')
     fs.mkdirSync(mockDir, { recursive: true })
 
-    const statsigEventsPath = path.join(testDir, 'statsig-events.json')
     const posthogEventsPath = path.join(testDir, 'posthog-events.json')
-    const initDelay = opts?.initDelay ?? 0
     const initThrows = opts?.initThrows ?? false
-
-    // Mock statsig-node module (server SDK — static Statsig object)
-    fs.writeFileSync(path.join(mockDir, 'statsig-mock.mjs'), `
-import * as fs from 'node:fs';
-const EVENTS_FILE = ${JSON.stringify(statsigEventsPath)};
-const _events = [];
-export const Statsig = {
-  async initialize(key, options) {
-    ${initDelay > 0 ? `await new Promise(r => setTimeout(r, ${initDelay}));` : ''}
-    ${initThrows ? `throw new Error('mock init failure');` : ''}
-  },
-  logEvent(user, name, value, metadata) {
-    _events.push({ name, value, metadata });
-  },
-  checkGate() { return false; },
-  getConfig() { return { get: (k, d) => d }; },
-  shutdown() {
-    try {
-      fs.writeFileSync(EVENTS_FILE, JSON.stringify(_events), 'utf-8');
-    } catch {}
-  },
-};
-`, 'utf-8')
 
     // Mock posthog-node module
     fs.writeFileSync(path.join(mockDir, 'posthog-mock.mjs'), `
@@ -79,6 +54,7 @@ import * as fs from 'node:fs';
 const EVENTS_FILE = ${JSON.stringify(posthogEventsPath)};
 export class PostHog {
   constructor(apiKey, options) {
+    ${initThrows ? `throw new Error('mock init failure');` : ''}
     this._events = [];
   }
   capture(message) {
@@ -92,14 +68,10 @@ export class PostHog {
 }
 `, 'utf-8')
 
-    // Loader hook — resolves statsig-node and posthog-node to our mocks
+    // Loader hook — resolves posthog-node to our mock
     fs.writeFileSync(path.join(mockDir, 'mock-loader.mjs'), `
-const STATSIG_MOCK_URL = new URL('./statsig-mock.mjs', import.meta.url).href;
 const POSTHOG_MOCK_URL = new URL('./posthog-mock.mjs', import.meta.url).href;
 export async function resolve(specifier, context, nextResolve) {
-  if (specifier === 'statsig-node') {
-    return { url: STATSIG_MOCK_URL, shortCircuit: true };
-  }
   if (specifier === 'posthog-node') {
     return { url: POSTHOG_MOCK_URL, shortCircuit: true };
   }
@@ -113,20 +85,20 @@ import { register } from 'node:module';
 register('./mock-loader.mjs', import.meta.url);
 `, 'utf-8')
 
-    return statsigEventsPath
+    return posthogEventsPath
   }
 
   /**
    * Helper to run an ESM script in a child process with isolated HOME.
    *
    * @param script - The test script body (analytics module is pre-imported)
-   * @param opts.useMock - Use mock Statsig (default: false)
-   * @param opts.mockOpts - Options for the mock Statsig
+   * @param opts.useMock - Use mock PostHog (default: false)
+   * @param opts.mockOpts - Options for the mock PostHog
    */
   function runAnalyticsScript(
     script: string,
     opts?: { useMock?: boolean; mockOpts?: { initDelay?: number; initThrows?: boolean } },
-  ): { queue: unknown[] | null; stdout: string; stderr: string; statsigEvents: unknown[] | null; posthogEvents: unknown[] | null } {
+  ): { queue: unknown[] | null; stdout: string; stderr: string; posthogEvents: unknown[] | null } {
     const configDir = path.join(testDir, '.proletariat')
     fs.mkdirSync(configDir, { recursive: true })
 
@@ -142,9 +114,9 @@ register('./mock-loader.mjs', import.meta.url);
       }),
     )
 
-    let statsigEventsPath: string | null = null
+    let posthogEventsPath: string | null = null
     if (opts?.useMock) {
-      statsigEventsPath = createMockStatsig(opts.mockOpts)
+      posthogEventsPath = createMockPostHog(opts.mockOpts)
     }
 
     // Prefix the script with the absolute import
@@ -194,19 +166,8 @@ ${script}
       }
     }
 
-    let statsigEvents: unknown[] | null = null
-    if (statsigEventsPath && fs.existsSync(statsigEventsPath)) {
-      try {
-        const parsed = JSON.parse(fs.readFileSync(statsigEventsPath, 'utf-8'))
-        statsigEvents = Array.isArray(parsed) ? parsed : null
-      } catch {
-        statsigEvents = null
-      }
-    }
-
-    const posthogEventsPath = path.join(testDir, 'posthog-events.json')
     let posthogEvents: unknown[] | null = null
-    if (fs.existsSync(posthogEventsPath)) {
+    if (posthogEventsPath && fs.existsSync(posthogEventsPath)) {
       try {
         const parsed = JSON.parse(fs.readFileSync(posthogEventsPath, 'utf-8'))
         posthogEvents = Array.isArray(parsed) ? parsed : null
@@ -215,10 +176,10 @@ ${script}
       }
     }
 
-    return { queue, stdout, stderr, statsigEvents, posthogEvents }
+    return { queue, stdout, stderr, posthogEvents }
   }
 
-  // ── Queue write mechanics (no Statsig init) ───────────────────────────
+  // ── Queue write mechanics (no PostHog init) ────────────────────────────
 
   it('trackEvent writes events to disk queue synchronously', () => {
     const { queue, stderr } = runAnalyticsScript(`
@@ -246,7 +207,7 @@ ${script}
     expect((event.metadata as Record<string, string>).command).to.equal('test:cmd')
   })
 
-  // ── Flush behavior with mock Statsig ──────────────────────────────────
+  // ── Flush behavior with mock PostHog ───────────────────────────────────
 
   it('shutdownAnalytics drains previous-run events from queue (PRLT-1013 regression)', () => {
     const configDir = path.join(testDir, '.proletariat')
@@ -263,69 +224,63 @@ ${script}
     )
 
     // Simulate a fast command: init → immediate shutdown (no explicit wait)
-    const { queue, statsigEvents, stderr } = runAnalyticsScript(`
+    const { queue, posthogEvents, stderr } = runAnalyticsScript(`
       initAnalytics('0.0.0-test');
       await shutdownAnalytics();
     `, { useMock: true })
 
     // After fix: shutdownAnalytics awaits the init promise, which calls
     // flushQueuedEvents(). Previous-run events should be drained from disk
-    // and delivered to Statsig.
+    // and delivered to PostHog.
     const hasOldEvent = queue?.some(
       (e: unknown) => ((e as Record<string, unknown>).metadata as Record<string, string>)?.command === 'old:cmd',
     ) ?? false
     expect(hasOldEvent, `previous-run events should be flushed from queue, stderr: ${stderr}`).to.be.false
 
-    // Verify events were actually sent to Statsig (via mock)
-    expect(statsigEvents, `statsig should have received events, stderr: ${stderr}`).to.not.be.null
-    expect(statsigEvents!.length).to.equal(2)
-    expect((statsigEvents![0] as Record<string, unknown>).name).to.equal('command_run')
-    expect((statsigEvents![1] as Record<string, unknown>).name).to.equal('agent_spawned')
+    // Verify events were actually sent to PostHog (via mock)
+    expect(posthogEvents, `posthog should have received events, stderr: ${stderr}`).to.not.be.null
+    expect(posthogEvents!.length).to.equal(2)
+    expect((posthogEvents![0] as Record<string, unknown>).event).to.equal('command_run')
+    expect((posthogEvents![1] as Record<string, unknown>).event).to.equal('agent_spawned')
   })
 
-  it('current-run events written after init are flushed via Statsig on shutdown', () => {
-    const { queue, statsigEvents, stderr } = runAnalyticsScript(`
+  it('current-run events written after init are flushed via PostHog on shutdown', () => {
+    const { queue, posthogEvents, stderr } = runAnalyticsScript(`
       initAnalytics('0.0.0-test');
       trackEvent('event_a', 1, { key: 'val1' });
       trackEvent('event_b', 2, { key: 'val2' });
       await shutdownAnalytics();
     `, { useMock: true })
 
-    // Events written during this run should be flushed to Statsig during
-    // shutdown (since the mock Statsig initializes instantly, the shutdown
+    // Events written during this run should be flushed to PostHog during
+    // shutdown (since the mock PostHog initializes instantly, the shutdown
     // flush picks them up)
-    expect(statsigEvents, `statsig should have received events, stderr: ${stderr}`).to.not.be.null
-    expect(statsigEvents!.length).to.equal(2)
-    expect((statsigEvents![0] as Record<string, unknown>).name).to.equal('event_a')
-    expect((statsigEvents![1] as Record<string, unknown>).name).to.equal('event_b')
+    expect(posthogEvents, `posthog should have received events, stderr: ${stderr}`).to.not.be.null
+    expect(posthogEvents!.length).to.equal(2)
+    expect((posthogEvents![0] as Record<string, unknown>).event).to.equal('event_a')
+    expect((posthogEvents![1] as Record<string, unknown>).event).to.equal('event_b')
 
     // Queue on disk should be empty (events were flushed)
     expect(queue).to.be.null
   })
 
-  it('events are flushed to PostHog when Statsig fails to initialize', () => {
-    const { queue, statsigEvents, posthogEvents, stderr } = runAnalyticsScript(`
+  it('events persist on disk when PostHog fails to initialize', () => {
+    const { queue, posthogEvents, stderr } = runAnalyticsScript(`
       initAnalytics('0.0.0-test');
       trackEvent('resilient_event', null, { source: 'test' });
       trackCommandRun({ command: 'test:fail', durationMs: 10, success: true, flags: [] });
       await shutdownAnalytics();
     `, { useMock: true, mockOpts: { initThrows: true } })
 
-    // Statsig failed to init, but PostHog succeeded — events should be
-    // flushed to PostHog and drained from the disk queue
-    expect(queue, `queue should be drained when PostHog succeeds, stderr: ${stderr}`).to.be.null
+    // PostHog failed to init — events should persist on disk for the next run
+    expect(queue, `queue should persist when PostHog fails, stderr: ${stderr}`).to.not.be.null
+    expect(queue!.length).to.equal(2)
 
-    // Statsig mock didn't get any events (init failed)
-    expect(statsigEvents).to.be.null
-
-    // PostHog should have received the events
-    expect(posthogEvents, `posthog should have received events, stderr: ${stderr}`).to.not.be.null
-    expect(posthogEvents!.length).to.equal(2)
-    expect((posthogEvents![0] as Record<string, unknown>).event).to.equal('resilient_event')
-    expect((posthogEvents![1] as Record<string, unknown>).event).to.equal('command_run')
+    // PostHog mock didn't get any events (init failed)
+    expect(posthogEvents).to.be.null
   })
 
-  it('previous-run events flushed while current-run event stays on disk until next flush', () => {
+  it('previous-run events flushed while current-run event also flushed on shutdown', () => {
     const configDir = path.join(testDir, '.proletariat')
     fs.mkdirSync(configDir, { recursive: true })
 
@@ -338,39 +293,36 @@ ${script}
       JSON.stringify(previousEvents),
     )
 
-    // Use mock with a slight delay so init completes between trackEvent and
-    // the shutdown flush — the init promise's flush clears old events, then
-    // the new event is written, then shutdown's flush sends it too
-    const { queue, statsigEvents, stderr } = runAnalyticsScript(`
+    const { queue, posthogEvents, stderr } = runAnalyticsScript(`
       initAnalytics('0.0.0-test');
-      // Wait briefly for mock Statsig to initialize
+      // Wait briefly for mock PostHog to initialize
       await new Promise(r => setTimeout(r, 50));
       // Track current command (simulates postrun hook)
       trackCommandRun({ command: 'new:cmd', durationMs: 25, success: true, flags: [] });
       await shutdownAnalytics();
     `, { useMock: true })
 
-    // Statsig should have received both old and new events
-    expect(statsigEvents, `statsig should have received events, stderr: ${stderr}`).to.not.be.null
-    const oldEventSent = statsigEvents!.some(
-      (e: unknown) => ((e as Record<string, unknown>).metadata as Record<string, string>)?.command === 'old:cmd',
+    // PostHog should have received both old and new events
+    expect(posthogEvents, `posthog should have received events, stderr: ${stderr}`).to.not.be.null
+    const oldEventSent = posthogEvents!.some(
+      (e: unknown) => ((e as Record<string, unknown>).properties as Record<string, string>)?.command === 'old:cmd',
     )
-    const newEventSent = statsigEvents!.some(
-      (e: unknown) => ((e as Record<string, unknown>).metadata as Record<string, string>)?.command === 'new:cmd',
+    const newEventSent = posthogEvents!.some(
+      (e: unknown) => ((e as Record<string, unknown>).properties as Record<string, string>)?.command === 'new:cmd',
     )
-    expect(oldEventSent, 'old events should be sent to Statsig').to.be.true
-    expect(newEventSent, 'new events should be sent to Statsig').to.be.true
+    expect(oldEventSent, 'old events should be sent to PostHog').to.be.true
+    expect(newEventSent, 'new events should be sent to PostHog').to.be.true
 
     // Queue on disk should be empty (all events flushed)
     expect(queue).to.be.null
   })
 
-  it('async Statsig init does not interfere after shutdown completes', () => {
+  it('async PostHog init does not interfere after shutdown completes', () => {
     const { queue, stderr } = runAnalyticsScript(`
       // Write event before init
       trackEvent('pre_init_event', null, { source: 'previous-run' });
 
-      // Init starts async Statsig init
+      // Init starts async PostHog init
       initAnalytics('0.0.0-test');
 
       // Shut down — awaits init promise (mock resolves instantly)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ importers:
       react:
         specifier: ^18.0.0
         version: 18.3.1
-      statsig-node:
-        specifier: ^6.5.1
-        version: 6.5.1
       string-width:
         specifier: ^8.1.1
         version: 8.1.1
@@ -3130,9 +3127,6 @@ packages:
     resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
     engines: {node: '>= 12'}
 
-  ip3country@5.0.0:
-    resolution: {integrity: sha512-lcFLMFU4eO1Z7tIpbVFZkaZ5ltqpeaRx7L9NsAbA9uA7/O/rj3RF8+evE5gDitooaTTIqjdzZrenFO/OOxQ2ew==}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3582,15 +3576,6 @@ packages:
   node-abi@3.87.0:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -4247,10 +4232,6 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
-  statsig-node@6.5.1:
-    resolution: {integrity: sha512-/rKvMMN9SWTK8+b7MyRP1wOsStsKf55Mdj8O2ffV/bCQ/38bXYCC/GVd3gVvBSwVCibAnkTz2v1gpRJSIKsBIg==}
-    engines: {pnpm: never}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4362,9 +4343,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -4459,10 +4437,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ua-parser-js@1.0.41:
-    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
-    hasBin: true
-
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -4499,10 +4473,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -4519,12 +4489,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -8426,8 +8390,6 @@ snapshots:
 
   ip-address@10.0.1: {}
 
-  ip3country@5.0.0: {}
-
   ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
@@ -8834,10 +8796,6 @@ snapshots:
   node-abi@3.87.0:
     dependencies:
       semver: 7.7.3
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-releases@2.0.27: {}
 
@@ -9512,15 +9470,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
-  statsig-node@6.5.1:
-    dependencies:
-      ip3country: 5.0.0
-      node-fetch: 2.7.0
-      ua-parser-js: 1.0.41
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - encoding
-
   statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
@@ -9638,8 +9587,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tr46@0.0.3: {}
-
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9748,8 +9695,6 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  ua-parser-js@1.0.41: {}
-
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -9807,8 +9752,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
-
   v8-compile-cache-lib@3.0.1: {}
 
   validate-npm-package-license@3.0.4:
@@ -9823,13 +9766,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves PRLT-1050: Remove Statsig — use PostHog only

## Description

Remove all Statsig telemetry integration from the CLI. The Statsig server SDK requires a secret key that cannot be committed to the open source repo (currently using a placeholder). PostHog is already working and sufficient.

Requirements:

* Remove statsig-node from dependencies in apps/cli/package.json
* Remove all Statsig initialization, event tracking, and shutdown code from apps/cli/src/lib/telemetry/analytics.ts
* Remove the STATSIG_SERVER_KEY constant
* Remove any Statsig-related imports
* Ensure PostHog remains the sole telemetry provider and all existing events still fire through PostHog
* Run pnpm build to verify no compile errors
* Do NOT remove PostHog — it stays

## External Issue Context

- Source: linear
- External key: PRLT-1050
- External id: a8b41746-4fb8-4a1d-a13d-9ae6cf1a706d
- URL: https://linear.app/proletariat/issue/PRLT-1050/remove-statsig-use-posthog-only
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- f21e2988 feat(PRLT-1050): remove Statsig telemetry, use PostHog as sole analytics provider

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
