### PR TITLE
feat(PRLT-1081): Database safety — WAL mode, auto-backup, corruption recovery

### DIFF
--- a/apps/cli/src/commands/db/repair.ts
+++ b/apps/cli/src/commands/db/repair.ts
@@ -1,0 +1,209 @@
+import { Command, Flags } from '@oclif/core'
+import * as fs from 'node:fs'
+import Database from 'better-sqlite3'
+import { styles } from '../../lib/styles.js'
+import {
+  getDatabasePath,
+  checkIntegrity,
+  repairDatabase,
+  getBackupPath,
+} from '../../lib/database/index.js'
+import {
+  getRegisteredHeadquarters,
+  getActiveWorkspace,
+} from '../../lib/machine-config.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { shouldOutputJson, createMetadata } from '../../lib/prompt-json.js'
+
+export default class DbRepair extends Command {
+  static description = 'Check database integrity and repair corruption'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --check-only',
+    '<%= config.bin %> <%= command.id %> --workspace /path/to/hq',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    'check-only': Flags.boolean({
+      description: 'Only check integrity, do not attempt repair',
+      default: false,
+    }),
+    workspace: Flags.string({
+      char: 'w',
+      description: 'Path to workspace (defaults to active workspace)',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(DbRepair)
+
+    const workspacePath = this.resolveWorkspacePath(flags.workspace)
+    if (!workspacePath) {
+      this.error('No workspace found. Run "prlt new" first or specify --workspace.')
+    }
+
+    const dbPath = getDatabasePath(workspacePath)
+    if (!fs.existsSync(dbPath)) {
+      this.error(`Database not found: ${dbPath}`)
+    }
+
+    // JSON output
+    if (shouldOutputJson(flags)) {
+      const result = this.runCheck(dbPath, flags['check-only'])
+      this.log(JSON.stringify({
+        ...result,
+        dbPath,
+        workspace: workspacePath,
+      }, null, 2))
+      return
+    }
+
+    this.log(`\n${styles.header('Database Repair')}`)
+    this.log('─'.repeat(50))
+    this.log(styles.muted(`Database: ${dbPath}`))
+
+    // List available backups
+    this.log(styles.subheader('\nBackups:'))
+    let backupCount = 0
+    for (let i = 1; i <= 5; i++) {
+      const bp = getBackupPath(dbPath, i)
+      if (fs.existsSync(bp)) {
+        const stat = fs.statSync(bp)
+        this.log(`  ${styles.code(`backup.${i}`)} — ${styles.muted(stat.mtime.toISOString())} (${formatBytes(stat.size)})`)
+        backupCount++
+      }
+    }
+    if (backupCount === 0) {
+      this.log(styles.muted('  No backups found'))
+    }
+
+    // Run integrity check
+    this.log(styles.subheader('\nIntegrity check:'))
+    let db: Database.Database | null = null
+    try {
+      db = new Database(dbPath, { readonly: true })
+      const check = checkIntegrity(db)
+      db.close()
+      db = null
+
+      if (check.ok) {
+        this.log(styles.success('  Database is healthy.'))
+
+        // Show journal mode
+        const readDb = new Database(dbPath, { readonly: true })
+        const mode = readDb.pragma('journal_mode', { simple: true })
+        readDb.close()
+        this.log(styles.muted(`  Journal mode: ${mode}`))
+        this.log('')
+        return
+      }
+
+      this.log(styles.error(`  Corruption detected (${check.errors.length} error(s)):`))
+      for (const err of check.errors.slice(0, 10)) {
+        this.log(styles.muted(`    - ${err}`))
+      }
+      if (check.errors.length > 10) {
+        this.log(styles.muted(`    ... and ${check.errors.length - 10} more`))
+      }
+    } catch (error) {
+      if (db) {
+        try { db.close() } catch { /* ignore */ }
+      }
+      this.log(styles.error(`  Could not open database: ${error instanceof Error ? error.message : error}`))
+    }
+
+    if (flags['check-only']) {
+      this.log(styles.muted('\n  --check-only: skipping repair'))
+      this.log('')
+      return
+    }
+
+    // Attempt repair
+    this.log(styles.subheader('\nAttempting repair:'))
+    const repair = repairDatabase(dbPath)
+
+    if (repair.success) {
+      this.log(styles.success(`  Repaired via ${repair.method}.`))
+      this.log(styles.muted(`  ${repair.message}`))
+    } else {
+      this.log(styles.error('  Repair failed.'))
+      this.log(styles.muted(`  ${repair.message}`))
+      this.log(styles.muted('  You may need to manually restore from an external backup.'))
+    }
+    this.log('')
+  }
+
+  private resolveWorkspacePath(explicit?: string): string | null {
+    if (explicit) {
+      return fs.existsSync(explicit) ? explicit : null
+    }
+
+    // Try active workspace first (returns a path string or null)
+    const active = getActiveWorkspace()
+    if (active && fs.existsSync(active)) {
+      return active
+    }
+
+    // Fall back to first registered HQ
+    const hqs = getRegisteredHeadquarters()
+    for (const hq of hqs) {
+      if (fs.existsSync(hq.path)) {
+        return hq.path
+      }
+    }
+
+    return null
+  }
+
+  private runCheck(dbPath: string, checkOnly: boolean): Record<string, unknown> {
+    let db: Database.Database | null = null
+    try {
+      db = new Database(dbPath, { readonly: true })
+      const check = checkIntegrity(db)
+      db.close()
+      db = null
+
+      if (check.ok) {
+        return { status: 'healthy', errors: [] }
+      }
+
+      if (checkOnly) {
+        return { status: 'corrupt', errors: check.errors, repaired: false }
+      }
+
+      const repair = repairDatabase(dbPath)
+      return {
+        status: 'corrupt',
+        errors: check.errors,
+        repaired: repair.success,
+        repairMethod: repair.method,
+        repairMessage: repair.message,
+      }
+    } catch (error) {
+      if (db) {
+        try { db.close() } catch { /* ignore */ }
+      }
+
+      if (checkOnly) {
+        return { status: 'error', errors: [error instanceof Error ? error.message : String(error)], repaired: false }
+      }
+
+      const repair = repairDatabase(dbPath)
+      return {
+        status: 'error',
+        errors: [error instanceof Error ? error.message : String(error)],
+        repaired: repair.success,
+        repairMethod: repair.method,
+        repairMessage: repair.message,
+      }
+    }
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/apps/cli/src/lib/database/db-safety.ts
+++ b/apps/cli/src/lib/database/db-safety.ts
@@ -1,0 +1,328 @@
+/**
+ * Database Safety — WAL mode, auto-backup, corruption recovery.
+ *
+ * Provides:
+ * - WAL journal mode configuration
+ * - Rotating backup (keeps last 5 copies)
+ * - Integrity check on open with auto-recovery
+ * - Manual repair via dump/reimport
+ *
+ * See: PRLT-1081
+ */
+
+import Database from 'better-sqlite3'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { throwIfNativeBindingError } from './native-validation.js'
+
+const MAX_BACKUPS = 5
+
+/**
+ * Enable WAL journal mode on a database connection.
+ * WAL allows concurrent readers with one writer and is significantly
+ * more resistant to corruption than the default journal_mode=delete.
+ */
+export function enableWALMode(db: Database.Database): void {
+  db.pragma('journal_mode = WAL')
+}
+
+/**
+ * Get the backup path for a given database path and backup number.
+ */
+export function getBackupPath(dbPath: string, n: number): string {
+  return `${dbPath}.backup.${n}`
+}
+
+/**
+ * Create a rotating backup of the database file.
+ * Keeps the last MAX_BACKUPS copies, numbered 1 (newest) through MAX_BACKUPS (oldest).
+ * Rotates existing backups before copying the current database.
+ *
+ * Returns true if backup was created, false if source didn't exist.
+ */
+export function createRotatingBackup(dbPath: string): boolean {
+  if (!fs.existsSync(dbPath)) {
+    return false
+  }
+
+  // Rotate existing backups: delete oldest, shift others up
+  const oldest = getBackupPath(dbPath, MAX_BACKUPS)
+  if (fs.existsSync(oldest)) {
+    fs.unlinkSync(oldest)
+  }
+
+  for (let i = MAX_BACKUPS - 1; i >= 1; i--) {
+    const src = getBackupPath(dbPath, i)
+    const dst = getBackupPath(dbPath, i + 1)
+    if (fs.existsSync(src)) {
+      fs.renameSync(src, dst)
+    }
+  }
+
+  // Copy current database as backup.1 (newest)
+  try {
+    fs.copyFileSync(dbPath, getBackupPath(dbPath, 1))
+    // Also copy WAL and SHM files if they exist (for WAL-mode databases)
+    const walPath = `${dbPath}-wal`
+    const shmPath = `${dbPath}-shm`
+    if (fs.existsSync(walPath)) {
+      fs.copyFileSync(walPath, `${getBackupPath(dbPath, 1)}-wal`)
+    }
+    if (fs.existsSync(shmPath)) {
+      fs.copyFileSync(shmPath, `${getBackupPath(dbPath, 1)}-shm`)
+    }
+    return true
+  } catch {
+    // Backup failure is not fatal — log and continue
+    return false
+  }
+}
+
+export interface IntegrityCheckResult {
+  ok: boolean
+  errors: string[]
+}
+
+/**
+ * Run PRAGMA integrity_check on a database.
+ * Returns { ok: true } if the database is healthy, or { ok: false, errors } with details.
+ */
+export function checkIntegrity(db: Database.Database): IntegrityCheckResult {
+  try {
+    const rows = db.pragma('integrity_check') as { integrity_check: string }[]
+    const errors = rows
+      .map(r => r.integrity_check)
+      .filter(msg => msg !== 'ok')
+
+    return { ok: errors.length === 0, errors }
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    }
+  }
+}
+
+/**
+ * Quick integrity check using PRAGMA quick_check (faster than full integrity_check).
+ * Skips checking that the contents of table rows match the indexes.
+ */
+export function quickCheckIntegrity(db: Database.Database): IntegrityCheckResult {
+  try {
+    const rows = db.pragma('quick_check') as { quick_check: string }[]
+    const errors = rows
+      .map(r => r.quick_check)
+      .filter(msg => msg !== 'ok')
+
+    return { ok: errors.length === 0, errors }
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    }
+  }
+}
+
+export interface RepairResult {
+  success: boolean
+  method: 'dump-reimport' | 'backup-restore' | 'none'
+  message: string
+}
+
+/**
+ * Attempt to repair a corrupted database.
+ *
+ * Strategy:
+ * 1. Try dump/reimport — opens the corrupt DB, dumps all SQL, creates a new DB
+ * 2. If dump fails, fall back to the most recent backup
+ *
+ * The original corrupt file is preserved as dbPath.corrupt for forensics.
+ */
+export function repairDatabase(dbPath: string): RepairResult {
+  // Try dump/reimport first
+  const dumpResult = attemptDumpReimport(dbPath)
+  if (dumpResult.success) {
+    return dumpResult
+  }
+
+  // Fall back to backup restore
+  const backupResult = attemptBackupRestore(dbPath)
+  if (backupResult.success) {
+    return backupResult
+  }
+
+  return {
+    success: false,
+    method: 'none',
+    message: `Could not repair database. Dump failed: ${dumpResult.message}. No usable backups found.`,
+  }
+}
+
+/**
+ * Attempt recovery via .dump and reimport.
+ * Opens the corrupt database, extracts as much SQL as possible,
+ * then creates a fresh database from that SQL.
+ */
+function attemptDumpReimport(dbPath: string): RepairResult {
+  let corruptDb: Database.Database | null = null
+  let newDb: Database.Database | null = null
+  const tempPath = `${dbPath}.repair-temp`
+
+  try {
+    // Open corrupt database — may partially work
+    corruptDb = new Database(dbPath, { readonly: true })
+
+    // Dump all recoverable SQL
+    const tables = corruptDb.prepare(
+      "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY CASE type WHEN 'table' THEN 1 WHEN 'index' THEN 2 ELSE 3 END"
+    ).all() as { sql: string }[]
+
+    if (tables.length === 0) {
+      return { success: false, method: 'dump-reimport', message: 'No tables found in corrupt database' }
+    }
+
+    // Create new database with recovered schema
+    newDb = new Database(tempPath)
+    newDb.pragma('journal_mode = WAL')
+
+    for (const { sql } of tables) {
+      try {
+        newDb.exec(sql)
+      } catch {
+        // Skip objects that fail to recreate (e.g., references to missing tables)
+      }
+    }
+
+    // Copy data table by table
+    const tableNames = corruptDb.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    ).all() as { name: string }[]
+
+    let rowsRecovered = 0
+    for (const { name } of tableNames) {
+      try {
+        const rows = corruptDb.prepare(`SELECT * FROM "${name}"`).all()
+        if (rows.length === 0) continue
+
+        const columns = Object.keys(rows[0] as Record<string, unknown>)
+        const placeholders = columns.map(() => '?').join(', ')
+        const insertSql = `INSERT OR IGNORE INTO "${name}" (${columns.map(c => `"${c}"`).join(', ')}) VALUES (${placeholders})`
+
+        const insertStmt = newDb.prepare(insertSql)
+        const insertAll = newDb.transaction((data: Record<string, unknown>[]) => {
+          for (const row of data) {
+            insertStmt.run(...columns.map(c => row[c]))
+          }
+        })
+
+        insertAll(rows as Record<string, unknown>[])
+        rowsRecovered += rows.length
+      } catch {
+        // Skip tables that can't be read
+      }
+    }
+
+    corruptDb.close()
+    corruptDb = null
+    newDb.close()
+    newDb = null
+
+    // Swap files: corrupt → .corrupt, repaired → original
+    const corruptBackupPath = `${dbPath}.corrupt`
+    if (fs.existsSync(corruptBackupPath)) {
+      fs.unlinkSync(corruptBackupPath)
+    }
+    fs.renameSync(dbPath, corruptBackupPath)
+    fs.renameSync(tempPath, dbPath)
+
+    // Clean up old WAL/SHM files from the corrupt database
+    for (const suffix of ['-wal', '-shm']) {
+      const f = `${dbPath}${suffix}`
+      if (fs.existsSync(f)) {
+        fs.unlinkSync(f)
+      }
+    }
+
+    return {
+      success: true,
+      method: 'dump-reimport',
+      message: `Recovered ${rowsRecovered} rows from ${tableNames.length} tables. Corrupt file saved as ${path.basename(corruptBackupPath)}.`,
+    }
+  } catch (error) {
+    // Clean up on failure
+    if (corruptDb) {
+      try { corruptDb.close() } catch { /* ignore */ }
+    }
+    if (newDb) {
+      try { newDb.close() } catch { /* ignore */ }
+    }
+    if (fs.existsSync(tempPath)) {
+      try { fs.unlinkSync(tempPath) } catch { /* ignore */ }
+    }
+
+    return {
+      success: false,
+      method: 'dump-reimport',
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * Attempt recovery by restoring from the most recent valid backup.
+ * Tries backups 1 through MAX_BACKUPS, validates each with integrity_check.
+ */
+function attemptBackupRestore(dbPath: string): RepairResult {
+  for (let i = 1; i <= MAX_BACKUPS; i++) {
+    const backupPath = getBackupPath(dbPath, i)
+    if (!fs.existsSync(backupPath)) {
+      continue
+    }
+
+    // Validate the backup
+    let backupDb: Database.Database | null = null
+    try {
+      backupDb = new Database(backupPath, { readonly: true })
+      const check = checkIntegrity(backupDb)
+      backupDb.close()
+      backupDb = null
+
+      if (!check.ok) {
+        continue
+      }
+
+      // Backup is valid — swap it in
+      const corruptBackupPath = `${dbPath}.corrupt`
+      if (fs.existsSync(corruptBackupPath)) {
+        fs.unlinkSync(corruptBackupPath)
+      }
+      fs.renameSync(dbPath, corruptBackupPath)
+      fs.copyFileSync(backupPath, dbPath)
+
+      // Clean up old WAL/SHM files
+      for (const suffix of ['-wal', '-shm']) {
+        const f = `${dbPath}${suffix}`
+        if (fs.existsSync(f)) {
+          fs.unlinkSync(f)
+        }
+      }
+
+      return {
+        success: true,
+        method: 'backup-restore',
+        message: `Restored from backup.${i}. Corrupt file saved as ${path.basename(corruptBackupPath)}.`,
+      }
+    } catch {
+      if (backupDb) {
+        try { backupDb.close() } catch { /* ignore */ }
+      }
+      continue
+    }
+  }
+
+  return {
+    success: false,
+    method: 'backup-restore',
+    message: 'No valid backups found',
+  }
+}

--- a/apps/cli/src/lib/database/driver.ts
+++ b/apps/cli/src/lib/database/driver.ts
@@ -154,10 +154,11 @@ export function wrapDatabase(db: Database.Database): DatabaseDriver {
 
 /**
  * Create a DatabaseDriver by opening a new better-sqlite3 connection.
- * Configures standard pragmas (foreign keys, busy timeout).
+ * Configures standard pragmas (WAL mode, foreign keys, busy timeout).
  */
 export function openDriver(dbPath: string, options?: { foreignKeys?: boolean; busyTimeout?: number }): DatabaseDriver {
   const db = new Database(dbPath)
+  db.pragma('journal_mode = WAL')
   if (options?.foreignKeys !== false) {
     db.pragma('foreign_keys = ON')
   }

--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -115,3 +115,15 @@ export {
   SettingsStore,
   createSettingsStore,
 } from './settings-store.js'
+
+// Database safety (WAL, backup, integrity, repair)
+export {
+  enableWALMode,
+  createRotatingBackup,
+  checkIntegrity,
+  quickCheckIntegrity,
+  repairDatabase,
+  getBackupPath,
+  type IntegrityCheckResult,
+  type RepairResult,
+} from './db-safety.js'

--- a/apps/cli/src/lib/database/workspace.ts
+++ b/apps/cli/src/lib/database/workspace.ts
@@ -18,6 +18,12 @@ import {
 import { eq } from 'drizzle-orm'
 import type { DatabaseDriver } from './driver.js'
 import { BetterSqlite3Driver } from './driver.js'
+import {
+  enableWALMode,
+  createRotatingBackup,
+  quickCheckIntegrity,
+  repairDatabase,
+} from './db-safety.js'
 
 export interface WorkspaceConfig {
   id: number
@@ -90,7 +96,12 @@ export function getConfigPath(workspacePath: string): string {
 }
 
 /**
- * Open workspace database connection
+ * Open workspace database connection.
+ *
+ * Safety features (PRLT-1081):
+ * - Creates a rotating backup before opening (keeps last 5)
+ * - Enables WAL journal mode for corruption resistance
+ * - Runs a quick integrity check; auto-repairs if corruption detected
  */
 export function openWorkspaceDatabase(workspacePath: string): Database.Database {
   const dbPath = getDatabasePath(workspacePath)
@@ -99,6 +110,9 @@ export function openWorkspaceDatabase(workspacePath: string): Database.Database 
     throw new Error(`Database not found: ${dbPath}. Run 'prlt new' first.`)
   }
 
+  // Auto-backup before opening (cheap insurance against corruption)
+  createRotatingBackup(dbPath)
+
   let db: Database.Database
   try {
     db = new Database(dbPath)
@@ -106,8 +120,40 @@ export function openWorkspaceDatabase(workspacePath: string): Database.Database 
     throwIfNativeBindingError(error, 'openWorkspaceDatabase')
     throw error
   }
+
+  // Enable WAL mode — allows concurrent readers with one writer,
+  // significantly more resistant to corruption than journal_mode=delete
+  enableWALMode(db)
   db.pragma('foreign_keys = ON')
   db.pragma('busy_timeout = 5000')
+
+  // Quick integrity check on startup
+  const integrity = quickCheckIntegrity(db)
+  if (!integrity.ok) {
+    db.close()
+
+    // Attempt auto-repair
+    const repair = repairDatabase(dbPath)
+    if (!repair.success) {
+      throw new Error(
+        `Database corruption detected in ${dbPath}.\n` +
+        `Integrity errors: ${integrity.errors.join('; ')}\n` +
+        `Auto-repair failed: ${repair.message}\n` +
+        `Run 'prlt db repair' for manual recovery options.`
+      )
+    }
+
+    // Re-open the repaired database
+    try {
+      db = new Database(dbPath)
+    } catch (error) {
+      throwIfNativeBindingError(error, 'openWorkspaceDatabase (post-repair)')
+      throw error
+    }
+    enableWALMode(db)
+    db.pragma('foreign_keys = ON')
+    db.pragma('busy_timeout = 5000')
+  }
 
   runDrizzleMigrations(db, ALL_MIGRATIONS)
   ensureEphemeralAgentTypes(db)
@@ -155,6 +201,7 @@ export function createWorkspaceDatabase(
     throw error
   }
 
+  enableWALMode(db)
   db.pragma('foreign_keys = ON')
   runDrizzleMigrations(db, ALL_MIGRATIONS)
 

--- a/apps/cli/test/unit/db-safety.test.ts
+++ b/apps/cli/test/unit/db-safety.test.ts
@@ -1,0 +1,190 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import {
+  enableWALMode,
+  createRotatingBackup,
+  checkIntegrity,
+  quickCheckIntegrity,
+  repairDatabase,
+  getBackupPath,
+} from '../../src/lib/database/db-safety.js'
+
+describe('db-safety', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-db-safety-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function createTestDb(dbPath: string): Database.Database {
+    const db = new Database(dbPath)
+    db.exec('CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)')
+    db.exec("INSERT INTO test VALUES (1, 'hello')")
+    db.exec("INSERT INTO test VALUES (2, 'world')")
+    return db
+  }
+
+  describe('enableWALMode', () => {
+    it('should set journal_mode to WAL', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+
+      enableWALMode(db)
+      const mode = db.pragma('journal_mode', { simple: true })
+      expect(mode).to.equal('wal')
+
+      db.close()
+    })
+  })
+
+  describe('createRotatingBackup', () => {
+    it('should create backup.1 from the database file', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+      db.close()
+
+      const result = createRotatingBackup(dbPath)
+      expect(result).to.be.true
+      expect(fs.existsSync(getBackupPath(dbPath, 1))).to.be.true
+    })
+
+    it('should rotate existing backups', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+      db.close()
+
+      // Create 3 backups
+      createRotatingBackup(dbPath)
+      createRotatingBackup(dbPath)
+      createRotatingBackup(dbPath)
+
+      expect(fs.existsSync(getBackupPath(dbPath, 1))).to.be.true
+      expect(fs.existsSync(getBackupPath(dbPath, 2))).to.be.true
+      expect(fs.existsSync(getBackupPath(dbPath, 3))).to.be.true
+    })
+
+    it('should limit to 5 backups', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+      db.close()
+
+      for (let i = 0; i < 7; i++) {
+        createRotatingBackup(dbPath)
+      }
+
+      expect(fs.existsSync(getBackupPath(dbPath, 1))).to.be.true
+      expect(fs.existsSync(getBackupPath(dbPath, 5))).to.be.true
+      expect(fs.existsSync(getBackupPath(dbPath, 6))).to.be.false
+    })
+
+    it('should return false if source does not exist', () => {
+      const result = createRotatingBackup(path.join(tmpDir, 'nonexistent.db'))
+      expect(result).to.be.false
+    })
+  })
+
+  describe('checkIntegrity / quickCheckIntegrity', () => {
+    it('should report ok for a healthy database', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+
+      const full = checkIntegrity(db)
+      expect(full.ok).to.be.true
+      expect(full.errors).to.have.length(0)
+
+      const quick = quickCheckIntegrity(db)
+      expect(quick.ok).to.be.true
+      expect(quick.errors).to.have.length(0)
+
+      db.close()
+    })
+  })
+
+  describe('repairDatabase', () => {
+    it('should recover data from a valid database via dump-reimport', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+      db.close()
+
+      // Simulate by running repair on a valid database
+      // (dump-reimport should still work and preserve data)
+      const result = repairDatabase(dbPath)
+      expect(result.success).to.be.true
+      expect(result.method).to.equal('dump-reimport')
+
+      // Verify data survived
+      const repaired = new Database(dbPath)
+      const rows = repaired.prepare('SELECT * FROM test ORDER BY id').all() as { id: number; value: string }[]
+      expect(rows).to.have.length(2)
+      expect(rows[0].value).to.equal('hello')
+      expect(rows[1].value).to.equal('world')
+      repaired.close()
+
+      // Corrupt backup should exist
+      expect(fs.existsSync(`${dbPath}.corrupt`)).to.be.true
+    })
+
+    it('should fall back to backup if dump fails on a truly corrupt file', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      const db = createTestDb(dbPath)
+      db.close()
+
+      // Create a backup first
+      createRotatingBackup(dbPath)
+
+      // Corrupt the database by overwriting with garbage
+      fs.writeFileSync(dbPath, Buffer.from('this is not a sqlite database'))
+
+      const result = repairDatabase(dbPath)
+      expect(result.success).to.be.true
+      expect(result.method).to.equal('backup-restore')
+
+      // Verify restored data
+      const restored = new Database(dbPath)
+      const rows = restored.prepare('SELECT * FROM test ORDER BY id').all() as { id: number; value: string }[]
+      expect(rows).to.have.length(2)
+      expect(rows[0].value).to.equal('hello')
+      restored.close()
+    })
+
+    it('should fail gracefully when no recovery is possible', () => {
+      const dbPath = path.join(tmpDir, 'test.db')
+      // Write garbage with no backups
+      fs.writeFileSync(dbPath, Buffer.from('corrupted'))
+
+      const result = repairDatabase(dbPath)
+      expect(result.success).to.be.false
+      expect(result.method).to.equal('none')
+    })
+  })
+
+  describe('WAL mode on openWorkspaceDatabase', () => {
+    it('should set WAL mode when opening a fresh workspace database', () => {
+      // This is an integration-style test — create a minimal workspace structure
+      const wsPath = path.join(tmpDir, 'workspace')
+      const prltDir = path.join(wsPath, '.proletariat')
+      fs.mkdirSync(prltDir, { recursive: true })
+
+      const dbPath = path.join(prltDir, 'workspace.db')
+      const db = new Database(dbPath)
+      db.exec('CREATE TABLE IF NOT EXISTS prlt_migrations (id TEXT PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL)')
+      db.exec('CREATE TABLE IF NOT EXISTS workspace (id INTEGER PRIMARY KEY, type TEXT NOT NULL DEFAULT "hq", workspace_name TEXT NOT NULL DEFAULT "test", has_pmo INTEGER NOT NULL DEFAULT 0, active_theme_id TEXT, created_at TEXT NOT NULL DEFAULT "")')
+      db.exec("INSERT OR IGNORE INTO workspace VALUES (1, 'hq', 'test', 0, NULL, '2024-01-01')")
+      db.close()
+
+      // Now open with enableWALMode directly and verify
+      const db2 = new Database(dbPath)
+      enableWALMode(db2)
+      const mode = db2.pragma('journal_mode', { simple: true })
+      expect(mode).to.equal('wal')
+      db2.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **WAL mode**: Set `PRAGMA journal_mode=WAL` on every database open (`openWorkspaceDatabase`, `createWorkspaceDatabase`, `openDriver`). WAL allows concurrent readers with one writer and is significantly more resistant to corruption than `journal_mode=delete`.
- **Auto-backup**: Create a rotating backup (last 5 copies) of `workspace.db` every time it's opened, before any writes. Backups are stored as `workspace.db.backup.1` through `.backup.5`.
- **Integrity check on startup**: Run `PRAGMA quick_check` when opening the database. If corruption is detected, auto-repair is attempted via dump/reimport or backup restore. Users get a clear error message with guidance.
- **`prlt db repair` command**: New CLI command for manual database recovery. Supports `--check-only` mode, JSON output, and workspace path override.

## Test plan

- [x] Unit tests for all db-safety functions (WAL mode, backup rotation, integrity check, repair via dump-reimport, repair via backup restore, graceful failure)
- [x] Build passes (`pnpm build`)
- [x] All 10 new tests pass (`pnpm test:unit -- --grep db-safety`)

## Files changed

| File | Change |
|------|--------|
| `apps/cli/src/lib/database/db-safety.ts` | New module: WAL, backup rotation, integrity check, repair logic |
| `apps/cli/src/lib/database/workspace.ts` | Add WAL mode, auto-backup, integrity check to `openWorkspaceDatabase` and `createWorkspaceDatabase` |
| `apps/cli/src/lib/database/driver.ts` | Add WAL mode to `openDriver` |
| `apps/cli/src/lib/database/index.ts` | Export db-safety functions |
| `apps/cli/src/commands/db/repair.ts` | New `prlt db repair` command |
| `apps/cli/test/unit/db-safety.test.ts` | 10 unit tests covering all safety features |

Closes PRLT-1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)