### PR TITLE
chore: bump version to 0.3.93

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.92",
+  "version": "0.3.93",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Version bump 0.3.92 → 0.3.93

Includes: PRLT-1064 (PMO decoupling), PRLT-1104 (DAL), PRLT-1103 (version cache), PRLT-1105 (workspace detection), PRLT-1106 (code quality), PRLT-1107 (schema migration), PRLT-1108 (Docker auth)