### PR TITLE
PRLT-1130: Bake pnpm install into Docker image — eliminate 5-15 min cold start per agent

### DIFF
--- a/apps/cli/src/commands/docker/index.ts
+++ b/apps/cli/src/commands/docker/index.ts
@@ -26,6 +26,7 @@ export default class Docker extends PromptCommand {
     '<%= config.bin %> docker shell WORK-001',
     '<%= config.bin %> docker restart abc123',
     '<%= config.bin %> docker sync',
+    '<%= config.bin %> docker rebuild-cache',
     '<%= config.bin %> docker clean',
     '<%= config.bin %> docker prune',
   ]
@@ -49,6 +50,7 @@ export default class Docker extends PromptCommand {
       { name: 'Shell into container', value: 'shell', command: 'prlt docker shell <target> --json' },
       { name: 'Restart a container', value: 'restart', command: 'prlt docker restart <target> --json' },
       { name: 'Sync containers from Docker', value: 'sync', command: 'prlt docker sync --json' },
+      { name: 'Rebuild pnpm store cache', value: 'rebuild-cache', command: 'prlt docker rebuild-cache --json' },
       { name: 'Clean orphaned containers', value: 'clean', command: 'prlt docker clean --json' },
       { name: 'Prune unused resources', value: 'prune', command: 'prlt docker prune --json' },
       { name: 'Exit', value: 'exit', command: 'prlt docker --exit' },

--- a/apps/cli/src/commands/docker/rebuild-cache.ts
+++ b/apps/cli/src/commands/docker/rebuild-cache.ts
@@ -1,0 +1,161 @@
+import { Command, Flags } from '@oclif/core'
+import { styles } from '../../lib/styles.js'
+import { isDockerRunning } from '../../lib/execution/runners.js'
+import {
+  PNPM_STORE_CACHE_VOLUME,
+  pnpmStoreCacheExists,
+  removePnpmStoreCache,
+  buildPnpmStoreCache,
+} from '../../lib/execution/runners/docker-management.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { machineOutputFlags } from '../../lib/pmo/base-command.js'
+import { execSync } from 'node:child_process'
+
+export default class DockerRebuildCache extends Command {
+  static description = 'Rebuild the shared pnpm store cache volume for fast agent installs'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --force',
+  ]
+
+  static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Delete and rebuild the cache even if it already exists',
+      default: false,
+    }),
+    'delete-only': Flags.boolean({
+      description: 'Only delete the cache volume (next agent spawn rebuilds it)',
+      default: false,
+    }),
+    ...machineOutputFlags,
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(DockerRebuildCache)
+    const jsonMode = shouldOutputJson(flags)
+
+    if (!isDockerRunning()) {
+      if (jsonMode) {
+        this.log(JSON.stringify({ success: false, error: 'Docker is not running' }))
+      } else {
+        this.log(`\n${styles.error('Docker is not running')}`)
+        this.log(`${styles.muted('Start Docker Desktop or the Docker daemon first.')}\n`)
+      }
+      return
+    }
+
+    const cacheExists = pnpmStoreCacheExists()
+
+    if (cacheExists && !flags.force && !flags['delete-only']) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          success: true,
+          action: 'none',
+          message: `Cache volume ${PNPM_STORE_CACHE_VOLUME} already exists. Use --force to rebuild.`,
+        }))
+      } else {
+        this.log(`\n${styles.success('Cache exists')} Volume ${styles.code(PNPM_STORE_CACHE_VOLUME)} is already present.`)
+        this.log(`${styles.muted('Use --force to delete and rebuild, or --delete-only to just remove it.')}\n`)
+      }
+      return
+    }
+
+    // Step 1: Remove existing cache
+    if (cacheExists) {
+      if (!jsonMode) {
+        this.log(`\nRemoving existing cache volume ${styles.code(PNPM_STORE_CACHE_VOLUME)}...`)
+      }
+      const removed = removePnpmStoreCache()
+      if (!removed) {
+        if (jsonMode) {
+          this.log(JSON.stringify({
+            success: false,
+            error: `Failed to remove cache volume. It may be in use by a running container.`,
+          }))
+        } else {
+          this.log(`${styles.error('Failed to remove cache volume.')} It may be in use by a running container.`)
+          this.log(`${styles.muted('Stop containers using this volume first: prlt docker stop --all')}\n`)
+        }
+        return
+      }
+      if (!jsonMode) {
+        this.log(`${styles.success('Removed')} cache volume deleted`)
+      }
+    }
+
+    if (flags['delete-only']) {
+      if (jsonMode) {
+        this.log(JSON.stringify({ success: true, action: 'deleted' }))
+      } else {
+        this.log(`\n${styles.success('Done')} Cache volume removed. Next agent spawn will rebuild it automatically.\n`)
+      }
+      return
+    }
+
+    // Step 2: Find an agent image to use for building the cache
+    let imageName: string | null = null
+    try {
+      const images = execSync(
+        'docker images --filter "reference=prlt-agent-*" --format "{{.Repository}}:{{.Tag}}" | head -1',
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
+      ).trim()
+      if (images) {
+        imageName = images
+      }
+    } catch {
+      // No existing agent images
+    }
+
+    if (!imageName) {
+      if (jsonMode) {
+        this.log(JSON.stringify({
+          success: false,
+          error: 'No agent Docker image found. Spawn an agent first to build the base image.',
+        }))
+      } else {
+        this.log(`\n${styles.error('No agent image found.')}`)
+        this.log(`${styles.muted('Spawn an agent first (prlt work start) to build the base Docker image.')}\n`)
+      }
+      return
+    }
+
+    // Step 3: Find a workspace with lockfiles
+    let agentDir: string | null = null
+    try {
+      // Look for the most recently used agent directory
+      const containers = execSync(
+        'docker ps -a --filter "name=prlt-agent-" --format "{{.Mounts}}" | head -1',
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
+      ).trim()
+      // Fall back to current working directory
+      if (!containers) {
+        agentDir = process.cwd()
+      }
+    } catch {
+      // Ignore
+    }
+
+    if (!agentDir) {
+      agentDir = process.cwd()
+    }
+
+    if (!jsonMode) {
+      this.log(`\nBuilding pnpm store cache using image ${styles.code(imageName)}...`)
+      this.log(`${styles.muted('This may take a few minutes on first run.')}`)
+    }
+
+    const success = buildPnpmStoreCache(agentDir, imageName)
+
+    if (jsonMode) {
+      this.log(JSON.stringify({ success, action: success ? 'rebuilt' : 'failed', image: imageName }))
+    } else if (success) {
+      this.log(`\n${styles.success('Cache rebuilt')} Volume ${styles.code(PNPM_STORE_CACHE_VOLUME)} is ready.`)
+      this.log(`${styles.muted('Agent containers will now mount this cache for fast pnpm installs.')}\n`)
+    } else {
+      this.log(`\n${styles.error('Cache build failed.')}`)
+      this.log(`${styles.muted('Check Docker logs for details. The next agent spawn will try again automatically.')}\n`)
+    }
+  }
+}

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -134,6 +134,10 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
     mounts.push('source=${localEnv:PRLT_REPO_PATH},target=/opt/prlt,type=bind,readonly,consistency=cached')
   }
 
+  // PRLT-1130: Mount pnpm store cache read-only for fast installs.
+  // If the volume doesn't exist yet, Docker creates an empty one (setup script handles gracefully).
+  mounts.push('source=pnpm-store-cache,target=/tmp/pnpm-store-cache,type=volume,readonly')
+
   const devcontainerJson: DevcontainerJson = {
     name: `Agent: ${options.agentName}`,
     build: {
@@ -703,6 +707,23 @@ WRAPPER_EOF
     echo "prlt wrapper ready at $WRAPPER (also available as prltdev)"
 elif [ "$PRLT_CONFIGURED" = "false" ]; then
     echo "No mounted prlt found, skipping setup"
+fi
+
+# PRLT-1130: Configure pnpm store directory BEFORE installing workspace deps.
+# Must happen before pnpm install so packages go to the right store location.
+pnpm config set store-dir /tmp/pnpm-store 2>/dev/null || true
+
+# PRLT-1130: Populate pnpm store from read-only cache if available.
+# The cache volume is mounted at /tmp/pnpm-store-cache:ro by the Docker runner.
+# We copy its contents to the writable /tmp/pnpm-store so pnpm install can
+# find packages locally instead of downloading them (seconds vs minutes).
+if [ -d "/tmp/pnpm-store-cache" ] && [ "$(ls -A /tmp/pnpm-store-cache 2>/dev/null)" ]; then
+    echo "Loading pnpm store from cache..."
+    mkdir -p /tmp/pnpm-store
+    cp -a /tmp/pnpm-store-cache/. /tmp/pnpm-store/ 2>/dev/null || true
+    echo "pnpm store cache loaded"
+else
+    echo "No pnpm store cache found, will download packages from network"
 fi
 
 # Install workspace dependencies if package.json exists

--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -19,6 +19,9 @@ import { readDevcontainerJson } from '../devcontainer.js'
 import { isClaudeExecutor } from './executor.js'
 import { getMachineId } from '../../telemetry/analytics.js'
 
+/** Docker volume name for the shared pnpm store cache (PRLT-1130) */
+export const PNPM_STORE_CACHE_VOLUME = 'pnpm-store-cache'
+
 /**
  * Parse a Docker memory string (e.g., '4g', '512m', '2048m') into bytes.
  */
@@ -257,6 +260,9 @@ export function createDockerContainer(
       repoName => `-v "${context.hqPath}/repos/${repoName}:/hq/repos/${repoName}:cached"`
     ),
     ...(isClaudeExecutor(executor) ? [`-v "claude-credentials:/home/node/.claude"`] : []),
+    // PRLT-1130: Mount pnpm store cache read-only for fast installs.
+    // If the cache volume doesn't exist, Docker creates an empty one (harmless).
+    ...(pnpmStoreCacheExists() ? [`-v "${PNPM_STORE_CACHE_VOLUME}:/tmp/pnpm-store-cache:ro"`] : []),
   ]
 
   const hasWorktrees = context.repoWorktrees && context.repoWorktrees.length > 0
@@ -349,12 +355,8 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
     console.debug(`[runners:docker] Container setup scripts failed:`, error)
   }
 
-  try {
-    execSync(`docker exec ${containerId} pnpm config set store-dir /tmp/pnpm-store`, { stdio: 'pipe' })
-    console.debug(`[runners:docker] Configured pnpm store-dir to /tmp/pnpm-store`)
-  } catch (error) {
-    console.debug(`[runners:docker] Failed to configure pnpm store (pnpm may not be installed):`, error)
-  }
+  // NOTE: pnpm store-dir is now configured inside setup-prlt.sh (PRLT-1130)
+  // to ensure it's set BEFORE pnpm install runs during workspace setup.
 
   if (isClaudeExecutor(executor)) {
     try {
@@ -430,6 +432,100 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
 }
 
 /**
+ * Check if the pnpm store cache Docker volume exists.
+ */
+export function pnpmStoreCacheExists(): boolean {
+  try {
+    execSync(`docker volume inspect ${PNPM_STORE_CACHE_VOLUME}`, { stdio: 'pipe', timeout: 5000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Build the pnpm store cache volume by running pnpm install in a temporary container.
+ * The cache volume is populated with all workspace dependencies from pnpm-lock.yaml.
+ * Subsequent agent containers mount this read-only for fast installs (PRLT-1130).
+ */
+export function buildPnpmStoreCache(agentDir: string, imageName: string): boolean {
+  console.debug(`[runners:docker] Building pnpm store cache volume...`)
+
+  const builderName = 'prlt-pnpm-cache-builder'
+
+  // Remove any leftover builder container
+  try {
+    execSync(`docker rm -f ${builderName}`, { stdio: 'pipe', timeout: 10000 })
+  } catch {
+    // Ignore — container may not exist
+  }
+
+  try {
+    // Run a temporary container to populate the cache.
+    // Workspace is mounted read-only (only need lockfiles + package.json).
+    // Cache volume is mounted writable so pnpm can write to the store.
+    const installScript = [
+      'pnpm config set store-dir /tmp/pnpm-store',
+      'for dir in /workspace/*/; do',
+      '  if [ -f "$dir/pnpm-lock.yaml" ]; then',
+      '    echo "Caching deps from $dir..."',
+      '    cd "$dir" && pnpm install --frozen-lockfile 2>&1 || pnpm install 2>&1',
+      '  fi',
+      'done',
+      'echo "pnpm store cache built successfully"',
+    ].join(' && ')
+
+    const buildCmd = [
+      'docker run --rm',
+      `--name ${builderName}`,
+      '--user node',
+      `-v "${agentDir}:/workspace:ro"`,
+      `-v "${PNPM_STORE_CACHE_VOLUME}:/tmp/pnpm-store"`,
+      imageName,
+      'bash', '-c',
+      JSON.stringify(installScript),
+    ].join(' ')
+
+    console.debug(`[runners:docker] Running cache builder: ${buildCmd}`)
+    execSync(buildCmd, { stdio: 'pipe', timeout: 600000 }) // 10 min timeout
+    console.debug(`[runners:docker] pnpm store cache built successfully`)
+    return true
+  } catch (error) {
+    console.debug(`[runners:docker] Failed to build pnpm store cache:`, error)
+    // Don't remove the volume — partial data is still useful
+    return false
+  }
+}
+
+/**
+ * Ensure the pnpm store cache volume exists and is populated.
+ * If not, builds it from the agent's workspace lockfiles.
+ * This is a no-op if the cache already exists (PRLT-1130).
+ */
+export function ensurePnpmStoreCache(agentDir: string, imageName: string): void {
+  if (pnpmStoreCacheExists()) {
+    console.debug(`[runners:docker] pnpm store cache volume exists, reusing`)
+    return
+  }
+  console.debug(`[runners:docker] No pnpm store cache found, building...`)
+  buildPnpmStoreCache(agentDir, imageName)
+}
+
+/**
+ * Delete the pnpm store cache volume.
+ * Returns true if the volume was removed (or didn't exist).
+ */
+export function removePnpmStoreCache(): boolean {
+  try {
+    execSync(`docker volume rm ${PNPM_STORE_CACHE_VOLUME}`, { stdio: 'pipe', timeout: 10000 })
+    return true
+  } catch {
+    // Volume may not exist or may be in use
+    return !pnpmStoreCacheExists()
+  }
+}
+
+/**
  * Ensure a Docker container is running for the agent.
  * Reuses running containers to preserve in-progress work (TKT-1028).
  */
@@ -492,6 +588,10 @@ export function ensureDockerContainer(
     registry: buildArgs.PRLT_REGISTRY,
     version: buildArgs.PRLT_VERSION,
   }
+
+  // PRLT-1130: Ensure pnpm store cache is populated before creating the container.
+  // This builds the cache volume on first spawn; subsequent spawns reuse it.
+  ensurePnpmStoreCache(context.agentDir, imageName)
 
   console.debug(`[runners:docker] Creating container ${containerName}`)
   if (!createDockerContainer(context, containerName, imageName, config, executor, prltInfo)) {

--- a/apps/cli/test/unit/pnpm-store-cache.test.ts
+++ b/apps/cli/test/unit/pnpm-store-cache.test.ts
@@ -1,0 +1,119 @@
+import { expect } from 'chai'
+import {
+  PNPM_STORE_CACHE_VOLUME,
+} from '../../src/lib/execution/runners/docker-management.js'
+import {
+  generateDevcontainerJson,
+  generatePrltSetupScript,
+  DevcontainerOptions,
+} from '../../src/lib/execution/devcontainer.js'
+
+/**
+ * Tests for pnpm store cache feature (PRLT-1130).
+ * Validates cache volume naming, mount configuration, and setup script behavior.
+ */
+describe('pnpm Store Cache (PRLT-1130)', () => {
+  // ===========================================================================
+  // Cache volume constant
+  // ===========================================================================
+  describe('PNPM_STORE_CACHE_VOLUME', () => {
+    it('should be named pnpm-store-cache', () => {
+      expect(PNPM_STORE_CACHE_VOLUME).to.equal('pnpm-store-cache')
+    })
+  })
+
+  // ===========================================================================
+  // Devcontainer JSON — cache mount
+  // ===========================================================================
+  describe('devcontainer.json cache mount', () => {
+    const makeOptions = (overrides: Partial<DevcontainerOptions> = {}): DevcontainerOptions => ({
+      agentName: 'test-agent',
+      agentDir: '/path/to/agents/staff/test-agent',
+      ...overrides,
+    })
+
+    it('should include pnpm-store-cache volume mount as read-only', () => {
+      const options = makeOptions()
+      const result = generateDevcontainerJson(options)
+
+      const cacheMount = result.mounts.find(m => m.includes('pnpm-store-cache'))
+      expect(cacheMount).to.exist
+      expect(cacheMount).to.include('target=/tmp/pnpm-store-cache')
+      expect(cacheMount).to.include('type=volume')
+      expect(cacheMount).to.include('readonly')
+    })
+
+    it('should mount cache at /tmp/pnpm-store-cache (not /tmp/pnpm-store)', () => {
+      // Cache is mounted read-only at a separate path from the writable store.
+      // The setup script copies from cache to the writable store.
+      const options = makeOptions()
+      const result = generateDevcontainerJson(options)
+
+      const cacheMount = result.mounts.find(m => m.includes('pnpm-store-cache'))
+      expect(cacheMount).to.include('target=/tmp/pnpm-store-cache')
+      expect(cacheMount).to.not.include('target=/tmp/pnpm-store,')
+    })
+  })
+
+  // ===========================================================================
+  // Setup script — pnpm store-dir configuration
+  // ===========================================================================
+  describe('setup script pnpm store-dir', () => {
+    it('should configure pnpm store-dir to /tmp/pnpm-store', () => {
+      const script = generatePrltSetupScript()
+
+      expect(script).to.include('pnpm config set store-dir /tmp/pnpm-store')
+    })
+
+    it('should configure store-dir BEFORE install_workspace_deps', () => {
+      const script = generatePrltSetupScript()
+
+      const storeDirIndex = script.indexOf('pnpm config set store-dir /tmp/pnpm-store')
+      const installDepsIndex = script.indexOf('install_workspace_deps')
+      expect(storeDirIndex).to.be.greaterThan(-1)
+      expect(installDepsIndex).to.be.greaterThan(-1)
+      expect(storeDirIndex).to.be.lessThan(installDepsIndex,
+        'store-dir must be configured before install_workspace_deps runs')
+    })
+  })
+
+  // ===========================================================================
+  // Setup script — cache population
+  // ===========================================================================
+  describe('setup script cache population', () => {
+    it('should check for cache directory at /tmp/pnpm-store-cache', () => {
+      const script = generatePrltSetupScript()
+
+      expect(script).to.include('/tmp/pnpm-store-cache')
+    })
+
+    it('should copy cache contents to writable store', () => {
+      const script = generatePrltSetupScript()
+
+      expect(script).to.include('cp -a /tmp/pnpm-store-cache/. /tmp/pnpm-store/')
+    })
+
+    it('should populate cache BEFORE install_workspace_deps', () => {
+      const script = generatePrltSetupScript()
+
+      const cachePopIndex = script.indexOf('cp -a /tmp/pnpm-store-cache')
+      const installDepsIndex = script.indexOf('install_workspace_deps')
+      expect(cachePopIndex).to.be.greaterThan(-1)
+      expect(installDepsIndex).to.be.greaterThan(-1)
+      expect(cachePopIndex).to.be.lessThan(installDepsIndex,
+        'cache population must happen before install_workspace_deps')
+    })
+
+    it('should handle missing cache gracefully (fallback message)', () => {
+      const script = generatePrltSetupScript()
+
+      expect(script).to.include('No pnpm store cache found')
+    })
+
+    it('should create writable store directory before copying', () => {
+      const script = generatePrltSetupScript()
+
+      expect(script).to.include('mkdir -p /tmp/pnpm-store')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-1130: Bake pnpm install into Docker image — eliminate 5-15 min cold start per agent

## Description

## Problem

Every agent spawn runs `pnpm install` at container startup (5-15 min, sometimes hangs). This is the biggest bottleneck in agent lifecycle.

## Root cause

The worktree is bind-mounted at `/workspace`, so we can't bake `node_modules` into the Docker image — the mount overwrites it. `pnpm install` must run at runtime.

## Fix: Read-only pnpm store cache

Previous attempts to share a pnpm store volume failed because multiple agents wrote to it concurrently, causing conflicts.

The fix is to separate reads from writes:

### 1\. Build a cache volume (one-time, or when lockfile changes)

* Run a builder container that does `pnpm install` and populates the pnpm store
* Save the store to a named Docker volume (`pnpm-store-cache`)
* Rebuild only when `pnpm-lock.yaml` changes on main

### 2\. Mount read-only in agent containers

* Mount the cache volume as read-only: `-v pnpm-store-cache:/tmp/pnpm-store:ro`
* `pnpm install` in each agent reads from cache (fast, seconds)
* Any new packages (rare) fall back to network download
* No concurrent writes, no conflicts

### 3\. Cache rebuild trigger

* After merging PRs that change `pnpm-lock.yaml`, rebuild the cache volume
* Could be a `prlt` command: `prlt docker rebuild-cache`
* Or automatic: detect lockfile change on `git pull` and rebuild

### Expected result

* First spawn after lockfile change: \~1-2 min (cache rebuild + install)
* All subsequent spawns: under 30 seconds
* No concurrent write conflicts

## Previous issue

Shared pnpm store with concurrent writes caused conflicts. This approach avoids that by mounting read-only.

## Files

* `.devcontainer/entrypoint.sh` or `setup-prlt.sh` — pnpm install with store config
* `apps/cli/src/lib/execution/runners/docker-management.ts` — add read-only cache volume mount
* New: cache builder script or command

## External Issue Context

- Source: linear
- External key: PRLT-1130
- External id: d2ff6996-6a57-4d40-a9a6-2993dcca3315
- URL: https://linear.app/proletariat/issue/PRLT-1130/bake-pnpm-install-into-docker-image-eliminate-5-15-min-cold-start-per
- Status: Ready
- Priority: P0
- Labels: None

## Changes

- f3a58075 feat(PRLT-1130): read-only pnpm store cache: eliminate 5-15 min cold start per agent

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
