### PR TITLE
feat(PRLT-1136): run full test suite on PRs, not just smoke

### DIFF
--- a/apps/cli/test/unit/ci-workflow-tiers.test.ts
+++ b/apps/cli/test/unit/ci-workflow-tiers.test.ts
@@ -1,0 +1,68 @@
+/**
+ * CI Workflow Tier Regression Test — PRLT-1136
+ *
+ * Ensures the GitHub Actions test workflow runs the full test suite on PRs,
+ * not just smoke tests. This prevents silent main breakage where tests only
+ * fail post-merge because they weren't run on the PR.
+ *
+ * If this test fails, it means someone has changed the PR tier back to
+ * smoke-only, which will allow untested code to merge into main.
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WORKFLOW_PATH = path.resolve(__dirname, '../../../../.github/workflows/test.yml')
+
+describe('CI workflow test tiers (PRLT-1136)', () => {
+  let workflowContent: string
+
+  before(() => {
+    workflowContent = fs.readFileSync(WORKFLOW_PATH, 'utf-8')
+  })
+
+  it('should exist at .github/workflows/test.yml', () => {
+    expect(fs.existsSync(WORKFLOW_PATH)).to.be.true
+  })
+
+  it('should set TIER="full" for pull_request events, not "smoke"', () => {
+    // The PR tier assignment is in the else branch of the tier detection logic.
+    // It must be "full" to prevent silent main breakage.
+    // Match the pattern: else block sets TIER="full" (not "smoke")
+    const prTierMatch = workflowContent.match(
+      /else\s*\n\s*#.*pull_request.*\n\s*TIER="(\w+)"/
+    )
+    expect(prTierMatch, 'Could not find PR tier assignment in workflow').to.not.be.null
+    expect(prTierMatch![1]).to.equal(
+      'full',
+      'PR tier must be "full" — smoke-only PRs caused silent main breakage (PRLT-1136)'
+    )
+  })
+
+  it('should run full suite for both push and pull_request events', () => {
+    // The early-exit block must handle both push and pull_request events.
+    // This ensures PRs get all e2e shards, same as main pushes.
+    expect(workflowContent).to.include(
+      'github.event_name }}" == "push" || "${{ github.event_name }}" == "pull_request"',
+      'Early-exit block must run full suite for both push and pull_request events'
+    )
+  })
+
+  it('should include all 7 e2e shards for PRs', () => {
+    // After the push || pull_request condition, the next e2e_shards line must include all shards
+    const allShards = ['pmo', 'execution', 'agent-flows', 'json-mode', 'integrations', 'standalone', 'infrastructure']
+    const pushPrBlock = workflowContent.split('push" || "${{ github.event_name }}" == "pull_request"')[1]
+    expect(pushPrBlock, 'Could not find push/PR early-exit block').to.not.be.undefined
+
+    // Extract the e2e_shards value from the block (before the next exit 0)
+    const shardsMatch = pushPrBlock?.match(/e2e_shards=(\[.*?\])/)
+    expect(shardsMatch, 'Could not find e2e_shards in push/PR block').to.not.be.null
+
+    const shards = JSON.parse(shardsMatch![1].replace(/'/g, '"'))
+    for (const shard of allShards) {
+      expect(shards).to.include(shard, `Missing e2e shard: ${shard}`)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: PRs only ran @smoke-tagged tests. Main ran the full suite. This caused main to be red for days without anyone noticing — the telemetry test only ran on main.
- **Fix**: Change PR test tier from `smoke` to `full` in `.github/workflows/test.yml` so PRs run all unit tests and all 7 e2e shards — same as main pushes (~5-7 min, acceptable for a merge gate)
- **Regression test**: Added `ci-workflow-tiers.test.ts` that validates the workflow YAML expects full tier for PRs

## ⚠️ Workflow File Push Blocked — Needs `workflow` Scope

The agent's GitHub OAuth token lacks `workflow` scope, which GitHub requires for pushing changes to `.github/workflows/` files. The regression test is pushed, but the workflow file change needs to be applied manually.

**To complete this PR**, run on a machine with workflow scope:

```bash
git checkout PRLT-1136/feat/chrismcdermut/silky-gates/run-full-test-suite
```

Then apply these changes to `.github/workflows/test.yml` (3 locations in the `detect-changes` step):

**1. Update comment (line ~36-40):**
```diff
-# - standard: scoped tests based on change detection (current PR behavior)
+# - standard: scoped tests based on change detection
-# - pull_request: smoke (fast feedback)
+# - pull_request: full (prevent silent main breakage)
```

**2. Change PR tier from smoke to full (line ~79-80):**
```diff
-            # pull_request: use smoke tier for fast feedback
-            TIER="smoke"
+            # pull_request: run full suite to prevent silent main breakage
+            TIER="full"
```

**3. Add pull_request to early-exit block (line ~85-89):**
```diff
-          # For push to main and manual dispatch (standard/full), always run full suite
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          # For push to main and PRs, always run the full suite
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "pull_request" ]]; then
             echo "run_tests=true" >> "$GITHUB_OUTPUT"
             echo "scope=full" >> "$GITHUB_OUTPUT"
-            echo "reason=Full suite: push event" >> "$GITHUB_OUTPUT"
+            echo "reason=Full suite: ${{ github.event_name }} event" >> "$GITHUB_OUTPUT"
```

**To fix the token for future agents:** Run `gh auth refresh -h github.com -s workflow` on the host machine.

## Test plan

- [ ] Apply workflow file changes (requires `workflow` scope token)
- [ ] Verify PR CI runs all 7 e2e shards (pmo, execution, agent-flows, json-mode, integrations, standalone, infrastructure)
- [ ] Verify PR CI runs full unit test suite (not smoke-only)
- [ ] Verify push-to-main behavior unchanged
- [ ] Verify workflow_dispatch behavior unchanged
- [ ] Verify docs-only PRs still skip tests (handled before tier logic)
- [ ] Regression test passes: `npx mocha test/unit/ci-workflow-tiers.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)