### PR TITLE
fix(PRLT-1135): telemetry tests import from source, not dist/

### DIFF
--- a/apps/cli/test/unit/analytics-queue.test.ts
+++ b/apps/cli/test/unit/analytics-queue.test.ts
@@ -17,9 +17,9 @@ import { execFileSync } from 'node:child_process'
  */
 describe('Analytics queue persistence', () => {
   let testDir: string
-  // Absolute path to the built analytics module
-  // Tests run from apps/cli/ so dist/ is directly under cwd
-  const analyticsPath = path.resolve(process.cwd(), 'dist/lib/telemetry/analytics.js')
+  // Absolute path to the source analytics module (not dist/ — tests must not depend on build artifacts)
+  // Uses .js extension for Node16 module resolution (ts-node/esm resolves .js → .ts)
+  const analyticsPath = path.resolve(process.cwd(), 'src/lib/telemetry/analytics.js')
   // Convert to file:// URL for ESM imports in child scripts
   const analyticsUrl = `file://${analyticsPath}`
 
@@ -130,7 +130,7 @@ ${script}
     const scriptPath = path.join(testDir, 'test-script.mjs')
     fs.writeFileSync(scriptPath, fullScript, 'utf-8')
 
-    const nodeArgs: string[] = []
+    const nodeArgs: string[] = ['--loader', 'ts-node/esm']
     if (opts?.useMock) {
       const registerPath = path.join(testDir, 'mock', 'register-mock.mjs')
       nodeArgs.push('--import', registerPath)

--- a/apps/cli/test/unit/telemetry-identity.test.ts
+++ b/apps/cli/test/unit/telemetry-identity.test.ts
@@ -15,7 +15,9 @@ import { execFileSync } from 'node:child_process'
 
 describe('Telemetry Identity (PRLT-1111)', () => {
   let testDir: string
-  const analyticsPath = path.resolve(process.cwd(), 'dist/lib/telemetry/analytics.js')
+  // Use source path (not dist/) — tests must not depend on build artifacts
+  // .js extension for Node16 module resolution (ts-node/esm resolves .js → .ts)
+  const analyticsPath = path.resolve(process.cwd(), 'src/lib/telemetry/analytics.js')
   const analyticsUrl = `file://${analyticsPath}`
 
   beforeEach(() => {
@@ -51,7 +53,7 @@ ${script}
     let stdout = ''
     let stderr = ''
     try {
-      stdout = execFileSync('node', [scriptPath], {
+      stdout = execFileSync('node', ['--loader', 'ts-node/esm', scriptPath], {
         env: {
           ...process.env,
           HOME: testDir,
@@ -235,8 +237,8 @@ ${script}
 
   describe('Docker container PRLT_TELEMETRY_MACHINE_ID passthrough', () => {
     it('createDockerContainer imports getMachineId from analytics', async () => {
-      // Verify the import relationship exists by checking the built output
-      const dockerMgmtPath = path.resolve(process.cwd(), 'dist/lib/execution/runners/docker-management.js')
+      // Verify the import relationship exists by checking the source
+      const dockerMgmtPath = path.resolve(process.cwd(), 'src/lib/execution/runners/docker-management.ts')
       const content = fs.readFileSync(dockerMgmtPath, 'utf-8')
       expect(content).to.include('getMachineId')
       expect(content).to.include('PRLT_TELEMETRY_MACHINE_ID')


### PR DESCRIPTION
## Summary

- **Fix**: Changed telemetry test files (`analytics-queue.test.ts`, `telemetry-identity.test.ts`) to import from `src/` instead of `dist/` — tests no longer depend on build artifacts
- **Root cause**: Tests spawned child processes that `import()` from `dist/lib/telemetry/analytics.js`, but CI runs unit tests and build in parallel, so `dist/` doesn't exist yet
- **Changes**: Import path changed to `src/lib/telemetry/analytics.js` with `--loader ts-node/esm` for child processes; docker-management source check reads `.ts` instead of compiled `.js`

## Test plan

- [x] `analytics-queue.test.ts` — all 7 tests pass (without dist/ present)
- [x] `telemetry-identity.test.ts` — all 9 tests pass (without dist/ present)
- [x] Build passes (`pnpm build`)
- [ ] Full unit test suite passes in CI

Fixes: https://linear.app/proletariat/issue/PRLT-1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)