### PR TITLE
PRLT-1103: Update notification shows stale version — 20-hour cache too long for rapid publishes

### DIFF
--- a/apps/cli/src/hooks/init.ts
+++ b/apps/cli/src/hooks/init.ts
@@ -107,7 +107,7 @@ const hook: Hook<'init'> = async function ({ id, argv, config }) {
   try {
     const updateInfo = getCachedUpdateInfo(config.version)
     const updateResult = await handleUpdatePrompt(updateInfo)
-    triggerBackgroundCheck(updateInfo.packageManager)
+    triggerBackgroundCheck(updateInfo.packageManager, config.version)
     if (updateResult === 'stop') {
       // User chose to update — exitCode already set, let oclif lifecycle complete
       return

--- a/apps/cli/src/lib/update-check.ts
+++ b/apps/cli/src/lib/update-check.ts
@@ -36,7 +36,7 @@ export type PackageManager = 'brew' | 'npm' | 'standalone'
 // ---------------------------------------------------------------------------
 
 /** Minimum hours between version checks */
-const CHECK_INTERVAL_HOURS = 20
+const CHECK_INTERVAL_HOURS = 4
 
 /** npm package name for registry lookup */
 const NPM_PACKAGE_NAME = '@proletariat/cli'
@@ -106,10 +106,19 @@ export function writeCache(cache: VersionCheckCache): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if enough time has elapsed since the last check.
+ * Returns true if enough time has elapsed since the last check,
+ * or if the cache is stale because the installed version is newer
+ * than the cached "latest" version.
  */
-export function shouldCheck(cache: VersionCheckCache): boolean {
+export function shouldCheck(cache: VersionCheckCache, currentVersion?: string): boolean {
   if (!cache.last_checked_at) {
+    return true
+  }
+
+  // If the installed version is newer than what's cached as "latest",
+  // the cache is stale — a newer version was published and the user
+  // already has it (or the cache recorded an outdated value).
+  if (currentVersion && cache.latest_version && isNewerVersion(cache.latest_version, currentVersion)) {
     return true
   }
 
@@ -434,11 +443,14 @@ export function getCachedUpdateInfo(currentVersion: string): UpdateInfo {
  * The fetch runs without blocking startup, but the promise is tracked
  * internally so it can be flushed before process exit via
  * {@link flushPendingVersionCheck}.
+ *
+ * When `currentVersion` is provided, forces a re-check if the installed
+ * version is newer than the cached "latest" (stale cache detection).
  */
-export function triggerBackgroundCheck(pm: PackageManager): void {
+export function triggerBackgroundCheck(pm: PackageManager, currentVersion?: string): void {
   const cache = readCache()
 
-  if (!shouldCheck(cache)) {
+  if (!shouldCheck(cache, currentVersion)) {
     return
   }
 

--- a/apps/cli/test/unit/update-check.test.ts
+++ b/apps/cli/test/unit/update-check.test.ts
@@ -90,16 +90,16 @@ describe('Update Check', () => {
       expect(shouldCheck({ latest_version: null, last_checked_at: null, dismissed_version: null })).to.be.true
     })
 
-    it('returns true when last check was more than 20 hours ago', () => {
-      const twentyOneHoursAgo = new Date(Date.now() - 21 * 60 * 60 * 1000).toISOString()
+    it('returns true when last check was more than 4 hours ago', () => {
+      const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString()
       expect(shouldCheck({
         latest_version: '1.0.0',
-        last_checked_at: twentyOneHoursAgo,
+        last_checked_at: fiveHoursAgo,
         dismissed_version: null,
       })).to.be.true
     })
 
-    it('returns false when last check was less than 20 hours ago', () => {
+    it('returns false when last check was less than 4 hours ago', () => {
       const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()
       expect(shouldCheck({
         latest_version: '1.0.0',
@@ -114,6 +114,44 @@ describe('Update Check', () => {
         last_checked_at: 'not-a-date',
         dismissed_version: null,
       })).to.be.true
+    })
+
+    it('returns true when installed version is newer than cached latest (stale cache)', () => {
+      const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()
+      // User is on 0.3.92 but cache says latest is 0.3.91 — cache is stale
+      expect(shouldCheck({
+        latest_version: '0.3.91',
+        last_checked_at: oneHourAgo,
+        dismissed_version: null,
+      }, '0.3.92')).to.be.true
+    })
+
+    it('returns false when cached latest is newer than installed version (cache is valid)', () => {
+      const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()
+      // User is on 0.3.91, cache says latest is 0.3.92 — cache is still valid
+      expect(shouldCheck({
+        latest_version: '0.3.92',
+        last_checked_at: oneHourAgo,
+        dismissed_version: null,
+      }, '0.3.91')).to.be.false
+    })
+
+    it('returns false when installed version equals cached latest (no staleness)', () => {
+      const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()
+      expect(shouldCheck({
+        latest_version: '0.3.92',
+        last_checked_at: oneHourAgo,
+        dismissed_version: null,
+      }, '0.3.92')).to.be.false
+    })
+
+    it('falls back to time-based check when no currentVersion provided', () => {
+      const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()
+      expect(shouldCheck({
+        latest_version: '0.3.91',
+        last_checked_at: oneHourAgo,
+        dismissed_version: null,
+      })).to.be.false
     })
   })
 


### PR DESCRIPTION
## Summary

Resolves PRLT-1103: Update notification shows stale version — 20-hour cache too long for rapid publishes

## Description

## Problem

The update checker caches the latest version in `~/.proletariat/version-check.json` with a 20-hour TTL (`CHECK_INTERVAL_HOURS = 20` in `update-check.ts`). When multiple versions publish within that window (e.g., 0.3.91 then 0.3.92 an hour later), the notification tells users to update to the old version.

## Repro

1. 0.3.91 publishes, user runs prlt, cache stores `latest_version: 0.3.91`
2. 0.3.92 publishes 1 hour later (hotfix/revert)
3. User runs prlt again — notification says "update to 0.3.91" even though 0.3.92 is latest
4. Cache won't refresh for another 19 hours

## Fix options

1. Shorten cache TTL (e.g., 1-4 hours instead of 20)
2. Always do a background fetch, just don't block on it — cache is only used if fetch hasn't completed yet
3. Invalidate cache when the fetched version is older than current installed version (user already has newer)
4. Compare cached version against installed version — if installed >= cached, force a re-check

Option 4 is simplest: if user is on 0.3.92 and cache says 0.3.91, the cache is clearly stale.

## Location

* `apps/cli/src/lib/update-check.ts` — `shouldCheck()`, `CHECK_INTERVAL_HOURS`, `getCachedUpdateInfo()`
* Cache file: `~/.proletariat/version-check.json`

## Related

* Update prompt logic in `apps/cli/src/lib/update-prompt.ts`

## External Issue Context

- Source: linear
- External key: PRLT-1103
- External id: 6219a476-2520-44b7-804b-ff6b34cb7810
- URL: https://linear.app/proletariat/issue/PRLT-1103/update-notification-shows-stale-version-20-hour-cache-too-long-for
- Status: Backlog
- Priority: P1
- Labels: None

## Changes

- 3db576e3 feat(PRLT-1103): fix stale version cache: reduce TTL to 4h and invalidate when installed > cached

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
