### PR TITLE
PRLT-1107: Idempotent schema catch-up migration + enforce migrations rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,10 @@ const result = await provider.listTickets(projectId, filter)
 
 Provider implementations live in `apps/cli/src/lib/providers/`.
 
+## Migrations
+
+**Every schema change MUST have a migration.** If you add a table, column, or index, create a numbered migration in `apps/cli/src/lib/database/migrations/`. Never modify the schema with raw SQL outside of migrations.
+
 ## Database Access
 
 **All database access MUST go through the DAL** (`src/lib/database/index.ts`). Never import `better-sqlite3` or the database driver directly.

--- a/apps/cli/src/lib/database/migrations/0016_schema_catchup.ts
+++ b/apps/cli/src/lib/database/migrations/0016_schema_catchup.ts
@@ -1,0 +1,185 @@
+/**
+ * Migration 0016 — Idempotent Schema Catch-up
+ *
+ * Brings ANY schema version up to the current state. Safe to run on:
+ * - A fresh (empty) database
+ * - A database from v0.3.80 or earlier
+ * - An already-current database (no-op)
+ *
+ * Strategy:
+ * 1. CREATE TABLE IF NOT EXISTS for every table (no indexes yet)
+ * 2. PRAGMA table_info() checks + ALTER TABLE ADD COLUMN for missing columns
+ * 3. CREATE INDEX IF NOT EXISTS for all indexes (columns now guaranteed to exist)
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+import { CREATE_TABLES_SQL } from '../workspace-schema.js'
+import { PMO_TABLE_SCHEMAS, PMO_INDEXES } from '../../pmo/schema.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getColumns(db: Database.Database, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as Array<{ name: string }>
+  return new Set(rows.map(r => r.name))
+}
+
+function hasTable(db: Database.Database, table: string): boolean {
+  const row = db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name=?"
+  ).get(table) as { name: string } | undefined
+  return !!row
+}
+
+function addColumnIfMissing(
+  db: Database.Database,
+  table: string,
+  column: string,
+  definition: string,
+  cols: Set<string>,
+): void {
+  if (!cols.has(column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+export const schemaCatchup: Migration = {
+  id: '0016',
+  name: 'schema_catchup',
+  up(db) {
+    // =======================================================================
+    // 1. Ensure every table exists (CREATE TABLE IF NOT EXISTS — no-op when
+    //    the table already exists). Run table creation BEFORE indexes so that
+    //    missing columns can be added in step 2.
+    // =======================================================================
+
+    // Core workspace tables (includes its own indexes using IF NOT EXISTS,
+    // but workspace-schema indexes only reference columns from their own
+    // CREATE TABLE, so they're safe to run here).
+    db.exec(CREATE_TABLES_SQL)
+
+    // PMO tables — create each individually WITHOUT indexes.
+    // PMO_INDEXES reference columns that may not exist yet on old tables.
+    for (const sql of Object.values(PMO_TABLE_SCHEMAS)) {
+      db.exec(sql)
+    }
+
+    // =======================================================================
+    // 2. Back-fill missing columns on tables that may predate later changes.
+    //    Each block checks table existence first (for truly empty DBs where
+    //    step 1 already created the full table, this is a no-op).
+    // =======================================================================
+
+    // --- agents ---
+    if (hasTable(db, 'agents')) {
+      const cols = getColumns(db, 'agents')
+      addColumnIfMissing(db, 'agents', 'base_name', 'TEXT', cols)
+      addColumnIfMissing(db, 'agents', 'mount_mode', "TEXT NOT NULL DEFAULT 'worktree'", cols)
+      addColumnIfMissing(db, 'agents', 'cleaned_at', 'TEXT', cols)
+    }
+
+    // --- agent_worktrees ---
+    if (hasTable(db, 'agent_worktrees')) {
+      const cols = getColumns(db, 'agent_worktrees')
+      addColumnIfMissing(db, 'agent_worktrees', 'last_commit_hash', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_worktrees', 'commits_ahead', 'INTEGER NOT NULL DEFAULT 0', cols)
+      addColumnIfMissing(db, 'agent_worktrees', 'is_clean', 'INTEGER NOT NULL DEFAULT 1', cols)
+      addColumnIfMissing(db, 'agent_worktrees', 'last_checked', 'TEXT', cols)
+    }
+
+    // --- pmo_tickets ---
+    if (hasTable(db, 'pmo_tickets')) {
+      const cols = getColumns(db, 'pmo_tickets')
+      addColumnIfMissing(db, 'pmo_tickets', 'status_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_tickets', 'position', 'INTEGER NOT NULL DEFAULT 0', cols)
+      addColumnIfMissing(db, 'pmo_tickets', 'epic_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_tickets', 'labels', "TEXT NOT NULL DEFAULT '[]'", cols)
+      addColumnIfMissing(db, 'pmo_tickets', 'last_synced_from_spec', 'TIMESTAMP', cols)
+      addColumnIfMissing(db, 'pmo_tickets', 'last_synced_from_board', 'TIMESTAMP', cols)
+    }
+
+    // --- pmo_actions ---
+    if (hasTable(db, 'pmo_actions')) {
+      const cols = getColumns(db, 'pmo_actions')
+      addColumnIfMissing(db, 'pmo_actions', 'from_state', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'to_state', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'executor', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'environment', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'permission_mode', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'timeout', 'INTEGER', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'model', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'is_default', 'INTEGER NOT NULL DEFAULT 0', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'updated_at', 'TIMESTAMP', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'review_gate', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_actions', 'network_allowlist', 'TEXT', cols)
+    }
+
+    // --- agent_work ---
+    if (hasTable(db, 'agent_work')) {
+      const cols = getColumns(db, 'agent_work')
+      addColumnIfMissing(db, 'agent_work', 'session_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'host', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'external_source', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'external_key', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'external_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'external_url', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'cleanup_policy', "TEXT NOT NULL DEFAULT 'on-exit'", cols)
+      addColumnIfMissing(db, 'agent_work', 'last_heartbeat', 'TEXT', cols)
+      addColumnIfMissing(db, 'agent_work', 'retries', 'INTEGER DEFAULT 0', cols)
+      addColumnIfMissing(db, 'agent_work', 'lifecycle_state', "TEXT DEFAULT 'healthy'", cols)
+    }
+
+    // --- pmo_work_hooks ---
+    if (hasTable(db, 'pmo_work_hooks')) {
+      const cols = getColumns(db, 'pmo_work_hooks')
+      addColumnIfMissing(db, 'pmo_work_hooks', 'mode', "TEXT DEFAULT 'auto'", cols)
+      addColumnIfMissing(db, 'pmo_work_hooks', 'priority', 'INTEGER DEFAULT 0', cols)
+      addColumnIfMissing(db, 'pmo_work_hooks', 'project_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_work_hooks', 'source', "TEXT DEFAULT 'cli'", cols)
+      addColumnIfMissing(db, 'pmo_work_hooks', 'config', 'TEXT', cols)
+    }
+
+    // --- pmo_projects ---
+    if (hasTable(db, 'pmo_projects')) {
+      const cols = getColumns(db, 'pmo_projects')
+      addColumnIfMissing(db, 'pmo_projects', 'phase_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_projects', 'workflow_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_projects', 'is_archived', 'INTEGER NOT NULL DEFAULT 0', cols)
+      addColumnIfMissing(db, 'pmo_projects', 'target_date', 'TIMESTAMP', cols)
+      addColumnIfMissing(db, 'pmo_projects', 'initiative_id', 'TEXT', cols)
+    }
+
+    // --- pmo_epics ---
+    if (hasTable(db, 'pmo_epics')) {
+      const cols = getColumns(db, 'pmo_epics')
+      addColumnIfMissing(db, 'pmo_epics', 'file_path', 'TEXT', cols)
+      addColumnIfMissing(db, 'pmo_epics', 'spec_id', 'TEXT', cols)
+    }
+
+    // --- containers ---
+    if (hasTable(db, 'containers')) {
+      const cols = getColumns(db, 'containers')
+      addColumnIfMissing(db, 'containers', 'docker_name', 'TEXT', cols)
+      addColumnIfMissing(db, 'containers', 'image', 'TEXT', cols)
+      addColumnIfMissing(db, 'containers', 'current_execution_id', 'TEXT', cols)
+      addColumnIfMissing(db, 'containers', 'last_seen_at', 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP', cols)
+    }
+
+    // =======================================================================
+    // 3. Create all indexes (now safe — all columns are guaranteed to exist)
+    // =======================================================================
+
+    // PMO indexes (covers most tables)
+    db.exec(PMO_INDEXES)
+
+    // Migration-added indexes not in PMO_INDEXES
+    db.exec('CREATE INDEX IF NOT EXISTS idx_agent_work_lifecycle ON agent_work(lifecycle_state, status)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -21,6 +21,7 @@ import { addActionNetworkAllowlist } from './0012_add_action_network_allowlist.j
 import { agentLifecycleStates } from './0013_agent_lifecycle_states.js'
 import { agentWorkLifecycle } from './0014_agent_work_lifecycle.js'
 import { orchestrateHooks } from './0015_orchestrate_hooks.js'
+import { schemaCatchup } from './0016_schema_catchup.js'
 
 /**
  * Ordered list of all migrations.
@@ -42,4 +43,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   agentLifecycleStates,
   agentWorkLifecycle,
   orchestrateHooks,
+  schemaCatchup,
 ]

--- a/apps/cli/test/unit/migrations.test.ts
+++ b/apps/cli/test/unit/migrations.test.ts
@@ -330,4 +330,314 @@ describe('Database Migration System', () => {
       db.close()
     })
   })
+
+  describe('0016_schema_catchup', () => {
+    function getTableNames(db: Database.Database): string[] {
+      const rows = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+      ).all() as { name: string }[]
+      return rows.map(r => r.name)
+    }
+
+    function getTableColumns(db: Database.Database, table: string): string[] {
+      const rows = db.prepare(`PRAGMA table_info('${table}')`).all() as { name: string }[]
+      return rows.map(r => r.name).sort()
+    }
+
+    function getIndexNames(db: Database.Database): string[] {
+      const rows = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+      ).all() as { name: string }[]
+      return rows.map(r => r.name)
+    }
+
+    it('fresh DB: all migrations produce expected tables', () => {
+      const db = openDb()
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      const tables = getTableNames(db)
+
+      // Core workspace tables
+      for (const t of ['workspace', 'repositories', 'agents', 'agent_worktrees',
+        'agent_themes', 'agent_theme_names', 'workspace_settings', 'media_items']) {
+        expect(tables, `missing table: ${t}`).to.include(t)
+      }
+
+      // PMO tables
+      for (const t of ['pmo_projects', 'pmo_tickets', 'pmo_actions', 'pmo_workflows',
+        'pmo_workflow_statuses', 'pmo_workflow_rules', 'pmo_work_hooks', 'agent_work',
+        'containers', 'pmo_labels', 'pmo_label_groups', 'pmo_ticket_labels',
+        'pmo_roadmaps', 'pmo_roadmap_projects', 'pmo_external_issue_map',
+        'pmo_external_execution_map', 'pmo_ticket_templates']) {
+        expect(tables, `missing table: ${t}`).to.include(t)
+      }
+
+      db.close()
+    })
+
+    it('fresh DB: agents table has all expected columns', () => {
+      const db = openDb()
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      const cols = getTableColumns(db, 'agents')
+      for (const c of ['name', 'type', 'status', 'base_name', 'theme_id',
+        'worktree_path', 'mount_mode', 'created_at', 'cleaned_at']) {
+        expect(cols, `missing column: agents.${c}`).to.include(c)
+      }
+
+      db.close()
+    })
+
+    it('fresh DB: agent_work table has lifecycle columns', () => {
+      const db = openDb()
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      const cols = getTableColumns(db, 'agent_work')
+      for (const c of ['last_heartbeat', 'retries', 'lifecycle_state',
+        'external_source', 'external_key', 'external_id', 'external_url',
+        'cleanup_policy', 'session_id', 'host']) {
+        expect(cols, `missing column: agent_work.${c}`).to.include(c)
+      }
+
+      db.close()
+    })
+
+    it('fresh DB: pmo_work_hooks has orchestrate columns', () => {
+      const db = openDb()
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      const cols = getTableColumns(db, 'pmo_work_hooks')
+      for (const c of ['mode', 'priority', 'project_id', 'source', 'config']) {
+        expect(cols, `missing column: pmo_work_hooks.${c}`).to.include(c)
+      }
+
+      db.close()
+    })
+
+    it('catch-up recovers a mid-version DB missing tables and columns', () => {
+      const db = openDb()
+
+      // Simulate a v0.3.80-era database: only core workspace tables,
+      // basic PMO tables, no newer tables/columns
+      db.exec(`
+        CREATE TABLE workspace (
+          id INTEGER PRIMARY KEY CHECK (id = 1),
+          type TEXT NOT NULL,
+          workspace_name TEXT NOT NULL,
+          has_pmo BOOLEAN DEFAULT FALSE,
+          active_theme_id TEXT,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE repositories (
+          name TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          type TEXT DEFAULT 'main',
+          source_url TEXT,
+          action TEXT,
+          added_at TEXT NOT NULL
+        );
+        CREATE TABLE agent_themes (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL UNIQUE,
+          display_name TEXT NOT NULL,
+          description TEXT,
+          builtin BOOLEAN DEFAULT FALSE,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE agent_theme_names (
+          theme_id TEXT NOT NULL,
+          name TEXT NOT NULL,
+          PRIMARY KEY (theme_id, name),
+          FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE CASCADE
+        );
+        CREATE TABLE agents (
+          name TEXT PRIMARY KEY,
+          type TEXT NOT NULL DEFAULT 'persistent',
+          status TEXT NOT NULL DEFAULT 'active',
+          base_name TEXT,
+          theme_id TEXT,
+          worktree_path TEXT,
+          created_at TEXT NOT NULL,
+          cleaned_at TEXT
+        );
+        CREATE TABLE agent_worktrees (
+          agent_name TEXT NOT NULL,
+          repo_name TEXT NOT NULL,
+          worktree_path TEXT NOT NULL,
+          branch TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          PRIMARY KEY (agent_name, repo_name)
+        );
+        CREATE TABLE workspace_settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        CREATE TABLE pmo_projects (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          template TEXT,
+          description TEXT,
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE pmo_tickets (
+          id TEXT PRIMARY KEY,
+          project_id TEXT NOT NULL DEFAULT 'default',
+          title TEXT NOT NULL,
+          description TEXT,
+          priority TEXT,
+          category TEXT,
+          status TEXT NOT NULL DEFAULT 'backlog',
+          status_id TEXT,
+          owner TEXT,
+          assignee TEXT,
+          branch TEXT,
+          spec_id TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE pmo_actions (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL UNIQUE,
+          description TEXT,
+          prompt TEXT NOT NULL,
+          end_prompt TEXT,
+          modifies_code INTEGER NOT NULL DEFAULT 1,
+          is_builtin INTEGER NOT NULL DEFAULT 0,
+          position INTEGER NOT NULL DEFAULT 0,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE agent_work (
+          id TEXT PRIMARY KEY,
+          ticket_id TEXT NOT NULL,
+          agent_name TEXT NOT NULL,
+          executor TEXT NOT NULL,
+          environment TEXT NOT NULL DEFAULT 'host',
+          display_mode TEXT NOT NULL DEFAULT 'terminal',
+          permission_mode TEXT NOT NULL DEFAULT 'safe',
+          status TEXT NOT NULL DEFAULT 'starting',
+          branch TEXT,
+          pid TEXT,
+          container_id TEXT,
+          started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          completed_at TIMESTAMP,
+          exit_code INTEGER,
+          error_message TEXT,
+          log_path TEXT
+        );
+        CREATE TABLE pmo_work_hooks (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL UNIQUE,
+          event TEXT NOT NULL,
+          action_type TEXT NOT NULL,
+          action_value TEXT NOT NULL,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          description TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE containers (
+          id TEXT PRIMARY KEY,
+          agent_name TEXT NOT NULL,
+          docker_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'unknown',
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+
+        INSERT INTO workspace (id, type, workspace_name, has_pmo, created_at)
+        VALUES (1, 'hq', 'test-workspace', 1, '2024-01-01T00:00:00.000Z');
+      `)
+
+      // Manually mark 0001 through 0005 as already applied (simulating partial upgrade)
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS prlt_migrations (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          applied_at TEXT NOT NULL
+        );
+        INSERT INTO prlt_migrations (id, name, applied_at) VALUES
+          ('0001', 'baseline', '2024-01-01T00:00:00.000Z'),
+          ('0002', 'work_hooks', '2024-01-01T00:00:00.000Z'),
+          ('0003', 'actions_redesign', '2024-01-01T00:00:00.000Z'),
+          ('0004', 'workflow_rules', '2024-01-01T00:00:00.000Z'),
+          ('0005', 'provider_status_mapping', '2024-01-01T00:00:00.000Z');
+      `)
+
+      // Verify some columns/tables are missing before catch-up
+      expect(columnExists(db, 'agents', 'mount_mode')).to.be.false
+      expect(columnExists(db, 'agent_worktrees', 'commits_ahead')).to.be.false
+      expect(columnExists(db, 'pmo_tickets', 'position')).to.be.false
+      expect(columnExists(db, 'pmo_tickets', 'epic_id')).to.be.false
+      expect(columnExists(db, 'agent_work', 'lifecycle_state')).to.be.false
+      expect(columnExists(db, 'pmo_work_hooks', 'mode')).to.be.false
+      expect(columnExists(db, 'pmo_projects', 'workflow_id')).to.be.false
+      expect(tableExists(db, 'media_items')).to.be.false
+      expect(tableExists(db, 'pmo_labels')).to.be.false
+
+      // Run remaining migrations (0006–0016 including catch-up)
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      // All columns should now exist
+      expect(columnExists(db, 'agents', 'mount_mode')).to.be.true
+      expect(columnExists(db, 'agent_worktrees', 'commits_ahead')).to.be.true
+      expect(columnExists(db, 'agent_worktrees', 'is_clean')).to.be.true
+      expect(columnExists(db, 'pmo_tickets', 'position')).to.be.true
+      expect(columnExists(db, 'pmo_tickets', 'status_id')).to.be.true
+      expect(columnExists(db, 'pmo_tickets', 'labels')).to.be.true
+      expect(columnExists(db, 'pmo_actions', 'review_gate')).to.be.true
+      expect(columnExists(db, 'pmo_actions', 'network_allowlist')).to.be.true
+      expect(columnExists(db, 'agent_work', 'lifecycle_state')).to.be.true
+      expect(columnExists(db, 'agent_work', 'cleanup_policy')).to.be.true
+      expect(columnExists(db, 'pmo_work_hooks', 'mode')).to.be.true
+      expect(columnExists(db, 'pmo_work_hooks', 'source')).to.be.true
+      expect(columnExists(db, 'pmo_projects', 'workflow_id')).to.be.true
+      expect(columnExists(db, 'pmo_projects', 'is_archived')).to.be.true
+      expect(columnExists(db, 'containers', 'image')).to.be.true
+
+      // Missing tables should have been created
+      expect(tableExists(db, 'media_items')).to.be.true
+      expect(tableExists(db, 'pmo_labels')).to.be.true
+      expect(tableExists(db, 'pmo_label_groups')).to.be.true
+      expect(tableExists(db, 'pmo_ticket_labels')).to.be.true
+      expect(tableExists(db, 'pmo_roadmaps')).to.be.true
+      expect(tableExists(db, 'pmo_ticket_templates')).to.be.true
+      expect(tableExists(db, 'pmo_external_issue_map')).to.be.true
+
+      db.close()
+    })
+
+    it('catch-up is a no-op on an already-current DB', () => {
+      const db = openDb()
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      // Capture full schema state
+      const tablesBefore = getTableNames(db)
+      const columnsBefore: Record<string, string[]> = {}
+      for (const t of tablesBefore) {
+        columnsBefore[t] = getTableColumns(db, t)
+      }
+      const indexesBefore = getIndexNames(db)
+
+      // Run catch-up again by itself (simulating re-run)
+      // The migration is already recorded so it won't run, but verify state is unchanged
+      runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+      const tablesAfter = getTableNames(db)
+      const columnsAfter: Record<string, string[]> = {}
+      for (const t of tablesAfter) {
+        columnsAfter[t] = getTableColumns(db, t)
+      }
+      const indexesAfter = getIndexNames(db)
+
+      expect(tablesAfter).to.deep.equal(tablesBefore)
+      expect(columnsAfter).to.deep.equal(columnsBefore)
+      expect(indexesAfter).to.deep.equal(indexesBefore)
+
+      db.close()
+    })
+
+    it('catch-up includes 0016 in migration registry', () => {
+      expect(ALL_MIGRATIONS.some(m => m.id === '0016' && m.name === 'schema_catchup')).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Resolves PRLT-1107: Idempotent schema catch-up migration + enforce migrations rule in CLAUDE.md

## Description

## Problem

Many schema changes were made without corresponding migrations. Users upgrading from older versions may have missing tables or columns, causing runtime errors.

## Fix

### 1\. Catch-up migration (`0015_schema_catchup.ts`)

Write a single idempotent migration that brings ANY schema version to current state:

* Use `CREATE TABLE IF NOT EXISTS` for all tables
* For missing columns: check `sqlite_master` / `PRAGMA table_info()` before `ALTER TABLE ADD COLUMN`
* For missing indexes: `CREATE INDEX IF NOT EXISTS`
* Must be safe to run on a fresh DB, a v0.3.80 DB, or a current DB — no-op if already up to date

### How to build it

1. Get the full current schema: `sqlite3 workspace.db .schema`
2. For every table, write `CREATE TABLE IF NOT EXISTS`
3. For every column that was added after initial table creation, write a conditional ALTER:

```typescript
const cols = db.prepare("PRAGMA table_info('agents')").all().map(c => c.name)
if (!cols.includes('new_column')) {
  db.exec("ALTER TABLE agents ADD COLUMN new_column TEXT")
}
```

4. Run the migration on a fresh DB and an existing DB — both should succeed

### 2\. Add rule to [CLAUDE.md](<http://CLAUDE.md>)

Add to [CLAUDE.md](<http://CLAUDE.md>) under a `## Migrations` section:

```
## Migrations

**Every schema change MUST have a migration.** If you add a table, column, or index, create a numbered migration in `apps/cli/src/lib/database/migrations/`. Never modify the schema with raw SQL outside of migrations.
```

### 3\. Audit current schema vs migrations

Compare the current `workspace.db` schema against what the existing migrations create. Document any gaps found — these are the columns/tables the catch-up migration needs to cover.

## Testing

* Create a fresh DB (empty), run all migrations including catch-up — should match current schema
* Take a DB from an older version (or simulate by dropping some columns), run migrations — should recover
* Run catch-up on an already-current DB — should be a no-op

## External Issue Context

- Source: linear
- External key: PRLT-1107
- External id: d5d5820a-be20-40d1-a017-c62a1233b1f1
- URL: https://linear.app/proletariat/issue/PRLT-1107/idempotent-schema-catch-up-migration-enforce-migrations-rule-in
- Status: Ready
- Priority: P0
- Labels: None

## Changes

- 57d3bdfa feat(PRLT-1107): add idempotent schema catch-up migration and enforce migrations rule

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
