### PR TITLE
chore: bump version to 0.3.94

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.93",
+  "version": "0.3.94",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Version bump to publish latest changes including PRLT-1113 (deleted PMO commands), PRLT-1055 (ClickUp), PRLT-1112 (MCP auto-gen), PRLT-1130 (Docker speed).