### PR TITLE
chore: bump version to 0.3.95

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.94",
+  "version": "0.3.95",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Version bump to 0.3.95. Includes branch naming fix (PRLT-1125), heartbeat (PRLT-1142), auto-ship (PRLT-1144), auto-rebase (PRLT-1143), and 13 other merged PRs.