### PR TITLE
chore: bump version to 0.3.86

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.85",
+  "version": "0.3.86",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump version from 0.3.85 to 0.3.86

## What shipped in 0.3.86
- All 7 work primitives (groom, resolve, implement, review, peek, poke, stop)
- Container GC via Claude Code stop hook
- Safe session cleanup with confirmation before killing active agents
- Stop creating local PMO tickets when cloud provider connected
- Branch naming uses external provider ID (PRLT-xxx not TKT-xxx)