### PR TITLE
PRLT-1114: Agent secret isolation — prevent agents from reading/committing credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,14 @@ Thumbs.db
 temp/
 tmp/
 
-# PMO
+# PMO & credentials
 .proletariat/
+.proletariat-credentials/
+
+# Secrets / credential files
+credentials.json
+*.key
+*.pem
 pmo/projects/*/board.md
 ROADMAP.md
 

--- a/apps/cli/src/lib/asana/config.ts
+++ b/apps/cli/src/lib/asana/config.ts
@@ -2,6 +2,7 @@ import type Database from 'better-sqlite3'
 import type { AsanaConfig } from './types.js'
 import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
 
 const ASANA_CONFIG_KEYS = {
   accessToken: 'asana.access_token',
@@ -12,14 +13,14 @@ const ASANA_CONFIG_KEYS = {
 } as const
 
 export function isAsanaConfigured(db: Database.Database): boolean {
-  return new SettingsStore(db).has(ASANA_CONFIG_KEYS.accessToken)
+  return hasCredential(db, ASANA_CONFIG_KEYS.accessToken)
 }
 
 export function loadAsanaConfig(db: Database.Database): AsanaConfig | null {
-  const settings = new SettingsStore(db)
-  const accessToken = settings.get(ASANA_CONFIG_KEYS.accessToken)
+  const accessToken = getCredential(db, ASANA_CONFIG_KEYS.accessToken)
   if (!accessToken) return null
 
+  const settings = new SettingsStore(db)
   return {
     accessToken,
     workspaceGid: settings.get(ASANA_CONFIG_KEYS.workspaceGid) ?? undefined,
@@ -30,7 +31,7 @@ export function loadAsanaConfig(db: Database.Database): AsanaConfig | null {
 }
 
 export function saveAsanaAccessToken(db: Database.Database, accessToken: string): void {
-  new SettingsStore(db).set(ASANA_CONFIG_KEYS.accessToken, accessToken)
+  setCredential(db, ASANA_CONFIG_KEYS.accessToken, accessToken)
 }
 
 export function saveAsanaWorkspace(db: Database.Database, workspaceGid: string, workspaceName: string): void {
@@ -48,7 +49,11 @@ export function saveAsanaProject(db: Database.Database, projectGid: string, proj
 export function clearAsanaConfig(db: Database.Database): void {
   const settings = new SettingsStore(db)
   for (const key of Object.values(ASANA_CONFIG_KEYS)) {
-    settings.delete(key)
+    if (key === ASANA_CONFIG_KEYS.accessToken) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
   }
 }
 
@@ -70,6 +75,6 @@ export function getAsanaAccessToken(db: Database.Database): string | null {
   const envToken = process.env.PRLT_ASANA_ACCESS_TOKEN || process.env.ASANA_ACCESS_TOKEN
   if (envToken) return envToken
 
-  // 3. Legacy: stored workspace setting
-  return new SettingsStore(db).get(ASANA_CONFIG_KEYS.accessToken)
+  // 3. Legacy: stored workspace setting (now in credentials.db)
+  return getCredential(db, ASANA_CONFIG_KEYS.accessToken)
 }

--- a/apps/cli/src/lib/database/credential-store.ts
+++ b/apps/cli/src/lib/database/credential-store.ts
@@ -1,0 +1,326 @@
+/**
+ * Credential Store
+ *
+ * Stores API keys and tokens in a separate credentials.db file
+ * that is NOT mounted into agent containers. This prevents agents
+ * from reading or leaking credentials.
+ *
+ * Credentials are stored at {workspacePath}/.proletariat-credentials/credentials.db
+ * while the main workspace.db lives at {workspacePath}/.proletariat/workspace.db.
+ * Only .proletariat/ is mounted into containers, keeping credentials isolated.
+ *
+ * PRLT-1114: Agent secret isolation
+ */
+
+import Database from 'better-sqlite3'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+const CREDENTIALS_TABLE = 'credentials'
+
+/** Known credential setting keys that must be stored in credentials.db */
+const CREDENTIAL_KEYS = new Set([
+  'linear.api_key',
+  'jira.api_token',
+  'asana.access_token',
+  'trello.api_key',
+  'trello.api_token',
+  'shortcut.api_token',
+  'monday.api_token',
+])
+
+/**
+ * Check if a workspace_settings key stores a credential (API key or token).
+ */
+export function isCredentialKey(key: string): boolean {
+  return CREDENTIAL_KEYS.has(key)
+}
+
+/**
+ * Get the path to the credentials database for a workspace.
+ */
+export function getCredentialDatabasePath(workspacePath: string): string {
+  return path.join(workspacePath, '.proletariat-credentials', 'credentials.db')
+}
+
+/**
+ * Derive the workspace root path from a workspace.db Database instance.
+ * workspace.db is at {workspacePath}/.proletariat/workspace.db
+ * Returns empty string for in-memory databases (used in tests).
+ */
+function deriveWorkspacePath(db: Database.Database): string {
+  const dbName = db.name
+  // In-memory or unnamed databases don't have a filesystem path
+  if (!dbName || dbName === ':memory:' || dbName === '') return ''
+  return path.dirname(path.dirname(dbName))
+}
+
+/**
+ * Open or create the credentials database.
+ * Creates the directory and schema if they don't exist.
+ */
+function openCredentialDb(workspacePath: string): Database.Database {
+  const dbPath = getCredentialDatabasePath(workspacePath)
+  const dir = path.dirname(dbPath)
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+
+  const credDb = new Database(dbPath)
+  credDb.pragma('journal_mode = WAL')
+  credDb.pragma('foreign_keys = ON')
+  credDb.pragma('busy_timeout = 5000')
+
+  credDb.exec(`
+    CREATE TABLE IF NOT EXISTS ${CREDENTIALS_TABLE} (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `)
+
+  return credDb
+}
+
+// Cache open credential db connections keyed by workspace path
+const credentialDbCache = new Map<string, Database.Database>()
+
+/**
+ * Get a cached credential database connection.
+ * Returns null if credentials.db cannot be opened (e.g., in agent containers
+ * where the credentials directory is not mounted).
+ */
+function getCachedCredentialDb(workspacePath: string, autoCreate: boolean): Database.Database | null {
+  const cached = credentialDbCache.get(workspacePath)
+  if (cached) {
+    try {
+      cached.pragma('journal_mode')
+      return cached
+    } catch {
+      credentialDbCache.delete(workspacePath)
+    }
+  }
+
+  const dbPath = getCredentialDatabasePath(workspacePath)
+  const dir = path.dirname(dbPath)
+
+  // If the credentials directory doesn't exist and we're not auto-creating,
+  // return null. This is expected in agent containers where only .proletariat/
+  // is mounted, not .proletariat-credentials/.
+  if (!autoCreate && !fs.existsSync(dir)) {
+    return null
+  }
+
+  try {
+    const credDb = openCredentialDb(workspacePath)
+    credentialDbCache.set(workspacePath, credDb)
+    return credDb
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Get a credential value, with automatic migration from workspace.db.
+ *
+ * Resolution order:
+ * 1. Check credentials.db (if available)
+ * 2. Fall back to workspace.db (for backward compatibility)
+ * 3. If found in workspace.db, migrate to credentials.db and delete from workspace.db
+ *
+ * In agent containers, credentials.db won't exist and workspace.db will have
+ * credentials removed — so this returns null, which is the desired behavior.
+ *
+ * For in-memory databases (tests), falls back to workspace_settings directly
+ * since there's no filesystem path to store credentials.db.
+ */
+export function getCredential(workspaceDb: Database.Database, key: string): string | null {
+  const workspacePath = deriveWorkspacePath(workspaceDb)
+
+  // In-memory databases (tests) — use workspace_settings directly
+  if (!workspacePath) {
+    try {
+      const row = workspaceDb
+        .prepare('SELECT value FROM workspace_settings WHERE key = ?')
+        .get(key) as { value: string } | undefined
+      return row?.value ?? null
+    } catch {
+      return null
+    }
+  }
+
+  // Check credentials.db first (don't auto-create just for reads)
+  const credDb = getCachedCredentialDb(workspacePath, false)
+  if (credDb) {
+    const row = credDb
+      .prepare(`SELECT value FROM ${CREDENTIALS_TABLE} WHERE key = ?`)
+      .get(key) as { value: string } | undefined
+    if (row) return row.value
+  }
+
+  // Fall back to workspace.db (backward compatibility + auto-migration)
+  let fallbackValue: string | null = null
+  try {
+    const fallbackRow = workspaceDb
+      .prepare('SELECT value FROM workspace_settings WHERE key = ?')
+      .get(key) as { value: string } | undefined
+    fallbackValue = fallbackRow?.value ?? null
+  } catch {
+    // workspace.db may not have the table yet
+  }
+
+  if (fallbackValue) {
+    // Auto-migrate: move credential to credentials.db (auto-create on write)
+    const writeDb = getCachedCredentialDb(workspacePath, true)
+    if (writeDb) {
+      writeDb
+        .prepare(`INSERT OR REPLACE INTO ${CREDENTIALS_TABLE} (key, value) VALUES (?, ?)`)
+        .run(key, fallbackValue)
+    }
+    // Remove from workspace.db so agents can't see it
+    try {
+      workspaceDb.prepare('DELETE FROM workspace_settings WHERE key = ?').run(key)
+    } catch {
+      // workspace.db may be read-only in containers
+    }
+    return fallbackValue
+  }
+
+  return null
+}
+
+/**
+ * Set a credential value. Always writes to credentials.db.
+ * Also removes from workspace.db if present (migration cleanup).
+ * For in-memory databases (tests), writes to workspace_settings directly.
+ */
+export function setCredential(workspaceDb: Database.Database, key: string, value: string): void {
+  const workspacePath = deriveWorkspacePath(workspaceDb)
+
+  // In-memory databases (tests) — use workspace_settings directly
+  if (!workspacePath) {
+    workspaceDb.prepare(`
+      INSERT INTO workspace_settings (key, value)
+      VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run(key, value)
+    return
+  }
+
+  const credDb = getCachedCredentialDb(workspacePath, true)
+  if (!credDb) {
+    throw new Error(`Cannot open credential store at ${getCredentialDatabasePath(workspacePath)}`)
+  }
+
+  credDb
+    .prepare(`INSERT OR REPLACE INTO ${CREDENTIALS_TABLE} (key, value) VALUES (?, ?)`)
+    .run(key, value)
+
+  // Clean up from workspace.db if it was there
+  try {
+    workspaceDb.prepare('DELETE FROM workspace_settings WHERE key = ?').run(key)
+  } catch {
+    // workspace.db may be read-only in containers
+  }
+}
+
+/**
+ * Delete a credential from both credentials.db and workspace.db.
+ * For in-memory databases (tests), deletes from workspace_settings directly.
+ */
+export function deleteCredential(workspaceDb: Database.Database, key: string): void {
+  const workspacePath = deriveWorkspacePath(workspaceDb)
+
+  // In-memory databases (tests) — use workspace_settings directly
+  if (!workspacePath) {
+    try {
+      workspaceDb.prepare('DELETE FROM workspace_settings WHERE key = ?').run(key)
+    } catch {
+      // Table may not exist
+    }
+    return
+  }
+
+  const credDb = getCachedCredentialDb(workspacePath, false)
+  if (credDb) {
+    credDb.prepare(`DELETE FROM ${CREDENTIALS_TABLE} WHERE key = ?`).run(key)
+  }
+
+  // Also delete from workspace.db in case it's still there
+  try {
+    workspaceDb.prepare('DELETE FROM workspace_settings WHERE key = ?').run(key)
+  } catch {
+    // workspace.db may be read-only
+  }
+}
+
+/**
+ * Check if a credential exists in either credentials.db or workspace.db.
+ */
+export function hasCredential(workspaceDb: Database.Database, key: string): boolean {
+  return getCredential(workspaceDb, key) !== null
+}
+
+/**
+ * Close all cached credential database connections.
+ * Call this during cleanup/shutdown.
+ */
+export function closeAllCredentialStores(): void {
+  for (const [, db] of credentialDbCache) {
+    try {
+      db.close()
+    } catch {
+      // Ignore close errors
+    }
+  }
+  credentialDbCache.clear()
+}
+
+/**
+ * Eagerly migrate all known credential keys from workspace.db to credentials.db.
+ * This is safe to call multiple times (idempotent).
+ * Useful during workspace open to proactively move all credentials out.
+ * No-op for in-memory databases (tests).
+ */
+export function migrateCredentials(workspaceDb: Database.Database): void {
+  const workspacePath = deriveWorkspacePath(workspaceDb)
+  if (!workspacePath) return // In-memory databases (tests)
+
+  // Check if any credentials exist in workspace.db
+  let hasAny = false
+  try {
+    for (const key of CREDENTIAL_KEYS) {
+      const row = workspaceDb
+        .prepare('SELECT value FROM workspace_settings WHERE key = ?')
+        .get(key) as { value: string } | undefined
+      if (row) {
+        hasAny = true
+        break
+      }
+    }
+  } catch {
+    return // workspace_settings table may not exist
+  }
+
+  if (!hasAny) return
+
+  // Open/create credentials.db and migrate
+  const credDb = getCachedCredentialDb(workspacePath, true)
+  if (!credDb) return
+
+  for (const key of CREDENTIAL_KEYS) {
+    try {
+      const row = workspaceDb
+        .prepare('SELECT value FROM workspace_settings WHERE key = ?')
+        .get(key) as { value: string } | undefined
+      if (row) {
+        credDb
+          .prepare(`INSERT OR REPLACE INTO ${CREDENTIALS_TABLE} (key, value) VALUES (?, ?)`)
+          .run(key, row.value)
+        workspaceDb.prepare('DELETE FROM workspace_settings WHERE key = ?').run(key)
+      }
+    } catch {
+      // Skip individual key failures
+    }
+  }
+}

--- a/apps/cli/src/lib/database/index.ts
+++ b/apps/cli/src/lib/database/index.ts
@@ -126,6 +126,18 @@ export {
   createSettingsStore,
 } from './settings-store.js'
 
+// Credential store (PRLT-1114: agent secret isolation)
+export {
+  isCredentialKey,
+  getCredentialDatabasePath,
+  getCredential,
+  setCredential,
+  deleteCredential,
+  hasCredential,
+  closeAllCredentialStores,
+  migrateCredentials,
+} from './credential-store.js'
+
 // Database safety (WAL, backup, integrity, repair)
 export {
   enableWALMode,

--- a/apps/cli/src/lib/database/workspace.ts
+++ b/apps/cli/src/lib/database/workspace.ts
@@ -12,6 +12,7 @@ import { isReadOnlyHQMount } from '../container.js'
 import { throwIfNativeBindingError } from './native-validation.js'
 import { runDrizzleMigrations } from './migrator.js'
 import { ALL_MIGRATIONS } from './migrations/index.js'
+import { migrateCredentials } from './credential-store.js'
 import { createDrizzleConnection, type DrizzleDB } from './drizzle.js'
 import {
   workspace as workspaceTable,
@@ -170,6 +171,10 @@ export function openWorkspaceDatabase(workspacePath: string, options?: { readonl
 
     runDrizzleMigrations(db, ALL_MIGRATIONS)
     ensureEphemeralAgentTypes(db)
+
+    // PRLT-1114: Move credentials from workspace.db to separate credentials.db
+    // so they are not exposed when .proletariat/ is mounted into agent containers
+    migrateCredentials(db)
   }
 
   return db

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -732,6 +732,37 @@ for repo_dir in /workspace/*/; do
     fi
 done
 
+# PRLT-1114: Install pre-commit hook to catch secrets before they are committed
+# Uses core.hooksPath so the hook applies to all repos the agent touches
+setup_secret_detection_hook() {
+    local hooks_dir="/home/node/.git-hooks"
+    mkdir -p "$hooks_dir"
+
+    cat > "$hooks_dir/pre-commit" << 'HOOKEOF'
+#!/bin/bash
+# Pre-commit hook: prevent committing secrets (PRLT-1114)
+# Scans staged changes for known API key / token patterns.
+
+SECRET_PATTERNS='lin_api_[A-Za-z0-9]|ghp_[A-Za-z0-9]|gho_[A-Za-z0-9]|ghs_[A-Za-z0-9]|xox[bprs]-[A-Za-z0-9]|sk-[A-Za-z0-9]{20,}'
+
+if git diff --cached --diff-filter=d -U0 | grep -qE "$SECRET_PATTERNS"; then
+    echo "ERROR: Possible secret detected in staged changes!" >&2
+    echo "" >&2
+    echo "Matched lines:" >&2
+    git diff --cached --diff-filter=d -U0 | grep -nE "$SECRET_PATTERNS" | head -5 >&2
+    echo "" >&2
+    echo "Remove the secret before committing." >&2
+    exit 1
+fi
+HOOKEOF
+
+    chmod +x "$hooks_dir/pre-commit"
+    /usr/bin/git config --global core.hooksPath "$hooks_dir"
+    echo "Secret detection pre-commit hook installed"
+}
+
+setup_secret_detection_hook
+
 echo "Workspace setup complete"
 `
 }

--- a/apps/cli/src/lib/jira/config.ts
+++ b/apps/cli/src/lib/jira/config.ts
@@ -7,6 +7,7 @@
 import type Database from 'better-sqlite3'
 import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
 
 const JIRA_CONFIG_KEYS = {
   baseUrl: 'jira.base_url',
@@ -41,7 +42,7 @@ export function isJiraConfigured(db: Database.Database): boolean {
 
   const settings = new SettingsStore(db)
   const hasDbConfig = settings.has(JIRA_CONFIG_KEYS.baseUrl)
-    && settings.has(JIRA_CONFIG_KEYS.apiToken)
+    && hasCredential(db, JIRA_CONFIG_KEYS.apiToken)
 
   if (hasDbConfig) return true
 
@@ -67,7 +68,7 @@ export function loadJiraConfig(db: Database.Database): JiraConfig | null {
     || process.env.PRLT_JIRA_HOST
     || process.env.JIRA_HOST
 
-  const apiToken = settings.get(JIRA_CONFIG_KEYS.apiToken)
+  const apiToken = getCredential(db, JIRA_CONFIG_KEYS.apiToken)
     || process.env.PRLT_JIRA_API_TOKEN
     || process.env.JIRA_API_TOKEN
 
@@ -93,7 +94,7 @@ export function loadJiraConfig(db: Database.Database): JiraConfig | null {
 export function saveJiraConfig(db: Database.Database, config: JiraConfig): void {
   const settings = new SettingsStore(db)
   settings.set(JIRA_CONFIG_KEYS.baseUrl, config.baseUrl)
-  settings.set(JIRA_CONFIG_KEYS.apiToken, config.apiToken)
+  setCredential(db, JIRA_CONFIG_KEYS.apiToken, config.apiToken)
   if (config.email) {
     settings.set(JIRA_CONFIG_KEYS.email, config.email)
   }
@@ -108,6 +109,10 @@ export function saveJiraConfig(db: Database.Database, config: JiraConfig): void 
 export function clearJiraConfig(db: Database.Database): void {
   const settings = new SettingsStore(db)
   for (const key of Object.values(JIRA_CONFIG_KEYS)) {
-    settings.delete(key)
+    if (key === JIRA_CONFIG_KEYS.apiToken) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
   }
 }

--- a/apps/cli/src/lib/linear/config.ts
+++ b/apps/cli/src/lib/linear/config.ts
@@ -8,6 +8,7 @@ import type Database from 'better-sqlite3'
 import type { LinearConfig } from './types.js'
 import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
 
 const LINEAR_CONFIG_KEYS = {
   apiKey: 'linear.api_key',
@@ -24,8 +25,7 @@ const LINEAR_CONFIG_KEYS = {
  * Check if Linear is configured (API key is stored).
  */
 export function isLinearConfigured(db: Database.Database): boolean {
-  const settings = new SettingsStore(db)
-  return settings.has(LINEAR_CONFIG_KEYS.apiKey)
+  return hasCredential(db, LINEAR_CONFIG_KEYS.apiKey)
 }
 
 /**
@@ -33,10 +33,10 @@ export function isLinearConfigured(db: Database.Database): boolean {
  * Returns null if not configured.
  */
 export function loadLinearConfig(db: Database.Database): LinearConfig | null {
-  const settings = new SettingsStore(db)
-  const apiKey = settings.get(LINEAR_CONFIG_KEYS.apiKey)
+  const apiKey = getCredential(db, LINEAR_CONFIG_KEYS.apiKey)
   if (!apiKey) return null
 
+  const settings = new SettingsStore(db)
   return {
     apiKey,
     defaultTeamId: settings.get(LINEAR_CONFIG_KEYS.defaultTeamId) ?? undefined,
@@ -49,7 +49,7 @@ export function loadLinearConfig(db: Database.Database): LinearConfig | null {
  * Save Linear API key to the database.
  */
 export function saveLinearApiKey(db: Database.Database, apiKey: string): void {
-  new SettingsStore(db).set(LINEAR_CONFIG_KEYS.apiKey, apiKey)
+  setCredential(db, LINEAR_CONFIG_KEYS.apiKey, apiKey)
 }
 
 /**
@@ -74,7 +74,11 @@ export function saveLinearOrganization(db: Database.Database, name: string): voi
 export function clearLinearConfig(db: Database.Database): void {
   const settings = new SettingsStore(db)
   for (const key of Object.values(LINEAR_CONFIG_KEYS)) {
-    settings.delete(key)
+    if (key === LINEAR_CONFIG_KEYS.apiKey) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
   }
 }
 
@@ -105,6 +109,6 @@ export function getLinearApiKey(db: Database.Database): string | null {
   const envKey = process.env.PRLT_LINEAR_API_KEY || process.env.LINEAR_API_KEY
   if (envKey) return envKey
 
-  // 3. Legacy: stored workspace setting
-  return new SettingsStore(db).get(LINEAR_CONFIG_KEYS.apiKey)
+  // 3. Legacy: stored workspace setting (now in credentials.db)
+  return getCredential(db, LINEAR_CONFIG_KEYS.apiKey)
 }

--- a/apps/cli/src/lib/monday/config.ts
+++ b/apps/cli/src/lib/monday/config.ts
@@ -2,6 +2,7 @@ import type Database from 'better-sqlite3'
 import type { MondayConfig } from './types.js'
 import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
 
 const MONDAY_CONFIG_KEYS = {
   apiToken: 'monday.api_token',
@@ -11,12 +12,12 @@ const MONDAY_CONFIG_KEYS = {
 } as const
 
 export function isMondayConfigured(db: Database.Database): boolean {
-  return new SettingsStore(db).has(MONDAY_CONFIG_KEYS.apiToken)
+  return hasCredential(db, MONDAY_CONFIG_KEYS.apiToken)
 }
 
 export function loadMondayConfig(db: Database.Database): MondayConfig | null {
   const settings = new SettingsStore(db)
-  const apiToken = settings.get(MONDAY_CONFIG_KEYS.apiToken)
+  const apiToken = getCredential(db, MONDAY_CONFIG_KEYS.apiToken)
   if (!apiToken) return null
 
   return {
@@ -28,7 +29,7 @@ export function loadMondayConfig(db: Database.Database): MondayConfig | null {
 }
 
 export function saveMondayApiToken(db: Database.Database, apiToken: string): void {
-  new SettingsStore(db).set(MONDAY_CONFIG_KEYS.apiToken, apiToken)
+  setCredential(db, MONDAY_CONFIG_KEYS.apiToken, apiToken)
 }
 
 export function saveMondayBoard(db: Database.Database, boardId: string, boardName: string): void {
@@ -44,7 +45,11 @@ export function saveMondayAccountName(db: Database.Database, accountName: string
 export function clearMondayConfig(db: Database.Database): void {
   const settings = new SettingsStore(db)
   for (const key of Object.values(MONDAY_CONFIG_KEYS)) {
-    settings.delete(key)
+    if (key === MONDAY_CONFIG_KEYS.apiToken) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
   }
 }
 
@@ -64,7 +69,7 @@ export function getMondayApiToken(db: Database.Database): string | null {
   const envToken = process.env.PRLT_MONDAY_API_TOKEN || process.env.MONDAY_API_TOKEN
   if (envToken) return envToken
 
-  return new SettingsStore(db).get(MONDAY_CONFIG_KEYS.apiToken)
+  return getCredential(db, MONDAY_CONFIG_KEYS.apiToken)
 }
 
 export function getMondayBoardId(db: Database.Database): string | null {

--- a/apps/cli/src/lib/shortcut/config.ts
+++ b/apps/cli/src/lib/shortcut/config.ts
@@ -7,6 +7,7 @@
 import type Database from 'better-sqlite3'
 import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
 
 const SHORTCUT_CONFIG_KEYS = {
   apiToken: 'shortcut.api_token',
@@ -22,7 +23,7 @@ export interface ShortcutConfig {
  * Check if Shortcut is configured.
  */
 export function isShortcutConfigured(db: Database.Database): boolean {
-  const hasDbConfig = new SettingsStore(db).has(SHORTCUT_CONFIG_KEYS.apiToken)
+  const hasDbConfig = hasCredential(db, SHORTCUT_CONFIG_KEYS.apiToken)
   if (hasDbConfig) return true
 
   const hasEnvToken = !!(process.env.PRLT_SHORTCUT_API_TOKEN || process.env.SHORTCUT_API_TOKEN)
@@ -34,7 +35,7 @@ export function isShortcutConfigured(db: Database.Database): boolean {
  */
 export function loadShortcutConfig(db: Database.Database): ShortcutConfig | null {
   const settings = new SettingsStore(db)
-  const apiToken = settings.get(SHORTCUT_CONFIG_KEYS.apiToken)
+  const apiToken = getCredential(db, SHORTCUT_CONFIG_KEYS.apiToken)
     || process.env.PRLT_SHORTCUT_API_TOKEN
     || process.env.SHORTCUT_API_TOKEN
 
@@ -54,7 +55,7 @@ export function loadShortcutConfig(db: Database.Database): ShortcutConfig | null
  */
 export function saveShortcutConfig(db: Database.Database, config: ShortcutConfig): void {
   const settings = new SettingsStore(db)
-  settings.set(SHORTCUT_CONFIG_KEYS.apiToken, config.apiToken)
+  setCredential(db, SHORTCUT_CONFIG_KEYS.apiToken, config.apiToken)
   if (config.workspaceSlug) {
     settings.set(SHORTCUT_CONFIG_KEYS.workspaceSlug, config.workspaceSlug)
   }
@@ -64,7 +65,7 @@ export function saveShortcutConfig(db: Database.Database, config: ShortcutConfig
  * Save the Shortcut API token.
  */
 export function saveShortcutApiToken(db: Database.Database, apiToken: string): void {
-  new SettingsStore(db).set(SHORTCUT_CONFIG_KEYS.apiToken, apiToken)
+  setCredential(db, SHORTCUT_CONFIG_KEYS.apiToken, apiToken)
 }
 
 /**
@@ -80,7 +81,11 @@ export function saveShortcutWorkspaceSlug(db: Database.Database, slug: string): 
 export function clearShortcutConfig(db: Database.Database): void {
   const settings = new SettingsStore(db)
   for (const key of Object.values(SHORTCUT_CONFIG_KEYS)) {
-    settings.delete(key)
+    if (key === SHORTCUT_CONFIG_KEYS.apiToken) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
   }
 }
 
@@ -105,6 +110,6 @@ export function getShortcutApiToken(db: Database.Database): string | null {
   const envKey = process.env.PRLT_SHORTCUT_API_TOKEN || process.env.SHORTCUT_API_TOKEN
   if (envKey) return envKey
 
-  // 3. Legacy: stored workspace setting
-  return new SettingsStore(db).get(SHORTCUT_CONFIG_KEYS.apiToken)
+  // 3. Legacy: stored workspace setting (now in credentials.db)
+  return getCredential(db, SHORTCUT_CONFIG_KEYS.apiToken)
 }

--- a/apps/cli/src/lib/trello/config.ts
+++ b/apps/cli/src/lib/trello/config.ts
@@ -7,6 +7,7 @@
 import type Database from 'better-sqlite3'
 import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
 
 const TRELLO_CONFIG_KEYS = {
   apiKey: 'trello.api_key',
@@ -26,9 +27,8 @@ export interface TrelloConfig {
  * Check if Trello is configured.
  */
 export function isTrelloConfigured(db: Database.Database): boolean {
-  const settings = new SettingsStore(db)
-  const hasDbConfig = settings.has(TRELLO_CONFIG_KEYS.apiKey)
-    && settings.has(TRELLO_CONFIG_KEYS.apiToken)
+  const hasDbConfig = hasCredential(db, TRELLO_CONFIG_KEYS.apiKey)
+    && hasCredential(db, TRELLO_CONFIG_KEYS.apiToken)
   if (hasDbConfig) return true
 
   const hasEnvKey = !!(process.env.PRLT_TRELLO_API_KEY || process.env.TRELLO_API_KEY)
@@ -41,11 +41,11 @@ export function isTrelloConfigured(db: Database.Database): boolean {
  */
 export function loadTrelloConfig(db: Database.Database): TrelloConfig | null {
   const settings = new SettingsStore(db)
-  const apiKey = settings.get(TRELLO_CONFIG_KEYS.apiKey)
+  const apiKey = getCredential(db, TRELLO_CONFIG_KEYS.apiKey)
     || process.env.PRLT_TRELLO_API_KEY
     || process.env.TRELLO_API_KEY
 
-  const apiToken = settings.get(TRELLO_CONFIG_KEYS.apiToken)
+  const apiToken = getCredential(db, TRELLO_CONFIG_KEYS.apiToken)
     || process.env.PRLT_TRELLO_API_TOKEN
     || process.env.TRELLO_API_TOKEN
 
@@ -66,8 +66,8 @@ export function loadTrelloConfig(db: Database.Database): TrelloConfig | null {
  */
 export function saveTrelloConfig(db: Database.Database, config: TrelloConfig): void {
   const settings = new SettingsStore(db)
-  settings.set(TRELLO_CONFIG_KEYS.apiKey, config.apiKey)
-  settings.set(TRELLO_CONFIG_KEYS.apiToken, config.apiToken)
+  setCredential(db, TRELLO_CONFIG_KEYS.apiKey, config.apiKey)
+  setCredential(db, TRELLO_CONFIG_KEYS.apiToken, config.apiToken)
   if (config.boardId) {
     settings.set(TRELLO_CONFIG_KEYS.boardId, config.boardId)
   }
@@ -77,11 +77,11 @@ export function saveTrelloConfig(db: Database.Database, config: TrelloConfig): v
 }
 
 export function saveTrelloApiKey(db: Database.Database, apiKey: string): void {
-  new SettingsStore(db).set(TRELLO_CONFIG_KEYS.apiKey, apiKey)
+  setCredential(db, TRELLO_CONFIG_KEYS.apiKey, apiKey)
 }
 
 export function saveTrelloApiToken(db: Database.Database, apiToken: string): void {
-  new SettingsStore(db).set(TRELLO_CONFIG_KEYS.apiToken, apiToken)
+  setCredential(db, TRELLO_CONFIG_KEYS.apiToken, apiToken)
 }
 
 export function saveTrelloBoard(db: Database.Database, boardId: string, boardName: string): void {
@@ -93,7 +93,11 @@ export function saveTrelloBoard(db: Database.Database, boardId: string, boardNam
 export function clearTrelloConfig(db: Database.Database): void {
   const settings = new SettingsStore(db)
   for (const key of Object.values(TRELLO_CONFIG_KEYS)) {
-    settings.delete(key)
+    if (key === TRELLO_CONFIG_KEYS.apiKey || key === TRELLO_CONFIG_KEYS.apiToken) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
   }
 }
 
@@ -113,12 +117,12 @@ export function getTrelloApiKey(db: Database.Database): string | null {
   const envKey = process.env.PRLT_TRELLO_API_KEY || process.env.TRELLO_API_KEY
   if (envKey) return envKey
 
-  return new SettingsStore(db).get(TRELLO_CONFIG_KEYS.apiKey)
+  return getCredential(db, TRELLO_CONFIG_KEYS.apiKey)
 }
 
 export function getTrelloApiToken(db: Database.Database): string | null {
   const envToken = process.env.PRLT_TRELLO_API_TOKEN || process.env.TRELLO_API_TOKEN
   if (envToken) return envToken
 
-  return new SettingsStore(db).get(TRELLO_CONFIG_KEYS.apiToken)
+  return getCredential(db, TRELLO_CONFIG_KEYS.apiToken)
 }

--- a/apps/cli/src/lib/work-source/provider-sources.ts
+++ b/apps/cli/src/lib/work-source/provider-sources.ts
@@ -15,6 +15,7 @@ import type Database from 'better-sqlite3'
 import type { WorkSourceProvider } from './config.js'
 import { WORK_SOURCE_PROVIDERS, isWorkSourceProvider } from './config.js'
 import { SettingsStore } from '../database/settings-store.js'
+import { isCredentialKey, getCredential } from '../database/credential-store.js'
 
 const PROVIDER_SOURCES_KEY = 'work.provider_sources'
 
@@ -363,7 +364,12 @@ export function resolveApiKey(
   const envValue = process.env[entry.apiKeyRef]
   if (envValue) return envValue
 
-  // Try workspace_settings key
+  // Try credential store for known credential keys (PRLT-1114)
+  if (isCredentialKey(entry.apiKeyRef)) {
+    return getCredential(db, entry.apiKeyRef)
+  }
+
+  // Try workspace_settings key for non-credential keys
   const dbValue = settingsFor(db).get(entry.apiKeyRef)
   if (dbValue) return dbValue
 

--- a/apps/cli/test/unit/credential-store.test.ts
+++ b/apps/cli/test/unit/credential-store.test.ts
@@ -1,0 +1,224 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+import {
+  isCredentialKey,
+  getCredentialDatabasePath,
+  getCredential,
+  setCredential,
+  deleteCredential,
+  hasCredential,
+  migrateCredentials,
+  closeAllCredentialStores,
+} from '../../src/lib/database/credential-store.js'
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createTempWorkspace(): { workspacePath: string; db: Database.Database } {
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-cred-test-'))
+  const proletariatDir = path.join(workspacePath, '.proletariat')
+  fs.mkdirSync(proletariatDir, { recursive: true })
+
+  const dbPath = path.join(proletariatDir, 'workspace.db')
+  const db = new Database(dbPath)
+  db.pragma('journal_mode = WAL')
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workspace_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `)
+  return { workspacePath, db }
+}
+
+function cleanup(workspacePath: string, db: Database.Database): void {
+  try { db.close() } catch { /* */ }
+  closeAllCredentialStores()
+  try { fs.rmSync(workspacePath, { recursive: true, force: true }) } catch { /* */ }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Credential Store (PRLT-1114)', () => {
+  let workspacePath: string
+  let db: Database.Database
+
+  beforeEach(() => {
+    const setup = createTempWorkspace()
+    workspacePath = setup.workspacePath
+    db = setup.db
+  })
+
+  afterEach(() => {
+    cleanup(workspacePath, db)
+  })
+
+  describe('isCredentialKey', () => {
+    it('should identify known credential keys', () => {
+      expect(isCredentialKey('linear.api_key')).to.be.true
+      expect(isCredentialKey('jira.api_token')).to.be.true
+      expect(isCredentialKey('asana.access_token')).to.be.true
+      expect(isCredentialKey('trello.api_key')).to.be.true
+      expect(isCredentialKey('trello.api_token')).to.be.true
+      expect(isCredentialKey('shortcut.api_token')).to.be.true
+      expect(isCredentialKey('monday.api_token')).to.be.true
+    })
+
+    it('should not identify non-credential keys', () => {
+      expect(isCredentialKey('linear.default_team_id')).to.be.false
+      expect(isCredentialKey('jira.base_url')).to.be.false
+      expect(isCredentialKey('asana.workspace_gid')).to.be.false
+      expect(isCredentialKey('trello.board_id')).to.be.false
+      expect(isCredentialKey('work.provider_sources')).to.be.false
+    })
+  })
+
+  describe('getCredentialDatabasePath', () => {
+    it('should return path outside .proletariat directory', () => {
+      const credPath = getCredentialDatabasePath('/home/user/workspace')
+      expect(credPath).to.equal('/home/user/workspace/.proletariat-credentials/credentials.db')
+      expect(credPath).to.not.include('.proletariat/')
+    })
+  })
+
+  describe('setCredential / getCredential', () => {
+    it('should store credentials in credentials.db, not workspace.db', () => {
+      setCredential(db, 'linear.api_key', 'lin_api_test123')
+      const value = getCredential(db, 'linear.api_key')
+      expect(value).to.equal('lin_api_test123')
+
+      // Verify NOT in workspace.db
+      const row = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('linear.api_key')
+      expect(row).to.be.undefined
+    })
+
+    it('should store credential in separate credentials.db file', () => {
+      setCredential(db, 'linear.api_key', 'lin_api_test456')
+
+      const credDbPath = getCredentialDatabasePath(workspacePath)
+      expect(fs.existsSync(credDbPath)).to.be.true
+    })
+
+    it('should return null for non-existent credentials', () => {
+      expect(getCredential(db, 'linear.api_key')).to.be.null
+    })
+  })
+
+  describe('auto-migration from workspace.db', () => {
+    it('should migrate credential from workspace.db on first read', () => {
+      // Seed credential directly in workspace.db (legacy behavior)
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('linear.api_key', 'lin_api_legacy')
+
+      // getCredential should find it and migrate
+      const value = getCredential(db, 'linear.api_key')
+      expect(value).to.equal('lin_api_legacy')
+
+      // Should be removed from workspace.db
+      const row = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('linear.api_key')
+      expect(row).to.be.undefined
+
+      // Should now be in credentials.db
+      const credDbPath = getCredentialDatabasePath(workspacePath)
+      const credDb = new Database(credDbPath, { readonly: true })
+      const credRow = credDb.prepare('SELECT value FROM credentials WHERE key = ?').get('linear.api_key') as { value: string } | undefined
+      expect(credRow?.value).to.equal('lin_api_legacy')
+      credDb.close()
+    })
+  })
+
+  describe('migrateCredentials', () => {
+    it('should move all credential keys from workspace.db to credentials.db', () => {
+      // Seed multiple credentials in workspace.db
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('linear.api_key', 'lin_api_bulk1')
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('jira.api_token', 'jira_token_bulk')
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('linear.default_team_id', 'team123')
+
+      migrateCredentials(db)
+
+      // Credentials should be gone from workspace.db
+      const linRow = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('linear.api_key')
+      const jiraRow = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('jira.api_token')
+      expect(linRow).to.be.undefined
+      expect(jiraRow).to.be.undefined
+
+      // Non-credential settings should remain
+      const teamRow = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('linear.default_team_id') as { value: string }
+      expect(teamRow.value).to.equal('team123')
+
+      // Credentials should be in credentials.db
+      const credDbPath = getCredentialDatabasePath(workspacePath)
+      const credDb = new Database(credDbPath, { readonly: true })
+      const linCred = credDb.prepare('SELECT value FROM credentials WHERE key = ?').get('linear.api_key') as { value: string }
+      const jiraCred = credDb.prepare('SELECT value FROM credentials WHERE key = ?').get('jira.api_token') as { value: string }
+      expect(linCred.value).to.equal('lin_api_bulk1')
+      expect(jiraCred.value).to.equal('jira_token_bulk')
+      credDb.close()
+    })
+
+    it('should be idempotent', () => {
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('linear.api_key', 'lin_api_idem')
+
+      migrateCredentials(db)
+      migrateCredentials(db)
+
+      const value = getCredential(db, 'linear.api_key')
+      expect(value).to.equal('lin_api_idem')
+    })
+  })
+
+  describe('deleteCredential', () => {
+    it('should remove from credentials.db', () => {
+      setCredential(db, 'linear.api_key', 'lin_api_del')
+      expect(hasCredential(db, 'linear.api_key')).to.be.true
+
+      deleteCredential(db, 'linear.api_key')
+      expect(hasCredential(db, 'linear.api_key')).to.be.false
+    })
+
+    it('should also clean up from workspace.db if present', () => {
+      db.prepare('INSERT INTO workspace_settings (key, value) VALUES (?, ?)').run('linear.api_key', 'lin_api_cleanup')
+      deleteCredential(db, 'linear.api_key')
+
+      const row = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('linear.api_key')
+      expect(row).to.be.undefined
+    })
+  })
+
+  describe('hasCredential', () => {
+    it('should return true when credential exists', () => {
+      setCredential(db, 'shortcut.api_token', 'sc_token')
+      expect(hasCredential(db, 'shortcut.api_token')).to.be.true
+    })
+
+    it('should return false when credential does not exist', () => {
+      expect(hasCredential(db, 'shortcut.api_token')).to.be.false
+    })
+  })
+
+  describe('agent container isolation', () => {
+    it('should not expose credentials when only .proletariat is mounted', () => {
+      // Simulate: credential is stored properly
+      setCredential(db, 'linear.api_key', 'lin_api_secret')
+
+      // Verify workspace.db has NO credential
+      const row = db.prepare('SELECT value FROM workspace_settings WHERE key = ?').get('linear.api_key')
+      expect(row).to.be.undefined
+
+      // An agent reading workspace.db directly would see nothing
+      const agentSettings = db.prepare('SELECT * FROM workspace_settings WHERE key LIKE ?').all('%.api_%')
+      const credentialLeaks = agentSettings.filter((r: any) =>
+        ['linear.api_key', 'jira.api_token', 'asana.access_token',
+         'trello.api_key', 'trello.api_token', 'shortcut.api_token',
+         'monday.api_token'].includes(r.key)
+      )
+      expect(credentialLeaks).to.have.lengthOf(0)
+    })
+  })
+})

--- a/apps/cli/test/unit/devcontainer.test.ts
+++ b/apps/cli/test/unit/devcontainer.test.ts
@@ -546,6 +546,18 @@ describe('Devcontainer', () => {
 
         expect(script).to.include('is up to date')
       })
+
+      it('should install pre-commit hook for secret detection (PRLT-1114)', () => {
+        const script = generatePrltSetupScript()
+
+        expect(script).to.include('setup_secret_detection_hook')
+        expect(script).to.include('core.hooksPath')
+        expect(script).to.include('lin_api_')
+        expect(script).to.include('ghp_')
+        expect(script).to.include('gho_')
+        expect(script).to.include('xox[bprs]-')
+        expect(script).to.include('Possible secret detected')
+      })
     })
 
     describe('createDevcontainerConfig with git identity', () => {


### PR DESCRIPTION
## Summary

Resolves PRLT-1114: Agent secret isolation — prevent agents from reading/committing credentials

## Description

## Problem

PR #963 (from agent raw-andreesen) committed the Linear API key to the repo. GitHub secret scanning detected it and Linear auto-revoked the key.

Agents can access secrets because:

1. workspace.db is mounted into agent containers (`-v .proletariat:/hq/.proletariat:cached`)
2. The DB contains API keys in `workspace_settings` table
3. Agents can read the DB, extract secrets, and commit them to code

## Fix

### 1\. Don't mount credential-containing DB into agent containers

* Either mount workspace.db as read-only with sensitive fields redacted
* Or create a separate agent-safe view that excludes credential rows
* Or split workspace.db: `workspace.db` (config, agents, state) + `credentials.db` (API keys, tokens) — only mount workspace.db

### 2\. Pre-commit hook to catch secrets

Add a git pre-commit hook that scans for patterns like `lin_api_`, `ghp_`, `gho_`, `sk-` etc.

```bash
if git diff --cached | grep -qE 'lin_api_|ghp_|gho_|sk-|Bearer'; then
  echo 'ERROR: Possible secret in commit'
  exit 1
fi
```

This should be in the devcontainer setup so agents get it automatically.

### 3\. .gitignore for common secret files

Ensure `.env`, `credentials.json`, `*.key`, `workspace.db` are in .gitignore.

### 4\. Agent credential proxy

Longer term: agents should authenticate through a proxy/broker that provides scoped tokens, not raw API keys. The agent gets a short-lived token for the specific operations it needs.

## Files

* `apps/cli/src/lib/execution/runners/docker-management.ts` — volume mounts
* `.devcontainer/` — pre-commit hook setup
* `apps/cli/src/lib/database/` — credential storage location

## External Issue Context

- Source: linear
- External key: PRLT-1114
- External id: 189def31-89f4-4260-96b2-e91d0b62ae57
- URL: https://linear.app/proletariat/issue/PRLT-1114/agent-secret-isolation-prevent-agents-from-readingcommitting
- Status: Ready
- Priority: P0
- Labels: None

## Changes

- 80d0ec42 feat(PRLT-1114): agent secret isolation: split credentials.db, pre-commit hook, gitignore hardening

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
