### PR TITLE
PRLT-1096: prlt orchestrate — autonomous pipeline daemon with event-driven hooks

### DIFF
--- a/apps/cli/src/commands/hook/export.ts
+++ b/apps/cli/src/commands/hook/export.ts
@@ -1,0 +1,67 @@
+/**
+ * prlt hook export — Export hook configuration to YAML.
+ *
+ * Dumps the current hook configuration from the database as YAML,
+ * suitable for saving to .proletariat/hooks.yml.
+ */
+
+import { openWorkspaceDatabase } from '../../lib/database/index.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { exportHooksToYaml } from '../../lib/orchestrate/index.js'
+
+export default class HookExport extends PMOCommand {
+  static description = 'Export hook configuration as YAML'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(HookExport)
+    const jsonMode = shouldOutputJson(flags)
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook export', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const db = openWorkspaceDatabase(workspaceInfo.path)
+
+    try {
+      const yamlContent = exportHooksToYaml(db)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { yaml: yamlContent },
+          createMetadata('hook export', flags),
+        )
+        return
+      }
+
+      this.log(styles.title('Hook Configuration (YAML)'))
+      this.log('')
+      this.log(yamlContent)
+      this.log(styles.muted('  Save to .proletariat/hooks.yml to version control'))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/fire.ts
+++ b/apps/cli/src/commands/hook/fire.ts
@@ -1,0 +1,170 @@
+/**
+ * prlt hook fire <event> — Manually fire an orchestrate event.
+ *
+ * This is the bridge between external event sources (GitHub Actions, polling, etc.)
+ * and the internal orchestrate engine. When an external system detects an event
+ * (e.g., CI passes), it runs `prlt hook fire on_ci_green --pr 123` to trigger
+ * the configured hooks.
+ */
+
+import { Args, Flags } from '@oclif/core'
+import { openWorkspaceDatabase } from '../../lib/database/index.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import {
+  OrchestrateEngine,
+  ORCHESTRATE_EVENTS,
+} from '../../lib/orchestrate/index.js'
+import type { OrchestrateEventContext } from '../../lib/orchestrate/index.js'
+
+export default class HookFire extends PMOCommand {
+  static description = 'Fire an orchestrate event to trigger configured hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> on_ci_green --pr 123',
+    '<%= config.bin %> <%= command.id %> on_pr_merged --ticket TKT-100 --pr 456',
+    '<%= config.bin %> <%= command.id %> on_ticket_ready --ticket TKT-200',
+    '<%= config.bin %> <%= command.id %> on_agent_died --ticket TKT-100 --agent bold-turing',
+  ]
+
+  static args = {
+    event: Args.string({
+      description: 'Event name to fire',
+      required: true,
+      options: ORCHESTRATE_EVENTS,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+    ticket: Flags.string({
+      description: 'Ticket ID',
+      char: 't',
+    }),
+    pr: Flags.integer({
+      description: 'PR number',
+    }),
+    branch: Flags.string({
+      description: 'Branch name',
+    }),
+    agent: Flags.string({
+      description: 'Agent name',
+    }),
+    action: Flags.string({
+      description: 'Action to execute (for direct invocation)',
+    }),
+    'pr-url': Flags.string({
+      description: 'PR URL',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Show what would happen without executing',
+      default: false,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(HookFire)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook fire', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const db = openWorkspaceDatabase(workspaceInfo.path)
+
+    try {
+      const ctx: OrchestrateEventContext = {
+        event: args.event,
+        ticket: parsedFlags.ticket as string | undefined,
+        pr: parsedFlags.pr as number | undefined,
+        branch: parsedFlags.branch as string | undefined,
+        agent: parsedFlags.agent as string | undefined,
+        prUrl: parsedFlags['pr-url'] as string | undefined,
+      }
+
+      if (parsedFlags['dry-run']) {
+        // Show what hooks would fire
+        const hooks = db.prepare(
+          'SELECT name, event, action_type, action_value, mode FROM pmo_work_hooks WHERE event = ? AND enabled = 1 ORDER BY priority ASC'
+        ).all(args.event) as Array<{ name: string; event: string; action_type: string; action_value: string; mode?: string }>
+
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { event: args.event, hooks, context: ctx, dryRun: true },
+            createMetadata('hook fire', flags),
+          )
+          return
+        }
+
+        if (hooks.length === 0) {
+          this.log(styles.info(`No hooks configured for event: ${args.event}`))
+          return
+        }
+
+        this.log(styles.title(`Dry run: ${args.event}`))
+        this.log('')
+        for (const hook of hooks) {
+          const mode = hook.mode || 'auto'
+          this.log(`  ${styles.code(hook.name)} ${styles.muted('→')} ${hook.action_value} ${styles.muted(`(${mode})`)}`)
+        }
+        this.log('')
+        this.log(styles.muted(`${hooks.length} hook${hooks.length === 1 ? '' : 's'} would fire`))
+        return
+      }
+
+      // Create engine and fire event
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          if (!jsonMode) this.log(styles.muted(msg))
+        },
+      })
+
+      const results = await engine.fireEvent(args.event, ctx)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { event: args.event, results, context: ctx },
+          createMetadata('hook fire', flags),
+        )
+        return
+      }
+
+      if (results.length === 0) {
+        this.log(styles.info(`No hooks configured for event: ${args.event}`))
+        return
+      }
+
+      this.log(styles.title(`Fired: ${args.event}`))
+      this.log('')
+      for (const result of results) {
+        const status = result.skipped
+          ? styles.muted('skipped')
+          : result.awaitingConfirmation
+            ? styles.warning('awaiting confirmation')
+            : result.success
+              ? styles.success('success')
+              : styles.error(`failed: ${result.error}`)
+        this.log(`  ${styles.code(result.action)} ${styles.muted('→')} ${status} ${styles.muted(`(${result.durationMs}ms)`)}`)
+      }
+      this.log('')
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/index.ts
+++ b/apps/cli/src/commands/hook/index.ts
@@ -1,0 +1,60 @@
+/**
+ * prlt hook — Interactive menu for orchestrate hooks.
+ */
+
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+
+export default class Hook extends PMOCommand {
+  static description = 'Manage orchestrate hooks (event-driven pipeline automation)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> hook fire on_ci_green --pr 123',
+    '<%= config.bin %> hook list',
+    '<%= config.bin %> hook preset supervised',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Hook)
+    const jsonMode = shouldOutputJson(flags)
+
+    const menuChoices = [
+      { id: 'list', name: 'List configured hooks', command: 'prlt hook list --json' },
+      { id: 'fire', name: 'Fire an event', command: 'prlt hook fire --json' },
+      { id: 'preset', name: 'Apply a preset', command: 'prlt hook preset --json' },
+      { id: 'add', name: 'Add a new hook', command: 'prlt work hooks add --json' },
+      { id: 'cancel', name: 'Cancel', command: '' },
+    ]
+
+    const action = await this.selectFromList({
+      message: 'Orchestrate Hooks - What would you like to do?',
+      items: menuChoices,
+      getName: (c) => c.name,
+      getValue: (c) => c.id,
+      getCommand: (c) => c.command,
+      jsonMode: jsonMode ? { flags, commandName: 'hook' } : null,
+    })
+
+    if (action === 'cancel' || !action) return
+
+    switch (action) {
+      case 'list':
+        await this.config.runCommand('hook:list')
+        break
+      case 'fire':
+        await this.config.runCommand('hook:fire')
+        break
+      case 'preset':
+        await this.config.runCommand('hook:preset')
+        break
+      case 'add':
+        await this.config.runCommand('work:hooks:add')
+        break
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/list.ts
+++ b/apps/cli/src/commands/hook/list.ts
@@ -1,0 +1,175 @@
+/**
+ * prlt hook list — List all configured orchestrate hooks.
+ *
+ * Shows hooks with their mode, priority, and source.
+ */
+
+import { Flags } from '@oclif/core'
+import { openWorkspaceDatabase } from '../../lib/database/index.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { ORCHESTRATE_EVENTS } from '../../lib/orchestrate/index.js'
+
+interface HookRow {
+  id: string
+  name: string
+  event: string
+  action_type: string
+  action_value: string
+  enabled: number
+  description: string | null
+  mode: string | null
+  priority: number | null
+  source: string | null
+  config: string | null
+  created_at: string
+}
+
+export default class HookList extends PMOCommand {
+  static description = 'List configured orchestrate hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --event on_ci_green',
+    '<%= config.bin %> <%= command.id %> --mode auto',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    event: Flags.string({
+      description: 'Filter by event name',
+    }),
+    mode: Flags.string({
+      description: 'Filter by mode (auto, confirm, notify, off)',
+      options: ['auto', 'confirm', 'notify', 'off'],
+    }),
+    source: Flags.string({
+      description: 'Filter by source (yaml, cli, preset)',
+      options: ['yaml', 'cli', 'preset'],
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(HookList)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook list', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const db = openWorkspaceDatabase(workspaceInfo.path)
+
+    try {
+      let sql = 'SELECT * FROM pmo_work_hooks WHERE 1=1'
+      const params: unknown[] = []
+
+      if (parsedFlags.event) {
+        sql += ' AND event = ?'
+        params.push(parsedFlags.event)
+      }
+
+      if (parsedFlags.mode) {
+        sql += ' AND mode = ?'
+        params.push(parsedFlags.mode)
+      }
+
+      if (parsedFlags.source) {
+        sql += ' AND source = ?'
+        params.push(parsedFlags.source)
+      }
+
+      sql += ' ORDER BY event ASC, priority ASC, created_at ASC'
+
+      let hooks: HookRow[]
+      try {
+        hooks = db.prepare(sql).all(...params) as HookRow[]
+      } catch {
+        // Fallback without new columns
+        hooks = db.prepare('SELECT * FROM pmo_work_hooks ORDER BY created_at ASC').all() as HookRow[]
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            hooks: hooks.map(h => ({
+              id: h.id,
+              name: h.name,
+              event: h.event,
+              actionType: h.action_type,
+              actionValue: h.action_value,
+              enabled: h.enabled === 1,
+              mode: h.mode || 'auto',
+              priority: h.priority ?? 0,
+              source: h.source || 'cli',
+              description: h.description,
+              config: h.config ? JSON.parse(h.config) : null,
+            })),
+            count: hooks.length,
+          },
+          createMetadata('hook list', flags),
+        )
+        return
+      }
+
+      if (hooks.length === 0) {
+        this.log(styles.info('No hooks configured.'))
+        this.log(styles.muted('  Add one with: prlt work hooks add'))
+        this.log(styles.muted('  Or apply a preset: prlt hook preset supervised'))
+        return
+      }
+
+      this.log(styles.title('Orchestrate Hooks'))
+      this.log('')
+
+      // Group by event
+      const grouped: Record<string, HookRow[]> = {}
+      for (const hook of hooks) {
+        if (!grouped[hook.event]) grouped[hook.event] = []
+        grouped[hook.event].push(hook)
+      }
+
+      for (const [event, eventHooks] of Object.entries(grouped)) {
+        this.log(`  ${styles.emphasis(event)}`)
+        for (const hook of eventHooks) {
+          const enabled = hook.enabled === 1
+          const mode = hook.mode || 'auto'
+          const source = hook.source || 'cli'
+          const status = !enabled
+            ? styles.muted('off')
+            : mode === 'auto'
+              ? styles.success('auto')
+              : mode === 'confirm'
+                ? styles.warning('confirm')
+                : mode === 'notify'
+                  ? styles.info('notify')
+                  : styles.muted('off')
+
+          this.log(`    ${status} ${styles.code(hook.action_value)} ${styles.muted(`[${source}]`)}`)
+          if (hook.description) {
+            this.log(`         ${styles.muted(hook.description)}`)
+          }
+        }
+        this.log('')
+      }
+
+      this.log(styles.muted(`  ${hooks.length} hook${hooks.length === 1 ? '' : 's'} configured`))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/preset.ts
+++ b/apps/cli/src/commands/hook/preset.ts
@@ -1,0 +1,94 @@
+/**
+ * prlt hook preset <name> — Apply a hook preset.
+ *
+ * Presets:
+ * - aggressive: auto everything
+ * - conservative: confirm everything
+ * - supervised: auto for safe ops, confirm for destructive
+ */
+
+import { Args } from '@oclif/core'
+import { openWorkspaceDatabase } from '../../lib/database/index.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { applyPreset, PRESET_NAMES, PRESETS } from '../../lib/orchestrate/index.js'
+import type { PresetName } from '../../lib/orchestrate/index.js'
+
+export default class HookPreset extends PMOCommand {
+  static description = 'Apply a hook preset (aggressive, conservative, supervised)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> aggressive',
+    '<%= config.bin %> <%= command.id %> conservative',
+    '<%= config.bin %> <%= command.id %> supervised',
+  ]
+
+  static args = {
+    preset: Args.string({
+      description: 'Preset name to apply',
+      required: true,
+      options: PRESET_NAMES,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(HookPreset)
+    const jsonMode = shouldOutputJson(flags)
+    const presetName = args.preset as PresetName
+
+    if (!PRESET_NAMES.includes(presetName)) {
+      if (jsonMode) {
+        outputErrorAsJson('INVALID_PRESET', `Unknown preset: ${presetName}. Valid: ${PRESET_NAMES.join(', ')}`, createMetadata('hook preset', flags))
+        return
+      }
+      this.error(`Unknown preset: ${presetName}. Valid: ${PRESET_NAMES.join(', ')}`)
+    }
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook preset', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const db = openWorkspaceDatabase(workspaceInfo.path)
+
+    try {
+      const count = applyPreset(db, presetName)
+      const preset = PRESETS[presetName]
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            preset: presetName,
+            description: preset.description,
+            hooksApplied: count,
+          },
+          createMetadata('hook preset', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Applied preset: ${presetName}`))
+      this.log(styles.muted(`  ${preset.description}`))
+      this.log(styles.muted(`  ${count} hooks configured`))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -1,0 +1,303 @@
+/**
+ * prlt orchestrate — Autonomous pipeline daemon with event-driven hooks.
+ *
+ * Starts the orchestrate engine which:
+ * 1. Loads hook configuration from DB (synced from YAML/presets/CLI)
+ * 2. Subscribes to EventBus events for internal triggers
+ * 3. Optionally polls external sources (Linear, GitHub) for events
+ * 4. Executes matching hooks with mode-aware behavior (auto/confirm/notify/off)
+ *
+ * External events can also be fired via `prlt hook fire <event>`.
+ */
+
+import { Flags } from '@oclif/core'
+import * as readline from 'node:readline'
+import { openWorkspaceDatabase } from '../../lib/database/index.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import {
+  OrchestrateEngine,
+  OrchestratePoller,
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  PRESET_NAMES,
+} from '../../lib/orchestrate/index.js'
+import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
+import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
+import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
+export default class Orchestrate extends PMOCommand {
+  static description = 'Start the autonomous pipeline daemon with event-driven hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --preset supervised',
+    '<%= config.bin %> <%= command.id %> --load-yaml',
+    '<%= config.bin %> <%= command.id %> --poll-interval 300',
+    '<%= config.bin %> <%= command.id %> --once on_ci_green --pr 123',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    preset: Flags.string({
+      description: 'Apply a preset before starting (aggressive, conservative, supervised)',
+      options: PRESET_NAMES,
+    }),
+    'load-yaml': Flags.boolean({
+      description: 'Load hooks from .proletariat/hooks.yml before starting',
+      default: false,
+    }),
+    'poll-interval': Flags.integer({
+      description: 'Poll interval in seconds for external event sources (0 to disable)',
+      default: 0,
+    }),
+    once: Flags.string({
+      description: 'Fire a single event and exit (useful for CI/GitHub Actions)',
+    }),
+    ticket: Flags.string({
+      description: 'Ticket ID (for --once)',
+      char: 't',
+    }),
+    pr: Flags.integer({
+      description: 'PR number (for --once)',
+    }),
+    branch: Flags.string({
+      description: 'Branch name (for --once)',
+    }),
+    agent: Flags.string({
+      description: 'Agent name (for --once)',
+    }),
+    verbose: Flags.boolean({
+      description: 'Show detailed output',
+      char: 'v',
+      default: false,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Orchestrate)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('orchestrate', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const db = openWorkspaceDatabase(workspaceInfo.path)
+    const verbose = parsedFlags.verbose as boolean
+
+    try {
+      // Load YAML config if requested
+      if (parsedFlags['load-yaml']) {
+        const hooksYaml = loadHooksYaml(workspaceInfo.path)
+        if (hooksYaml) {
+          const count = syncHooksFromYaml(db, hooksYaml)
+          this.log(styles.muted(`  Loaded ${count} hooks from hooks.yml`))
+        } else {
+          this.log(styles.muted('  No .proletariat/hooks.yml found'))
+        }
+
+        const workflowYaml = loadWorkflowYaml(workspaceInfo.path)
+        if (workflowYaml) {
+          this.log(styles.muted('  Loaded workflow.yml'))
+          // Store workflow config in settings for later use
+          if (workflowYaml.branches?.target) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.branches.target', ?)").run(workflowYaml.branches.target)
+            } catch { /* ignore */ }
+          }
+          if (workflowYaml.branches?.strategy) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.branches.strategy', ?)").run(workflowYaml.branches.strategy)
+            } catch { /* ignore */ }
+          }
+          if (workflowYaml.review?.auto_merge_on_green !== undefined) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.review.auto_merge_on_green', ?)").run(String(workflowYaml.review.auto_merge_on_green))
+            } catch { /* ignore */ }
+          }
+        }
+      }
+
+      // Apply preset if specified
+      if (parsedFlags.preset) {
+        const count = applyPreset(db, parsedFlags.preset as PresetName)
+        this.log(styles.muted(`  Applied preset "${parsedFlags.preset}" (${count} hooks)`))
+      }
+
+      // Readline interface for interactive confirmations in daemon mode
+      let rl: readline.Interface | null = null
+
+      // Create the orchestrate engine
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          if (verbose || jsonMode) {
+            this.log(msg)
+          }
+        },
+        onConfirm: async (hookName, event, action) => {
+          // In JSON mode, output as JSON and auto-deny (external system should handle)
+          if (jsonMode) {
+            outputSuccessAsJson(
+              { type: 'confirmation_required', hookName, event, action },
+              createMetadata('orchestrate', flags),
+            )
+            return false
+          }
+
+          // Interactive confirmation via readline
+          return new Promise<boolean>((resolve) => {
+            this.log('')
+            this.log(`${styles.warning('[confirm]')} Hook "${hookName}" wants to run:`)
+            this.log(`  Event: ${styles.emphasis(event)}`)
+            this.log(`  Action: ${styles.code(action)}`)
+
+            if (!rl) {
+              rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+            }
+
+            rl.question(`  Approve? (yes/no): `, (answer) => {
+              const approved = answer.trim().toLowerCase().startsWith('y')
+              if (approved) {
+                this.log(styles.success('  Approved'))
+              } else {
+                this.log(styles.muted('  Denied'))
+              }
+              resolve(approved)
+            })
+          })
+        },
+        onNotify: (hookName, event, action, result) => {
+          this.log(`${styles.info('[notify]')} ${hookName}: ${event} → ${action} (${result.success ? 'ok' : 'failed'})`)
+        },
+      })
+
+      // Initialize work-lifecycle systems
+      initWorkLifecycleAdapter()
+      initHookManager(db)
+
+      // One-shot mode: fire a single event and exit
+      if (parsedFlags.once) {
+        const eventName = parsedFlags.once as string
+        const results = await engine.fireEvent(eventName, {
+          event: eventName,
+          ticket: parsedFlags.ticket as string | undefined,
+          pr: parsedFlags.pr as number | undefined,
+          branch: parsedFlags.branch as string | undefined,
+          agent: parsedFlags.agent as string | undefined,
+        })
+
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { event: eventName, results, mode: 'once' },
+            createMetadata('orchestrate', flags),
+          )
+          return
+        }
+
+        this.logResults(eventName, results)
+        return
+      }
+
+      // Daemon mode: start the engine and run until stopped
+      engine.start()
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { status: 'running', mode: 'daemon' },
+          createMetadata('orchestrate', flags),
+        )
+      } else {
+        this.log('')
+        this.log(styles.title('Orchestrate daemon started'))
+        this.log(styles.muted('  Listening for events on the EventBus'))
+        this.log(styles.muted('  Press Ctrl+C to stop'))
+
+        // Show configured hooks summary
+        try {
+          const hookCount = (db.prepare('SELECT COUNT(*) as count FROM pmo_work_hooks WHERE enabled = 1').get() as { count: number })?.count ?? 0
+          this.log(styles.muted(`  ${hookCount} active hooks`))
+        } catch { /* ignore */ }
+
+        if (parsedFlags['poll-interval'] && (parsedFlags['poll-interval'] as number) > 0) {
+          this.log(styles.muted(`  Polling every ${parsedFlags['poll-interval']}s for external events`))
+        }
+        this.log('')
+      }
+
+      // Set up polling if configured
+      const pollInterval = parsedFlags['poll-interval'] as number
+      let pollTimer: ReturnType<typeof setInterval> | null = null
+      let poller: OrchestratePoller | null = null
+
+      if (pollInterval > 0) {
+        poller = new OrchestratePoller({
+          engine,
+          db,
+          log: (msg) => { if (verbose) this.log(styles.muted(msg)) },
+          cwd: workspaceInfo.path,
+        })
+        pollTimer = setInterval(() => {
+          void poller!.poll()
+        }, pollInterval * 1000)
+      }
+
+      // Keep the process alive until signal
+      await new Promise<void>((resolve) => {
+        const cleanup = () => {
+          engine.stop()
+          if (pollTimer) clearInterval(pollTimer)
+          if (rl) { rl.close(); rl = null }
+          this.log(styles.muted('\n  Orchestrate daemon stopped'))
+          resolve()
+        }
+
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Log the results of firing an event.
+   */
+  private logResults(event: string, results: OrchestrateActionResult[]): void {
+    if (results.length === 0) {
+      this.log(styles.info(`No hooks configured for event: ${event}`))
+      return
+    }
+
+    this.log(styles.title(`Event: ${event}`))
+    for (const result of results) {
+      const status = result.skipped
+        ? styles.muted('skipped')
+        : result.awaitingConfirmation
+          ? styles.warning('awaiting')
+          : result.success
+            ? styles.success('ok')
+            : styles.error('failed')
+      this.log(`  ${status} ${result.action} ${styles.muted(`${result.durationMs}ms`)}`)
+      if (result.error) {
+        this.log(`       ${styles.error(result.error)}`)
+      }
+    }
+  }
+}

--- a/apps/cli/src/lib/database/migrations/0014_agent_work_lifecycle.ts
+++ b/apps/cli/src/lib/database/migrations/0014_agent_work_lifecycle.ts
@@ -1,0 +1,48 @@
+/**
+ * Migration 0014 — Agent Work Lifecycle States
+ *
+ * Adds lifecycle tracking columns to agent_work for the orchestrate daemon.
+ * - last_heartbeat: tracks when the agent last reported activity
+ * - retries: tracks respawn attempts for on_agent_died hooks
+ * - lifecycle_state: high-level state (healthy, idle, died, completed)
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const agentWorkLifecycle: Migration = {
+  id: '0014',
+  name: 'agent_work_lifecycle',
+  up: (db: Database.Database) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_work'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(agent_work)").all() as { name: string }[]
+    const existingCols = new Set(tableInfo.map(col => col.name))
+
+    if (!existingCols.has('last_heartbeat')) {
+      db.exec(
+        "ALTER TABLE agent_work ADD COLUMN last_heartbeat TEXT"
+      )
+    }
+
+    if (!existingCols.has('retries')) {
+      db.exec(
+        "ALTER TABLE agent_work ADD COLUMN retries INTEGER NOT NULL DEFAULT 0"
+      )
+    }
+
+    if (!existingCols.has('lifecycle_state')) {
+      db.exec(
+        "ALTER TABLE agent_work ADD COLUMN lifecycle_state TEXT DEFAULT 'healthy' CHECK (lifecycle_state IN ('healthy', 'idle', 'died', 'completed'))"
+      )
+    }
+
+    // Index for lifecycle state queries (used by orchestrate polling)
+    db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_agent_work_lifecycle ON agent_work(lifecycle_state, status)"
+    )
+  },
+}

--- a/apps/cli/src/lib/database/migrations/0015_orchestrate_hooks.ts
+++ b/apps/cli/src/lib/database/migrations/0015_orchestrate_hooks.ts
@@ -1,0 +1,58 @@
+/**
+ * Migration 0015 — Orchestrate Hooks
+ *
+ * Extends pmo_work_hooks with mode (auto/confirm/notify/off), priority,
+ * project_id, source, and config columns for the orchestrate daemon.
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const orchestrateHooks: Migration = {
+  id: '0015',
+  name: 'orchestrate_hooks',
+  up: (db: Database.Database) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(pmo_work_hooks)").all() as { name: string }[]
+    const existingCols = new Set(tableInfo.map(col => col.name))
+
+    if (!existingCols.has('mode')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'off'))"
+      )
+    }
+
+    if (!existingCols.has('priority')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0"
+      )
+    }
+
+    if (!existingCols.has('project_id')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT"
+      )
+    }
+
+    if (!existingCols.has('source')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))"
+      )
+    }
+
+    if (!existingCols.has('config')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT"
+      )
+    }
+
+    // Create index for priority-ordered lookup
+    db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)"
+    )
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -19,6 +19,8 @@ import { addTicketPosition } from './0010_add_ticket_position.js'
 import { addReviewGate } from './0011_add_review_gate.js'
 import { addActionNetworkAllowlist } from './0012_add_action_network_allowlist.js'
 import { agentLifecycleStates } from './0013_agent_lifecycle_states.js'
+import { agentWorkLifecycle } from './0014_agent_work_lifecycle.js'
+import { orchestrateHooks } from './0015_orchestrate_hooks.js'
 
 /**
  * Ordered list of all migrations.
@@ -38,4 +40,6 @@ export const ALL_MIGRATIONS: Migration[] = [
   addReviewGate,
   addActionNetworkAllowlist,
   agentLifecycleStates,
+  agentWorkLifecycle,
+  orchestrateHooks,
 ]

--- a/apps/cli/src/lib/events/events.ts
+++ b/apps/cli/src/lib/events/events.ts
@@ -116,6 +116,28 @@ export interface WorkflowRuleMatchedEvent {
 }
 
 // =============================================================================
+// Orchestrate Events
+// =============================================================================
+
+/**
+ * Generic event payload for orchestrate daemon events.
+ * These events are triggered externally (GitHub Actions, polling, prlt hook fire)
+ * and carry flexible context.
+ */
+export interface OrchestrateGenericEvent {
+  ticket?: string
+  pr?: number
+  branch?: string
+  agent?: string
+  container?: string
+  executionId?: string
+  prUrl?: string
+  projectId?: string
+  timestamp: Date
+  [key: string]: unknown
+}
+
+// =============================================================================
 // Event Map
 // =============================================================================
 
@@ -141,6 +163,19 @@ export interface RuntimeEventMap {
   'work:pr_merged': WorkPRMergedEvent
   'work:pr_closed': WorkPRClosedEvent
   'work:completed': WorkCompletedEvent
+
+  // Orchestrate events (external triggers + daemon events)
+  'on_ci_green': OrchestrateGenericEvent
+  'on_ci_failed': OrchestrateGenericEvent
+  'on_pr_opened': OrchestrateGenericEvent
+  'on_pr_merged': OrchestrateGenericEvent
+  'on_pr_conflicting': OrchestrateGenericEvent
+  'on_ticket_ready': OrchestrateGenericEvent
+  'on_agent_spawned': OrchestrateGenericEvent
+  'on_agent_died': OrchestrateGenericEvent
+  'on_agent_completed': OrchestrateGenericEvent
+  'on_agent_idle': OrchestrateGenericEvent
+  'on_version_published': OrchestrateGenericEvent
 }
 
 /** Union of all event names. */

--- a/apps/cli/src/lib/events/index.ts
+++ b/apps/cli/src/lib/events/index.ts
@@ -13,6 +13,7 @@ export type {
   AgentOutputEvent,
   TicketStatusChangedEvent,
   TicketPRLinkedEvent,
+  OrchestrateGenericEvent,
 } from './events.js'
 
 export {

--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -1,0 +1,208 @@
+/**
+ * Orchestrate Built-in Actions
+ *
+ * Implementations for the built-in hook actions that the orchestrate daemon
+ * can execute. Each action receives an event context and returns a result.
+ *
+ * Actions use prlt CLI commands where possible to keep behavior consistent
+ * with manual invocations.
+ */
+
+import { execSync } from 'node:child_process'
+import type { OrchestrateEventContext, OrchestrateActionResult } from './types.js'
+
+type ActionHandler = (ctx: OrchestrateEventContext, config?: Record<string, unknown>) => OrchestrateActionResult
+
+/**
+ * Merge a PR via `prlt work ship`.
+ */
+const mergePr: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket && !ctx.pr) {
+      return { action: 'merge-pr', success: false, error: 'No ticket or PR number in context', durationMs: Date.now() - start }
+    }
+
+    const args: string[] = ['prlt', 'work', 'ship']
+    if (ctx.ticket) args.push(ctx.ticket)
+    if (ctx.pr) args.push('--pr', String(ctx.pr))
+    args.push('--yes') // Skip confirmation
+
+    execSync(args.join(' '), { timeout: 120_000, stdio: 'pipe' })
+    return { action: 'merge-pr', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'merge-pr', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Move a ticket to a target status.
+ */
+const moveTicket: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    const target = (config?.target as string) || 'done'
+    if (!ctx.ticket) {
+      return { action: 'move-ticket', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt ticket move ${ctx.ticket} --to "${target}" --yes`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'move-ticket', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'move-ticket', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Rebase conflicting PRs after a merge.
+ */
+const rebaseConflictingPrs: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    execSync('prlt work rebase --all --yes 2>/dev/null || true', { timeout: 300_000, stdio: 'pipe' })
+    return { action: 'rebase-conflicting-prs', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'rebase-conflicting-prs', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Spawn an agent for a ticket.
+ */
+const spawnAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'spawn-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Respawn a failed/died agent.
+ */
+const respawn: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'respawn', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --yes --display background --force`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'respawn', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'respawn', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Send a notification about an event.
+ */
+const notify: ActionHandler = (ctx) => {
+  const start = Date.now()
+  const parts: string[] = []
+  if (ctx.event) parts.push(`[${ctx.event}]`)
+  if (ctx.ticket) parts.push(`ticket=${ctx.ticket}`)
+  if (ctx.pr) parts.push(`PR=#${ctx.pr}`)
+  if (ctx.agent) parts.push(`agent=${ctx.agent}`)
+
+  // eslint-disable-next-line no-console
+  console.log(`[orchestrate:notify] ${parts.join(' ')}`)
+  return { action: 'notify', success: true, durationMs: Date.now() - start }
+}
+
+/**
+ * Clean up a container after agent completion.
+ */
+const cleanupContainer: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.agent && !ctx.container) {
+      return { action: 'cleanup-container', success: false, error: 'No agent or container in context', durationMs: Date.now() - start }
+    }
+
+    const target = ctx.container || ctx.agent
+    execSync(`prlt docker rm ${target} --yes 2>/dev/null || true`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'cleanup-container', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'cleanup-container', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Spawn a fix agent after CI failure.
+ */
+const spawnFixAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-fix-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --action revise --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'spawn-fix-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-fix-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Health check / poke an idle agent.
+ */
+const healthCheck: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.agent) {
+      return { action: 'health-check', success: false, error: 'No agent in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt poke ${ctx.agent} "Are you still working? Please provide a status update."`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'health-check', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'health-check', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+// =============================================================================
+// Action Registry
+// =============================================================================
+
+/**
+ * Registry of built-in action handlers.
+ */
+export const ACTION_HANDLERS: Record<string, ActionHandler> = {
+  'merge-pr': mergePr,
+  'move-ticket': moveTicket,
+  'rebase-conflicting-prs': rebaseConflictingPrs,
+  'spawn-agent': spawnAgent,
+  'respawn': respawn,
+  'notify': notify,
+  'cleanup-container': cleanupContainer,
+  'spawn-fix-agent': spawnFixAgent,
+  'health-check': healthCheck,
+}
+
+/**
+ * Execute a built-in action by name.
+ */
+export function executeBuiltinAction(
+  actionName: string,
+  ctx: OrchestrateEventContext,
+  config?: Record<string, unknown>,
+): OrchestrateActionResult {
+  const handler = ACTION_HANDLERS[actionName]
+  if (!handler) {
+    return {
+      action: actionName,
+      success: false,
+      error: `Unknown action: ${actionName}`,
+      durationMs: 0,
+    }
+  }
+  return handler(ctx, config)
+}

--- a/apps/cli/src/lib/orchestrate/config-loader.ts
+++ b/apps/cli/src/lib/orchestrate/config-loader.ts
@@ -1,0 +1,238 @@
+/**
+ * Orchestrate Config Loader
+ *
+ * Loads .proletariat/hooks.yml and .proletariat/workflow.yml files,
+ * validates them, and syncs hook configurations into the database.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import yaml from 'js-yaml'
+import type Database from 'better-sqlite3'
+import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
+import type { HookableEvent, HookActionType } from '../work-lifecycle/hooks/types.js'
+import type {
+  HooksYaml,
+  HookYamlEntry,
+  WorkflowYaml,
+  OrchestrateEvent,
+  HookMode,
+  PresetName,
+} from './types.js'
+import { ORCHESTRATE_EVENTS, HOOK_MODES } from './types.js'
+import { getPreset } from './presets.js'
+
+// =============================================================================
+// YAML File Loading
+// =============================================================================
+
+/**
+ * Load and parse .proletariat/hooks.yml from an HQ path.
+ * Returns null if the file doesn't exist.
+ */
+export function loadHooksYaml(hqPath: string): HooksYaml | null {
+  const filePath = path.join(hqPath, '.proletariat', 'hooks.yml')
+  if (!fs.existsSync(filePath)) return null
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const parsed = yaml.load(content) as HooksYaml | null
+  return parsed ?? null
+}
+
+/**
+ * Load and parse .proletariat/workflow.yml from an HQ path.
+ * Returns null if the file doesn't exist.
+ */
+export function loadWorkflowYaml(hqPath: string): WorkflowYaml | null {
+  const filePath = path.join(hqPath, '.proletariat', 'workflow.yml')
+  if (!fs.existsSync(filePath)) return null
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const parsed = yaml.load(content) as WorkflowYaml | null
+  return parsed ?? null
+}
+
+// =============================================================================
+// Hook Sync
+// =============================================================================
+
+/**
+ * Map an OrchestrateEvent + action string into an existing HookableEvent + HookActionType.
+ * For built-in actions, we use 'shell' type with a `prlt` command as the action value.
+ */
+function mapToHookConfig(
+  event: OrchestrateEvent,
+  entry: HookYamlEntry,
+): { event: HookableEvent; actionType: HookActionType; actionValue: string } | null {
+  // Map orchestrate events to hookable events where possible
+  const eventMap: Partial<Record<OrchestrateEvent, HookableEvent>> = {
+    'work:started': 'work:started',
+    'work:status_changed': 'work:status_changed',
+    'work:pr_created': 'work:pr_created',
+    'work:completed': 'work:completed',
+    'agent:spawned': 'agent:spawned',
+    'agent:stopped': 'agent:stopped',
+  }
+
+  const hookEvent = eventMap[event]
+
+  // For events without a direct mapping, store as shell hook with prlt hook fire
+  const resolvedEvent = hookEvent ?? 'work:status_changed'
+  const actionValue = `prlt hook fire ${event} --action ${entry.action}`
+
+  return {
+    event: resolvedEvent,
+    actionType: 'shell',
+    actionValue,
+  }
+}
+
+/**
+ * Sync hooks from a parsed YAML config into the database.
+ * Clears existing YAML-sourced hooks and replaces them.
+ */
+export function syncHooksFromYaml(db: Database.Database, hooksYaml: HooksYaml): number {
+  const storage = new WorkHookStorage(db)
+  let count = 0
+
+  // Clear existing YAML-sourced hooks
+  try {
+    db.exec("DELETE FROM pmo_work_hooks WHERE source = 'yaml'")
+  } catch {
+    // source column might not exist yet — ignore
+  }
+
+  for (const [eventName, entries] of Object.entries(hooksYaml)) {
+    if (!Array.isArray(entries)) continue
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      if (!entry.action) continue
+
+      const mode = entry.mode && HOOK_MODES.includes(entry.mode as HookMode)
+        ? entry.mode as HookMode
+        : 'auto'
+
+      const hookName = `yaml:${eventName}:${entry.action}:${i}`
+
+      try {
+        const hook = storage.create({
+          name: hookName,
+          event: (eventName as HookableEvent) || 'work:status_changed',
+          actionType: 'shell',
+          actionValue: entry.action,
+          description: `From hooks.yml: ${eventName} → ${entry.action} (${mode})`,
+        })
+
+        // Update the mode and source via raw SQL since WorkHookStorage doesn't support these yet
+        try {
+          db.prepare(
+            "UPDATE pmo_work_hooks SET mode = ?, priority = ?, source = 'yaml', config = ? WHERE id = ?"
+          ).run(mode, i, entry.max_retries ? JSON.stringify({ max_retries: entry.max_retries }) : null, hook.id)
+        } catch {
+          // Columns might not exist yet
+        }
+
+        count++
+      } catch {
+        // Skip duplicates
+      }
+    }
+  }
+
+  return count
+}
+
+/**
+ * Apply a preset to the database, replacing existing preset-sourced hooks.
+ */
+export function applyPreset(db: Database.Database, presetName: PresetName): number {
+  const preset = getPreset(presetName)
+  const storage = new WorkHookStorage(db)
+  let count = 0
+
+  // Clear existing preset-sourced hooks
+  try {
+    db.exec("DELETE FROM pmo_work_hooks WHERE source = 'preset'")
+  } catch {
+    // source column might not exist yet
+  }
+
+  for (let i = 0; i < preset.hooks.length; i++) {
+    const hook = preset.hooks[i]
+    const hookName = `preset:${presetName}:${hook.event}:${hook.action}:${i}`
+
+    try {
+      const created = storage.create({
+        name: hookName,
+        event: mapOrchestrateToHookable(hook.event),
+        actionType: 'shell',
+        actionValue: `prlt hook fire ${hook.event} --action ${hook.action}`,
+        description: `Preset ${presetName}: ${hook.event} → ${hook.action} (${hook.mode})`,
+      })
+
+      try {
+        db.prepare(
+          "UPDATE pmo_work_hooks SET mode = ?, priority = ?, source = 'preset', config = ? WHERE id = ?"
+        ).run(hook.mode, i, hook.config ? JSON.stringify(hook.config) : null, created.id)
+      } catch {
+        // Columns might not exist
+      }
+
+      count++
+    } catch {
+      // Skip duplicates
+    }
+  }
+
+  return count
+}
+
+/**
+ * Map orchestrate event to the closest hookable event.
+ * For new orchestrate events, use a fallback.
+ */
+function mapOrchestrateToHookable(event: OrchestrateEvent): HookableEvent {
+  const directMap: Partial<Record<OrchestrateEvent, HookableEvent>> = {
+    'work:started': 'work:started',
+    'work:status_changed': 'work:status_changed',
+    'work:pr_created': 'work:pr_created',
+    'work:completed': 'work:completed',
+    'agent:spawned': 'agent:spawned',
+    'agent:stopped': 'agent:stopped',
+  }
+  return directMap[event] ?? 'work:status_changed'
+}
+
+/**
+ * Export current hook configuration to YAML format.
+ */
+export function exportHooksToYaml(db: Database.Database): string {
+  const storage = new WorkHookStorage(db)
+  const hooks = storage.list()
+
+  const grouped: Record<string, Array<{ action: string; mode: string; config?: Record<string, unknown> }>> = {}
+
+  for (const hook of hooks) {
+    const event = hook.event
+    if (!grouped[event]) grouped[event] = []
+
+    let mode = 'auto'
+    let config: Record<string, unknown> | undefined
+    try {
+      const row = db.prepare("SELECT mode, config FROM pmo_work_hooks WHERE id = ?").get(hook.id) as { mode?: string; config?: string } | undefined
+      if (row?.mode) mode = row.mode
+      if (row?.config) config = JSON.parse(row.config) as Record<string, unknown>
+    } catch {
+      // mode column might not exist
+    }
+
+    grouped[event].push({
+      action: hook.actionValue,
+      mode,
+      ...(config ? config : {}),
+    })
+  }
+
+  return yaml.dump(grouped, { indent: 2, lineWidth: 120 })
+}

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -1,0 +1,372 @@
+/**
+ * Orchestrate Engine
+ *
+ * The core daemon loop that:
+ * 1. Loads hook configuration from DB (synced from YAML/presets/CLI)
+ * 2. Subscribes to EventBus events
+ * 3. Executes matching hooks with mode-aware behavior
+ * 4. Optionally polls external sources for events
+ *
+ * The engine extends the existing HookManager with mode support
+ * and built-in action execution.
+ */
+
+import { execSync } from 'node:child_process'
+import type Database from 'better-sqlite3'
+import { getEventBus } from '../events/event-bus.js'
+import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
+import { executeBuiltinAction, ACTION_HANDLERS } from './actions.js'
+import type {
+  OrchestrateEvent,
+  OrchestrateEventContext,
+  OrchestrateActionResult,
+  HookMode,
+} from './types.js'
+import { ORCHESTRATE_EVENTS } from './types.js'
+
+// =============================================================================
+// Extended Hook Row (includes mode, priority, config)
+// =============================================================================
+
+interface ExtendedHookRow {
+  id: string
+  name: string
+  event: string
+  action_type: string
+  action_value: string
+  enabled: number
+  description: string | null
+  mode: string | null
+  priority: number | null
+  config: string | null
+}
+
+// =============================================================================
+// Engine
+// =============================================================================
+
+export interface OrchestrateEngineOptions {
+  /** Database connection */
+  db: Database.Database
+  /** Logger function */
+  log?: (msg: string) => void
+  /** Callback for confirm-mode hooks (returns true to approve) */
+  onConfirm?: (hookName: string, event: string, action: string) => Promise<boolean>
+  /** Callback for notifications */
+  onNotify?: (hookName: string, event: string, action: string, result: OrchestrateActionResult) => void
+}
+
+export class OrchestrateEngine {
+  private db: Database.Database
+  private hookStorage: WorkHookStorage
+  private unsubscribers: Array<() => void> = []
+  private log: (msg: string) => void
+  private onConfirm?: (hookName: string, event: string, action: string) => Promise<boolean>
+  private onNotify?: (hookName: string, event: string, action: string, result: OrchestrateActionResult) => void
+  private running = false
+  private pendingConfirmations: Array<{
+    hookName: string
+    event: string
+    action: string
+    ctx: OrchestrateEventContext
+    config?: Record<string, unknown>
+  }> = []
+
+  constructor(options: OrchestrateEngineOptions) {
+    this.db = options.db
+    this.hookStorage = new WorkHookStorage(options.db)
+    this.log = options.log ?? (() => {})
+    this.onConfirm = options.onConfirm
+    this.onNotify = options.onNotify
+  }
+
+  /**
+   * Start the orchestrate engine — subscribe to all orchestrate events.
+   */
+  start(): void {
+    if (this.running) return
+    this.running = true
+
+    const bus = getEventBus()
+
+    // Subscribe to standard RuntimeEventMap events
+    const standardEvents: Array<keyof import('../events/events.js').RuntimeEventMap> = [
+      'work:started',
+      'work:status_changed',
+      'work:pr_created',
+      'work:pr_merged',
+      'work:pr_closed',
+      'work:completed',
+      'agent:spawned',
+      'agent:stopped',
+    ]
+
+    for (const eventName of standardEvents) {
+      this.unsubscribers.push(
+        bus.on(eventName, (payload) => {
+          void this.handleEvent(eventName, payload as unknown as Record<string, unknown>)
+        }),
+      )
+    }
+
+    this.log('[orchestrate] Engine started, listening for events')
+  }
+
+  /**
+   * Stop the engine and clean up subscriptions.
+   */
+  stop(): void {
+    this.running = false
+    for (const unsub of this.unsubscribers) {
+      unsub()
+    }
+    this.unsubscribers = []
+    this.pendingConfirmations = []
+    this.log('[orchestrate] Engine stopped')
+  }
+
+  /**
+   * Fire an event manually (used by `prlt hook fire`).
+   * This is the entry point for external event sources (GitHub Actions, polling, etc.).
+   */
+  async fireEvent(event: string, ctx: OrchestrateEventContext): Promise<OrchestrateActionResult[]> {
+    return this.handleEvent(event, ctx as Record<string, unknown>)
+  }
+
+  /**
+   * Get pending confirmations for hooks in confirm mode.
+   */
+  getPendingConfirmations(): typeof this.pendingConfirmations {
+    return [...this.pendingConfirmations]
+  }
+
+  /**
+   * Approve a pending confirmation and execute it.
+   */
+  async approveConfirmation(index: number): Promise<OrchestrateActionResult | null> {
+    if (index < 0 || index >= this.pendingConfirmations.length) return null
+
+    const pending = this.pendingConfirmations.splice(index, 1)[0]
+    const result = executeBuiltinAction(pending.action, pending.ctx, pending.config)
+
+    this.log(`[orchestrate] Approved: ${pending.hookName} → ${pending.action} (${result.success ? 'success' : 'failed'})`)
+    return result
+  }
+
+  /**
+   * Deny a pending confirmation.
+   */
+  denyConfirmation(index: number): boolean {
+    if (index < 0 || index >= this.pendingConfirmations.length) return false
+
+    const pending = this.pendingConfirmations.splice(index, 1)[0]
+    this.log(`[orchestrate] Denied: ${pending.hookName} → ${pending.action}`)
+    return true
+  }
+
+  // ===========================================================================
+  // Private
+  // ===========================================================================
+
+  /**
+   * Handle an event by finding and executing matching hooks.
+   */
+  private async handleEvent(eventName: string, eventData: Record<string, unknown>): Promise<OrchestrateActionResult[]> {
+    const results: OrchestrateActionResult[] = []
+
+    try {
+      // Query hooks matching this event, ordered by priority
+      const hooks = this.getHooksForEvent(eventName)
+      if (hooks.length === 0) return results
+
+      // Build event context from the payload
+      const ctx = this.buildContext(eventName, eventData)
+
+      for (const hook of hooks) {
+        const mode = (hook.mode || 'auto') as HookMode
+        const config = hook.config ? JSON.parse(hook.config) as Record<string, unknown> : undefined
+
+        // Determine action — either a built-in action name or the raw action_value
+        const actionName = this.resolveActionName(hook)
+
+        if (mode === 'off') {
+          results.push({ action: actionName, success: true, durationMs: 0, skipped: true })
+          continue
+        }
+
+        if (mode === 'confirm') {
+          // Queue for confirmation
+          if (this.onConfirm) {
+            const approved = await this.onConfirm(hook.name, eventName, actionName)
+            if (!approved) {
+              this.log(`[orchestrate] Skipped (not confirmed): ${hook.name} → ${actionName}`)
+              results.push({ action: actionName, success: true, durationMs: 0, skipped: true })
+              continue
+            }
+          } else {
+            // No confirm handler — queue for later approval
+            this.pendingConfirmations.push({
+              hookName: hook.name,
+              event: eventName,
+              action: actionName,
+              ctx,
+              config,
+            })
+            this.log(`[orchestrate] Queued for confirmation: ${hook.name} → ${actionName}`)
+            results.push({ action: actionName, success: true, durationMs: 0, awaitingConfirmation: true })
+            continue
+          }
+        }
+
+        // Execute the action
+        const result = this.executeAction(actionName, ctx, config)
+        results.push(result)
+
+        this.log(
+          `[orchestrate] ${hook.name} → ${actionName}: ${result.success ? 'success' : `failed: ${result.error}`} (${result.durationMs}ms)`
+        )
+
+        // For notify mode, also fire the notification callback
+        if (mode === 'notify' && this.onNotify) {
+          this.onNotify(hook.name, eventName, actionName, result)
+        }
+      }
+    } catch (err) {
+      this.log(`[orchestrate] Error handling event ${eventName}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    return results
+  }
+
+  /**
+   * Get hooks for a given event from the database, ordered by priority.
+   */
+  private getHooksForEvent(eventName: string): ExtendedHookRow[] {
+    try {
+      return this.db.prepare(`
+        SELECT id, name, event, action_type, action_value, enabled, description, mode, priority, config
+        FROM pmo_work_hooks
+        WHERE event = ? AND enabled = 1
+        ORDER BY priority ASC, created_at ASC
+      `).all(eventName) as ExtendedHookRow[]
+    } catch {
+      // Fallback without mode/priority columns (pre-migration)
+      try {
+        const basic = this.db.prepare(`
+          SELECT id, name, event, action_type, action_value, enabled, description
+          FROM pmo_work_hooks
+          WHERE event = ? AND enabled = 1
+          ORDER BY created_at ASC
+        `).all(eventName) as ExtendedHookRow[]
+        return basic
+      } catch {
+        return []
+      }
+    }
+  }
+
+  /**
+   * Build an OrchestrateEventContext from raw event data.
+   */
+  private buildContext(eventName: string, data: Record<string, unknown>): OrchestrateEventContext {
+    return {
+      event: eventName,
+      ticket: (data.ticketId ?? data.workItemId ?? data.ticket) as string | undefined,
+      pr: (data.prNumber ?? data.pr) as number | undefined,
+      branch: data.branch as string | undefined,
+      agent: (data.agentName ?? data.agent ?? data.sessionId) as string | undefined,
+      container: data.containerId as string | undefined,
+      executionId: data.executionId as string | undefined,
+      prUrl: data.prUrl as string | undefined,
+      projectId: data.projectId as string | undefined,
+      ...data,
+    }
+  }
+
+  /**
+   * Resolve the action name from a hook row.
+   * Built-in actions are referenced by name; shell hooks use the raw command.
+   */
+  private resolveActionName(hook: ExtendedHookRow): string {
+    // If the action_value starts with "prlt hook fire", extract the --action value
+    const actionMatch = hook.action_value.match(/--action\s+(\S+)/)
+    if (actionMatch) return actionMatch[1]
+
+    // If it's a known built-in action name directly
+    if (ACTION_HANDLERS[hook.action_value]) return hook.action_value
+
+    // Otherwise it's a raw shell command — use the action_value as-is
+    return hook.action_value
+  }
+
+  /**
+   * Execute an action — either built-in or shell fallback.
+   */
+  private executeAction(
+    actionName: string,
+    ctx: OrchestrateEventContext,
+    config?: Record<string, unknown>,
+  ): OrchestrateActionResult {
+    // Try built-in action first
+    if (ACTION_HANDLERS[actionName]) {
+      return executeBuiltinAction(actionName, ctx, config)
+    }
+
+    // Fallback to shell execution
+    const start = Date.now()
+    try {
+      const env = {
+        ...process.env,
+        PRLT_HOOK_EVENT: ctx.event,
+        PRLT_HOOK_TICKET: ctx.ticket ?? '',
+        PRLT_HOOK_PR: ctx.pr ? String(ctx.pr) : '',
+        PRLT_HOOK_BRANCH: ctx.branch ?? '',
+        PRLT_HOOK_AGENT: ctx.agent ?? '',
+      }
+      execSync(actionName, { env, timeout: 30_000, stdio: 'pipe' })
+      return { action: actionName, success: true, durationMs: Date.now() - start }
+    } catch (err) {
+      return {
+        action: actionName,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Singleton
+// =============================================================================
+
+let _engine: OrchestrateEngine | undefined
+
+/**
+ * Initialize and start the orchestrate engine.
+ * Safe to call multiple times.
+ */
+export function initOrchestrateEngine(options: OrchestrateEngineOptions): OrchestrateEngine {
+  if (!_engine) {
+    _engine = new OrchestrateEngine(options)
+    _engine.start()
+  }
+  return _engine
+}
+
+/**
+ * Get the running orchestrate engine instance.
+ */
+export function getOrchestrateEngine(): OrchestrateEngine | undefined {
+  return _engine
+}
+
+/**
+ * Stop the orchestrate engine.
+ */
+export function stopOrchestrateEngine(): void {
+  if (_engine) {
+    _engine.stop()
+    _engine = undefined
+  }
+}

--- a/apps/cli/src/lib/orchestrate/index.ts
+++ b/apps/cli/src/lib/orchestrate/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Orchestrate module — public API.
+ *
+ * Event-driven pipeline automation daemon with HITL controls.
+ * Extends the work-lifecycle hook system with built-in actions,
+ * YAML config loading, presets, and mode-aware execution.
+ */
+
+export type {
+  OrchestrateEvent,
+  HookMode,
+  BuiltinAction,
+  HooksYaml,
+  HookYamlEntry,
+  WorkflowYaml,
+  PresetName,
+  OrchestrateEventContext,
+  OrchestrateActionResult,
+} from './types.js'
+
+export {
+  ORCHESTRATE_EVENTS,
+  HOOK_MODES,
+  BUILTIN_ACTIONS,
+  PRESET_NAMES,
+} from './types.js'
+
+export {
+  PRESETS,
+  getPreset,
+} from './presets.js'
+
+export {
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  exportHooksToYaml,
+} from './config-loader.js'
+
+export {
+  ACTION_HANDLERS,
+  executeBuiltinAction,
+} from './actions.js'
+
+export {
+  OrchestrateEngine,
+  initOrchestrateEngine,
+  getOrchestrateEngine,
+  stopOrchestrateEngine,
+} from './engine.js'
+
+export type { OrchestrateEngineOptions } from './engine.js'
+
+export { OrchestratePoller } from './poller.js'
+export type { PollerOptions } from './poller.js'

--- a/apps/cli/src/lib/orchestrate/poller.ts
+++ b/apps/cli/src/lib/orchestrate/poller.ts
@@ -1,0 +1,337 @@
+/**
+ * Orchestrate External Event Poller
+ *
+ * Polls external systems (GitHub, database) and fires orchestrate events
+ * when conditions are detected. This bridges external state changes into
+ * the internal event bus.
+ *
+ * Supported polls:
+ * - GitHub: open PR CI status, merge conflicts
+ * - Database: ready tickets, agent lifecycle states
+ */
+
+import { execSync } from 'node:child_process'
+import type Database from 'better-sqlite3'
+import { isGHInstalled, isGHAuthenticated, listOpenPRs, getPRChecks, getPRByNumber } from '../pr/index.js'
+import type { OrchestrateEngine } from './engine.js'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface PollerOptions {
+  engine: OrchestrateEngine
+  db: Database.Database
+  log: (msg: string) => void
+  /** Working directory for gh CLI commands */
+  cwd?: string
+}
+
+interface TrackedPR {
+  number: number
+  lastCIState: 'pending' | 'success' | 'failure' | 'unknown'
+  lastMergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+}
+
+// =============================================================================
+// Poller
+// =============================================================================
+
+export class OrchestratePoller {
+  private engine: OrchestrateEngine
+  private db: Database.Database
+  private log: (msg: string) => void
+  private cwd?: string
+
+  /** Tracks known PR state to detect transitions. */
+  private trackedPRs = new Map<number, TrackedPR>()
+
+  /** Track which tickets we've already fired on_ticket_ready for. */
+  private firedReadyTickets = new Set<string>()
+
+  /** Track known agent lifecycle states. */
+  private lastAgentStates = new Map<string, string>()
+
+  private ghAvailable: boolean | null = null
+
+  constructor(options: PollerOptions) {
+    this.engine = options.engine
+    this.db = options.db
+    this.log = options.log
+    this.cwd = options.cwd
+  }
+
+  /**
+   * Run one poll cycle. Called by the daemon on each interval.
+   */
+  async poll(): Promise<void> {
+    await this.pollReadyTickets()
+    await this.pollAgentLifecycle()
+    await this.pollGitHubPRs()
+  }
+
+  // ===========================================================================
+  // Ticket Polling
+  // ===========================================================================
+
+  /**
+   * Check for tickets in "Ready" (todo) status with no active agent.
+   * Fires on_ticket_ready for each.
+   */
+  private async pollReadyTickets(): Promise<void> {
+    try {
+      const readyTickets = this.db.prepare(`
+        SELECT t.id, t.title
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
+        WHERE ws.category = 'todo'
+          AND t.assignee IS NULL
+          AND t.id NOT IN (
+            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
+          )
+        LIMIT 10
+      `).all() as Array<{ id: string; title: string }>
+
+      for (const ticket of readyTickets) {
+        if (this.firedReadyTickets.has(ticket.id)) continue
+        this.firedReadyTickets.add(ticket.id)
+
+        this.log(`[poll] Detected ready ticket: ${ticket.id}`)
+        await this.engine.fireEvent('on_ticket_ready', {
+          event: 'on_ticket_ready',
+          ticket: ticket.id,
+        })
+      }
+    } catch {
+      // Non-fatal polling error
+    }
+  }
+
+  // ===========================================================================
+  // Agent Lifecycle Polling
+  // ===========================================================================
+
+  /**
+   * Check agent_work table for lifecycle state changes.
+   * Fires on_agent_died, on_agent_completed, on_agent_idle as appropriate.
+   */
+  private async pollAgentLifecycle(): Promise<void> {
+    try {
+      const agents = this.db.prepare(`
+        SELECT id, ticket_id, agent_name, status, lifecycle_state, container_id, last_heartbeat
+        FROM agent_work
+        WHERE status IN ('starting', 'running', 'error')
+        LIMIT 50
+      `).all() as Array<{
+        id: string
+        ticket_id: string
+        agent_name: string
+        status: string
+        lifecycle_state: string | null
+        container_id: string | null
+        last_heartbeat: string | null
+      }>
+
+      for (const agent of agents) {
+        const prevState = this.lastAgentStates.get(agent.id)
+        const currentState = agent.lifecycle_state || agent.status
+
+        if (prevState === currentState) continue
+        this.lastAgentStates.set(agent.id, currentState)
+
+        // Skip the first observation (we only fire on transitions)
+        if (!prevState) continue
+
+        const ctx = {
+          event: '',
+          ticket: agent.ticket_id,
+          agent: agent.agent_name,
+          container: agent.container_id || undefined,
+          executionId: agent.id,
+        }
+
+        if (currentState === 'died' || (agent.status === 'error' && prevState !== 'error')) {
+          this.log(`[poll] Agent died: ${agent.agent_name} (${agent.ticket_id})`)
+          await this.engine.fireEvent('on_agent_died', { ...ctx, event: 'on_agent_died' })
+        } else if (currentState === 'completed') {
+          this.log(`[poll] Agent completed: ${agent.agent_name} (${agent.ticket_id})`)
+          await this.engine.fireEvent('on_agent_completed', { ...ctx, event: 'on_agent_completed' })
+        } else if (currentState === 'idle') {
+          this.log(`[poll] Agent idle: ${agent.agent_name} (${agent.ticket_id})`)
+          await this.engine.fireEvent('on_agent_idle', { ...ctx, event: 'on_agent_idle' })
+        }
+      }
+
+      // Detect idle agents by heartbeat timeout (5 minutes)
+      try {
+        const idleAgents = this.db.prepare(`
+          SELECT id, ticket_id, agent_name, container_id
+          FROM agent_work
+          WHERE status = 'running'
+            AND last_heartbeat IS NOT NULL
+            AND datetime(last_heartbeat) < datetime('now', '-5 minutes')
+            AND (lifecycle_state IS NULL OR lifecycle_state = 'healthy')
+          LIMIT 10
+        `).all() as Array<{ id: string; ticket_id: string; agent_name: string; container_id: string | null }>
+
+        for (const agent of idleAgents) {
+          const prevState = this.lastAgentStates.get(agent.id)
+          if (prevState === 'idle') continue
+          this.lastAgentStates.set(agent.id, 'idle')
+
+          if (prevState) {
+            this.log(`[poll] Agent idle (heartbeat timeout): ${agent.agent_name}`)
+            await this.engine.fireEvent('on_agent_idle', {
+              event: 'on_agent_idle',
+              ticket: agent.ticket_id,
+              agent: agent.agent_name,
+              container: agent.container_id || undefined,
+              executionId: agent.id,
+            })
+          }
+        }
+      } catch {
+        // last_heartbeat column might not exist yet
+      }
+    } catch {
+      // Non-fatal polling error
+    }
+  }
+
+  // ===========================================================================
+  // GitHub PR Polling
+  // ===========================================================================
+
+  /**
+   * Check GitHub PRs for CI completion and merge conflicts.
+   * Fires on_ci_green, on_ci_failed, on_pr_conflicting, on_pr_merged.
+   */
+  private async pollGitHubPRs(): Promise<void> {
+    if (this.ghAvailable === null) {
+      this.ghAvailable = isGHInstalled() && isGHAuthenticated()
+    }
+    if (!this.ghAvailable) return
+
+    try {
+      const openPRs = listOpenPRs(this.cwd)
+
+      for (const pr of openPRs) {
+        const tracked = this.trackedPRs.get(pr.number)
+        const ticketId = this.extractTicketFromBranch(pr.headBranch)
+
+        // --- CI Status ---
+        const checks = getPRChecks(pr.number, this.cwd)
+        let ciState: TrackedPR['lastCIState'] = 'unknown'
+
+        if (checks.length > 0) {
+          const allDone = checks.every(c => c.status === 'COMPLETED' || c.conclusion)
+          if (allDone) {
+            const allPassed = checks.every(c =>
+              c.conclusion === 'SUCCESS' || c.conclusion === 'NEUTRAL' || c.conclusion === 'SKIPPED'
+            )
+            ciState = allPassed ? 'success' : 'failure'
+          } else {
+            ciState = 'pending'
+          }
+        }
+
+        // Fire CI events on state transition
+        if (tracked && ciState !== tracked.lastCIState && ciState !== 'pending' && ciState !== 'unknown') {
+          if (ciState === 'success') {
+            this.log(`[poll] CI green: PR #${pr.number}`)
+            await this.engine.fireEvent('on_ci_green', {
+              event: 'on_ci_green',
+              pr: pr.number,
+              branch: pr.headBranch,
+              ticket: ticketId,
+              prUrl: pr.url,
+            })
+          } else if (ciState === 'failure') {
+            this.log(`[poll] CI failed: PR #${pr.number}`)
+            await this.engine.fireEvent('on_ci_failed', {
+              event: 'on_ci_failed',
+              pr: pr.number,
+              branch: pr.headBranch,
+              ticket: ticketId,
+              prUrl: pr.url,
+            })
+          }
+        }
+
+        // --- Merge Conflicts ---
+        let mergeable: TrackedPR['lastMergeable'] = 'UNKNOWN'
+        try {
+          const mergeableResult = execSync(
+            `gh pr view ${pr.number} --json mergeable -q .mergeable`,
+            { cwd: this.cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+          ).trim()
+          if (mergeableResult === 'CONFLICTING') {
+            mergeable = 'CONFLICTING'
+          } else if (mergeableResult === 'MERGEABLE') {
+            mergeable = 'MERGEABLE'
+          }
+        } catch {
+          // gh command failed
+        }
+
+        if (
+          tracked &&
+          mergeable === 'CONFLICTING' &&
+          tracked.lastMergeable !== 'CONFLICTING'
+        ) {
+          this.log(`[poll] PR conflicting: PR #${pr.number}`)
+          await this.engine.fireEvent('on_pr_conflicting', {
+            event: 'on_pr_conflicting',
+            pr: pr.number,
+            branch: pr.headBranch,
+            ticket: ticketId,
+            prUrl: pr.url,
+          })
+        }
+
+        // Update tracking
+        this.trackedPRs.set(pr.number, {
+          number: pr.number,
+          lastCIState: ciState,
+          lastMergeable: mergeable,
+        })
+      }
+
+      // Detect merged/closed PRs (were tracked but no longer open)
+      for (const [prNum, tracked] of this.trackedPRs) {
+        if (!openPRs.some(p => p.number === prNum)) {
+          // PR was open, now it's not — check if merged
+          const pr = getPRByNumber(prNum, this.cwd)
+          if (pr?.state === 'MERGED') {
+            const ticketId = this.extractTicketFromBranch(pr.headBranch)
+            this.log(`[poll] PR merged: PR #${prNum}`)
+            await this.engine.fireEvent('on_pr_merged', {
+              event: 'on_pr_merged',
+              pr: prNum,
+              branch: pr.headBranch,
+              ticket: ticketId,
+              prUrl: pr.url,
+            })
+          }
+          this.trackedPRs.delete(prNum)
+        }
+      }
+    } catch {
+      // Non-fatal GitHub polling error
+    }
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  /**
+   * Extract ticket ID from branch name.
+   * Branch format: {ticketId}/{type}/{owner}/{agent}/{description}
+   */
+  private extractTicketFromBranch(branch: string): string | undefined {
+    // Match patterns like PRLT-123/... or TKT-456/...
+    const match = branch.match(/^([A-Z]+-\d+|TKT-\d+)\//)
+    return match ? match[1] : undefined
+  }
+}

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -1,0 +1,85 @@
+/**
+ * Orchestrate Presets
+ *
+ * Pre-configured hook sets for common automation levels.
+ *
+ * - aggressive: auto-everything — no human needed
+ * - conservative: confirm everything — human approves all
+ * - supervised: auto for safe ops, confirm for destructive
+ */
+
+import type { HookMode, OrchestrateEvent, PresetName } from './types.js'
+
+interface PresetHook {
+  event: OrchestrateEvent
+  action: string
+  mode: HookMode
+  config?: Record<string, unknown>
+}
+
+interface PresetDefinition {
+  name: PresetName
+  description: string
+  hooks: PresetHook[]
+}
+
+const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Record<string, unknown> }> = [
+  { event: 'on_ci_green', action: 'merge-pr' },
+  { event: 'on_pr_merged', action: 'move-ticket', config: { target: 'done' } },
+  { event: 'on_pr_opened', action: 'move-ticket', config: { target: 'review' } },
+  { event: 'on_pr_merged', action: 'rebase-conflicting-prs' },
+  { event: 'on_pr_conflicting', action: 'rebase-conflicting-prs' },
+  { event: 'on_ticket_ready', action: 'spawn-agent' },
+  { event: 'on_agent_died', action: 'respawn', config: { max_retries: 2 } },
+  { event: 'on_agent_died', action: 'notify' },
+  { event: 'on_ci_failed', action: 'notify' },
+  { event: 'on_ci_failed', action: 'spawn-fix-agent' },
+  { event: 'on_agent_completed', action: 'cleanup-container' },
+  { event: 'on_agent_idle', action: 'health-check' },
+  { event: 'on_agent_spawned', action: 'move-ticket', config: { target: 'in-progress' } },
+]
+
+/** Safe actions that can be auto-executed even in supervised mode. */
+const SAFE_ACTIONS = new Set([
+  'move-ticket',
+  'notify',
+  'cleanup-container',
+  'health-check',
+  'rebase-conflicting-prs',
+])
+
+export const PRESETS: Record<PresetName, PresetDefinition> = {
+  aggressive: {
+    name: 'aggressive',
+    description: 'Auto everything — no human needed',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: 'auto' as HookMode,
+    })),
+  },
+
+  conservative: {
+    name: 'conservative',
+    description: 'Confirm everything — human approves all actions',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: 'confirm' as HookMode,
+    })),
+  },
+
+  supervised: {
+    name: 'supervised',
+    description: 'Auto for safe ops, confirm for destructive actions',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: (SAFE_ACTIONS.has(h.action) ? 'auto' : 'confirm') as HookMode,
+    })),
+  },
+}
+
+/**
+ * Get a preset definition by name.
+ */
+export function getPreset(name: PresetName): PresetDefinition {
+  return PRESETS[name]
+}

--- a/apps/cli/src/lib/orchestrate/types.ts
+++ b/apps/cli/src/lib/orchestrate/types.ts
@@ -1,0 +1,190 @@
+/**
+ * Orchestrate Types
+ *
+ * Defines events, hook modes, actions, and presets for the orchestrate daemon.
+ * The orchestrate system extends the existing work-lifecycle hooks with
+ * built-in actions and HITL (human-in-the-loop) controls.
+ */
+
+// =============================================================================
+// Orchestrator Events
+// =============================================================================
+
+/**
+ * All events the orchestrate daemon can react to.
+ * Extends the existing HookableEvent set with CI/PR/agent lifecycle events.
+ */
+export type OrchestrateEvent =
+  // Existing work-lifecycle events
+  | 'work:started'
+  | 'work:status_changed'
+  | 'work:pr_created'
+  | 'work:pr_merged'
+  | 'work:pr_closed'
+  | 'work:completed'
+  | 'agent:spawned'
+  | 'agent:stopped'
+  // New orchestrator events
+  | 'on_ci_green'
+  | 'on_ci_failed'
+  | 'on_pr_opened'
+  | 'on_pr_merged'
+  | 'on_pr_conflicting'
+  | 'on_ticket_ready'
+  | 'on_agent_spawned'
+  | 'on_agent_died'
+  | 'on_agent_completed'
+  | 'on_agent_idle'
+  | 'on_version_published'
+
+/** All valid orchestrate event names. */
+export const ORCHESTRATE_EVENTS: OrchestrateEvent[] = [
+  'work:started',
+  'work:status_changed',
+  'work:pr_created',
+  'work:pr_merged',
+  'work:pr_closed',
+  'work:completed',
+  'agent:spawned',
+  'agent:stopped',
+  'on_ci_green',
+  'on_ci_failed',
+  'on_pr_opened',
+  'on_pr_merged',
+  'on_pr_conflicting',
+  'on_ticket_ready',
+  'on_agent_spawned',
+  'on_agent_died',
+  'on_agent_completed',
+  'on_agent_idle',
+  'on_version_published',
+]
+
+// =============================================================================
+// Hook Modes
+// =============================================================================
+
+/**
+ * Automation level for a hook.
+ *
+ * - auto: fires immediately, no human needed
+ * - confirm: pauses, notifies, waits for approval
+ * - notify: fires but also pings (log, Slack, dashboard)
+ * - off: disabled
+ */
+export type HookMode = 'auto' | 'confirm' | 'notify' | 'off'
+
+/** All valid hook modes. */
+export const HOOK_MODES: HookMode[] = ['auto', 'confirm', 'notify', 'off']
+
+// =============================================================================
+// Built-in Actions
+// =============================================================================
+
+/**
+ * Built-in orchestrate actions.
+ * These are first-class actions the daemon knows how to execute natively.
+ */
+export type BuiltinAction =
+  | 'merge-pr'
+  | 'move-ticket'
+  | 'rebase-conflicting-prs'
+  | 'spawn-agent'
+  | 'respawn'
+  | 'notify'
+  | 'cleanup-container'
+  | 'spawn-fix-agent'
+  | 'health-check'
+
+/** All valid built-in action names. */
+export const BUILTIN_ACTIONS: BuiltinAction[] = [
+  'merge-pr',
+  'move-ticket',
+  'rebase-conflicting-prs',
+  'spawn-agent',
+  'respawn',
+  'notify',
+  'cleanup-container',
+  'spawn-fix-agent',
+  'health-check',
+]
+
+// =============================================================================
+// Hook Configuration (YAML shape)
+// =============================================================================
+
+/**
+ * A single hook entry as defined in hooks.yml.
+ */
+export interface HookYamlEntry {
+  action: string
+  mode: HookMode
+  max_retries?: number
+  args?: Record<string, string>
+}
+
+/**
+ * The full hooks.yml file shape.
+ * Keys are event names, values are arrays of hook entries.
+ */
+export type HooksYaml = Record<string, HookYamlEntry[]>
+
+// =============================================================================
+// Workflow Configuration (YAML shape)
+// =============================================================================
+
+/**
+ * The .proletariat/workflow.yml file shape.
+ */
+export interface WorkflowYaml {
+  branches?: {
+    target?: string
+    strategy?: 'squash' | 'merge' | 'rebase'
+  }
+  on_implement_complete?: string[]
+  on_review_complete?: string[]
+  review?: {
+    required?: boolean | 'auto'
+    auto_merge_on_green?: boolean
+  }
+}
+
+// =============================================================================
+// Presets
+// =============================================================================
+
+/**
+ * Preset name for quick hook configuration.
+ */
+export type PresetName = 'aggressive' | 'conservative' | 'supervised'
+
+/** All valid preset names. */
+export const PRESET_NAMES: PresetName[] = ['aggressive', 'conservative', 'supervised']
+
+/**
+ * Event context passed to hook handlers at runtime.
+ */
+export interface OrchestrateEventContext {
+  event: string
+  ticket?: string
+  pr?: number
+  branch?: string
+  agent?: string
+  container?: string
+  executionId?: string
+  prUrl?: string
+  projectId?: string
+  [key: string]: unknown
+}
+
+/**
+ * Result of running a single orchestrate hook action.
+ */
+export interface OrchestrateActionResult {
+  action: string
+  success: boolean
+  error?: string
+  durationMs: number
+  skipped?: boolean
+  awaitingConfirmation?: boolean
+}

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -10,16 +10,29 @@ import type { RuntimeEventName } from '../../events/events.js'
 
 /**
  * Work lifecycle event names that can trigger hooks.
- * Subset of RuntimeEventName limited to work-relevant events.
+ * Subset of RuntimeEventName limited to work-relevant events,
+ * plus orchestrate daemon events for pipeline automation.
  */
 export type HookableEvent = Extract<
   RuntimeEventName,
   | 'work:started'
   | 'work:status_changed'
   | 'work:pr_created'
+  | 'work:pr_merged'
   | 'work:completed'
   | 'agent:spawned'
   | 'agent:stopped'
+  | 'on_ci_green'
+  | 'on_ci_failed'
+  | 'on_pr_opened'
+  | 'on_pr_merged'
+  | 'on_pr_conflicting'
+  | 'on_ticket_ready'
+  | 'on_agent_spawned'
+  | 'on_agent_died'
+  | 'on_agent_completed'
+  | 'on_agent_idle'
+  | 'on_version_published'
 >
 
 /** All hookable event names for validation. */
@@ -27,9 +40,21 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
   'work:started',
   'work:status_changed',
   'work:pr_created',
+  'work:pr_merged',
   'work:completed',
   'agent:spawned',
   'agent:stopped',
+  'on_ci_green',
+  'on_ci_failed',
+  'on_pr_opened',
+  'on_pr_merged',
+  'on_pr_conflicting',
+  'on_ticket_ready',
+  'on_agent_spawned',
+  'on_agent_died',
+  'on_agent_completed',
+  'on_agent_idle',
+  'on_version_published',
 ]
 
 /**

--- a/apps/cli/test/unit/orchestrate-actions.test.ts
+++ b/apps/cli/test/unit/orchestrate-actions.test.ts
@@ -1,0 +1,154 @@
+import { expect } from 'chai'
+import { executeBuiltinAction, ACTION_HANDLERS } from '../../src/lib/orchestrate/actions.js'
+import type { OrchestrateEventContext } from '../../src/lib/orchestrate/types.js'
+
+/**
+ * Unit tests for orchestrate built-in actions.
+ *
+ * Tests cover:
+ * - Action registry completeness
+ * - Notify action (pure, no side effects)
+ * - Error handling for missing context
+ * - Unknown action handling
+ */
+
+describe('Orchestrate Built-in Actions', () => {
+  // ===========================================================================
+  // Action Registry
+  // ===========================================================================
+
+  describe('action registry', () => {
+    const expectedActions = [
+      'merge-pr',
+      'move-ticket',
+      'rebase-conflicting-prs',
+      'spawn-agent',
+      'respawn',
+      'notify',
+      'cleanup-container',
+      'spawn-fix-agent',
+      'health-check',
+    ]
+
+    it('should have all expected actions registered', () => {
+      for (const action of expectedActions) {
+        expect(ACTION_HANDLERS).to.have.property(action)
+        expect(ACTION_HANDLERS[action]).to.be.a('function')
+      }
+    })
+
+    it('should have exactly the expected number of actions', () => {
+      expect(Object.keys(ACTION_HANDLERS)).to.have.length(expectedActions.length)
+    })
+  })
+
+  // ===========================================================================
+  // Notify Action (pure — no external dependencies)
+  // ===========================================================================
+
+  describe('notify action', () => {
+    it('should succeed with all context fields', () => {
+      const ctx: OrchestrateEventContext = {
+        event: 'on_ci_green',
+        ticket: 'TKT-100',
+        pr: 123,
+        agent: 'bold-turing',
+      }
+      const result = executeBuiltinAction('notify', ctx)
+      expect(result.action).to.equal('notify')
+      expect(result.success).to.be.true
+      expect(result.durationMs).to.be.a('number').and.at.least(0)
+    })
+
+    it('should succeed with minimal context', () => {
+      const result = executeBuiltinAction('notify', { event: 'on_ci_green' })
+      expect(result.success).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Missing Context Handling
+  // ===========================================================================
+
+  describe('missing context handling', () => {
+    it('merge-pr should fail without ticket or PR', () => {
+      const result = executeBuiltinAction('merge-pr', { event: 'on_ci_green' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket or PR')
+    })
+
+    it('move-ticket should fail without ticket', () => {
+      const result = executeBuiltinAction('move-ticket', { event: 'on_pr_merged' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket')
+    })
+
+    it('spawn-agent should fail without ticket', () => {
+      const result = executeBuiltinAction('spawn-agent', { event: 'on_ticket_ready' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket')
+    })
+
+    it('respawn should fail without ticket', () => {
+      const result = executeBuiltinAction('respawn', { event: 'on_agent_died' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket')
+    })
+
+    it('spawn-fix-agent should fail without ticket', () => {
+      const result = executeBuiltinAction('spawn-fix-agent', { event: 'on_ci_failed' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket')
+    })
+
+    it('health-check should fail without agent', () => {
+      const result = executeBuiltinAction('health-check', { event: 'on_agent_idle' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No agent')
+    })
+
+    it('cleanup-container should fail without agent or container', () => {
+      const result = executeBuiltinAction('cleanup-container', { event: 'on_agent_completed' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No agent or container')
+    })
+  })
+
+  // ===========================================================================
+  // Unknown Action
+  // ===========================================================================
+
+  describe('unknown action', () => {
+    it('should return failure for unregistered action name', () => {
+      const result = executeBuiltinAction('nonexistent-action', { event: 'on_ci_green' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('Unknown action')
+    })
+
+    it('should include the action name in the error', () => {
+      const result = executeBuiltinAction('does-not-exist', { event: 'on_ci_green' })
+      expect(result.error).to.include('does-not-exist')
+    })
+  })
+
+  // ===========================================================================
+  // Action Result Shape
+  // ===========================================================================
+
+  describe('result shape', () => {
+    it('should always include action, success, and durationMs', () => {
+      const result = executeBuiltinAction('notify', { event: 'test' })
+      expect(result).to.have.property('action')
+      expect(result).to.have.property('success')
+      expect(result).to.have.property('durationMs')
+    })
+
+    it('should include error only on failure', () => {
+      const success = executeBuiltinAction('notify', { event: 'test' })
+      expect(success.error).to.be.undefined
+
+      const failure = executeBuiltinAction('merge-pr', { event: 'test' })
+      expect(failure.error).to.be.a('string')
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-config-loader.test.ts
+++ b/apps/cli/test/unit/orchestrate-config-loader.test.ts
@@ -1,0 +1,246 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import {
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  exportHooksToYaml,
+} from '../../src/lib/orchestrate/config-loader.js'
+import Database from 'better-sqlite3'
+import { ensureHooksTable } from '../../src/lib/work-lifecycle/hooks/storage.js'
+
+/**
+ * Unit tests for orchestrate config loader.
+ *
+ * Tests cover:
+ * - YAML file loading and parsing
+ * - Hook sync from YAML to database
+ * - Preset application
+ * - YAML export
+ */
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  ensureHooksTable(db)
+  try {
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'off'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT")
+  } catch {
+    // Columns may already exist
+  }
+  return db
+}
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-test-'))
+}
+
+describe('Orchestrate Config Loader', () => {
+  let db: Database.Database
+  let tmpDir: string
+
+  beforeEach(() => {
+    db = createTestDb()
+    tmpDir = createTempDir()
+    fs.mkdirSync(path.join(tmpDir, '.proletariat'), { recursive: true })
+  })
+
+  afterEach(() => {
+    db.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  // ===========================================================================
+  // YAML Loading
+  // ===========================================================================
+
+  describe('loadHooksYaml', () => {
+    it('should return null when file does not exist', () => {
+      const result = loadHooksYaml(tmpDir)
+      expect(result).to.be.null
+    })
+
+    it('should parse valid hooks.yml', () => {
+      const yamlContent = `
+on_ci_green:
+  - action: merge-pr
+    mode: auto
+on_ticket_ready:
+  - action: spawn-agent
+    mode: confirm
+`
+      fs.writeFileSync(path.join(tmpDir, '.proletariat', 'hooks.yml'), yamlContent)
+
+      const result = loadHooksYaml(tmpDir)
+      expect(result).to.not.be.null
+      expect(result!.on_ci_green).to.be.an('array').with.length(1)
+      expect(result!.on_ci_green[0].action).to.equal('merge-pr')
+      expect(result!.on_ci_green[0].mode).to.equal('auto')
+      expect(result!.on_ticket_ready).to.be.an('array').with.length(1)
+      expect(result!.on_ticket_ready[0].mode).to.equal('confirm')
+    })
+  })
+
+  describe('loadWorkflowYaml', () => {
+    it('should return null when file does not exist', () => {
+      const result = loadWorkflowYaml(tmpDir)
+      expect(result).to.be.null
+    })
+
+    it('should parse valid workflow.yml', () => {
+      const yamlContent = `
+branches:
+  target: main
+  strategy: squash
+review:
+  required: false
+  auto_merge_on_green: true
+`
+      fs.writeFileSync(path.join(tmpDir, '.proletariat', 'workflow.yml'), yamlContent)
+
+      const result = loadWorkflowYaml(tmpDir)
+      expect(result).to.not.be.null
+      expect(result!.branches!.target).to.equal('main')
+      expect(result!.branches!.strategy).to.equal('squash')
+      expect(result!.review!.auto_merge_on_green).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Hook Sync
+  // ===========================================================================
+
+  describe('syncHooksFromYaml', () => {
+    it('should sync hooks from YAML to database', () => {
+      const hooksYaml = {
+        on_ci_green: [
+          { action: 'merge-pr', mode: 'auto' as const },
+        ],
+        on_pr_merged: [
+          { action: 'move-ticket', mode: 'auto' as const },
+          { action: 'rebase-conflicting-prs', mode: 'auto' as const },
+        ],
+      }
+
+      const count = syncHooksFromYaml(db, hooksYaml)
+      expect(count).to.equal(3)
+
+      const hooks = db.prepare('SELECT * FROM pmo_work_hooks').all() as Array<{ name: string; action_value: string }>
+      expect(hooks).to.have.length(3)
+    })
+
+    it('should replace existing YAML-sourced hooks on re-sync', () => {
+      const first = { on_ci_green: [{ action: 'merge-pr', mode: 'auto' as const }] }
+      syncHooksFromYaml(db, first)
+
+      const second = { on_ci_failed: [{ action: 'notify', mode: 'auto' as const }] }
+      const count = syncHooksFromYaml(db, second)
+      expect(count).to.equal(1)
+
+      // Old YAML hooks should be gone, new ones should be present
+      const hooks = db.prepare("SELECT * FROM pmo_work_hooks WHERE source = 'yaml'").all() as Array<{ action_value: string }>
+      expect(hooks).to.have.length(1)
+      expect(hooks[0].action_value).to.equal('notify')
+    })
+
+    it('should skip entries without an action', () => {
+      const hooksYaml = {
+        on_ci_green: [
+          { mode: 'auto' } as any,
+          { action: 'notify', mode: 'auto' },
+        ],
+      }
+      const count = syncHooksFromYaml(db, hooksYaml)
+      expect(count).to.equal(1)
+    })
+
+    it('should default to auto mode for invalid modes', () => {
+      const hooksYaml = {
+        on_ci_green: [
+          { action: 'notify', mode: 'invalid-mode' as any },
+        ],
+      }
+      syncHooksFromYaml(db, hooksYaml)
+
+      const hook = db.prepare("SELECT mode FROM pmo_work_hooks LIMIT 1").get() as { mode: string }
+      expect(hook.mode).to.equal('auto')
+    })
+  })
+
+  // ===========================================================================
+  // Preset Application
+  // ===========================================================================
+
+  describe('applyPreset', () => {
+    it('should apply aggressive preset', () => {
+      const count = applyPreset(db, 'aggressive')
+      expect(count).to.be.greaterThan(0)
+
+      const hooks = db.prepare("SELECT * FROM pmo_work_hooks WHERE source = 'preset'").all() as Array<{ mode: string }>
+      expect(hooks.length).to.equal(count)
+
+      for (const hook of hooks) {
+        expect(hook.mode).to.equal('auto')
+      }
+    })
+
+    it('should apply conservative preset', () => {
+      const count = applyPreset(db, 'conservative')
+      expect(count).to.be.greaterThan(0)
+
+      const hooks = db.prepare("SELECT * FROM pmo_work_hooks WHERE source = 'preset'").all() as Array<{ mode: string }>
+      for (const hook of hooks) {
+        expect(hook.mode).to.equal('confirm')
+      }
+    })
+
+    it('should replace previous preset hooks on re-apply', () => {
+      applyPreset(db, 'aggressive')
+      const countBefore = (db.prepare("SELECT COUNT(*) as c FROM pmo_work_hooks WHERE source = 'preset'").get() as { c: number }).c
+
+      applyPreset(db, 'conservative')
+      const countAfter = (db.prepare("SELECT COUNT(*) as c FROM pmo_work_hooks WHERE source = 'preset'").get() as { c: number }).c
+
+      expect(countAfter).to.equal(countBefore)
+    })
+
+    it('should not affect YAML-sourced hooks when applying preset', () => {
+      const hooksYaml = { on_ci_green: [{ action: 'merge-pr', mode: 'auto' as const }] }
+      syncHooksFromYaml(db, hooksYaml)
+
+      applyPreset(db, 'aggressive')
+
+      const yamlHooks = db.prepare("SELECT * FROM pmo_work_hooks WHERE source = 'yaml'").all()
+      expect(yamlHooks).to.have.length(1)
+    })
+  })
+
+  // ===========================================================================
+  // Export
+  // ===========================================================================
+
+  describe('exportHooksToYaml', () => {
+    it('should export empty config when no hooks exist', () => {
+      const yamlStr = exportHooksToYaml(db)
+      expect(yamlStr).to.be.a('string')
+      // Should be empty YAML (just {}\n or similar)
+      expect(yamlStr.trim()).to.satisfy((s: string) => s === '{}' || s === '')
+    })
+
+    it('should export hooks grouped by event', () => {
+      applyPreset(db, 'aggressive')
+      const yamlStr = exportHooksToYaml(db)
+      expect(yamlStr).to.be.a('string')
+      expect(yamlStr.length).to.be.greaterThan(10)
+      // Should contain at least some event names
+      expect(yamlStr).to.include('action')
+      expect(yamlStr).to.include('mode')
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-engine.test.ts
+++ b/apps/cli/test/unit/orchestrate-engine.test.ts
@@ -1,0 +1,308 @@
+import { expect } from 'chai'
+import { OrchestrateEngine } from '../../src/lib/orchestrate/engine.js'
+import Database from 'better-sqlite3'
+import { ensureHooksTable } from '../../src/lib/work-lifecycle/hooks/storage.js'
+import type { OrchestrateActionResult } from '../../src/lib/orchestrate/types.js'
+
+/**
+ * Unit tests for the OrchestrateEngine.
+ *
+ * Tests cover:
+ * - Event handling and hook execution
+ * - Mode-aware behavior (auto, confirm, notify, off)
+ * - Pending confirmation queue
+ * - Shell fallback execution
+ * - Error handling
+ */
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  ensureHooksTable(db)
+  // Add orchestrate columns
+  try {
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'off'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT")
+    db.exec("CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)")
+  } catch {
+    // Columns may already exist
+  }
+  return db
+}
+
+function insertHook(db: Database.Database, opts: {
+  name: string
+  event: string
+  action: string
+  mode?: string
+  priority?: number
+  config?: string
+  enabled?: number
+}): string {
+  const id = `hook-${Math.random().toString(36).slice(2, 8)}`
+  db.prepare(`
+    INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, mode, priority, source, config)
+    VALUES (?, ?, ?, 'shell', ?, ?, ?, ?, 'cli', ?)
+  `).run(id, opts.name, opts.event, opts.action, opts.enabled ?? 1, opts.mode ?? 'auto', opts.priority ?? 0, opts.config ?? null)
+  return id
+}
+
+describe('OrchestrateEngine', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  // ===========================================================================
+  // Basic Event Handling
+  // ===========================================================================
+
+  describe('fireEvent', () => {
+    it('should return empty results when no hooks match', async () => {
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(results).to.be.an('array').that.is.empty
+    })
+
+    it('should execute matching hooks and return results', async () => {
+      insertHook(db, { name: 'notify-ci', event: 'on_ci_green', action: 'notify', mode: 'auto' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green', pr: 123 })
+
+      expect(results).to.have.length(1)
+      expect(results[0].action).to.equal('notify')
+      expect(results[0].success).to.be.true
+    })
+
+    it('should execute hooks in priority order', async () => {
+      const executed: string[] = []
+      insertHook(db, { name: 'low-priority', event: 'on_ci_green', action: 'notify', mode: 'auto', priority: 10 })
+      insertHook(db, { name: 'high-priority', event: 'on_ci_green', action: 'notify', mode: 'auto', priority: 1 })
+
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          const match = msg.match(/(\w+-priority) →/)
+          if (match) executed.push(match[1])
+        },
+      })
+
+      await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(executed[0]).to.equal('high-priority')
+      expect(executed[1]).to.equal('low-priority')
+    })
+
+    it('should not execute disabled hooks', async () => {
+      insertHook(db, { name: 'disabled-hook', event: 'on_ci_green', action: 'notify', mode: 'auto', enabled: 0 })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(results).to.be.empty
+    })
+  })
+
+  // ===========================================================================
+  // Mode Behavior
+  // ===========================================================================
+
+  describe('modes', () => {
+    it('should skip hooks with mode=off', async () => {
+      insertHook(db, { name: 'off-hook', event: 'on_ci_green', action: 'notify', mode: 'off' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].skipped).to.be.true
+    })
+
+    it('should execute auto hooks immediately', async () => {
+      insertHook(db, { name: 'auto-hook', event: 'on_ci_green', action: 'notify', mode: 'auto' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(results[0].skipped).to.be.undefined
+      expect(results[0].awaitingConfirmation).to.be.undefined
+    })
+
+    it('should queue confirm hooks without onConfirm callback', async () => {
+      insertHook(db, { name: 'confirm-hook', event: 'on_ci_green', action: 'notify', mode: 'confirm' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].awaitingConfirmation).to.be.true
+      expect(engine.getPendingConfirmations()).to.have.length(1)
+    })
+
+    it('should call onConfirm callback for confirm mode hooks', async () => {
+      insertHook(db, { name: 'confirm-hook', event: 'on_ci_green', action: 'notify', mode: 'confirm' })
+
+      let confirmCalled = false
+      const engine = new OrchestrateEngine({
+        db,
+        onConfirm: async (hookName, event, action) => {
+          confirmCalled = true
+          expect(hookName).to.equal('confirm-hook')
+          expect(event).to.equal('on_ci_green')
+          return true
+        },
+      })
+
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(confirmCalled).to.be.true
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(results[0].awaitingConfirmation).to.be.undefined
+    })
+
+    it('should skip confirm hook when onConfirm returns false', async () => {
+      insertHook(db, { name: 'denied-hook', event: 'on_ci_green', action: 'notify', mode: 'confirm' })
+
+      const engine = new OrchestrateEngine({
+        db,
+        onConfirm: async () => false,
+      })
+
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(results).to.have.length(1)
+      expect(results[0].skipped).to.be.true
+    })
+
+    it('should call onNotify callback for notify mode hooks', async () => {
+      insertHook(db, { name: 'notify-hook', event: 'on_ci_green', action: 'notify', mode: 'notify' })
+
+      let notifyCalled = false
+      const engine = new OrchestrateEngine({
+        db,
+        onNotify: (hookName, event, action, result) => {
+          notifyCalled = true
+          expect(hookName).to.equal('notify-hook')
+          expect(event).to.equal('on_ci_green')
+          expect(action).to.equal('notify')
+          expect(result.success).to.be.true
+        },
+      })
+
+      await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(notifyCalled).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Pending Confirmations
+  // ===========================================================================
+
+  describe('pendingConfirmations', () => {
+    it('should approve a pending confirmation and execute it', async () => {
+      insertHook(db, { name: 'confirm-hook', event: 'on_ci_green', action: 'notify', mode: 'confirm' })
+      const engine = new OrchestrateEngine({ db })
+      await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      expect(engine.getPendingConfirmations()).to.have.length(1)
+
+      const result = await engine.approveConfirmation(0)
+      expect(result).to.not.be.null
+      expect(result!.success).to.be.true
+      expect(engine.getPendingConfirmations()).to.be.empty
+    })
+
+    it('should deny a pending confirmation and remove it', async () => {
+      insertHook(db, { name: 'confirm-hook', event: 'on_ci_green', action: 'notify', mode: 'confirm' })
+      const engine = new OrchestrateEngine({ db })
+      await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      const denied = engine.denyConfirmation(0)
+      expect(denied).to.be.true
+      expect(engine.getPendingConfirmations()).to.be.empty
+    })
+
+    it('should return null for out-of-range approval index', async () => {
+      const engine = new OrchestrateEngine({ db })
+      const result = await engine.approveConfirmation(99)
+      expect(result).to.be.null
+    })
+
+    it('should return false for out-of-range denial index', () => {
+      const engine = new OrchestrateEngine({ db })
+      const result = engine.denyConfirmation(99)
+      expect(result).to.be.false
+    })
+  })
+
+  // ===========================================================================
+  // Shell Fallback
+  // ===========================================================================
+
+  describe('shell fallback', () => {
+    it('should execute unknown actions as shell commands', async () => {
+      insertHook(db, { name: 'shell-hook', event: 'on_ci_green', action: 'echo hello', mode: 'auto' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(results[0].action).to.equal('echo hello')
+    })
+
+    it('should return failure for failed shell commands', async () => {
+      insertHook(db, { name: 'fail-hook', event: 'on_ci_green', action: 'exit 1', mode: 'auto' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.false
+      expect(results[0].error).to.be.a('string')
+    })
+  })
+
+  // ===========================================================================
+  // Start/Stop
+  // ===========================================================================
+
+  describe('start/stop', () => {
+    it('should be idempotent on multiple starts', () => {
+      const engine = new OrchestrateEngine({ db })
+      engine.start()
+      engine.start() // should not throw
+      engine.stop()
+    })
+
+    it('should clear pending confirmations on stop', async () => {
+      insertHook(db, { name: 'confirm-hook', event: 'on_ci_green', action: 'notify', mode: 'confirm' })
+      const engine = new OrchestrateEngine({ db })
+      await engine.fireEvent('on_ci_green', { event: 'on_ci_green' })
+      expect(engine.getPendingConfirmations()).to.have.length(1)
+
+      engine.stop()
+      expect(engine.getPendingConfirmations()).to.be.empty
+    })
+  })
+
+  // ===========================================================================
+  // Context Building
+  // ===========================================================================
+
+  describe('context building', () => {
+    it('should pass context fields through to actions', async () => {
+      insertHook(db, { name: 'ctx-hook', event: 'on_ci_green', action: 'notify', mode: 'auto' })
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', {
+        event: 'on_ci_green',
+        ticket: 'TKT-100',
+        pr: 456,
+        branch: 'feat/test',
+      })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-poller.test.ts
+++ b/apps/cli/test/unit/orchestrate-poller.test.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai'
+import { OrchestratePoller } from '../../src/lib/orchestrate/poller.js'
+import { OrchestrateEngine } from '../../src/lib/orchestrate/engine.js'
+import Database from 'better-sqlite3'
+import { ensureHooksTable } from '../../src/lib/work-lifecycle/hooks/storage.js'
+import type { OrchestrateEventContext } from '../../src/lib/orchestrate/types.js'
+
+/**
+ * Unit tests for OrchestratePoller.
+ *
+ * Tests cover:
+ * - Ticket polling (on_ticket_ready)
+ * - Agent lifecycle polling (on_agent_died, on_agent_completed, on_agent_idle)
+ * - Deduplication (same ticket not fired twice)
+ * - Graceful error handling
+ */
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  ensureHooksTable(db)
+
+  // Add orchestrate columns
+  try {
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto'")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli'")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT")
+  } catch {
+    // May already exist
+  }
+
+  // Create minimal ticket and status tables for polling
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pmo_workflow_statuses (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      category TEXT NOT NULL
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pmo_tickets (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      status_id TEXT NOT NULL,
+      assignee TEXT,
+      FOREIGN KEY (status_id) REFERENCES pmo_workflow_statuses(id)
+    )
+  `)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_work (
+      id TEXT PRIMARY KEY,
+      ticket_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'starting',
+      lifecycle_state TEXT,
+      container_id TEXT,
+      last_heartbeat TEXT
+    )
+  `)
+
+  // Insert a "todo" status
+  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ready', 'Ready', 'todo')").run()
+  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ip', 'In Progress', 'started')").run()
+
+  return db
+}
+
+describe('OrchestratePoller', () => {
+  let db: Database.Database
+  let engine: OrchestrateEngine
+  let firedEvents: Array<{ event: string; ctx: OrchestrateEventContext }>
+
+  beforeEach(() => {
+    db = createTestDb()
+    firedEvents = []
+
+    // Create engine that records fired events
+    engine = new OrchestrateEngine({
+      db,
+      log: () => {},
+    })
+
+    // Monkey-patch fireEvent to record calls without executing hooks
+    const origFireEvent = engine.fireEvent.bind(engine)
+    engine.fireEvent = async (event: string, ctx: OrchestrateEventContext) => {
+      firedEvents.push({ event, ctx })
+      return []
+    }
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  // ===========================================================================
+  // Ticket Polling
+  // ===========================================================================
+
+  describe('ticket polling', () => {
+    it('should fire on_ticket_ready for unassigned todo tickets', async () => {
+      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-1', 'Test ticket', 'status-ready', NULL)").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.have.length(1)
+      expect(readyEvents[0].ctx.ticket).to.equal('TKT-1')
+    })
+
+    it('should not fire for assigned tickets', async () => {
+      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-2', 'Assigned', 'status-ready', 'agent-1')").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.be.empty
+    })
+
+    it('should not fire for tickets with active agents', async () => {
+      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-3', 'Active', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status) VALUES ('aw-1', 'TKT-3', 'agent-1', 'running')").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.be.empty
+    })
+
+    it('should not fire the same ticket twice (deduplication)', async () => {
+      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-4', 'Dedup', 'status-ready', NULL)").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.have.length(1)
+    })
+
+    it('should not fire for non-todo tickets', async () => {
+      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-5', 'In Progress', 'status-ip', NULL)").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.be.empty
+    })
+  })
+
+  // ===========================================================================
+  // Agent Lifecycle Polling
+  // ===========================================================================
+
+  describe('agent lifecycle polling', () => {
+    it('should fire on_agent_died when lifecycle_state transitions to died', async () => {
+      db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-1', 'TKT-1', 'agent-1', 'running', 'healthy')").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      // First poll: observe initial state
+      await poller.poll()
+      expect(firedEvents.filter(e => e.event === 'on_agent_died')).to.be.empty
+
+      // Update to died state
+      db.prepare("UPDATE agent_work SET lifecycle_state = 'died', status = 'error' WHERE id = 'aw-1'").run()
+      await poller.poll()
+
+      const diedEvents = firedEvents.filter(e => e.event === 'on_agent_died')
+      expect(diedEvents).to.have.length(1)
+      expect(diedEvents[0].ctx.agent).to.equal('agent-1')
+    })
+
+    it('should fire on_agent_completed when lifecycle_state transitions to completed', async () => {
+      db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-2', 'TKT-2', 'agent-2', 'running', 'healthy')").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll() // observe initial
+
+      db.prepare("UPDATE agent_work SET lifecycle_state = 'completed' WHERE id = 'aw-2'").run()
+      await poller.poll()
+
+      const completedEvents = firedEvents.filter(e => e.event === 'on_agent_completed')
+      expect(completedEvents).to.have.length(1)
+      expect(completedEvents[0].ctx.ticket).to.equal('TKT-2')
+    })
+
+    it('should not fire on first observation (no transition)', async () => {
+      db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-3', 'TKT-3', 'agent-3', 'error', 'died')").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      // Should not fire because this is the first observation, not a transition
+      expect(firedEvents.filter(e => e.event === 'on_agent_died')).to.be.empty
+    })
+  })
+
+  // ===========================================================================
+  // Error Handling
+  // ===========================================================================
+
+  describe('error handling', () => {
+    it('should not throw on polling errors', async () => {
+      // Close the db to force errors, then create a new poller
+      const badDb = new Database(':memory:')
+      // Don't create tables — queries will fail
+      const badEngine = new OrchestrateEngine({ db: badDb, log: () => {} })
+      const poller = new OrchestratePoller({ engine: badEngine, db: badDb, log: () => {} })
+
+      // Should not throw
+      await poller.poll()
+      badDb.close()
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-presets.test.ts
+++ b/apps/cli/test/unit/orchestrate-presets.test.ts
@@ -1,0 +1,137 @@
+import { expect } from 'chai'
+import { PRESETS, getPreset } from '../../src/lib/orchestrate/presets.js'
+import { BUILTIN_ACTIONS, PRESET_NAMES, HOOK_MODES } from '../../src/lib/orchestrate/types.js'
+import type { HookMode, PresetName } from '../../src/lib/orchestrate/types.js'
+
+/**
+ * Unit tests for orchestrate presets.
+ *
+ * Tests cover:
+ * - Preset completeness and validity
+ * - Aggressive: all auto
+ * - Conservative: all confirm
+ * - Supervised: safe=auto, destructive=confirm
+ */
+
+const SAFE_ACTIONS = new Set([
+  'move-ticket',
+  'notify',
+  'cleanup-container',
+  'health-check',
+  'rebase-conflicting-prs',
+])
+
+describe('Orchestrate Presets', () => {
+  // ===========================================================================
+  // Preset Registry
+  // ===========================================================================
+
+  describe('registry', () => {
+    it('should define all preset names', () => {
+      for (const name of PRESET_NAMES) {
+        expect(PRESETS).to.have.property(name)
+      }
+    })
+
+    it('should return preset via getPreset()', () => {
+      for (const name of PRESET_NAMES) {
+        const preset = getPreset(name)
+        expect(preset).to.exist
+        expect(preset.name).to.equal(name)
+        expect(preset.description).to.be.a('string').with.length.greaterThan(0)
+        expect(preset.hooks).to.be.an('array').with.length.greaterThan(0)
+      }
+    })
+
+    it('should have valid modes on all hooks in all presets', () => {
+      for (const name of PRESET_NAMES) {
+        const preset = getPreset(name)
+        for (const hook of preset.hooks) {
+          expect(HOOK_MODES).to.include(hook.mode, `Invalid mode "${hook.mode}" in preset "${name}" for ${hook.event}→${hook.action}`)
+        }
+      }
+    })
+
+    it('should have valid event names on all hooks', () => {
+      for (const name of PRESET_NAMES) {
+        const preset = getPreset(name)
+        for (const hook of preset.hooks) {
+          expect(hook.event).to.be.a('string').with.length.greaterThan(0)
+        }
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Aggressive Preset
+  // ===========================================================================
+
+  describe('aggressive', () => {
+    it('should set all hooks to auto mode', () => {
+      const preset = getPreset('aggressive')
+      for (const hook of preset.hooks) {
+        expect(hook.mode).to.equal('auto', `Expected auto for ${hook.event}→${hook.action}`)
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Conservative Preset
+  // ===========================================================================
+
+  describe('conservative', () => {
+    it('should set all hooks to confirm mode', () => {
+      const preset = getPreset('conservative')
+      for (const hook of preset.hooks) {
+        expect(hook.mode).to.equal('confirm', `Expected confirm for ${hook.event}→${hook.action}`)
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Supervised Preset
+  // ===========================================================================
+
+  describe('supervised', () => {
+    it('should set safe actions to auto', () => {
+      const preset = getPreset('supervised')
+      const safeHooks = preset.hooks.filter(h => SAFE_ACTIONS.has(h.action))
+
+      expect(safeHooks.length).to.be.greaterThan(0, 'Should have at least one safe hook')
+      for (const hook of safeHooks) {
+        expect(hook.mode).to.equal('auto', `Expected auto for safe action ${hook.event}→${hook.action}`)
+      }
+    })
+
+    it('should set destructive actions to confirm', () => {
+      const preset = getPreset('supervised')
+      const destructiveHooks = preset.hooks.filter(h => !SAFE_ACTIONS.has(h.action))
+
+      expect(destructiveHooks.length).to.be.greaterThan(0, 'Should have at least one destructive hook')
+      for (const hook of destructiveHooks) {
+        expect(hook.mode).to.equal('confirm', `Expected confirm for destructive action ${hook.event}→${hook.action}`)
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Consistency
+  // ===========================================================================
+
+  describe('consistency', () => {
+    it('all presets should have the same number of hooks', () => {
+      const counts = PRESET_NAMES.map(name => getPreset(name).hooks.length)
+      expect(new Set(counts).size).to.equal(1, 'All presets should have the same hook count')
+    })
+
+    it('all presets should cover the same events', () => {
+      const eventSets = PRESET_NAMES.map(name =>
+        new Set(getPreset(name).hooks.map(h => `${h.event}:${h.action}`))
+      )
+      const first = eventSets[0]
+      for (let i = 1; i < eventSets.length; i++) {
+        expect([...first]).to.have.members([...eventSets[i]], `Preset ${PRESET_NAMES[i]} has different events than ${PRESET_NAMES[0]}`)
+      }
+    })
+  })
+})

--- a/docs/orchestrate/github-actions.yml
+++ b/docs/orchestrate/github-actions.yml
@@ -1,0 +1,75 @@
+# Example GitHub Actions workflows for prlt orchestrate
+#
+# These workflows bridge GitHub events to the prlt orchestrate daemon
+# via `prlt hook fire`. Copy and adapt them for your repository.
+
+# =============================================================================
+# CI Green → Auto-merge
+# =============================================================================
+# name: On CI Complete
+# on:
+#   check_suite:
+#     types: [completed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.check_suite.conclusion == 'success'
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_ci_green \
+#             --pr ${{ github.event.check_suite.pull_requests[0].number }} \
+#             --branch ${{ github.event.check_suite.head_branch }}
+
+# =============================================================================
+# CI Failed → Notify
+# =============================================================================
+# name: On CI Failed
+# on:
+#   check_suite:
+#     types: [completed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.check_suite.conclusion == 'failure'
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_ci_failed \
+#             --pr ${{ github.event.check_suite.pull_requests[0].number }} \
+#             --branch ${{ github.event.check_suite.head_branch }}
+
+# =============================================================================
+# PR Opened → Move ticket to Review
+# =============================================================================
+# name: On PR Opened
+# on:
+#   pull_request:
+#     types: [opened]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_pr_opened \
+#             --pr ${{ github.event.pull_request.number }} \
+#             --branch ${{ github.event.pull_request.head.ref }}
+
+# =============================================================================
+# PR Merged → Move ticket to Done + rebase siblings
+# =============================================================================
+# name: On PR Merged
+# on:
+#   pull_request:
+#     types: [closed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.pull_request.merged == true
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_pr_merged \
+#             --pr ${{ github.event.pull_request.number }} \
+#             --branch ${{ github.event.pull_request.head.ref }}

--- a/docs/orchestrate/hooks.example.yml
+++ b/docs/orchestrate/hooks.example.yml
@@ -1,0 +1,60 @@
+# .proletariat/hooks.yml
+#
+# Event-driven hook configuration for prlt orchestrate.
+# Load with: prlt orchestrate --load-yaml
+# Or apply a preset instead: prlt hook preset supervised
+#
+# Modes:
+#   auto    — fires immediately, no human needed
+#   confirm — pauses, waits for approval
+#   notify  — fires but also pings
+#   off     — disabled
+
+on_ci_green:
+  - action: merge-pr
+    mode: auto
+
+on_pr_merged:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: done
+  - action: rebase-conflicting-prs
+    mode: auto
+
+on_pr_opened:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: review
+
+on_ticket_ready:
+  - action: spawn-agent
+    mode: confirm
+
+on_agent_died:
+  - action: respawn
+    mode: auto
+    max_retries: 2
+  - action: notify
+    mode: auto
+
+on_ci_failed:
+  - action: notify
+    mode: auto
+  - action: spawn-fix-agent
+    mode: confirm
+
+on_agent_completed:
+  - action: cleanup-container
+    mode: auto
+
+on_agent_idle:
+  - action: health-check
+    mode: auto
+
+on_agent_spawned:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: in-progress

--- a/docs/orchestrate/workflow.example.yml
+++ b/docs/orchestrate/workflow.example.yml
@@ -1,0 +1,19 @@
+# .proletariat/workflow.yml
+#
+# Workflow configuration — controls the shape of the work pipeline.
+# Separate from hooks — this determines branch strategy, PR behavior,
+# and review requirements.
+
+branches:
+  target: main                      # or develop, staging
+  strategy: squash                  # squash, merge, rebase
+
+on_implement_complete:
+  - create-pr                       # or commit-to-branch, draft-pr
+
+on_review_complete:
+  - merge-pr                        # or auto-merge-on-green
+
+review:
+  required: false                   # or true, or "auto" (AI review)
+  auto_merge_on_green: true         # merge when CI passes, no human review


### PR DESCRIPTION
## Summary

Resolves PRLT-1096: prlt orchestrate — autonomous pipeline daemon with event-driven hooks

## Description

## CRITICAL: CI FIX NEEDED

PR #942 is failing because files import from `../../lib/database/sqlite.js` which does NOT exist on main. The sql.js migration was reverted. Main uses better-sqlite3.

**The fix:** Every import of `../database/sqlite.js` or `../../lib/database/sqlite.js` needs to be replaced with the correct better-sqlite3 database import. Check how other commands on main import the database (e.g., look at `src/commands/work/start.ts` or `src/commands/config/index.ts` for the correct import pattern).

**Files that need fixing:**

* src/commands/hook/export.ts
* src/commands/hook/fire.ts
* src/commands/hook/list.ts
* src/commands/hook/preset.ts
* src/commands/orchestrate/index.ts
* src/commands/work/rebase.ts
* src/lib/database/migrations/0013_agent_lifecycle_states.ts
* src/lib/database/migrations/0014_orchestrate_hooks.ts
* src/lib/orchestrate/config-loader.ts
* src/lib/orchestrate/engine.ts

Rebase onto main first, then fix all imports, then push.

---

## Original ticket description

## Problem

The orchestrator today is a human manually typing everything. Every action below should be automated.

## Event table — what the human types vs what should trigger it

| Human action | Event | Hook |
| -- | -- | -- |
| "are there PRs open?" | on_pr_opened | notify orchestrator |
| "it's green, merge it" | on_ci_green | auto-merge via `prlt work ship` |
| "move ticket to In Progress" | on_agent_spawned | move ticket (PRLT-1091 landed) |
| "move ticket to Done" | on_pr_merged | move ticket to done |
| "move ticket to Review" | on_pr_opened | move ticket to review |
| "it has merge conflicts" | on_pr_conflicting | auto-rebase via `prlt work rebase` |
| "the agent died, respawn" | on_agent_died | respawn agent |
| "clean up old containers" | on_agent_completed | cleanup container |
| "check agent progress" | on_agent_idle | health check / poke |
| "spawn agents on ready tickets" | on_ticket_ready | spawn agent |

## Architecture: Event bus + hooks

### Hook configuration with HITL controls

Each hook has a `mode` that controls automation level:

```yaml
# .proletariat/hooks.yml
on_ci_green:
  - action: merge-pr
    mode: auto

on_pr_merged:
  - action: move-ticket done
    mode: auto
  - action: rebase-conflicting-prs
    mode: auto

on_ticket_ready:
  - action: spawn-agent
    mode: confirm

on_agent_died:
  - action: respawn
    mode: auto
    max_retries: 2
```

**Modes:** auto, confirm, notify, off

### Config storage

YAML is authoring format. DB is runtime source of truth.

1. User writes `.proletariat/hooks.yml` or `prlt config set hooks.on_ci_green ...`
2. prlt loads into database on init
3. Runtime reads from DB
4. `prlt config export` dumps back to YAML

### Workflow configuration

```yaml
branches:
  target: main
  strategy: squash

review:
  required: false
  auto_merge_on_green: true
```

## Dependencies

| Piece | Ticket | Status |
| -- | -- | -- |
| moveTicket syncs to provider | PRLT-1091 | Done |
| prlt works in containers | PRLT-1090 | Done |
| Ship/merge command | PRLT-1092 | Done |
| State resolution engine | PRLT-1087 | Done |
| Auto-rebase | PRLT-1093 | Done |
| Agent lifecycle/GC | PRLT-1097 | Done |
| Event bus + hook system | This ticket | In Progress |

## External Issue Context

- Source: linear
- External key: PRLT-1096
- External id: 9cc07246-bd55-4b49-b302-a71882146fcb
- URL: https://linear.app/proletariat/issue/PRLT-1096/prlt-orchestrate-autonomous-pipeline-daemon-with-event-driven-hooks
- Status: Backlog
- Priority: Unset
- Labels: None

## Changes

- 681ecf33 feat(PRLT-1096): feat: orchestrate daemon with event-driven hooks and fixed database imports

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
