### PR TITLE
feat(PRLT-1152): route PMO bootstrap through db-safety auto-repair layer

### DIFF
--- a/apps/cli/src/lib/database/pmo-bootstrap.ts
+++ b/apps/cli/src/lib/database/pmo-bootstrap.ts
@@ -3,6 +3,13 @@
  *
  * Raw SQL operations required for PMO initialization and teardown.
  * These run before the storage layer is available.
+ *
+ * All database opens go through openSafeDatabase() which provides:
+ * - Rotating backup before open
+ * - Quick integrity check on startup
+ * - Auto-repair on corruption (dump/reimport or backup restore)
+ *
+ * See: PRLT-1152
  */
 
 import Database from 'better-sqlite3'
@@ -11,19 +18,62 @@ import { createDrizzleConnection } from './drizzle.js'
 import {
   workspaceSettings as workspaceSettingsTable,
 } from './drizzle-schema.js'
+import {
+  createRotatingBackup,
+  quickCheckIntegrity,
+  repairDatabase,
+} from './db-safety.js'
+
+/**
+ * Open a database connection with safety features (backup, integrity check, auto-repair).
+ * Used by PMO bootstrap functions that need raw SQL access before the full workspace
+ * database lifecycle is available.
+ */
+function openSafeDatabase(dbPath: string, caller: string): Database.Database {
+  // Create backup before opening (cheap insurance against corruption)
+  createRotatingBackup(dbPath)
+
+  let db: Database.Database
+  try {
+    db = new Database(dbPath)
+  } catch (error) {
+    throwIfNativeBindingError(error, caller)
+    throw error
+  }
+
+  // Quick integrity check — auto-repair if corrupt
+  const integrity = quickCheckIntegrity(db)
+  if (!integrity.ok) {
+    db.close()
+
+    const repair = repairDatabase(dbPath)
+    if (!repair.success) {
+      throw new Error(
+        `Database corruption detected in ${dbPath}.\n` +
+        `Integrity errors: ${integrity.errors.join('; ')}\n` +
+        `Auto-repair failed: ${repair.message}\n` +
+        `Run 'prlt db repair' for manual recovery options.`
+      )
+    }
+
+    // Re-open the repaired database
+    try {
+      db = new Database(dbPath)
+    } catch (error) {
+      throwIfNativeBindingError(error, `${caller} (post-repair)`)
+      throw error
+    }
+  }
+
+  return db
+}
 
 /**
  * Check if PMO tables exist and get basic stats.
  * Raw SQL: uses sqlite_master introspection (pre-migration bootstrap).
  */
 export function checkPMOExists(dbPath: string): { exists: boolean; projectCount: number; ticketCount: number } {
-  let db: Database.Database
-  try {
-    db = new Database(dbPath)
-  } catch (error) {
-    throwIfNativeBindingError(error, 'checkPMOExists')
-    throw error
-  }
+  const db = openSafeDatabase(dbPath, 'checkPMOExists')
   try {
     const result = db.prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_projects'"
@@ -51,13 +101,7 @@ export function checkPMOExists(dbPath: string): { exists: boolean; projectCount:
  * Raw SQL: pre-migration bootstrap query.
  */
 export function getPMOSetting(dbPath: string, key: string): string | null {
-  let db: Database.Database
-  try {
-    db = new Database(dbPath)
-  } catch (error) {
-    throwIfNativeBindingError(error, 'getPMOSetting')
-    throw error
-  }
+  const db = openSafeDatabase(dbPath, 'getPMOSetting')
   try {
     const result = db.prepare('SELECT value FROM pmo_settings WHERE key = ?').get(key) as { value: string } | undefined
     return result?.value ?? null
@@ -73,13 +117,7 @@ export function getPMOSetting(dbPath: string, key: string): string | null {
  * Raw SQL: DDL operations (DROP TABLE) are not supported by Drizzle.
  */
 export function dropPMOTables(dbPath: string, tables: string[]): void {
-  let db: Database.Database
-  try {
-    db = new Database(dbPath)
-  } catch (error) {
-    throwIfNativeBindingError(error, 'dropPMOTables')
-    throw error
-  }
+  const db = openSafeDatabase(dbPath, 'dropPMOTables')
   try {
     for (const table of tables) {
       try {

--- a/apps/cli/test/unit/db-safety.test.ts
+++ b/apps/cli/test/unit/db-safety.test.ts
@@ -11,6 +11,11 @@ import {
   repairDatabase,
   getBackupPath,
 } from '../../src/lib/database/db-safety.js'
+import {
+  checkPMOExists,
+  getPMOSetting,
+  dropPMOTables,
+} from '../../src/lib/database/pmo-bootstrap.js'
 
 describe('db-safety', () => {
   let tmpDir: string
@@ -162,6 +167,93 @@ describe('db-safety', () => {
       const result = repairDatabase(dbPath)
       expect(result.success).to.be.false
       expect(result.method).to.equal('none')
+    })
+  })
+
+  // =========================================================================
+  // PRLT-1152: PMO bootstrap must use db-safety auto-repair layer
+  // =========================================================================
+  describe('PMO bootstrap auto-repair (PRLT-1152)', () => {
+    function createPMODatabase(dbPath: string): void {
+      const db = new Database(dbPath)
+      db.exec('CREATE TABLE pmo_projects (id TEXT PRIMARY KEY, name TEXT)')
+      db.exec('CREATE TABLE pmo_tickets (id TEXT PRIMARY KEY, title TEXT)')
+      db.exec('CREATE TABLE pmo_settings (key TEXT PRIMARY KEY, value TEXT)')
+      db.exec("INSERT INTO pmo_projects VALUES ('P1', 'Project 1')")
+      db.exec("INSERT INTO pmo_tickets VALUES ('T1', 'Ticket 1')")
+      db.exec("INSERT INTO pmo_settings VALUES ('version', '1.0')")
+      db.close()
+    }
+
+    it('checkPMOExists auto-repairs a corrupt database instead of failing', () => {
+      const dbPath = path.join(tmpDir, 'workspace.db')
+      createPMODatabase(dbPath)
+
+      // Create a backup before corruption so repair has something to restore from
+      createRotatingBackup(dbPath)
+
+      // Corrupt the database
+      fs.writeFileSync(dbPath, Buffer.from('this is not a sqlite database'))
+
+      // Before the fix (PRLT-1152), this would throw SQLITE_CORRUPT or
+      // report PMO not found. After the fix, it should auto-repair and succeed.
+      const result = checkPMOExists(dbPath)
+      expect(result.exists).to.be.true
+      expect(result.projectCount).to.equal(1)
+      expect(result.ticketCount).to.equal(1)
+    })
+
+    it('getPMOSetting auto-repairs a corrupt database instead of failing', () => {
+      const dbPath = path.join(tmpDir, 'workspace.db')
+      createPMODatabase(dbPath)
+      createRotatingBackup(dbPath)
+
+      // Corrupt the database
+      fs.writeFileSync(dbPath, Buffer.from('this is not a sqlite database'))
+
+      const value = getPMOSetting(dbPath, 'version')
+      expect(value).to.equal('1.0')
+    })
+
+    it('dropPMOTables auto-repairs a corrupt database instead of failing', () => {
+      const dbPath = path.join(tmpDir, 'workspace.db')
+      createPMODatabase(dbPath)
+      createRotatingBackup(dbPath)
+
+      // Corrupt the database
+      fs.writeFileSync(dbPath, Buffer.from('this is not a sqlite database'))
+
+      // Should auto-repair and then drop tables without throwing
+      dropPMOTables(dbPath, ['pmo_projects', 'pmo_tickets'])
+
+      // Verify tables were dropped from the repaired database
+      const db = new Database(dbPath)
+      const tables = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('pmo_projects', 'pmo_tickets')"
+      ).all()
+      expect(tables).to.have.length(0)
+      db.close()
+    })
+
+    it('checkPMOExists throws descriptive error when repair is impossible', () => {
+      const dbPath = path.join(tmpDir, 'workspace.db')
+      // Write garbage with no backups available
+      fs.writeFileSync(dbPath, Buffer.from('corrupted beyond repair'))
+
+      expect(() => checkPMOExists(dbPath)).to.throw('Database corruption detected')
+    })
+
+    it('checkPMOExists creates a backup before opening', () => {
+      const dbPath = path.join(tmpDir, 'workspace.db')
+      createPMODatabase(dbPath)
+
+      // No backups should exist yet
+      expect(fs.existsSync(getBackupPath(dbPath, 1))).to.be.false
+
+      checkPMOExists(dbPath)
+
+      // After calling checkPMOExists, a backup should have been created
+      expect(fs.existsSync(getBackupPath(dbPath, 1))).to.be.true
     })
   })
 


### PR DESCRIPTION
## Summary
- **Route all PMO bootstrap database opens through a new `openSafeDatabase()` helper** that provides rotating backup, quick integrity check, and auto-repair on corruption — matching the safety features of `openWorkspaceDatabase()`.
- Fixes `checkPMOExists()`, `getPMOSetting()`, and `dropPMOTables()` which previously used raw `new Database(dbPath)` calls, bypassing the db-safety layer entirely.
- When workspace.db is corrupt, PMO bootstrap now auto-repairs (dump/reimport or backup restore) instead of throwing an unhelpful "PMO not found" error.

## Root Cause
`pmo-bootstrap.ts` opened raw better-sqlite3 connections directly, bypassing the backup, integrity check, and auto-repair logic in `db-safety.ts`. This caused a production incident where a corrupt db made all PMO and orchestrator commands unusable despite healthy backups existing.

## Test plan
- [x] 5 new regression tests in `db-safety.test.ts` covering:
  - `checkPMOExists` auto-repairs corrupt DB (restore from backup)
  - `getPMOSetting` auto-repairs corrupt DB
  - `dropPMOTables` auto-repairs corrupt DB
  - Descriptive error thrown when repair is impossible (no backups)
  - Backup is created before opening
- [x] All 60 existing database tests pass (no regressions)
- [x] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: PRLT-1152