### PR TITLE
chore: bump version to 0.3.91

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.90",
+  "version": "0.3.91",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Version bump. Includes PRLT-1074 (sql.js), PRLT-1092, PRLT-1088, PRLT-1089, PRLT-1087.