### PR TITLE
PRLT-1095: Agent GitHub tokens need workflow scope to push CI file changes

### DIFF
--- a/apps/cli/src/commands/gh/login.ts
+++ b/apps/cli/src/commands/gh/login.ts
@@ -80,7 +80,8 @@ export default class GHLogin extends Command {
     this.log(styles.muted('Starting GitHub authentication...\n'));
 
     // Run gh auth login interactively - track for cleanup on Ctrl+C
-    const child = spawn('gh', ['auth', 'login'], {
+    // PRLT-1095: Request 'workflow' scope so agents can push .github/workflows/ changes
+    const child = spawn('gh', ['auth', 'login', '-s', 'workflow'], {
       stdio: 'inherit',
       shell: true,
     });

--- a/apps/cli/src/commands/gh/status.ts
+++ b/apps/cli/src/commands/gh/status.ts
@@ -2,6 +2,7 @@ import { Command } from '@oclif/core';
 import chalk from 'chalk';
 import { styles } from '../../lib/styles.js';
 import { isGHInstalled, isGHAuthenticated, getGHUsername, isGHTokenInEnv } from '../../lib/pr/index.js';
+import { hasWorkflowScope } from '../../lib/execution/runners/shared.js';
 import {
   isMachineOutput,
   outputSuccessAsJson,
@@ -31,6 +32,7 @@ export default class GHStatus extends Command {
     const ghAuthenticated = ghInstalled && isGHAuthenticated();
     const username = ghAuthenticated ? getGHUsername() : null;
     const ghTokenSet = isGHTokenInEnv();
+    const workflowScope = ghAuthenticated ? hasWorkflowScope() : false;
 
     // In JSON mode, output status as JSON
     if (jsonMode) {
@@ -40,6 +42,7 @@ export default class GHStatus extends Command {
           ghAuthenticated,
           username,
           ghTokenSet,
+          workflowScope,
           ready: ghInstalled && ghAuthenticated && ghTokenSet,
         },
         createMetadata('gh status', flags)
@@ -76,14 +79,28 @@ export default class GHStatus extends Command {
     // Check if GH_TOKEN is available for devcontainers
     if (ghTokenSet) {
       this.log(chalk.green('  ✓ GH_TOKEN available for devcontainers'));
-      this.log(styles.muted(''));
-      this.log(chalk.green('All set! PR creation will work in both host and devcontainers.'));
     } else {
       this.log(chalk.yellow('  ⚠ GH_TOKEN not set'));
       this.log(styles.muted(''));
       this.log(styles.muted('    PR creation works on host, but not in devcontainers.'));
       this.log(styles.muted('    Run to see setup instructions:'));
       this.log(chalk.cyan('      prlt gh token'));
+    }
+
+    // PRLT-1095: Check workflow scope for CI file modifications
+    if (workflowScope) {
+      this.log(chalk.green('  ✓ Token has workflow scope (can push CI changes)'));
+    } else {
+      this.log(chalk.yellow('  ⚠ Token missing workflow scope'));
+      this.log(styles.muted(''));
+      this.log(styles.muted('    Agents cannot push changes to .github/workflows/ files.'));
+      this.log(styles.muted('    Add the workflow scope:'));
+      this.log(chalk.cyan('      gh auth refresh -h github.com -s workflow'));
+    }
+
+    if (ghTokenSet && workflowScope) {
+      this.log(styles.muted(''));
+      this.log(chalk.green('All set! PR creation and CI changes will work in devcontainers.'));
     }
   }
 }

--- a/apps/cli/src/lib/execution/runners/devcontainer.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer.ts
@@ -33,6 +33,7 @@ import {
   checkDockerDaemon,
   ensureDockerContainer,
   copyClaudeCredentials,
+  ensureWorkflowScope,
 } from './shared.js'
 
 import { runDevcontainerInTmux } from './devcontainer-tmux.js'
@@ -216,6 +217,15 @@ export async function runDevcontainer(
         }
       } catch (err) {
         console.debug('[runners:docker] gh auth token failed:', err)
+      }
+    }
+
+    // PRLT-1095: Ensure token has workflow scope for pushing .github/workflows/ changes.
+    // Without this scope, agents cannot update CI files even when the ticket requires it.
+    if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
+      const hasScope = ensureWorkflowScope()
+      if (!hasScope) {
+        console.debug('[runners:docker] WARNING: GitHub token lacks workflow scope. Agents will not be able to push changes to .github/workflows/ files. Run: gh auth refresh -h github.com -s workflow')
       }
     }
 

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -155,6 +155,122 @@ export function isGitHubTokenAvailable(): boolean {
 }
 
 // =============================================================================
+// GitHub Token Scopes (PRLT-1095)
+// =============================================================================
+
+/**
+ * Get the OAuth scopes of the current GitHub token.
+ * Parses `gh auth status` output to extract the "Token scopes:" line.
+ * Returns an array of scope strings (e.g. ['repo', 'workflow']).
+ */
+export function getGitHubTokenScopes(): string[] {
+  try {
+    // gh auth status writes to stderr
+    const output = execSync('gh auth status', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 })
+    return parseScopesFromAuthStatus(output)
+  } catch (error: unknown) {
+    // gh auth status exits non-zero when not authenticated, but still writes status to stderr
+    const stderr = (error as { stderr?: string })?.stderr || ''
+    if (stderr) {
+      return parseScopesFromAuthStatus(stderr)
+    }
+    return []
+  }
+}
+
+/**
+ * Parse scope strings from gh auth status output.
+ * Handles both active and inactive account entries — returns scopes from the active account.
+ */
+export function parseScopesFromAuthStatus(output: string): string[] {
+  const lines = output.split('\n')
+  let inActiveAccount = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Track whether we're in the active account block
+    if (trimmed.startsWith('- Active account: true')) {
+      inActiveAccount = true
+      continue
+    }
+    if (trimmed.startsWith('- Active account: false')) {
+      inActiveAccount = false
+      continue
+    }
+
+    // Only parse scopes from the active account
+    if (inActiveAccount && trimmed.startsWith('- Token scopes:')) {
+      const scopePart = trimmed.replace('- Token scopes:', '').trim()
+      if (!scopePart || scopePart === "''") return []
+      return scopePart
+        .replace(/^'|'$/g, '')
+        .split(',')
+        .map(s => s.trim().replace(/^'|'$/g, ''))
+        .filter(Boolean)
+    }
+  }
+
+  // Fallback: if no "Active account" markers found, parse first Token scopes line
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('- Token scopes:')) {
+      const scopePart = trimmed.replace('- Token scopes:', '').trim()
+      if (!scopePart || scopePart === "''") return []
+      return scopePart
+        .replace(/^'|'$/g, '')
+        .split(',')
+        .map(s => s.trim().replace(/^'|'$/g, ''))
+        .filter(Boolean)
+    }
+  }
+
+  return []
+}
+
+/**
+ * Check if the current GitHub token has the 'workflow' scope.
+ * The workflow scope is required to push changes to .github/workflows/ files.
+ */
+export function hasWorkflowScope(): boolean {
+  const scopes = getGitHubTokenScopes()
+  return scopes.includes('workflow')
+}
+
+/**
+ * Attempt to ensure the GitHub token has workflow scope.
+ * If the current token lacks it, tries `gh auth refresh -s workflow` to add the scope.
+ * Returns true if workflow scope is (now) available, false otherwise.
+ */
+export function ensureWorkflowScope(): boolean {
+  if (hasWorkflowScope()) return true
+
+  console.debug('[runners:github] Token missing workflow scope, attempting gh auth refresh...')
+  try {
+    execSync('gh auth refresh -h github.com -s workflow', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 30000,
+    })
+    // Re-fetch the token after refresh so env vars pick up the new one
+    try {
+      const refreshedToken = execSync('gh auth token', { encoding: 'utf-8', stdio: 'pipe' }).trim()
+      if (refreshedToken) {
+        process.env.GITHUB_TOKEN = refreshedToken
+        process.env.GH_TOKEN = refreshedToken
+      }
+    } catch {
+      // Non-fatal — token refresh may have worked but re-fetch failed
+    }
+    console.debug('[runners:github] Successfully added workflow scope to token')
+    return true
+  } catch {
+    console.debug('[runners:github] Failed to refresh token with workflow scope (may require interactive auth)')
+    return false
+  }
+}
+
+// =============================================================================
 // Docker Status Check
 // =============================================================================
 

--- a/apps/cli/test/unit/runner-shared.test.ts
+++ b/apps/cli/test/unit/runner-shared.test.ts
@@ -10,6 +10,9 @@ import {
   checkDockerDaemon,
   getGitHubToken,
   isGitHubTokenAvailable,
+  getGitHubTokenScopes,
+  parseScopesFromAuthStatus,
+  hasWorkflowScope,
 } from '../../src/lib/execution/runners/shared.js'
 import type { ExecutionContext, TerminalApp } from '../../src/lib/execution/types.js'
 
@@ -213,6 +216,85 @@ describe('Runner Shared Utilities (TKT-140)', () => {
 
     it('should be consistent with getGitHubToken', () => {
       expect(isGitHubTokenAvailable()).to.equal(getGitHubToken() !== null)
+    })
+  })
+
+  // =========================================================================
+  // GitHub Token Scopes (PRLT-1095)
+  // =========================================================================
+  describe('parseScopesFromAuthStatus', () => {
+    it('should parse scopes from active account', () => {
+      const output = [
+        'github.com',
+        '  ✓ Logged in to github.com account testuser (GITHUB_TOKEN)',
+        '  - Active account: true',
+        '  - Git operations protocol: ssh',
+        '  - Token: gho_****',
+        "  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'",
+      ].join('\n')
+      const scopes = parseScopesFromAuthStatus(output)
+      expect(scopes).to.deep.equal(['gist', 'read:org', 'repo', 'workflow'])
+    })
+
+    it('should prefer active account over inactive account', () => {
+      const output = [
+        'github.com',
+        '  ✓ Logged in to github.com account user1 (GITHUB_TOKEN)',
+        '  - Active account: true',
+        '  - Token: gho_****',
+        "  - Token scopes: 'repo'",
+        '',
+        '  ✓ Logged in to github.com account user2 (hosts.yml)',
+        '  - Active account: false',
+        '  - Token: gho_****',
+        "  - Token scopes: 'repo', 'workflow'",
+      ].join('\n')
+      const scopes = parseScopesFromAuthStatus(output)
+      expect(scopes).to.deep.equal(['repo'])
+      expect(scopes).to.not.include('workflow')
+    })
+
+    it('should return empty array for no scopes', () => {
+      const output = [
+        '  - Active account: true',
+        "  - Token scopes: ''",
+      ].join('\n')
+      expect(parseScopesFromAuthStatus(output)).to.deep.equal([])
+    })
+
+    it('should return empty array for empty input', () => {
+      expect(parseScopesFromAuthStatus('')).to.deep.equal([])
+    })
+
+    it('should fall back to first Token scopes line when no Active account markers', () => {
+      const output = [
+        'github.com',
+        '  ✓ Logged in to github.com',
+        "  - Token scopes: 'repo', 'workflow'",
+      ].join('\n')
+      const scopes = parseScopesFromAuthStatus(output)
+      expect(scopes).to.deep.equal(['repo', 'workflow'])
+    })
+  })
+
+  describe('getGitHubTokenScopes', () => {
+    it('should return an array', () => {
+      const scopes = getGitHubTokenScopes()
+      expect(scopes).to.be.an('array')
+    })
+
+    it('should not throw', () => {
+      expect(() => getGitHubTokenScopes()).to.not.throw()
+    })
+  })
+
+  describe('hasWorkflowScope', () => {
+    it('should return a boolean', () => {
+      expect(hasWorkflowScope()).to.be.a('boolean')
+    })
+
+    it('should not throw', () => {
+      expect(() => hasWorkflowScope()).to.not.throw()
     })
   })
 })

--- a/specs/integrations/github.md
+++ b/specs/integrations/github.md
@@ -39,6 +39,7 @@ Displays:
 - gh CLI installation status
 - Authentication status and username
 - GH_TOKEN availability for devcontainers
+- Token workflow scope status (required for CI file changes)
 
 ### Token Setup
 
@@ -65,6 +66,36 @@ Provides shell-specific instructions for setting `GH_TOKEN` environment variable
 | GH_TOKEN | GitHub personal access token | Devcontainer PR creation |
 | GITHUB_TOKEN | Alternative token name | Some integrations |
 
+## Token Scopes
+
+The GitHub token must have the **`workflow`** scope for agents to push changes to `.github/workflows/` files. Without this scope, agents will fail when tickets require CI/CD changes.
+
+### Required Scopes
+
+| Scope | Purpose |
+|-------|---------|
+| `repo` | Push code, create PRs |
+| `workflow` | Push changes to `.github/workflows/` files |
+
+### Checking Scopes
+
+```bash
+# Check current token scopes
+gh auth status
+
+# If workflow scope is missing, add it
+gh auth refresh -h github.com -s workflow
+```
+
+### How It Works
+
+When spawning a Docker agent, `prlt` automatically:
+1. Checks if the token has the `workflow` scope
+2. Attempts `gh auth refresh -s workflow` if the scope is missing
+3. Warns if the scope cannot be added (e.g., non-interactive environment)
+
+New logins via `prlt gh login` automatically request the `workflow` scope.
+
 ## Token Setup by Shell
 
 ### Zsh (~/.zshrc)
@@ -83,6 +114,7 @@ export GH_TOKEN=$(gh auth token)
 - **Host auth sufficient**: `gh auth login` works for host operations
 - **Token for containers**: `GH_TOKEN` must be exported for devcontainer access
 - **Token refresh**: Token is dynamically fetched from gh CLI, stays current
+- **Workflow scope required**: Token must have `workflow` scope for CI file changes (PRLT-1095)
 
 ## Related Domains
 


### PR DESCRIPTION
## Summary

Resolves PRLT-1095: Agent GitHub tokens need workflow scope to push CI file changes

## Description

## Problem

Docker agents use a GitHub token (`GITHUB_TOKEN`) that lacks the `workflow` scope. This means agents cannot push changes to `.github/workflows/` files, even when the ticket requires CI changes.

Hit this on PRLT-1074 — the agent removed better-sqlite3 but couldn't update the CI workflow to remove the native binding verification steps.

## Fix

Either:

1. Generate agent tokens with `workflow` scope included
2. Or use a fine-grained PAT with `actions:write` permission
3. Or detect when an agent needs to modify workflow files and spawn on host instead

## Related

* PRLT-1074: sql.js migration (hit this issue)
* PRLT-1088: Workspace context in agent prompts

## External Issue Context

- Source: linear
- External key: PRLT-1095
- External id: 44f185a1-93b1-427c-8308-1ee405cddb5b
- URL: https://linear.app/proletariat/issue/PRLT-1095/agent-github-tokens-need-workflow-scope-to-push-ci-file-changes
- Status: Backlog
- Priority: P1
- Labels: None

## Changes

- c02e5759 feat(PRLT-1095): add workflow scope to agent GitHub tokens for CI file push support

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
