### PR TITLE
PRLT-1090: prlt CLI must work inside agent containers — fix directory walkup and HQ paths

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -40,6 +40,12 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
     return
   }
 
+  // Skip when running inside an agent container — the container has
+  // its own HQ context and should not trigger first-time user flows
+  if (process.env.PRLT_AGENT_NAME) {
+    return
+  }
+
   // Skip init redirect when explicitly disabled (e.g., e2e test isolation)
   if (process.env.PRLT_SKIP_INIT_REDIRECT === '1') {
     return

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -37,6 +37,7 @@ import { getGitIdentity } from '../pr/index.js';
 import { getPMOContext } from '../pmo/index.js';
 import { resolveRemoteUrl } from '../repos/git.js';
 import { getClaudeCodeVersion } from '../workspace-config.js';
+import { isContainerEnvironment, tryMkdir } from '../container.js';
 
 /**
  * Resolve the directory for an agent, cascading through resolution strategies.
@@ -135,8 +136,10 @@ export function getWorkspaceInfo(): WorkspaceInfo {
       try {
         const config = getWorkspaceConfig(hqPath);
         if (config) {
-          // Discover agents on disk and sync with database
-          discoverAgentsOnDisk(hqPath);
+          // Skip agent discovery in container environments — HQ may be read-only
+          if (!isContainerEnvironment()) {
+            discoverAgentsOnDisk(hqPath);
+          }
           const agents = getWorkspaceAgents(hqPath);
           const repositories = getWorkspaceRepositories(hqPath);
           const activeTheme = getActiveTheme(hqPath);
@@ -175,8 +178,10 @@ export function getWorkspaceInfo(): WorkspaceInfo {
       try {
         const config = getWorkspaceConfig(currentDir);
         if (config) {
-          // Discover agents on disk and sync with database
-          discoverAgentsOnDisk(currentDir);
+          // Skip agent discovery in container environments — HQ may be read-only
+          if (!isContainerEnvironment()) {
+            discoverAgentsOnDisk(currentDir);
+          }
           const agents = getWorkspaceAgents(currentDir);
           const repositories = getWorkspaceRepositories(currentDir);
           const activeTheme = getActiveTheme(currentDir);
@@ -626,15 +631,21 @@ export async function createEphemeralAgent(
     const baseName = extractBaseName(agentName);
 
     // Create temp agents directory if it doesn't exist
-    if (!fs.existsSync(tempAgentsBasePath)) {
-      fs.mkdirSync(tempAgentsBasePath, { recursive: true });
+    if (!tryMkdir(tempAgentsBasePath, 'ephemeral agents base')) {
+      throw new Error(
+        `Cannot create ephemeral agents directory: ${tempAgentsBasePath}\n` +
+        'The directory may be read-only. Agent creation requires write access to HQ.'
+      );
     }
 
     const agentDir = path.join(tempAgentsBasePath, agentName);
 
     // Create agent directory
-    if (!fs.existsSync(agentDir)) {
-      fs.mkdirSync(agentDir, { recursive: true });
+    if (!tryMkdir(agentDir, 'ephemeral agent')) {
+      throw new Error(
+        `Cannot create agent directory: ${agentDir}\n` +
+        'The directory may be read-only. Agent creation requires write access to HQ.'
+      );
     }
 
     // Create worktrees/clones for each repository

--- a/apps/cli/src/lib/container.ts
+++ b/apps/cli/src/lib/container.ts
@@ -1,0 +1,78 @@
+/**
+ * Container environment detection and read-only mode utilities.
+ *
+ * When running inside an agent container (devcontainer), the HQ directory
+ * is typically mounted read-only. The CLI should operate in a degraded
+ * mode that avoids writing to HQ paths.
+ *
+ * Detection signals:
+ * - PRLT_AGENT_NAME env var is set (agent is running in a container)
+ * - DEVCONTAINER=true env var is set (running inside a devcontainer)
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Check if the CLI is running inside a container environment.
+ *
+ * Returns true when PRLT_AGENT_NAME is set or DEVCONTAINER=true,
+ * indicating the process is inside an agent container where HQ
+ * may be read-only.
+ */
+export function isContainerEnvironment(): boolean {
+  return !!(process.env.PRLT_AGENT_NAME || process.env.DEVCONTAINER === 'true')
+}
+
+/**
+ * Check if a given path is part of a read-only HQ mount in a container.
+ *
+ * Returns true only when:
+ * 1. We're inside a container (PRLT_AGENT_NAME or DEVCONTAINER=true)
+ * 2. PRLT_HQ_PATH is set
+ * 3. The given path is at or under PRLT_HQ_PATH
+ *
+ * This prevents local/test databases from being accidentally treated
+ * as read-only while ensuring the mounted HQ database is opened safely.
+ */
+export function isReadOnlyHQMount(targetPath: string): boolean {
+  if (!isContainerEnvironment()) return false
+
+  const hqPath = process.env.PRLT_HQ_PATH
+  if (!hqPath) return false
+
+  const normalizedTarget = path.resolve(targetPath)
+  const normalizedHQ = path.resolve(hqPath)
+
+  return normalizedTarget === normalizedHQ || normalizedTarget.startsWith(normalizedHQ + '/')
+}
+
+/**
+ * Attempt to create a directory, logging a warning instead of crashing
+ * if the operation fails with a permission error.
+ *
+ * @param dirPath - Directory path to create
+ * @param label  - Human-readable label for warning messages
+ * @returns true if directory exists or was created, false if creation failed
+ */
+export function tryMkdir(dirPath: string, label?: string): boolean {
+  if (fs.existsSync(dirPath)) {
+    return true
+  }
+
+  try {
+    fs.mkdirSync(dirPath, { recursive: true })
+    return true
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'EACCES' || code === 'EROFS' || code === 'EPERM') {
+      const tag = label ? ` (${label})` : ''
+      // In container mode this is expected — only warn when not in a container
+      if (!isContainerEnvironment()) {
+        console.warn(`Warning: Could not create directory${tag}: ${dirPath} (${code})`)
+      }
+      return false
+    }
+    throw err
+  }
+}

--- a/apps/cli/src/lib/database/driver.ts
+++ b/apps/cli/src/lib/database/driver.ts
@@ -156,9 +156,12 @@ export function wrapDatabase(db: Database.Database): DatabaseDriver {
  * Create a DatabaseDriver by opening a new better-sqlite3 connection.
  * Configures standard pragmas (WAL mode, foreign keys, busy timeout).
  */
-export function openDriver(dbPath: string, options?: { foreignKeys?: boolean; busyTimeout?: number }): DatabaseDriver {
-  const db = new Database(dbPath)
-  db.pragma('journal_mode = WAL')
+export function openDriver(dbPath: string, options?: { foreignKeys?: boolean; busyTimeout?: number; readonly?: boolean }): DatabaseDriver {
+  const readOnly = options?.readonly ?? false
+  const db = new Database(dbPath, readOnly ? { readonly: true } : undefined)
+  if (!readOnly) {
+    db.pragma('journal_mode = WAL')
+  }
   if (options?.foreignKeys !== false) {
     db.pragma('foreign_keys = ON')
   }

--- a/apps/cli/src/lib/database/workspace.ts
+++ b/apps/cli/src/lib/database/workspace.ts
@@ -8,6 +8,7 @@ import Database from 'better-sqlite3'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { isEphemeralAgentName } from '../themes.js'
+import { isReadOnlyHQMount } from '../container.js'
 import { throwIfNativeBindingError } from './native-validation.js'
 import { runDrizzleMigrations } from './migrator.js'
 import { ALL_MIGRATIONS } from './migrations/index.js'
@@ -103,60 +104,73 @@ export function getConfigPath(workspacePath: string): string {
  * - Enables WAL journal mode for corruption resistance
  * - Runs a quick integrity check; auto-repairs if corruption detected
  */
-export function openWorkspaceDatabase(workspacePath: string): Database.Database {
+export function openWorkspaceDatabase(workspacePath: string, options?: { readonly?: boolean }): Database.Database {
   const dbPath = getDatabasePath(workspacePath)
 
   if (!fs.existsSync(dbPath)) {
     throw new Error(`Database not found: ${dbPath}. Run 'prlt new' first.`)
   }
 
-  // Auto-backup before opening (cheap insurance against corruption)
-  createRotatingBackup(dbPath)
+  // Determine if we should open read-only.
+  // In container environments, the HQ mount at PRLT_HQ_PATH is typically
+  // read-only. We detect this by checking if the workspace path matches
+  // the HQ path AND we're in a container. This avoids accidentally opening
+  // local/test databases as read-only.
+  const readOnly = options?.readonly ?? isReadOnlyHQMount(workspacePath)
+
+  if (!readOnly) {
+    // Auto-backup before opening (cheap insurance against corruption)
+    createRotatingBackup(dbPath)
+  }
 
   let db: Database.Database
   try {
-    db = new Database(dbPath)
+    db = new Database(dbPath, readOnly ? { readonly: true } : undefined)
   } catch (error) {
     throwIfNativeBindingError(error, 'openWorkspaceDatabase')
     throw error
   }
 
-  // Enable WAL mode — allows concurrent readers with one writer,
-  // significantly more resistant to corruption than journal_mode=delete
-  enableWALMode(db)
+  if (!readOnly) {
+    // Enable WAL mode — allows concurrent readers with one writer,
+    // significantly more resistant to corruption than journal_mode=delete
+    enableWALMode(db)
+  }
   db.pragma('foreign_keys = ON')
   db.pragma('busy_timeout = 5000')
 
-  // Quick integrity check on startup
-  const integrity = quickCheckIntegrity(db)
-  if (!integrity.ok) {
-    db.close()
+  if (!readOnly) {
+    // Quick integrity check on startup
+    const integrity = quickCheckIntegrity(db)
+    if (!integrity.ok) {
+      db.close()
 
-    // Attempt auto-repair
-    const repair = repairDatabase(dbPath)
-    if (!repair.success) {
-      throw new Error(
-        `Database corruption detected in ${dbPath}.\n` +
-        `Integrity errors: ${integrity.errors.join('; ')}\n` +
-        `Auto-repair failed: ${repair.message}\n` +
-        `Run 'prlt db repair' for manual recovery options.`
-      )
+      // Attempt auto-repair
+      const repair = repairDatabase(dbPath)
+      if (!repair.success) {
+        throw new Error(
+          `Database corruption detected in ${dbPath}.\n` +
+          `Integrity errors: ${integrity.errors.join('; ')}\n` +
+          `Auto-repair failed: ${repair.message}\n` +
+          `Run 'prlt db repair' for manual recovery options.`
+        )
+      }
+
+      // Re-open the repaired database
+      try {
+        db = new Database(dbPath)
+      } catch (error) {
+        throwIfNativeBindingError(error, 'openWorkspaceDatabase (post-repair)')
+        throw error
+      }
+      enableWALMode(db)
+      db.pragma('foreign_keys = ON')
+      db.pragma('busy_timeout = 5000')
     }
 
-    // Re-open the repaired database
-    try {
-      db = new Database(dbPath)
-    } catch (error) {
-      throwIfNativeBindingError(error, 'openWorkspaceDatabase (post-repair)')
-      throw error
-    }
-    enableWALMode(db)
-    db.pragma('foreign_keys = ON')
-    db.pragma('busy_timeout = 5000')
+    runDrizzleMigrations(db, ALL_MIGRATIONS)
+    ensureEphemeralAgentTypes(db)
   }
-
-  runDrizzleMigrations(db, ALL_MIGRATIONS)
-  ensureEphemeralAgentTypes(db)
 
   return db
 }

--- a/apps/cli/src/lib/init/index.ts
+++ b/apps/cli/src/lib/init/index.ts
@@ -285,17 +285,15 @@ export async function promptForOrganization(): Promise<string> {
 export function createHQStructure(hqPath: string, hqName: string, themeId?: string, quiet?: boolean): void {
   if (!quiet) console.log(chalk.blue(`\n🏗️  Creating HQ at ${hqPath}...`));
 
-  // Get theme-specific directory names
-  const persistentDir = getThemePersistentDir(themeId);
-  const ephemeralDir = getThemeEphemeralDir(themeId);
-
-  // Create directories
+  // Create core directories (required for HQ to function)
   fs.mkdirSync(hqPath, { recursive: true });
   fs.mkdirSync(path.join(hqPath, '.proletariat'), { recursive: true });
   fs.mkdirSync(path.join(hqPath, 'repos'), { recursive: true });
-  fs.mkdirSync(path.join(hqPath, 'agents'), { recursive: true });
-  fs.mkdirSync(path.join(hqPath, 'agents', persistentDir), { recursive: true });
-  fs.mkdirSync(path.join(hqPath, 'agents', ephemeralDir), { recursive: true });
+
+  // Agent directories are created lazily when agents are actually
+  // added (in createAgentWorktrees / createEphemeralAgent), not
+  // eagerly here. This avoids permission errors in container
+  // environments where HQ may be read-only.
 }
 
 /**

--- a/apps/cli/src/lib/pmo/find-pmo.ts
+++ b/apps/cli/src/lib/pmo/find-pmo.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { openDriver } from '../database/driver.js';
 import { isValidHQ } from '../workspace.js';
+import { isReadOnlyHQMount } from '../container.js';
 import { throwIfNativeBindingError } from '../database/native-validation.js';
 
 /**
@@ -47,7 +48,7 @@ function hasPMOTables(dbPath: string): boolean {
   }
 
   try {
-    const driver = openDriver(dbPath, { foreignKeys: false });
+    const driver = openDriver(dbPath, { foreignKeys: false, readonly: isReadOnlyHQMount(path.dirname(path.dirname(dbPath))) });
     const result = driver.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_projects'"
     ).get();
@@ -102,7 +103,7 @@ export function findPMO(): string | null {
           if (hasTables) {
             // Read PMO path from database (new behavior)
             try {
-              const driver = openDriver(dbPath, { foreignKeys: false });
+              const driver = openDriver(dbPath, { foreignKeys: false, readonly: isReadOnlyHQMount(path.dirname(path.dirname(dbPath))) });
               const result = driver.prepare('SELECT value FROM pmo_settings WHERE key = ?').get('pmo_path') as { value: string } | undefined;
               driver.close();
 
@@ -154,7 +155,7 @@ export function findPMO(): string | null {
         const dbPath = path.join(activeHqPath, '.proletariat', 'workspace.db');
         if (hasPMOTables(dbPath)) {
           try {
-            const driver = openDriver(dbPath, { foreignKeys: false });
+            const driver = openDriver(dbPath, { foreignKeys: false, readonly: isReadOnlyHQMount(path.dirname(path.dirname(dbPath))) });
             const result = driver.prepare('SELECT value FROM pmo_settings WHERE key = ?').get('pmo_path') as { value: string } | undefined;
             driver.close();
 

--- a/apps/cli/test/unit/container-environment.test.ts
+++ b/apps/cli/test/unit/container-environment.test.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { isContainerEnvironment, tryMkdir } from '../../src/lib/container.js'
+
+describe('container environment detection', () => {
+  const originalEnv = { ...process.env }
+
+  afterEach(() => {
+    // Restore environment
+    process.env = { ...originalEnv }
+  })
+
+  describe('isContainerEnvironment', () => {
+    it('should return false when no container env vars are set', () => {
+      delete process.env.PRLT_AGENT_NAME
+      delete process.env.DEVCONTAINER
+      expect(isContainerEnvironment()).to.be.false
+    })
+
+    it('should return true when PRLT_AGENT_NAME is set', () => {
+      process.env.PRLT_AGENT_NAME = 'test-agent'
+      delete process.env.DEVCONTAINER
+      expect(isContainerEnvironment()).to.be.true
+    })
+
+    it('should return true when DEVCONTAINER=true', () => {
+      delete process.env.PRLT_AGENT_NAME
+      process.env.DEVCONTAINER = 'true'
+      expect(isContainerEnvironment()).to.be.true
+    })
+
+    it('should return false when DEVCONTAINER is set to something other than true', () => {
+      delete process.env.PRLT_AGENT_NAME
+      process.env.DEVCONTAINER = 'false'
+      expect(isContainerEnvironment()).to.be.false
+    })
+
+    it('should return true when both PRLT_AGENT_NAME and DEVCONTAINER are set', () => {
+      process.env.PRLT_AGENT_NAME = 'test-agent'
+      process.env.DEVCONTAINER = 'true'
+      expect(isContainerEnvironment()).to.be.true
+    })
+  })
+
+  describe('tryMkdir', () => {
+    let tmpDir: string
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-container-test-'))
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('should return true when directory already exists', () => {
+      expect(tryMkdir(tmpDir, 'test')).to.be.true
+    })
+
+    it('should create directory and return true when path is writable', () => {
+      const newDir = path.join(tmpDir, 'new-subdir')
+      expect(fs.existsSync(newDir)).to.be.false
+      expect(tryMkdir(newDir, 'test')).to.be.true
+      expect(fs.existsSync(newDir)).to.be.true
+    })
+
+    it('should create nested directories with recursive flag', () => {
+      const nested = path.join(tmpDir, 'a', 'b', 'c')
+      expect(tryMkdir(nested, 'test')).to.be.true
+      expect(fs.existsSync(nested)).to.be.true
+    })
+
+    it('should return false when directory creation fails with EACCES', () => {
+      // Create a read-only directory
+      const readOnlyDir = path.join(tmpDir, 'readonly')
+      fs.mkdirSync(readOnlyDir)
+      fs.chmodSync(readOnlyDir, 0o444)
+
+      const result = tryMkdir(path.join(readOnlyDir, 'child'), 'test')
+      expect(result).to.be.false
+
+      // Restore write permission for cleanup
+      fs.chmodSync(readOnlyDir, 0o755)
+    })
+
+    it('should throw on non-permission errors', () => {
+      // Path with null byte is invalid and throws ENOENT-style error
+      expect(() => tryMkdir('/dev/null/impossible/path\0', 'test')).to.throw()
+    })
+  })
+})

--- a/apps/cli/test/unit/regression-prlt1090-container-readonly.test.ts
+++ b/apps/cli/test/unit/regression-prlt1090-container-readonly.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Regression test for PRLT-1090
+ *
+ * Verifies that the CLI can open workspace databases in read-only mode
+ * when running inside agent containers, preventing EACCES errors on
+ * read-only HQ mounts.
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { openWorkspaceDatabase } from '../../src/lib/database/workspace.js'
+import { runDrizzleMigrations } from '../../src/lib/database/migrator.js'
+import { ALL_MIGRATIONS } from '../../src/lib/database/migrations/index.js'
+
+describe('PRLT-1090: container read-only database access', () => {
+  const originalEnv = { ...process.env }
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-1090-'))
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function createTestWorkspace(workspacePath: string): void {
+    const proletariatDir = path.join(workspacePath, '.proletariat')
+    fs.mkdirSync(proletariatDir, { recursive: true })
+
+    const dbPath = path.join(proletariatDir, 'workspace.db')
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    db.pragma('foreign_keys = ON')
+    runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+    // Insert workspace config row
+    db.exec(`
+      INSERT OR IGNORE INTO workspace (id, type, workspace_name, has_pmo, created_at)
+      VALUES (1, 'hq', 'test-hq', 0, datetime('now'))
+    `)
+
+    // Checkpoint WAL to main database file so read-only opens work
+    db.pragma('wal_checkpoint(TRUNCATE)')
+    db.close()
+
+    // Write config.json
+    fs.writeFileSync(
+      path.join(proletariatDir, 'config.json'),
+      JSON.stringify({ version: '1.0.0', type: 'hq', schemaVersion: 1 })
+    )
+  }
+
+  /**
+   * Simulate container environment by setting env vars.
+   * PRLT_HQ_PATH must point to the workspace for read-only detection to trigger.
+   */
+  function simulateContainer(hqPath: string): void {
+    process.env.PRLT_AGENT_NAME = 'test-agent-1'
+    process.env.DEVCONTAINER = 'true'
+    process.env.PRLT_HQ_PATH = hqPath
+  }
+
+  it('should open database read-only when in container with matching PRLT_HQ_PATH', () => {
+    createTestWorkspace(tmpDir)
+    simulateContainer(tmpDir)
+
+    const db = openWorkspaceDatabase(tmpDir)
+    expect(db).to.exist
+
+    // Should be able to read
+    const row = db.prepare('SELECT workspace_name FROM workspace WHERE id = 1').get() as { workspace_name: string }
+    expect(row.workspace_name).to.equal('test-hq')
+
+    db.close()
+  })
+
+  it('should not create backup files in container mode', () => {
+    createTestWorkspace(tmpDir)
+    simulateContainer(tmpDir)
+
+    const db = openWorkspaceDatabase(tmpDir)
+    db.close()
+
+    // Verify no backup files were created
+    const dbDir = path.join(tmpDir, '.proletariat')
+    const files = fs.readdirSync(dbDir)
+    const backupFiles = files.filter(f => f.includes('.backup.'))
+    expect(backupFiles).to.have.length(0)
+  })
+
+  it('should reject writes in container mode (read-only db)', () => {
+    createTestWorkspace(tmpDir)
+    simulateContainer(tmpDir)
+
+    const db = openWorkspaceDatabase(tmpDir)
+
+    // Attempting to write should fail
+    expect(() => {
+      db.exec("UPDATE workspace SET workspace_name = 'modified' WHERE id = 1")
+    }).to.throw(/readonly/)
+
+    db.close()
+  })
+
+  it('should succeed with read-only .proletariat dir in container mode', () => {
+    // Create workspace with journal_mode=delete so no WAL/SHM files are needed.
+    const proletariatDir = path.join(tmpDir, '.proletariat')
+    fs.mkdirSync(proletariatDir, { recursive: true })
+
+    const dbPath = path.join(proletariatDir, 'workspace.db')
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = delete')
+    db.pragma('foreign_keys = ON')
+    runDrizzleMigrations(db, ALL_MIGRATIONS)
+    db.exec(`
+      INSERT OR IGNORE INTO workspace (id, type, workspace_name, has_pmo, created_at)
+      VALUES (1, 'hq', 'test-hq', 0, datetime('now'))
+    `)
+    db.close()
+
+    fs.writeFileSync(
+      path.join(proletariatDir, 'config.json'),
+      JSON.stringify({ version: '1.0.0', type: 'hq', schemaVersion: 1 })
+    )
+
+    // Make .proletariat read-only to simulate container mount
+    fs.chmodSync(dbPath, 0o444)
+    fs.chmodSync(path.join(proletariatDir, 'config.json'), 0o444)
+    fs.chmodSync(proletariatDir, 0o555)
+
+    simulateContainer(tmpDir)
+
+    try {
+      const rodb = openWorkspaceDatabase(tmpDir)
+      expect(rodb).to.exist
+
+      const row = rodb.prepare('SELECT workspace_name FROM workspace WHERE id = 1').get() as { workspace_name: string }
+      expect(row.workspace_name).to.equal('test-hq')
+
+      rodb.close()
+    } finally {
+      // Restore permissions for cleanup
+      fs.chmodSync(proletariatDir, 0o755)
+      fs.chmodSync(dbPath, 0o644)
+      fs.chmodSync(path.join(proletariatDir, 'config.json'), 0o644)
+    }
+  })
+
+  it('should open writable database when not in container', () => {
+    createTestWorkspace(tmpDir)
+
+    // Ensure container env vars are not set
+    delete process.env.PRLT_AGENT_NAME
+    delete process.env.DEVCONTAINER
+    delete process.env.PRLT_HQ_PATH
+
+    const db = openWorkspaceDatabase(tmpDir)
+    expect(db).to.exist
+
+    // Should create backup files
+    const dbDir = path.join(tmpDir, '.proletariat')
+    const files = fs.readdirSync(dbDir)
+    const backupFiles = files.filter(f => f.includes('.backup.'))
+    expect(backupFiles.length).to.be.greaterThan(0)
+
+    db.close()
+  })
+
+  it('should open writable database in container when path does not match PRLT_HQ_PATH', () => {
+    createTestWorkspace(tmpDir)
+
+    // Set container env but with a different HQ path
+    process.env.PRLT_AGENT_NAME = 'test-agent-1'
+    process.env.DEVCONTAINER = 'true'
+    process.env.PRLT_HQ_PATH = '/some/other/hq'
+
+    const db = openWorkspaceDatabase(tmpDir)
+    expect(db).to.exist
+
+    // Should create backup files since this is not the read-only HQ mount
+    const dbDir = path.join(tmpDir, '.proletariat')
+    const files = fs.readdirSync(dbDir)
+    const backupFiles = files.filter(f => f.includes('.backup.'))
+    expect(backupFiles.length).to.be.greaterThan(0)
+
+    db.close()
+  })
+
+  it('should support explicit readonly option override', () => {
+    createTestWorkspace(tmpDir)
+
+    // Not in container, but explicitly request readonly
+    delete process.env.PRLT_AGENT_NAME
+    delete process.env.DEVCONTAINER
+
+    const db = openWorkspaceDatabase(tmpDir, { readonly: true })
+    expect(db).to.exist
+
+    expect(() => {
+      db.exec("UPDATE workspace SET workspace_name = 'modified' WHERE id = 1")
+    }).to.throw(/readonly/)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-1090: prlt CLI must work inside agent containers — fix directory walkup and HQ paths

## Description

## Problem

When agents run `prlt` commands inside containers, they fail with:

```
Error: EACCES: permission denied, mkdir '/hq/agents/temp'
```

## Root Cause

The CLI eagerly ensures the full HQ directory structure on every command — including `agents/temp/` — even when the command doesn't need agent directories.

Flow:

1. Agent runs `prlt ticket show TKT-241` inside container
2. CLI init hook resolves HQ to `/hq/` (via `PRLT_HQ_PATH` env var or directory walkup)
3. CLI calls `createHQStructure()` or directory-ensure logic which tries to `mkdir('/hq/agents/temp')`
4. `/hq/` is read-only or permissions don't allow creating subdirectories → EACCES
5. Command fails before it even runs

Relevant code:

* `lib/init/index.ts` lines 285-299: `createHQStructure()` eagerly creates agents/staff/ and agents/temp/
* `lib/database/index.ts` lines 856-945: `discoverAgentsOnDisk()` scans agents directories before workspace commands
* `lib/workspace.ts` lines 41-108: `findHQRoot()` resolves HQ via env var, walkup, or machine config

## Fix

Two-part fix:

### 1\. Lazy directory creation

Don't eagerly create the full HQ directory tree on every command. Only create directories when they're actually needed:

* `agents/temp/` → only in `createEphemeralAgent()` (already does this)
* `agents/staff/` → only in `createAgentWorktrees()`
* Stop calling `createHQStructure()` or ensure-directory logic in the init hook

### 2\. Container-aware mode

When running inside a container (detected via `PRLT_AGENT_NAME` env var or `DEVCONTAINER=true`):

* Skip directory structure enforcement entirely
* Operate in read-only mode against HQ if mounted
* Don't try to create/modify anything under `/hq/` — the container should only need to READ workspace config and the database
* Commands like `prlt ticket show`, `prlt session report` should work without write access to HQ

### 3\. Graceful degradation

If `mkdir` fails on a non-critical directory, log a warning and continue instead of crashing. Not every command needs `agents/temp/` to exist.

## Related

* PRLT-1088: Agent containers should include workspace context in prompt
* PRLT-1089: Tmux session not launching
* PRLT-1086: prlt do composable command

## External Issue Context

- Source: linear
- External key: PRLT-1090
- External id: 08fca4c7-b44d-425d-96ea-56f6fb723b2e
- URL: https://linear.app/proletariat/issue/PRLT-1090/prlt-cli-must-work-inside-agent-containers-fix-directory-walkup-and-hq
- Status: Backlog
- Priority: P0
- Labels: None

## Changes

- b641ecd9 feat(PRLT-1090): scope read-only DB mode to HQ mount path to avoid affecting local databases
- 85362f8d feat(PRLT-1090): fix container EACCES by adding read-only DB mode and lazy dir creation

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
