### PR TITLE
feat(PRLT-1146): bump container memory to 8g and reduce mocha parallelism to 2 jobs

### DIFF
--- a/apps/cli/.mocharc.json
+++ b/apps/cli/.mocharc.json
@@ -11,7 +11,7 @@
   "retries": 1,
   "timeout": 60000,
   "parallel": true,
-  "jobs": 4,
+  "jobs": 2,
   "node-option": [
     "loader=ts-node/esm",
     "experimental-specifier-resolution=node"

--- a/apps/cli/src/commands/config/index.ts
+++ b/apps/cli/src/commands/config/index.ts
@@ -381,9 +381,9 @@ export default class Config extends PromptCommand {
       case 'containers.memory': {
         const memoryChoices = [
           { name: '2g - Minimal (light tasks)', value: '2g', command: 'prlt config --set "containers.memory 2g" --json' },
-          { name: '4g - Default (recommended)', value: '4g', command: 'prlt config --set "containers.memory 4g" --json' },
+          { name: '4g - Minimal', value: '4g', command: 'prlt config --set "containers.memory 4g" --json' },
           { name: '6g - Large (complex builds)', value: '6g', command: 'prlt config --set "containers.memory 6g" --json' },
-          { name: '8g - Extra large', value: '8g', command: 'prlt config --set "containers.memory 8g" --json' },
+          { name: '8g - Default (recommended)', value: '8g', command: 'prlt config --set "containers.memory 8g" --json' },
         ]
         const { newMemory } = await this.prompt<{ newMemory: string }>([
           {

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -480,7 +480,7 @@ export const DEFAULT_EXECUTION_CONFIG: ExecutionConfig = {
   },
   devcontainer: {
     defaultImage: 'mcr.microsoft.com/devcontainers/base:ubuntu',
-    memory: '4g',
+    memory: '8g',
     cpus: 2,
     autoStart: true,
   },

--- a/apps/cli/test/unit/execution-config.test.ts
+++ b/apps/cli/test/unit/execution-config.test.ts
@@ -71,8 +71,8 @@ describe('Execution Config', () => {
       expect(DEFAULT_EXECUTION_CONFIG.terminal.app).to.equal('Terminal');
     });
 
-    it('has devcontainer.memory defaulting to 4g (PRLT-1099)', () => {
-      expect(DEFAULT_EXECUTION_CONFIG.devcontainer.memory).to.equal('4g');
+    it('has devcontainer.memory defaulting to 8g (PRLT-1146)', () => {
+      expect(DEFAULT_EXECUTION_CONFIG.devcontainer.memory).to.equal('8g');
     });
 
     it('has devcontainer.cpus defaulting to 2 (PRLT-1099)', () => {
@@ -303,9 +303,9 @@ describe('Execution Config', () => {
       expect(config.devcontainer.cpus).to.equal(4);
     });
 
-    it('uses default devcontainer memory/cpus when not configured (PRLT-1099)', () => {
+    it('uses default devcontainer memory/cpus when not configured (PRLT-1146)', () => {
       const config = loadExecutionConfig(db);
-      expect(config.devcontainer.memory).to.equal('4g');
+      expect(config.devcontainer.memory).to.equal('8g');
       expect(config.devcontainer.cpus).to.equal(2);
     });
 
@@ -315,6 +315,15 @@ describe('Execution Config', () => {
       const config = loadExecutionConfig(db);
       // Should fall back to default since 'invalid' cannot be parsed
       expect(config.devcontainer.cpus).to.equal(2);
+    });
+
+    it('default memory is at least 8g to prevent OOM in agent containers (PRLT-1146)', () => {
+      // Regression: agents were OOM-killed at 4g when mocha spawned parallel workers.
+      // The default must be >= 8g so containers have headroom for test parallelism + Claude.
+      const memoryStr = DEFAULT_EXECUTION_CONFIG.devcontainer.memory;
+      const match = memoryStr.match(/^(\d+)g$/);
+      expect(match, `memory "${memoryStr}" should be in "<N>g" format`).to.not.be.null;
+      expect(Number(match![1])).to.be.at.least(8);
     });
 
     it('round-trips VM settings through load', () => {

--- a/apps/cli/test/unit/mocha-parallelism.test.ts
+++ b/apps/cli/test/unit/mocha-parallelism.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Mocha Parallelism Regression Test — PRLT-1146
+ *
+ * Ensures mocha parallel jobs stay at 2 (not 4+) to prevent OOM kills in
+ * agent containers. At jobs=4, each worker uses 400-900MB which combined
+ * with Claude (~230MB) exceeds container memory limits.
+ *
+ * If this test fails, it means someone bumped mocha jobs back up, which
+ * will cause agent containers to OOM and silently die.
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const MOCHARC_PATH = path.resolve(__dirname, '../../.mocharc.json')
+
+describe('Mocha parallelism config (PRLT-1146)', () => {
+  let config: { jobs?: number; parallel?: boolean }
+
+  before(() => {
+    const raw = fs.readFileSync(MOCHARC_PATH, 'utf-8')
+    config = JSON.parse(raw)
+  })
+
+  it('should have parallel enabled', () => {
+    expect(config.parallel).to.equal(true)
+  })
+
+  it('should limit jobs to 2 to prevent OOM in agent containers', () => {
+    // Regression: 4 parallel workers * 400-900MB each = OOM at 4GB/8GB container limits.
+    // 2 workers keeps peak memory well within bounds.
+    expect(config.jobs).to.equal(2)
+  })
+})

--- a/docs/workflows/docker-setup.md
+++ b/docs/workflows/docker-setup.md
@@ -324,7 +324,7 @@ docker build -t my-prlt-image .
 Set container resource limits:
 
 ```bash
-docker run --memory=4g --cpus=2 ...
+docker run --memory=8g --cpus=2 ...
 ```
 
 ### Persistent Volumes


### PR DESCRIPTION
## Summary
- Bumps default container memory from 4GB to 8GB to prevent OOM kills when running tests alongside Claude
- Reduces mocha parallel jobs from 4 to 2 — each worker uses 400-900MB, so 4 workers + Claude (~230MB) exceeded the old 4GB limit
- Adds regression tests for both the memory default and mocha parallelism config

## Context
Agent containers were OOM-killed silently when running `pnpm test:unit` (PRLT-1137 lost 25 min of work with 7 uncommitted files). The container stayed 'Up' but all processes became zombies.

## Changes
- `apps/cli/src/lib/execution/types.ts` — default `devcontainer.memory` → `8g`
- `apps/cli/.mocharc.json` — `jobs` → `2`
- `apps/cli/src/commands/config/index.ts` — updated config menu labels
- `apps/cli/test/unit/execution-config.test.ts` — updated existing tests + added regression test
- `apps/cli/test/unit/mocha-parallelism.test.ts` — new regression test for mocharc jobs
- `docs/workflows/docker-setup.md` — updated example command

## Test plan
- [x] `pnpm build` passes
- [x] All PRLT-1146 regression tests pass (5/5)
- [ ] Verify pre-existing test failures are not caused by this PR

Closes PRLT-1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)