### PR TITLE
PRLT-1083: Route 4 remaining direct better-sqlite3 imports through DatabaseDriver

### DIFF
--- a/apps/cli/src/lib/dashboard/data.ts
+++ b/apps/cli/src/lib/dashboard/data.ts
@@ -7,7 +7,7 @@
 
 import * as path from 'node:path'
 import { execSync } from 'node:child_process'
-import Database from 'better-sqlite3'
+import { type DatabaseDriver, openDriver } from '../database/driver.js'
 import type { Board, Ticket, Column } from '../pmo/types.js'
 import { getWorkspaceInfo, getAllAgentsStatus, getAgentTmuxSessions } from '../agents/commands.js'
 import type { WorkspaceInfo, AgentStatus } from '../agents/commands.js'
@@ -148,13 +148,13 @@ export function gatherAgentData(): DashboardAgent[] {
 
 export function gatherSessionData(): DashboardSession[] {
   let executionStorage: ExecutionStorage | null = null
-  let db: Database.Database | null = null
+  let db: DatabaseDriver | null = null
   const sessions: DashboardSession[] = []
 
   try {
     const workspaceInfo = getWorkspaceInfo()
     const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
-    db = new Database(dbPath)
+    db = openDriver(dbPath, { foreignKeys: false })
     executionStorage = new ExecutionStorage(db)
   } catch {
     // Not in workspace — still discover tmux sessions below

--- a/apps/cli/src/lib/pmo/find-pmo.ts
+++ b/apps/cli/src/lib/pmo/find-pmo.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import Database from 'better-sqlite3';
+import { openDriver } from '../database/driver.js';
 import { isValidHQ } from '../workspace.js';
 import { throwIfNativeBindingError } from '../database/native-validation.js';
 
@@ -47,11 +47,11 @@ function hasPMOTables(dbPath: string): boolean {
   }
 
   try {
-    const db = new Database(dbPath);
-    const result = db.prepare(
+    const driver = openDriver(dbPath, { foreignKeys: false });
+    const result = driver.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_projects'"
     ).get();
-    db.close();
+    driver.close();
 
     return result !== undefined;
   } catch (error) {
@@ -102,9 +102,9 @@ export function findPMO(): string | null {
           if (hasTables) {
             // Read PMO path from database (new behavior)
             try {
-              const db = new Database(dbPath);
-              const result = db.prepare('SELECT value FROM pmo_settings WHERE key = ?').get('pmo_path') as { value: string } | undefined;
-              db.close();
+              const driver = openDriver(dbPath, { foreignKeys: false });
+              const result = driver.prepare('SELECT value FROM pmo_settings WHERE key = ?').get('pmo_path') as { value: string } | undefined;
+              driver.close();
 
               if (result) {
                 const absolutePath = path.isAbsolute(result.value)
@@ -154,9 +154,9 @@ export function findPMO(): string | null {
         const dbPath = path.join(activeHqPath, '.proletariat', 'workspace.db');
         if (hasPMOTables(dbPath)) {
           try {
-            const db = new Database(dbPath);
-            const result = db.prepare('SELECT value FROM pmo_settings WHERE key = ?').get('pmo_path') as { value: string } | undefined;
-            db.close();
+            const driver = openDriver(dbPath, { foreignKeys: false });
+            const result = driver.prepare('SELECT value FROM pmo_settings WHERE key = ?').get('pmo_path') as { value: string } | undefined;
+            driver.close();
 
             if (result) {
               return resolvePmoPath(result.value, activeHqPath);

--- a/apps/cli/src/lib/registry/index.ts
+++ b/apps/cli/src/lib/registry/index.ts
@@ -6,7 +6,7 @@
  * regardless of which workspace they belong to.
  */
 
-import Database from 'better-sqlite3'
+import { type DatabaseDriver, openDriver } from '../database/driver.js'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
@@ -86,7 +86,7 @@ function getMachineRegistryPath(): string {
  * Open (or create) the machine-level agent registry at ~/.prlt/agents.db.
  * Ensures the ~/.prlt directory and schema exist.
  */
-export function openMachineRegistry(): Database.Database {
+export function openMachineRegistry(): DatabaseDriver {
   const dbPath = getMachineRegistryPath()
   const dir = path.dirname(dbPath)
 
@@ -95,11 +95,10 @@ export function openMachineRegistry(): Database.Database {
   }
 
   try {
-    const db = new Database(dbPath)
-    db.pragma('journal_mode = WAL')
-    db.pragma('busy_timeout = 3000')
-    db.exec(REGISTRY_SCHEMA)
-    return db
+    const driver = openDriver(dbPath, { foreignKeys: false, busyTimeout: 3000 })
+    driver.pragma('journal_mode = WAL')
+    driver.exec(REGISTRY_SCHEMA)
+    return driver
   } catch (error) {
     throwIfNativeBindingError(error, 'machine agent registry')
     throw error
@@ -210,7 +209,7 @@ export function getMachineAgents(filters?: {
 
     sql += ' ORDER BY last_seen_at DESC'
 
-    const rows = db.prepare(sql).all(...params) as MachineAgentRow[]
+    const rows = db.prepare<MachineAgentRow>(sql).all(...params)
     return rows.map(rowToMachineAgent)
   } finally {
     db.close()
@@ -226,9 +225,9 @@ export function getMachineAgent(
 ): MachineAgent | undefined {
   const db = openMachineRegistry()
   try {
-    const row = db.prepare(
+    const row = db.prepare<MachineAgentRow>(
       'SELECT * FROM agents WHERE agent_name = ? AND project_path = ?'
-    ).get(agentName, projectPath) as MachineAgentRow | undefined
+    ).get(agentName, projectPath)
     return row ? rowToMachineAgent(row) : undefined
   } finally {
     db.close()

--- a/apps/cli/src/lib/session-store.ts
+++ b/apps/cli/src/lib/session-store.ts
@@ -11,7 +11,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
-import Database from 'better-sqlite3'
+import { type DatabaseDriver, openDriver } from './database/driver.js'
 import { execSync } from 'node:child_process'
 
 // =============================================================================
@@ -77,10 +77,10 @@ function getDbPath(): string {
 // =============================================================================
 
 export class SessionStore {
-  private db: Database.Database
+  private db: DatabaseDriver
 
   constructor(dbPath?: string) {
-    this.db = new Database(dbPath ?? getDbPath())
+    this.db = openDriver(dbPath ?? getDbPath(), { foreignKeys: false })
     this.ensureSchema()
   }
 
@@ -140,9 +140,9 @@ export class SessionStore {
    * Get a session by ID or agent name.
    */
   get(idOrName: string): SessionRecord | null {
-    const row = this.db.prepare(
+    const row = this.db.prepare<SessionRow>(
       `SELECT * FROM sessions WHERE id = ? OR agent_name = ? ORDER BY started_at DESC LIMIT 1`
-    ).get(idOrName, idOrName) as SessionRow | undefined
+    ).get(idOrName, idOrName)
 
     return row ? rowToSession(row) : null
   }
@@ -151,9 +151,9 @@ export class SessionStore {
    * Get a session by tmux session name.
    */
   getBySessionName(sessionName: string): SessionRecord | null {
-    const row = this.db.prepare(
+    const row = this.db.prepare<SessionRow>(
       `SELECT * FROM sessions WHERE session_name = ? ORDER BY started_at DESC LIMIT 1`
-    ).get(sessionName) as SessionRow | undefined
+    ).get(sessionName)
 
     return row ? rowToSession(row) : null
   }
@@ -164,13 +164,13 @@ export class SessionStore {
   list(status?: SessionRecord['status']): SessionRecord[] {
     let rows: SessionRow[]
     if (status) {
-      rows = this.db.prepare(
+      rows = this.db.prepare<SessionRow>(
         `SELECT * FROM sessions WHERE status = ? ORDER BY started_at DESC`
-      ).all(status) as SessionRow[]
+      ).all(status)
     } else {
-      rows = this.db.prepare(
+      rows = this.db.prepare<SessionRow>(
         `SELECT * FROM sessions ORDER BY started_at DESC`
-      ).all() as SessionRow[]
+      ).all()
     }
 
     return rows.map(rowToSession)


### PR DESCRIPTION
## Summary

- Replaces direct `import Database from 'better-sqlite3'` with `import { openDriver } from '../database/driver.js'` in 4 lib files that PR #919 missed:
  - `session-store.ts` — global session tracking
  - `registry/index.ts` — machine-level agent registry
  - `dashboard/data.ts` — dashboard data aggregation
  - `pmo/find-pmo.ts` — PMO directory resolution
- Uses `openDriver()` factory + `DatabaseDriver` interface instead of `new Database()` directly
- Leverages generic type parameters on `prepare<T>()` to maintain type safety

## Why

PR #919 introduced the `DatabaseDriver` abstraction but left these 4 files importing `better-sqlite3` directly. This blocks PRLT-1074 (sql.js swap) because the whole point of the abstraction is to have only one file (`driver.ts`) that knows about the concrete SQLite implementation.

## Test plan

- [x] TypeScript build passes (`pnpm build`)
- [x] Unit tests pass (3 pre-existing failures unrelated to this change)
- [x] No behavioral change — `openDriver()` wraps the same `better-sqlite3` underneath

Closes PRLT-1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)