### PR TITLE
chore: bump version to 0.3.87

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.86",
+  "version": "0.3.87",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump version from 0.3.86 to 0.3.87

## What shipped in 0.3.87
- Poke git bug fix (no longer requires git repo to send messages)
- Runtime uses external provider ID (PRLT-xxx not TKT-xxx)
- Configurable review gate (required/auto/post)
- Granular PostHog telemetry (primitive_executed, agent_spawned, agent_completed, ticket_operation)
- CI speed: parallel mocha, caching, smarter change detection