### PR TITLE
PRLT-1082: Agents stuck at Claude Code bypass permissions prompt despite --skip-permissions

### DIFF
--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -196,6 +196,29 @@ export function createDockerContainer(
 }
 
 /**
+ * Build the Claude Code stop hook config in the new matcher+hooks array format.
+ * PRLT-1082: The old flat format caused Claude Code to skip the entire settings.json
+ * due to validation error, breaking skipDangerousModePermissionPrompt.
+ */
+export function buildClaudeStopHookConfig(): Record<string, unknown> {
+  return {
+    hooks: {
+      Stop: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command' as const,
+              command: 'prlt session report --agent "$PRLT_AGENT_NAME" --status exited 2>/dev/null || true',
+            },
+          ],
+        },
+      ],
+    },
+  }
+}
+
+/**
  * Run the post-start setup commands in a container.
  */
 export function runContainerSetup(containerId: string, permissionMode: PermissionMode = 'safe', executor: ExecutorType = 'claude-code'): boolean {
@@ -268,16 +291,7 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
       // Uses $PRLT_AGENT_NAME shell variable which is set as a container env var
       // during createDockerContainer() — this ensures the correct agent name is used
       // regardless of which process is running the container setup.
-      const stopHookConfig = {
-        hooks: {
-          Stop: [
-            {
-              type: 'command' as const,
-              command: 'prlt session report --agent "$PRLT_AGENT_NAME" --status exited 2>/dev/null || true',
-            },
-          ],
-        },
-      }
+      const stopHookConfig = buildClaudeStopHookConfig()
       // Merge stop hook into existing settings.json
       const mergedSettings = { ...JSON.parse(claudeSettings), ...stopHookConfig }
       execSync(

--- a/apps/cli/test/unit/runner-docker.test.ts
+++ b/apps/cli/test/unit/runner-docker.test.ts
@@ -3,6 +3,7 @@ import {
   getAgentContainerName,
   getContainerName,
   getImageName,
+  buildClaudeStopHookConfig,
 } from '../../src/lib/execution/runners/docker-management.js'
 
 /**
@@ -35,6 +36,29 @@ describe('Docker Runner Utilities (TKT-140)', () => {
   describe('getContainerName', () => {
     it('should be the same function as getAgentContainerName', () => {
       expect(getContainerName('test')).to.equal(getAgentContainerName('test'))
+    })
+  })
+
+  // =========================================================================
+  // Claude Code Stop Hook Config (PRLT-1082)
+  // =========================================================================
+  describe('buildClaudeStopHookConfig', () => {
+    it('should use new matcher+hooks array format', () => {
+      const config = buildClaudeStopHookConfig() as {
+        hooks: { Stop: Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }> }
+      }
+      expect(config.hooks).to.exist
+      expect(config.hooks.Stop).to.be.an('array').with.lengthOf(1)
+      const entry = config.hooks.Stop[0]
+      // Must have matcher field (new format) — without this, Claude Code skips settings.json
+      expect(entry).to.have.property('matcher')
+      // Must have hooks array wrapper (new format) — not flat type/command at top level
+      expect(entry).to.have.property('hooks').that.is.an('array').with.lengthOf(1)
+      expect(entry.hooks[0]).to.have.property('type', 'command')
+      expect(entry.hooks[0]).to.have.property('command').that.includes('prlt session report')
+      // Regression: old format had type/command at same level as Stop array entries
+      expect(entry).to.not.have.property('type')
+      expect(entry).to.not.have.property('command')
     })
   })
 


### PR DESCRIPTION
## Summary

Resolves PRLT-1082: Agents stuck at Claude Code bypass permissions prompt despite --skip-permissions

## Description

## Problem

Agents get stuck at Claude Code's "Bypass Permissions mode" interactive confirmation prompt, even though:

* `skipDangerousModePermissionPrompt: true` is in `~/.claude/settings.json`
* `bypassPermissionsModeAccepted: true` is in `~/.claude.json`
* `--dangerously-skip-permissions --permission-mode bypassPermissions` flags are passed

## Root Cause

Claude Code changed its **hooks schema format** between versions. The old format:

```json
{"hooks": {"Stop": [{"type": "command", "command": "..."}]}}
```

The new format requires:

```json
{"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "..."}]}]}}
```

The settings.json generated by prlt uses the OLD format. This causes a **validation error** that makes Claude Code **skip the ENTIRE settings.json file** — including `skipDangerousModePermissionPrompt: true`. Without that setting, the bypass prompt always shows.

## Fix

1. Update `generatePrltSetupScript()` in `devcontainer.ts` to emit hooks in the new matcher+hooks array format
2. The settings.json template should produce:

```json
{
  "skipDangerousModePermissionPrompt": true,
  "hooks": {
    "Stop": [
      {
        "matcher": "",
        "hooks": [
          {
            "type": "command",
            "command": "prlt session report --agent \"$PRLT_AGENT_NAME\" --status exited 2>/dev/null || true"
          }
        ]
      }
    ]
  }
}
```

3. Verify the fix: Claude Code should start directly into interactive mode with no prompt

## Verified

* With old hooks format: settings.json skipped, bypass prompt shows
* With new hooks format: settings.json loaded, bypass prompt skipped, Claude starts immediately

## Related

* PRLT-1084: Pin Claude Code version (prevents future schema breaks)
* This was the root cause of ALL agent spawn failures in the last session

## External Issue Context

- Source: linear
- External key: PRLT-1082
- External id: 8877652b-31ef-46f8-bf36-89db6a1a499a
- URL: https://linear.app/proletariat/issue/PRLT-1082/agents-stuck-at-claude-code-bypass-permissions-prompt-despite-skip
- Status: Ready
- Priority: Unset
- Labels: None

## Changes

- 36a43441 fix(PRLT-1082): fix Claude Code hooks schema to use new matcher+hooks array format

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
