### PR TITLE
PRLT-1063: Make session cleanup safe — confirm before killing active agents

### DIFF
--- a/apps/cli/src/commands/session/cleanup.ts
+++ b/apps/cli/src/commands/session/cleanup.ts
@@ -13,6 +13,7 @@ import {
   shouldOutputJson,
   outputSuccessAsJson,
   outputErrorAsJson,
+  outputConfirmationNeededAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
 
@@ -23,6 +24,7 @@ export default class SessionCleanup extends PMOCommand {
     '<%= config.bin %> session cleanup',
     '<%= config.bin %> session cleanup --dry-run',
     '<%= config.bin %> session cleanup --force',
+    '<%= config.bin %> session cleanup --force --yes',
   ]
 
   static flags = {
@@ -37,6 +39,11 @@ export default class SessionCleanup extends PMOCommand {
       description: 'Remove all agent containers, including those with active executions',
       default: false,
     }),
+    yes: Flags.boolean({
+      char: 'y',
+      description: 'Skip confirmation prompt when using --force',
+      default: false,
+    }),
   }
 
   protected getPMOOptions() {
@@ -48,6 +55,7 @@ export default class SessionCleanup extends PMOCommand {
     const jsonMode = shouldOutputJson(flags)
     const dryRun = flags['dry-run']
     const force = flags.force
+    const skipConfirm = flags.yes
 
     // Get workspace info
     let workspaceInfo
@@ -68,14 +76,12 @@ export default class SessionCleanup extends PMOCommand {
     const executionStorage = new ExecutionStorage(db)
 
     try {
-      // Find active executions to determine which containers are still needed
+      // Always find active executions to determine which containers are still needed
       const activeAgentNames = new Set<string>()
-      if (!force) {
-        const runningExecutions = executionStorage.listExecutions({ status: 'running' })
-        const startingExecutions = executionStorage.listExecutions({ status: 'starting' })
-        for (const exec of [...runningExecutions, ...startingExecutions]) {
-          activeAgentNames.add(exec.agentName)
-        }
+      const runningExecutions = executionStorage.listExecutions({ status: 'running' })
+      const startingExecutions = executionStorage.listExecutions({ status: 'starting' })
+      for (const exec of [...runningExecutions, ...startingExecutions]) {
+        activeAgentNames.add(exec.agentName)
       }
 
       // List all containers first for reporting
@@ -98,7 +104,58 @@ export default class SessionCleanup extends PMOCommand {
         return
       }
 
-      // Perform cleanup
+      // When --force is used, confirm before killing active agents
+      if (force && activeAgentNames.size > 0 && !dryRun) {
+        // Find which active agents actually have containers
+        const activeAgentsWithContainers = allContainers
+          .filter(c => activeAgentNames.has(c.agentName))
+          .map(c => c.agentName)
+
+        if (activeAgentsWithContainers.length > 0 && !skipConfirm) {
+          const agentList = activeAgentsWithContainers.join(', ')
+          const count = activeAgentsWithContainers.length
+          const confirmMessage = `This will kill ${count} active agent${count === 1 ? '' : 's'}: ${agentList}. Continue?`
+
+          if (jsonMode) {
+            outputConfirmationNeededAsJson(
+              {
+                activeAgents: activeAgentsWithContainers,
+                totalContainers: allContainers.length,
+              },
+              `prlt session cleanup --force --yes`,
+              confirmMessage,
+              createMetadata('session cleanup', flags),
+            )
+            return
+          }
+
+          // Interactive confirmation using list selection (per CLAUDE.md UX rule)
+          const { confirm } = await this.prompt<{ confirm: boolean }>([
+            {
+              type: 'list',
+              name: 'confirm',
+              message: confirmMessage,
+              choices: [
+                { name: 'No, cancel', value: false },
+                { name: 'Yes, kill active agents and clean up', value: true },
+              ],
+              default: 0,
+            },
+          ], null)
+
+          if (!confirm) {
+            this.log(styles.muted('Operation cancelled.'))
+            return
+          }
+        }
+
+        // Force mode: pass empty set so all containers are cleaned
+        const result = cleanupCompletedContainers(new Set<string>(), { dryRun })
+        this.outputResult(result, dryRun, jsonMode, flags)
+        return
+      }
+
+      // Normal mode (no --force): skip active agents automatically
       const result = cleanupCompletedContainers(activeAgentNames, { dryRun })
 
       if (result.removed.length === 0 && result.errors.length === 0) {
@@ -121,47 +178,55 @@ export default class SessionCleanup extends PMOCommand {
         return
       }
 
-      // Output results
-      if (jsonMode) {
-        outputSuccessAsJson({
-          message: `${dryRun ? 'Would remove' : 'Removed'} ${result.removed.length} container(s)`,
-          dryRun,
-          ...result,
-        }, createMetadata('session cleanup', flags))
-        return
-      }
-
-      this.log('')
-      this.log(styles.header(`${dryRun ? '[DRY RUN] ' : ''}Container Cleanup`))
-      this.log('═'.repeat(50))
-
-      if (result.stopped.length > 0) {
-        this.log(styles.info(`  ${result.stopped.length} container(s) ${dryRun ? 'would be ' : ''}stopped:`))
-        for (const name of result.stopped) {
-          this.log(styles.muted(`    - ${name}`))
-        }
-      }
-
-      if (result.removed.length > 0) {
-        this.log(styles.success(`  ${result.removed.length} container(s) ${dryRun ? 'would be ' : ''}removed:`))
-        for (const name of result.removed) {
-          this.log(styles.muted(`    - ${name}`))
-        }
-      }
-
-      if (result.skipped.length > 0) {
-        this.log(styles.muted(`  ${result.skipped.length} container(s) skipped (active agents)`))
-      }
-
-      if (result.errors.length > 0) {
-        for (const err of result.errors) {
-          this.log(styles.error(`  ${err}`))
-        }
-      }
-
-      this.log('')
+      this.outputResult(result, dryRun, jsonMode, flags)
     } finally {
       db.close()
     }
+  }
+
+  private outputResult(
+    result: { stopped: string[]; removed: string[]; errors: string[]; skipped: string[] },
+    dryRun: boolean,
+    jsonMode: boolean,
+    flags: Record<string, unknown>,
+  ): void {
+    if (jsonMode) {
+      outputSuccessAsJson({
+        message: `${dryRun ? 'Would remove' : 'Removed'} ${result.removed.length} container(s)`,
+        dryRun,
+        ...result,
+      }, createMetadata('session cleanup', flags))
+      return
+    }
+
+    this.log('')
+    this.log(styles.header(`${dryRun ? '[DRY RUN] ' : ''}Container Cleanup`))
+    this.log('═'.repeat(50))
+
+    if (result.stopped.length > 0) {
+      this.log(styles.info(`  ${result.stopped.length} container(s) ${dryRun ? 'would be ' : ''}stopped:`))
+      for (const name of result.stopped) {
+        this.log(styles.muted(`    - ${name}`))
+      }
+    }
+
+    if (result.removed.length > 0) {
+      this.log(styles.success(`  ${result.removed.length} container(s) ${dryRun ? 'would be ' : ''}removed:`))
+      for (const name of result.removed) {
+        this.log(styles.muted(`    - ${name}`))
+      }
+    }
+
+    if (result.skipped.length > 0) {
+      this.log(styles.muted(`  ${result.skipped.length} container(s) skipped (active agents)`))
+    }
+
+    if (result.errors.length > 0) {
+      for (const err of result.errors) {
+        this.log(styles.error(`  ${err}`))
+      }
+    }
+
+    this.log('')
   }
 }

--- a/apps/cli/test/unit/session-cleanup-safety.test.ts
+++ b/apps/cli/test/unit/session-cleanup-safety.test.ts
@@ -1,0 +1,168 @@
+import { expect } from 'chai'
+import {
+  findCompletedContainers,
+  type ContainerInfo,
+} from '../../src/lib/execution/container-cleanup.js'
+
+/**
+ * Unit tests for session cleanup safety behavior (PRLT-1063)
+ *
+ * Tests that session cleanup properly:
+ * 1. Without --force: auto-excludes containers with active execution records
+ * 2. With --force: identifies active agents for confirmation prompt
+ *
+ * The interactive confirmation and JSON mode behavior is tested via
+ * the integration of findCompletedContainers with the active agent set.
+ */
+describe('@smoke Session Cleanup Safety (PRLT-1063)', () => {
+  const makeContainers = (...agents: Array<{ name: string; running: boolean }>): ContainerInfo[] =>
+    agents.map((a, i) => ({
+      containerId: `id${i}`,
+      containerName: `prlt-agent-${a.name}`,
+      agentName: a.name,
+      running: a.running,
+      status: a.running ? 'running' : 'exited',
+    }))
+
+  describe('normal mode (no --force): auto-exclude active agents', () => {
+    it('should skip containers with running execution records', () => {
+      const containers = makeContainers(
+        { name: 'busy-andreesen', running: true },
+        { name: 'idle-hoffman', running: false },
+        { name: 'done-khosla', running: false },
+      )
+      const activeAgentNames = new Set(['busy-andreesen'])
+
+      const completed = findCompletedContainers(containers, activeAgentNames)
+
+      expect(completed).to.have.length(2)
+      expect(completed.map(c => c.agentName)).to.deep.equal(['idle-hoffman', 'done-khosla'])
+      expect(completed.map(c => c.agentName)).to.not.include('busy-andreesen')
+    })
+
+    it('should skip containers with starting execution records', () => {
+      const containers = makeContainers(
+        { name: 'starting-agent', running: true },
+        { name: 'completed-agent', running: false },
+      )
+      // 'starting' status agents are also active
+      const activeAgentNames = new Set(['starting-agent'])
+
+      const completed = findCompletedContainers(containers, activeAgentNames)
+
+      expect(completed).to.have.length(1)
+      expect(completed[0].agentName).to.equal('completed-agent')
+    })
+
+    it('should skip multiple active agents', () => {
+      const containers = makeContainers(
+        { name: 'agent-a', running: true },
+        { name: 'agent-b', running: true },
+        { name: 'agent-c', running: false },
+      )
+      const activeAgentNames = new Set(['agent-a', 'agent-b'])
+
+      const completed = findCompletedContainers(containers, activeAgentNames)
+
+      expect(completed).to.have.length(1)
+      expect(completed[0].agentName).to.equal('agent-c')
+    })
+
+    it('should clean up nothing when all agents are active', () => {
+      const containers = makeContainers(
+        { name: 'agent-a', running: true },
+        { name: 'agent-b', running: true },
+      )
+      const activeAgentNames = new Set(['agent-a', 'agent-b'])
+
+      const completed = findCompletedContainers(containers, activeAgentNames)
+
+      expect(completed).to.have.length(0)
+    })
+  })
+
+  describe('force mode: identify active agents for confirmation', () => {
+    it('should identify active agents with containers for confirmation prompt', () => {
+      const containers = makeContainers(
+        { name: 'busy-andreesen', running: true },
+        { name: 'ideal-hoffman', running: true },
+        { name: 'fast-khosla', running: true },
+        { name: 'done-altman', running: false },
+      )
+      const activeAgentNames = new Set(['busy-andreesen', 'ideal-hoffman', 'fast-khosla'])
+
+      // In force mode, we identify which active agents have containers
+      const activeAgentsWithContainers = containers
+        .filter(c => activeAgentNames.has(c.agentName))
+        .map(c => c.agentName)
+
+      expect(activeAgentsWithContainers).to.have.length(3)
+      expect(activeAgentsWithContainers).to.deep.equal([
+        'busy-andreesen',
+        'ideal-hoffman',
+        'fast-khosla',
+      ])
+    })
+
+    it('should include all containers when force mode passes empty active set', () => {
+      const containers = makeContainers(
+        { name: 'busy-andreesen', running: true },
+        { name: 'ideal-hoffman', running: true },
+        { name: 'done-altman', running: false },
+      )
+
+      // After confirmation, force mode passes empty set to get all containers
+      const completed = findCompletedContainers(containers, new Set<string>())
+
+      expect(completed).to.have.length(3)
+    })
+
+    it('should handle no active agents in force mode (no confirmation needed)', () => {
+      const containers = makeContainers(
+        { name: 'done-agent-a', running: false },
+        { name: 'done-agent-b', running: false },
+      )
+      const activeAgentNames = new Set<string>()
+
+      const activeAgentsWithContainers = containers
+        .filter(c => activeAgentNames.has(c.agentName))
+        .map(c => c.agentName)
+
+      expect(activeAgentsWithContainers).to.have.length(0)
+    })
+
+    it('should handle active agents without containers (no confirmation needed)', () => {
+      const containers = makeContainers(
+        { name: 'done-agent', running: false },
+      )
+      // Agent is active in DB but has no container
+      const activeAgentNames = new Set(['ghost-agent'])
+
+      const activeAgentsWithContainers = containers
+        .filter(c => activeAgentNames.has(c.agentName))
+        .map(c => c.agentName)
+
+      expect(activeAgentsWithContainers).to.have.length(0)
+    })
+  })
+
+  describe('confirmation message formatting', () => {
+    it('should format singular agent message correctly', () => {
+      const activeAgents = ['busy-andreesen']
+      const count = activeAgents.length
+      const message = `This will kill ${count} active agent${count === 1 ? '' : 's'}: ${activeAgents.join(', ')}. Continue?`
+
+      expect(message).to.equal('This will kill 1 active agent: busy-andreesen. Continue?')
+    })
+
+    it('should format plural agent message correctly', () => {
+      const activeAgents = ['busy-andreesen', 'ideal-hoffman', 'fast-khosla']
+      const count = activeAgents.length
+      const message = `This will kill ${count} active agent${count === 1 ? '' : 's'}: ${activeAgents.join(', ')}. Continue?`
+
+      expect(message).to.equal(
+        'This will kill 3 active agents: busy-andreesen, ideal-hoffman, fast-khosla. Continue?'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-1063: Make session cleanup safe — confirm before killing active agents

## Description

Currently prlt session cleanup --force silently kills all containers including active ones. And without --force, cleanup returns zero because execution status is never updated (stop hook fix in PRLT-1061).

## Requirements

1. prlt session cleanup (no force) should only remove containers where execution record shows status completed/errored/exited. Skip containers with status running. This depends on PRLT-1061 (stop hook updating status).
2. prlt session cleanup --force should require confirmation listing active agents that will be killed: 'This will kill 3 active agents: busy-andreesen, ideal-hoffman, fast-khosla. Continue?'
3. prlt session cleanup should auto-exclude containers with active execution records. No --exclude flag needed — just read the database.
4. prlt work stop TICKET-ID should be the targeted way to kill a specific agent (being built in PRLT-1062).

## Depends on

* PRLT-1061 (stop hook updates execution status)
* PRLT-1052 / PRLT-1062 (prlt work stop primitive)

## External Issue Context

- Source: linear
- External key: PRLT-1063
- External id: f3286f93-79a2-48ea-ba1d-f3bd4c6ca993
- URL: https://linear.app/proletariat/issue/PRLT-1063/make-session-cleanup-safe-confirm-before-killing-active-agents
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 689bea4f feat(PRLT-1063): make session cleanup safe: confirm before killing active agents

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
