### PR TITLE
fix(PRLT-1134): session poke shell escaping — use execFileSync to bypass shell

### DIFF
--- a/apps/cli/src/lib/execution/session-utils.ts
+++ b/apps/cli/src/lib/execution/session-utils.ts
@@ -5,7 +5,7 @@
  * Used by session/list.ts, session/attach.ts, session/health.ts, and session/peek.ts commands.
  */
 
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 
 /**
  * Capture the last N lines from a tmux pane.
@@ -18,14 +18,15 @@ import { execSync } from 'node:child_process'
  */
 export function captureTmuxPane(sessionId: string, lines: number, containerId?: string): string | null {
   try {
-    const captureCmd = `tmux capture-pane -t "${sessionId}" -p -S -${lines}`
+    const args = ['capture-pane', '-t', sessionId, '-p', '-S', `-${lines}`]
     if (containerId) {
-      return execSync(
-        `docker exec ${containerId} bash -c '${captureCmd}'`,
-        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
-      ).trim()
+      return execFileSync('docker', ['exec', containerId, 'tmux', ...args], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 10000,
+      }).trim()
     }
-    return execSync(captureCmd, {
+    return execFileSync('tmux', args, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
@@ -271,57 +272,53 @@ export function findSessionForExecution(
  * Send a text message to a tmux session via send-keys.
  * Sends the text first, then Enter separately with a small delay
  * to avoid race conditions where Enter arrives before text is rendered.
+ *
+ * Uses execFileSync (no shell) to pass the message directly to tmux
+ * as an argv argument, avoiding all shell escaping issues with
+ * parentheses, quotes, newlines, dollar signs, backticks, etc.
  */
 export function sendTmuxMessage(sessionId: string, message: string, containerId?: string): void {
-  // Escape single quotes in the message for shell safety
-  const escapedMessage = message.replace(/'/g, "'\\''")
-
-  // First send Escape to clear any buffered input in the prompt — without
-  // this, text already typed by the agent concatenates with our message,
-  // producing garbage.
-  const sendEscapeCmd = `tmux send-keys -t "${sessionId}" Escape`
-  // Send the text (without Enter), using -l (literal) flag so tmux
-  // does not interpret special characters - message is delivered verbatim
-  const sendTextCmd = `tmux send-keys -l -t "${sessionId}" '${escapedMessage}'`
-  // Then send Enter separately (Enter is a tmux key name, not literal text)
-  const sendEnterCmd = `tmux send-keys -t "${sessionId}" Enter`
+  // Argument arrays for each tmux command — passed directly via execFileSync
+  // to bypass shell interpretation entirely.
+  const escapeArgs = ['send-keys', '-t', sessionId, 'Escape']
+  const textArgs = ['send-keys', '-l', '-t', sessionId, message]
+  const enterArgs = ['send-keys', '-t', sessionId, 'Enter']
 
   if (containerId) {
     // Clear any buffered input first
-    execSync(
-      `docker exec ${containerId} bash -c '${sendEscapeCmd}'`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 },
-    )
+    execFileSync('docker', ['exec', containerId, 'tmux', ...escapeArgs], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    })
     // Wait for Escape to take effect before sending new text
     execSync('sleep 0.2', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execSync(
-      `docker exec ${containerId} bash -c '${sendTextCmd}'`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 },
-    )
+    // Send the text literally — execFileSync bypasses shell, so the message
+    // reaches tmux verbatim regardless of content (parens, quotes, newlines, etc.)
+    execFileSync('docker', ['exec', containerId, 'tmux', ...textArgs], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    })
     // Small delay before sending Enter to avoid race conditions
     execSync('sleep 0.1', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execSync(
-      `docker exec ${containerId} bash -c '${sendEnterCmd}'`,
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 },
-    )
+    execFileSync('docker', ['exec', containerId, 'tmux', ...enterArgs], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    })
   } else {
     // Clear any buffered input first
-    execSync(sendEscapeCmd, {
-      encoding: 'utf-8',
+    execFileSync('tmux', escapeArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     })
     // Wait for Escape to take effect before sending new text
     execSync('sleep 0.2', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execSync(sendTextCmd, {
-      encoding: 'utf-8',
+    execFileSync('tmux', textArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     })
     // Small delay before sending Enter
     execSync('sleep 0.1', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execSync(sendEnterCmd, {
-      encoding: 'utf-8',
+    execFileSync('tmux', enterArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
     })

--- a/apps/cli/src/lib/runners/claude-code-runner.ts
+++ b/apps/cli/src/lib/runners/claude-code-runner.ts
@@ -7,7 +7,7 @@
  * compatibility with `prlt work start`.
  */
 
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
 import type { AgentRunner, AgentSession, SpawnConfig } from './agent-runner.js'
 import {
   runHost,
@@ -86,17 +86,20 @@ export class ClaudeCodeRunner implements AgentRunner {
       // Send Escape first to clear any buffered input in the prompt —
       // without this, text already typed by the agent concatenates with
       // our message, producing garbage.
-      execSync(
-        `tmux send-keys -t "${session.sessionName}" Escape`,
-        { stdio: 'pipe' },
-      )
+      execFileSync('tmux', ['send-keys', '-t', session.sessionName, 'Escape'], {
+        stdio: 'pipe',
+      })
       // Wait for Escape to take effect before sending new text
       await new Promise(resolve => setTimeout(resolve, 200))
-      // Send the message as keystrokes followed by Enter
-      execSync(
-        `tmux send-keys -t "${session.sessionName}" ${JSON.stringify(message)} Enter`,
-        { stdio: 'pipe' },
-      )
+      // Send the message as literal text — uses execFileSync (no shell) so
+      // parentheses, quotes, newlines, $, backticks, etc. are all safe.
+      execFileSync('tmux', ['send-keys', '-l', '-t', session.sessionName, message], {
+        stdio: 'pipe',
+      })
+      // Send Enter separately (Enter is a tmux key name, not literal text)
+      execFileSync('tmux', ['send-keys', '-t', session.sessionName, 'Enter'], {
+        stdio: 'pipe',
+      })
     } catch (error) {
       throw new Error(
         `Failed to send message to session "${session.sessionName}": ${

--- a/apps/cli/test/unit/send-tmux-message.test.ts
+++ b/apps/cli/test/unit/send-tmux-message.test.ts
@@ -1,0 +1,145 @@
+import { expect } from 'chai'
+import { execSync, execFileSync } from 'node:child_process'
+import {
+  sendTmuxMessage,
+  captureTmuxPane,
+} from '../../src/lib/execution/session-utils.js'
+
+/**
+ * Regression tests for PRLT-1134: session poke breaks on parentheses and newlines.
+ *
+ * These tests create real tmux sessions and verify that messages containing
+ * shell metacharacters are delivered verbatim, without shell interpretation.
+ */
+describe('sendTmuxMessage — shell escaping (PRLT-1134)', () => {
+  const TEST_SESSION = 'prlt-test-send-tmux-msg'
+
+  beforeEach(() => {
+    // Create a tmux session running cat, which echoes stdin to the pane
+    try {
+      execSync(`tmux kill-session -t ${TEST_SESSION} 2>/dev/null`, { stdio: 'pipe' })
+    } catch {
+      // Session may not exist
+    }
+    execFileSync('tmux', [
+      'new-session', '-d', '-s', TEST_SESSION, '-x', '200', '-y', '50',
+    ])
+    // Brief pause for session to initialize
+    execSync('sleep 0.3', { stdio: 'pipe' })
+  })
+
+  afterEach(() => {
+    try {
+      execSync(`tmux kill-session -t ${TEST_SESSION} 2>/dev/null`, { stdio: 'pipe' })
+    } catch {
+      // Best-effort cleanup
+    }
+  })
+
+  /**
+   * Capture the pane content and return just the text lines (trimmed, non-empty).
+   */
+  function getPaneContent(): string {
+    const raw = captureTmuxPane(TEST_SESSION, 200)
+    return raw ?? ''
+  }
+
+  it('should handle parentheses in message', () => {
+    const msg = 'Install foo (option 1) or bar'
+    sendTmuxMessage(TEST_SESSION, msg)
+    // Allow tmux to render
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('Install foo (option 1) or bar')
+  })
+
+  it('should handle single quotes in message', () => {
+    const msg = "it's a test with 'quotes'"
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include("it's a test with 'quotes'")
+  })
+
+  it('should handle double quotes in message', () => {
+    const msg = 'say "hello world"'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('say "hello world"')
+  })
+
+  it('should handle dollar signs and backticks without expansion', () => {
+    const msg = 'cost is $100 and `command` here'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('cost is $100')
+    expect(pane).to.include('`command`')
+  })
+
+  it('should handle semicolons and pipes', () => {
+    const msg = 'run this; then that | grep foo'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('run this; then that | grep foo')
+  })
+
+  it('should handle ampersands and redirects', () => {
+    const msg = 'cmd1 && cmd2 || cmd3 > /dev/null 2>&1'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('cmd1 && cmd2 || cmd3 > /dev/null 2>&1')
+  })
+
+  it('should handle exclamation marks and hash', () => {
+    const msg = 'hello! # this is not a comment'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('hello!')
+    expect(pane).to.include('# this is not a comment')
+  })
+
+  it('should handle curly braces and square brackets', () => {
+    const msg = 'data: {key: [1, 2, 3]}'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('data: {key: [1, 2, 3]}')
+  })
+
+  it('should handle backslashes', () => {
+    const msg = 'path\\to\\file and \\n literal'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('path\\to\\file')
+  })
+
+  it('should handle multi-line messages (newlines)', () => {
+    // Multi-line messages should be delivered to the pane.
+    // With send-keys -l, newlines become Enter keystrokes,
+    // which is the expected behavior for poke.
+    const msg = 'line one\nline two\nline three'
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    // All lines should appear in the pane
+    expect(pane).to.include('line one')
+    expect(pane).to.include('line two')
+    expect(pane).to.include('line three')
+  })
+
+  it('should handle mixed special characters', () => {
+    const msg = "Fix bug (issue #42): use `printf '%s'` instead of $var"
+    sendTmuxMessage(TEST_SESSION, msg)
+    execSync('sleep 0.5', { stdio: 'pipe' })
+    const pane = getPaneContent()
+    expect(pane).to.include('Fix bug (issue #42)')
+    expect(pane).to.include("printf '%s'")
+    expect(pane).to.include('$var')
+  })
+})


### PR DESCRIPTION
## Summary

- **Fix shell metacharacter escaping in `session poke`**: Replaced `execSync` (shell-based) with `execFileSync` (no shell) in `sendTmuxMessage()` and `ClaudeCodeRunner.poke()`, so messages containing parentheses, quotes, newlines, `$`, backticks, etc. are delivered verbatim to tmux
- **Root cause**: Messages were interpolated into shell command strings (`bash -c '...'`), causing shell metacharacters to be interpreted — e.g., `(option 1)` → "syntax error near unexpected token `)"`
- **Also fixed**: `captureTmuxPane()` converted to `execFileSync` for consistency

## Files Changed

- `apps/cli/src/lib/execution/session-utils.ts` — `sendTmuxMessage()` and `captureTmuxPane()` now use `execFileSync` with argument arrays
- `apps/cli/src/lib/runners/claude-code-runner.ts` — `ClaudeCodeRunner.poke()` now uses `execFileSync` with `-l` flag and separate Enter
- `apps/cli/test/unit/send-tmux-message.test.ts` — 11 regression tests covering parentheses, quotes, dollar signs, backticks, newlines, pipes, etc.

## Test plan

- [x] All 11 regression tests pass (real tmux sessions, not mocks)
- [x] Build passes (`pnpm build`)
- [x] Existing unit tests unaffected (2306 passing)
- [ ] Manual: `prlt session poke agent "Install foo (option 1) or bar"` — no syntax error
- [ ] Manual: `prlt session poke agent -F /path/to/multiline.txt` — lines not executed as commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)