### PR TITLE
feat(PRLT-1139): DB-first session discovery with runtime liveness probing

### DIFF
--- a/apps/cli/src/commands/session/attach.ts
+++ b/apps/cli/src/commands/session/attach.ts
@@ -10,12 +10,11 @@ import { openWorkspaceDatabase } from '../../lib/database/index.js'
 import { ExecutionStorage, loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
 import { detectTerminalApp } from '../orchestrator/attach.js'
 import {
-  parseSessionName,
+  findSessionForExecution,
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
-  flattenContainerSessions,
   findContainerSessionsByPrefix,
-  findSessionForExecution,
+  probeExecutionLiveness,
 } from '../../lib/execution/session-utils.js'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import {
@@ -31,11 +30,10 @@ interface SessionChoice {
   containerId?: string
   ticketId: string
   agentName: string
-  source: 'db' | 'discovered'  // Whether session was found in DB or discovered from tmux
 }
 
 export default class SessionAttach extends PMOCommand {
-  static description = 'Attach to an active tmux session'
+  static description = 'Attach to an active agent session (DB-tracked only)'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
@@ -88,7 +86,7 @@ export default class SessionAttach extends PMOCommand {
     // Check if JSON output mode is active
     const jsonMode = shouldOutputJson(flags)
 
-    // Get all available sessions (DB-driven)
+    // Get all available sessions (DB-driven only — no orphan discovery)
     const sessions = this.getVerifiedSessions()
 
     if (sessions.length === 0) {
@@ -176,9 +174,9 @@ export default class SessionAttach extends PMOCommand {
   }
 
   /**
-   * Get verified sessions from DB that have actual tmux processes
-   * DB-driven approach: Start with executions, verify tmux sessions exist
-   * Also discovers orphan sessions matching prlt naming pattern but not in DB
+   * Get verified sessions from DB that have alive runtimes.
+   * DB-first: query executions, then probe liveness per runtime environment.
+   * No orphan discovery — only DB-tracked sessions are attachable.
    */
   private getVerifiedSessions(): SessionChoice[] {
     const sessions: SessionChoice[] = []
@@ -191,120 +189,48 @@ export default class SessionAttach extends PMOCommand {
       db = openWorkspaceDatabase(workspaceInfo.path)
       executionStorage = new ExecutionStorage(db)
     } catch {
-      // Not in workspace, but we can still discover tmux sessions
+      return sessions
     }
 
     try {
-      // Get actual tmux sessions for verification
+      // Get active executions from DB
+      const activeExecutions = [
+        ...executionStorage.listExecutions({ status: 'running' }),
+        ...executionStorage.listExecutions({ status: 'starting' }),
+      ]
+
+      // For session ID discovery when DB has NULL session_id
       const hostTmuxSessions = getHostTmuxSessionNames()
       const containerTmuxSessions = getContainerTmuxSessionMap()
 
-      // Flatten all container sessions for orphan detection
-      const allContainerSessions = flattenContainerSessions(containerTmuxSessions)
-
-      // Track which tmux sessions we've matched to DB records
-      const matchedHostSessions = new Set<string>()
-      const matchedContainerSessions = new Set<string>()
-
-      // Get active executions from DB (if available)
-      const activeExecutions = executionStorage ? [
-        ...(executionStorage.listExecutions({ status: 'running' }) || []),
-        ...(executionStorage.listExecutions({ status: 'starting' }) || []),
-      ] : []
-
       for (const exec of activeExecutions) {
-        const isContainer = exec.environment === 'devcontainer'
-        let exists = false
-        let containerId: string | undefined
+        const isContainer = exec.environment === 'devcontainer' || exec.environment === 'docker'
         let actualSessionId = exec.sessionId
 
-        // If sessionId is NULL, try to find session by naming convention
-        if (!exec.sessionId) {
+        // If sessionId is NULL, try to find by naming convention
+        if (!actualSessionId) {
           if (isContainer && exec.containerId) {
             const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
             const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
-            if (match) {
-              actualSessionId = match
-              exists = true
-              containerId = exec.containerId
-            }
+            if (match) actualSessionId = match
           } else {
             const match = findSessionForExecution(exec.ticketId, exec.agentName, hostTmuxSessions)
-            if (match) {
-              actualSessionId = match
-              exists = true
-            }
-          }
-
-          // If still no match, skip this execution
-          if (!actualSessionId) {
-            continue
-          }
-        } else {
-          // sessionId is set, verify it exists
-          if (isContainer && exec.containerId) {
-            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
-            exists = containerSessions.includes(exec.sessionId)
-            containerId = exec.containerId
-          } else {
-            exists = hostTmuxSessions.includes(exec.sessionId)
+            if (match) actualSessionId = match
           }
         }
 
-        // Track matched sessions
-        if (exists && actualSessionId) {
-          if (isContainer && containerId) {
-            matchedContainerSessions.add(`${containerId}:${actualSessionId}`)
-          } else {
-            matchedHostSessions.add(actualSessionId)
-          }
+        // Probe runtime liveness
+        const alive = probeExecutionLiveness(exec.environment, exec.containerId, actualSessionId)
+        if (!alive || !actualSessionId) continue
 
-          sessions.push({
-            name: actualSessionId,
-            sessionId: actualSessionId,
-            type: isContainer ? 'container' : 'host',
-            containerId,
-            ticketId: exec.ticketId,
-            agentName: exec.agentName,
-            source: 'db',
-          })
-        }
-      }
-
-      // Discover orphan sessions: tmux sessions matching prlt pattern but not in DB
-      // Host sessions
-      for (const sessionName of hostTmuxSessions) {
-        if (matchedHostSessions.has(sessionName)) continue
-
-        const parsed = parseSessionName(sessionName)
-        if (parsed) {
-          sessions.push({
-            name: sessionName,
-            sessionId: sessionName,
-            type: 'host',
-            ticketId: parsed.ticketId,
-            agentName: parsed.agentName,
-            source: 'discovered',
-          })
-        }
-      }
-
-      // Container sessions
-      for (const { sessionName, containerId } of allContainerSessions) {
-        if (matchedContainerSessions.has(`${containerId}:${sessionName}`)) continue
-
-        const parsed = parseSessionName(sessionName)
-        if (parsed) {
-          sessions.push({
-            name: sessionName,
-            sessionId: sessionName,
-            type: 'container',
-            containerId,
-            ticketId: parsed.ticketId,
-            agentName: parsed.agentName,
-            source: 'discovered',
-          })
-        }
+        sessions.push({
+          name: actualSessionId,
+          sessionId: actualSessionId,
+          type: isContainer ? 'container' : 'host',
+          containerId: exec.containerId,
+          ticketId: exec.ticketId,
+          agentName: exec.agentName,
+        })
       }
     } finally {
       db?.close()

--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -5,12 +5,13 @@ import { getWorkspaceInfo } from '../../lib/agents/commands.js'
 import { openWorkspaceDatabase } from '../../lib/database/index.js'
 import { ExecutionStorage } from '../../lib/execution/index.js'
 import {
-  parseSessionName,
+  findSessionForExecution,
   getHostTmuxSessionNames,
   getContainerTmuxSessionMap,
   flattenContainerSessions,
   findContainerSessionsByPrefix,
-  findSessionForExecution,
+  parseSessionName,
+  probeExecutionLiveness,
 } from '../../lib/execution/session-utils.js'
 import { PromptCommand } from '../../lib/prompt-command.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
@@ -24,23 +25,28 @@ interface VerifiedSession {
   status: string
   environment: 'host' | 'container'
   containerId?: string
-  exists: boolean  // Whether the tmux session actually exists
-  source: 'db' | 'discovered'  // Whether session was found in DB or discovered from tmux
+  alive: boolean  // Whether the runtime is alive (container running / tmux session exists)
+  source: 'db' | 'orphan'  // DB-tracked or discovered orphan (garbage)
 }
 
 export default class SessionList extends PromptCommand {
-  static description = 'List active tmux sessions (host and container)'
+  static description = 'List active agent sessions (DB-first with runtime liveness probing)'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --all',
+    '<%= config.bin %> <%= command.id %> --orphans',
   ]
 
   static flags = {
     ...machineOutputFlags,
     all: Flags.boolean({
       char: 'a',
-      description: 'Show all sessions including stale DB records',
+      description: 'Show all sessions including stale DB records with dead runtimes',
+      default: false,
+    }),
+    orphans: Flags.boolean({
+      description: 'Also show orphan tmux sessions not tracked in the database',
       default: false,
     }),
   }
@@ -63,177 +69,147 @@ export default class SessionList extends PromptCommand {
       db = openWorkspaceDatabase(workspaceInfo.path)
       executionStorage = new ExecutionStorage(db)
     } catch {
-      // Not in a workspace, but we can still discover tmux sessions
+      // Not in a workspace — no DB sessions to show
       hasWorkspace = false
     }
 
     try {
-      // DB-driven approach: Start with executions, verify tmux sessions exist
-      const runningExecutions = executionStorage?.listExecutions({ status: 'running' }) || []
-      const startingExecutions = executionStorage?.listExecutions({ status: 'starting' }) || []
-      const activeExecutions = [...runningExecutions, ...startingExecutions]
-
-      // Refresh execution state so dead sessions aren't reported as running.
-      executionStorage?.cleanupStaleExecutions()
-
-      // Get list of actual tmux sessions for verification
-      const hostTmuxSessions = getHostTmuxSessionNames()
-      const containerTmuxSessions = getContainerTmuxSessionMap()
-
-      // Flatten all container sessions for orphan detection
-      const allContainerSessions = flattenContainerSessions(containerTmuxSessions)
-
-      // Track which tmux sessions we've matched to DB records
-      const matchedHostSessions = new Set<string>()
-      const matchedContainerSessions = new Set<string>()
-
-      // Build verified session list from DB records
       const sessions: VerifiedSession[] = []
 
-      for (const exec of activeExecutions) {
-        const isContainer = exec.environment === 'devcontainer'
-        let exists = false
-        let containerId: string | undefined
-        let actualSessionId = exec.sessionId
-
-        // If sessionId is NULL, try to find session by naming convention
-        if (!exec.sessionId) {
-          if (isContainer && exec.containerId) {
-            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
-            const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
-            if (match) {
-              actualSessionId = match
-              exists = true
-              containerId = exec.containerId
-            }
-          } else {
-            const match = findSessionForExecution(exec.ticketId, exec.agentName, hostTmuxSessions)
-            if (match) {
-              actualSessionId = match
-              exists = true
-            }
-          }
-
-          // If still no match, skip this execution (truly has no session)
-          if (!actualSessionId) {
-            continue
-          }
-        } else {
-          // sessionId is set, verify it exists
-          if (isContainer && exec.containerId) {
-            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
-            exists = containerSessions.includes(exec.sessionId)
-            containerId = exec.containerId
-          } else {
-            exists = hostTmuxSessions.includes(exec.sessionId)
-          }
-        }
-
-        // Track matched sessions to detect orphans later
-        if (exists && actualSessionId) {
-          if (isContainer && containerId) {
-            matchedContainerSessions.add(`${containerId}:${actualSessionId}`)
-          } else {
-            matchedHostSessions.add(actualSessionId)
-          }
-        }
-
-        // Only include active sessions by default.
-        // Use --all to include stale DB records (exists=false).
-        if (actualSessionId && (exists || flags.all)) {
-          sessions.push({
-            sessionId: actualSessionId,
-            ticketId: exec.ticketId,
-            agentName: exec.agentName,
-            status: exists ? exec.status : 'stale',
-            environment: isContainer ? 'container' : 'host',
-            containerId,
-            exists,
-            source: 'db',
-          })
-        }
-      }
-
-      // PRLT-1077: Self-healing recovery for background-mode spawns.
-      // Check stopped executions whose tmux sessions are still alive — they were
-      // incorrectly marked as stopped when the CLI exited but the agent continued.
       if (executionStorage) {
+        // ===================================================================
+        // DB-first: Query all active executions, then probe runtime liveness.
+        // The DB is the source of truth. Runtime checks confirm what IS running.
+        // ===================================================================
+        const runningExecutions = executionStorage.listExecutions({ status: 'running' })
+        const startingExecutions = executionStorage.listExecutions({ status: 'starting' })
+        const activeExecutions = [...runningExecutions, ...startingExecutions]
+
+        // For session ID discovery when DB has NULL session_id, we still need
+        // tmux session lists (but only for matching, not as source of truth)
+        const hostTmuxSessions = getHostTmuxSessionNames()
+        const containerTmuxSessions = getContainerTmuxSessionMap()
+
+        for (const exec of activeExecutions) {
+          const isContainer = exec.environment === 'devcontainer' || exec.environment === 'docker'
+          const containerId = exec.containerId
+          let actualSessionId = exec.sessionId
+
+          // If sessionId is NULL, try to find session by naming convention
+          if (!actualSessionId) {
+            if (isContainer && containerId) {
+              const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, containerId)
+              const match = findSessionForExecution(exec.ticketId, exec.agentName, containerSessions)
+              if (match) actualSessionId = match
+            } else {
+              const match = findSessionForExecution(exec.ticketId, exec.agentName, hostTmuxSessions)
+              if (match) actualSessionId = match
+            }
+          }
+
+          // Probe runtime liveness: docker inspect for containers, tmux has-session for host
+          const alive = probeExecutionLiveness(exec.environment, containerId, actualSessionId)
+
+          // By default only show alive sessions; --all includes stale (dead runtime) too
+          if (alive || flags.all) {
+            sessions.push({
+              sessionId: actualSessionId || `[${exec.id}]`,
+              ticketId: exec.ticketId,
+              agentName: exec.agentName,
+              status: alive ? exec.status : 'stale',
+              environment: isContainer ? 'container' : 'host',
+              containerId,
+              alive,
+              source: 'db',
+            })
+          }
+
+          // Note: we don't update DB status here — list is read-only.
+          // Dead executions are cleaned up by `prlt session prune` or `prlt work stop`.
+        }
+
+        // =================================================================
+        // PRLT-1077: Self-healing recovery for background-mode spawns.
+        // Check stopped executions whose runtimes are still alive — they
+        // were incorrectly marked as stopped when the CLI exited.
+        // =================================================================
         const stoppedExecutions = executionStorage.listExecutions({ status: 'stopped' })
         for (const exec of stoppedExecutions) {
-          const isContainer = exec.environment === 'devcontainer'
-          if (!exec.sessionId) continue
+          const isContainer = exec.environment === 'devcontainer' || exec.environment === 'docker'
+          const alive = probeExecutionLiveness(exec.environment, exec.containerId, exec.sessionId)
 
-          let sessionAlive = false
-          let containerId: string | undefined
-
-          if (isContainer && exec.containerId) {
-            const containerSessions = findContainerSessionsByPrefix(containerTmuxSessions, exec.containerId)
-            sessionAlive = containerSessions.includes(exec.sessionId)
-            containerId = exec.containerId
-          } else {
-            sessionAlive = hostTmuxSessions.includes(exec.sessionId)
-          }
-
-          if (sessionAlive) {
+          if (alive) {
             // Recover: update status back to 'running'
             executionStorage.updateStatus(exec.id, 'running')
 
-            // Track as matched so it's not reported as orphan
-            if (isContainer && containerId) {
-              matchedContainerSessions.add(`${containerId}:${exec.sessionId}`)
-            } else {
-              matchedHostSessions.add(exec.sessionId)
-            }
-
             sessions.push({
-              sessionId: exec.sessionId,
+              sessionId: exec.sessionId || `[${exec.id}]`,
               ticketId: exec.ticketId,
               agentName: exec.agentName,
               status: 'running',
               environment: isContainer ? 'container' : 'host',
-              containerId,
-              exists: true,
+              containerId: exec.containerId,
+              alive: true,
               source: 'db',
             })
           }
         }
       }
 
-      // Discover orphan sessions: tmux sessions matching prlt pattern but not in DB
-      // Host sessions
-      for (const sessionName of hostTmuxSessions) {
-        if (matchedHostSessions.has(sessionName)) continue
+      // ==================================================================
+      // Orphan discovery: only shown with --orphans flag.
+      // These are tmux sessions matching prlt pattern but NOT in the DB.
+      // They are garbage to prune, not first-class sessions.
+      // ==================================================================
+      let orphanCount = 0
+      if (flags.orphans) {
+        const hostTmuxSessions = getHostTmuxSessionNames()
+        const containerTmuxSessions = getContainerTmuxSessionMap()
+        const allContainerSessions = flattenContainerSessions(containerTmuxSessions)
 
-        const parsed = parseSessionName(sessionName)
-        if (parsed) {
-          sessions.push({
-            sessionId: sessionName,
-            ticketId: parsed.ticketId,
-            agentName: parsed.agentName,
-            status: 'orphan',
-            environment: 'host',
-            exists: true,
-            source: 'discovered',
-          })
+        // Build set of session IDs we've already matched from DB
+        const dbSessionIds = new Set(sessions.filter(s => s.source === 'db').map(s => s.sessionId))
+        const dbContainerSessionIds = new Set(
+          sessions.filter(s => s.source === 'db' && s.containerId)
+            .map(s => `${s.containerId}:${s.sessionId}`)
+        )
+
+        // Host orphans
+        for (const sessionName of hostTmuxSessions) {
+          if (dbSessionIds.has(sessionName)) continue
+          const parsed = parseSessionName(sessionName)
+          if (parsed) {
+            orphanCount++
+            sessions.push({
+              sessionId: sessionName,
+              ticketId: parsed.ticketId,
+              agentName: parsed.agentName,
+              status: 'orphan',
+              environment: 'host',
+              alive: true,
+              source: 'orphan',
+            })
+          }
         }
-      }
 
-      // Container sessions
-      for (const { sessionName, containerId } of allContainerSessions) {
-        if (matchedContainerSessions.has(`${containerId}:${sessionName}`)) continue
-
-        const parsed = parseSessionName(sessionName)
-        if (parsed) {
-          sessions.push({
-            sessionId: sessionName,
-            ticketId: parsed.ticketId,
-            agentName: parsed.agentName,
-            status: 'orphan',
-            environment: 'container',
-            containerId,
-            exists: true,
-            source: 'discovered',
-          })
+        // Container orphans
+        for (const { sessionName, containerId } of allContainerSessions) {
+          if (dbContainerSessionIds.has(`${containerId}:${sessionName}`)) continue
+          if (dbSessionIds.has(sessionName)) continue
+          const parsed = parseSessionName(sessionName)
+          if (parsed) {
+            orphanCount++
+            sessions.push({
+              sessionId: sessionName,
+              ticketId: parsed.ticketId,
+              agentName: parsed.agentName,
+              status: 'orphan',
+              environment: 'container',
+              containerId,
+              alive: true,
+              source: 'orphan',
+            })
+          }
         }
       }
 
@@ -244,7 +220,7 @@ export default class SessionList extends PromptCommand {
 
       if (sessions.length > 0) {
         this.log('')
-        this.log(styles.header('🖥️  Active Sessions'))
+        this.log(styles.header('Active Sessions'))
         this.log('═'.repeat(90))
 
         this.log(
@@ -266,8 +242,7 @@ export default class SessionList extends PromptCommand {
                              session.status === 'stale' ? styles.error :
                              session.status === 'orphan' ? styles.warning : styles.muted
 
-          // For orphan sessions, append source indicator
-          const statusText = session.source === 'discovered' ? `${session.status}*` : session.status
+          const statusText = session.source === 'orphan' ? `${session.status}*` : session.status
 
           // Truncate long session names to fit column
           const displaySession = session.sessionId.length > 32
@@ -287,41 +262,41 @@ export default class SessionList extends PromptCommand {
         this.log('')
         this.log('═'.repeat(90))
 
-        // Show attach command example
-        const firstSession = sessions.find(s => s.exists)
-        if (firstSession) {
+        // Show attach command example for alive DB sessions
+        const firstAlive = sessions.find(s => s.alive && s.source === 'db')
+        if (firstAlive) {
           this.log(styles.muted('\nCommands:'))
-          this.log(styles.muted(`  prlt session attach ${firstSession.sessionId}    Attach to session`))
+          this.log(styles.muted(`  prlt session attach ${firstAlive.sessionId}    Attach to session`))
           this.log('')
         }
 
         // Show stale sessions warning
-        const staleSessions = sessions.filter(s => !s.exists)
+        const staleSessions = sessions.filter(s => s.status === 'stale')
         if (staleSessions.length > 0) {
-          this.log(styles.warning(`\n⚠️  ${staleSessions.length} stale session(s) in DB without tmux process.`))
-          this.log(styles.muted('   Run `prlt work stop <work-id>` to clean up.'))
+          this.log(styles.warning(`\n  ${staleSessions.length} stale session(s) in DB with dead runtime.`))
+          this.log(styles.muted('   Run `prlt session prune` or `prlt work stop <work-id>` to clean up.'))
           this.log('')
         }
 
-        // Show orphan sessions note
-        const orphanSessions = sessions.filter(s => s.source === 'discovered')
-        if (orphanSessions.length > 0) {
-          this.log(styles.muted(`\n📋 ${orphanSessions.length} session(s) discovered from tmux (marked with *).`))
-          this.log(styles.muted('   These sessions match the prlt naming pattern but are not tracked in the database.'))
+        // Show orphan note
+        if (orphanCount > 0) {
+          this.log(styles.warning(`\n  ${orphanCount} orphan session(s) found in tmux but not in DB (marked with *).`))
+          this.log(styles.muted('   Run `prlt session prune` to clean them up.'))
           this.log('')
         }
 
       } else {
         this.log('')
         if (!hasWorkspace) {
-          this.log(styles.muted('Not in a workspace and no prlt-pattern tmux sessions found.'))
-          this.log('')
-          this.log(styles.muted('Run from a proletariat HQ directory to see tracked sessions,'))
+          this.log(styles.muted('Not in a workspace. Run from a proletariat HQ directory to see tracked sessions,'))
           this.log(styles.muted('or start work with: prlt work start <ticket-id>'))
         } else {
           this.log(styles.muted('No active sessions found.'))
           this.log('')
           this.log(styles.muted('Start work with: prlt work start <ticket-id>'))
+          if (!flags.orphans) {
+            this.log(styles.muted('Use --orphans to also check for untracked tmux sessions.'))
+          }
         }
         this.log('')
       }

--- a/apps/cli/src/commands/session/prune.ts
+++ b/apps/cli/src/commands/session/prune.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
 import { styles } from '../../lib/styles.js'
 import {
   getWorkspaceInfo,
@@ -16,6 +17,8 @@ import {
   flattenContainerSessions,
   findContainerSessionsByPrefix,
   findSessionForExecution,
+  probeExecutionLiveness,
+  checkDockerContainerAlive,
 } from '../../lib/execution/session-utils.js'
 import { PromptCommand } from '../../lib/prompt-command.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
@@ -28,13 +31,14 @@ import {
 
 interface PruneResult {
   staleExecutionsCleaned: number
+  completedSessionsKilled: string[]
   orphanSessionsKilled: string[]
   ephemeralAgentsCleaned: CleanupResult[]
   errors: string[]
 }
 
 export default class SessionPrune extends PromptCommand {
-  static description = 'Clean up stale sessions, orphan tmux sessions, and idle ephemeral agents'
+  static description = 'Clean up stale sessions, kill completed/failed execution runtimes, remove orphan tmux sessions, and clean idle ephemeral agents'
 
   static examples = [
     '<%= config.bin %> session prune',
@@ -98,25 +102,85 @@ export default class SessionPrune extends PromptCommand {
     try {
       const result: PruneResult = {
         staleExecutionsCleaned: 0,
+        completedSessionsKilled: [],
         orphanSessionsKilled: [],
         ephemeralAgentsCleaned: [],
         errors: [],
       }
 
       // =====================================================================
-      // Step 1: Clean up stale execution records
+      // Step 1: Clean up stale execution records (DB records with dead runtime)
       // =====================================================================
       const staleCount = executionStorage.cleanupStaleExecutions()
       result.staleExecutionsCleaned = staleCount
 
       // =====================================================================
-      // Step 2: Find and kill orphan tmux sessions
+      // Step 2: Kill runtimes for completed/failed/stopped DB records
+      // These are executions the DB knows about that have terminal status
+      // but whose tmux sessions or Docker containers are still running.
+      // =====================================================================
+      const completedExecutions = [
+        ...executionStorage.listExecutions({ status: 'completed' }),
+        ...executionStorage.listExecutions({ status: 'failed' }),
+        ...executionStorage.listExecutions({ status: 'stopped' }),
+      ]
+
+      for (const exec of completedExecutions) {
+        const isContainer = exec.environment === 'devcontainer' || exec.environment === 'docker'
+        const alive = probeExecutionLiveness(exec.environment, exec.containerId, exec.sessionId)
+
+        if (!alive) continue
+
+        const label = exec.sessionId || exec.containerId || exec.id
+
+        if (dryRun) {
+          result.completedSessionsKilled.push(label)
+          continue
+        }
+
+        // Kill the runtime
+        try {
+          if (isContainer && exec.containerId) {
+            // Kill tmux session inside container if we know the session ID
+            if (exec.sessionId) {
+              try {
+                execSync(
+                  `docker exec ${exec.containerId} tmux kill-session -t "${exec.sessionId}"`,
+                  { stdio: 'pipe', timeout: 10000 },
+                )
+              } catch {
+                // tmux session may already be gone
+              }
+            }
+            // Stop the container if it's still running
+            if (checkDockerContainerAlive(exec.containerId)) {
+              execSync(
+                `docker stop ${exec.containerId}`,
+                { stdio: 'pipe', timeout: 30000 },
+              )
+            }
+            result.completedSessionsKilled.push(label)
+          } else if (exec.sessionId) {
+            // Kill host tmux session
+            if (killTmuxSession(exec.sessionId)) {
+              result.completedSessionsKilled.push(label)
+            } else {
+              result.errors.push(`Failed to kill session for completed execution: ${label}`)
+            }
+          }
+        } catch (error) {
+          result.errors.push(`Failed to clean up runtime for ${label}: ${error instanceof Error ? error.message : error}`)
+        }
+      }
+
+      // =====================================================================
+      // Step 3: Find and kill orphan tmux sessions (not in DB = garbage)
       // =====================================================================
       const hostTmuxSessions = getHostTmuxSessionNames()
       const containerTmuxSessions = getContainerTmuxSessionMap()
       const allContainerSessions = flattenContainerSessions(containerTmuxSessions)
 
-      // Get DB-tracked active executions to know which sessions are accounted for
+      // Get all DB-tracked active executions to know which sessions are accounted for
       const runningExecutions = executionStorage.listExecutions({ status: 'running' })
       const startingExecutions = executionStorage.listExecutions({ status: 'starting' })
       const activeExecutions = [...runningExecutions, ...startingExecutions]
@@ -125,7 +189,7 @@ export default class SessionPrune extends PromptCommand {
       const matchedContainerSessions = new Set<string>()
 
       for (const exec of activeExecutions) {
-        const isContainer = exec.environment === 'devcontainer'
+        const isContainer = exec.environment === 'devcontainer' || exec.environment === 'docker'
         let actualSessionId = exec.sessionId
 
         if (!exec.sessionId) {
@@ -186,7 +250,6 @@ export default class SessionPrune extends PromptCommand {
           result.orphanSessionsKilled.push(`${containerId}:${sessionName}`)
         } else {
           try {
-            const { execSync } = await import('node:child_process')
             execSync(
               `docker exec ${containerId} tmux kill-session -t "${sessionName}"`,
               { stdio: 'pipe', timeout: 10000 },
@@ -199,7 +262,7 @@ export default class SessionPrune extends PromptCommand {
       }
 
       // =====================================================================
-      // Step 3: Clean up idle ephemeral agents
+      // Step 4: Clean up idle ephemeral agents
       // =====================================================================
       // Refresh workspace info after stale cleanup
       const freshWorkspaceInfo = getWorkspaceInfo()
@@ -216,7 +279,8 @@ export default class SessionPrune extends PromptCommand {
 
       // Determine total work to be done
       const totalOrphans = orphanHostSessions.length + orphanContainerSessions.length
-      const totalWork = staleCount + totalOrphans + cleanableAgents.length
+      const totalCompleted = result.completedSessionsKilled.length
+      const totalWork = staleCount + totalCompleted + totalOrphans + cleanableAgents.length
 
       if (totalWork === 0) {
         if (jsonMode) {
@@ -241,8 +305,11 @@ export default class SessionPrune extends PromptCommand {
         if (staleCount > 0) {
           this.log(styles.info(`  ${staleCount} stale execution record(s) ${dryRun ? 'would be ' : ''}cleaned`))
         }
+        if (totalCompleted > 0) {
+          this.log(styles.info(`  ${totalCompleted} completed/failed execution runtime(s) ${dryRun ? 'would be ' : ''}killed`))
+        }
         if (totalOrphans > 0) {
-          this.log(styles.info(`  ${totalOrphans} orphan tmux session(s) ${dryRun ? 'would be ' : ''}killed:`))
+          this.log(styles.info(`  ${totalOrphans} orphan tmux session(s) (not in DB) ${dryRun ? 'would be ' : ''}killed:`))
           for (const s of orphanHostSessions) {
             this.log(styles.muted(`    - ${s} (host)`))
           }
@@ -260,12 +327,13 @@ export default class SessionPrune extends PromptCommand {
       }
 
       // Confirm unless --yes or --dry-run
-      if (!skipConfirm && !dryRun && cleanableAgents.length > 0) {
+      if (!skipConfirm && !dryRun && (cleanableAgents.length > 0 || totalOrphans > 0 || totalCompleted > 0)) {
         if (jsonMode) {
           outputSuccessAsJson({
             message: 'Confirmation required',
             preview: {
               staleExecutions: staleCount,
+              completedRuntimes: totalCompleted,
               orphanSessions: totalOrphans,
               ephemeralAgents: cleanableAgents.map(a => a.name),
             },
@@ -273,11 +341,12 @@ export default class SessionPrune extends PromptCommand {
           return
         }
 
+        const totalDestructive = totalCompleted + totalOrphans + cleanableAgents.length
         const { confirm } = await this.prompt<{ confirm: boolean }>([
           {
             type: 'list',
             name: 'confirm',
-            message: `Prune ${cleanableAgents.length} ephemeral agent(s) and ${totalOrphans} orphan session(s)?`,
+            message: `Prune ${totalDestructive} item(s) (${totalCompleted} completed runtimes, ${totalOrphans} orphans, ${cleanableAgents.length} agents)?`,
             choices: [
               { name: 'No, cancel', value: false },
               { name: 'Yes, prune', value: true },
@@ -335,6 +404,7 @@ export default class SessionPrune extends PromptCommand {
           ...result,
           summary: {
             staleExecutionsCleaned: result.staleExecutionsCleaned,
+            completedSessionsKilled: result.completedSessionsKilled.length,
             orphanSessionsKilled: result.orphanSessionsKilled.length,
             ephemeralAgentsCleaned: result.ephemeralAgentsCleaned.filter(r => r.success).length,
             ephemeralAgentsFailed: result.ephemeralAgentsCleaned.filter(r => !r.success).length,
@@ -350,6 +420,9 @@ export default class SessionPrune extends PromptCommand {
 
       if (result.staleExecutionsCleaned > 0) {
         this.log(styles.success(`  ${result.staleExecutionsCleaned} stale execution(s) ${dryRun ? 'would be ' : ''}cleaned`))
+      }
+      if (result.completedSessionsKilled.length > 0) {
+        this.log(styles.success(`  ${result.completedSessionsKilled.length} completed/failed runtime(s) ${dryRun ? 'would be ' : ''}killed`))
       }
       if (result.orphanSessionsKilled.length > 0) {
         this.log(styles.success(`  ${result.orphanSessionsKilled.length} orphan session(s) ${dryRun ? 'would be ' : ''}killed`))

--- a/apps/cli/src/lib/execution/session-utils.ts
+++ b/apps/cli/src/lib/execution/session-utils.ts
@@ -269,6 +269,87 @@ export function findSessionForExecution(
 }
 
 /**
+ * Check if a Docker container is alive using docker inspect.
+ * Returns true if the container exists and is running.
+ */
+export function checkDockerContainerAlive(containerId: string): boolean {
+  try {
+    const output = execSync(
+      `docker inspect --format='{{.State.Running}}' ${containerId}`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
+    ).trim()
+    return output === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if a host tmux session is alive using tmux has-session.
+ * Returns true if the session exists.
+ */
+export function checkHostTmuxSessionAlive(sessionId: string): boolean {
+  try {
+    execSync(`tmux has-session -t "${sessionId}"`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if a tmux session inside a Docker container is alive.
+ * Returns true if the session exists in the container.
+ */
+export function checkContainerTmuxSessionAlive(containerId: string, sessionId: string): boolean {
+  try {
+    execSync(`docker exec ${containerId} tmux has-session -t "${sessionId}"`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Probe liveness for an execution based on its runtime environment.
+ * Uses docker inspect for containers and tmux has-session for host sessions.
+ * Returns whether the runtime is alive.
+ */
+export function probeExecutionLiveness(
+  environment: string,
+  containerId?: string,
+  sessionId?: string,
+): boolean {
+  if (environment === 'devcontainer' || environment === 'docker') {
+    if (containerId) {
+      // First check if the container itself is running
+      if (!checkDockerContainerAlive(containerId)) {
+        return false
+      }
+      // If we have a session ID, also verify the tmux session inside the container
+      if (sessionId) {
+        return checkContainerTmuxSessionAlive(containerId, sessionId)
+      }
+      // Container is running but no session ID to check — treat as alive
+      return true
+    }
+    return false
+  }
+
+  // Host environment: check tmux session
+  if (sessionId) {
+    return checkHostTmuxSessionAlive(sessionId)
+  }
+  return false
+}
+
+/**
  * Send a text message to a tmux session via send-keys.
  * Sends the text first, then Enter separately with a small delay
  * to avoid race conditions where Enter arrives before text is rendered.

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -208,8 +208,8 @@ describe('@smoke Session Commands E2E Tests', () => {
       expect(sessions).to.be.an('array');
     });
 
-    it('should return DB-tracked sessions even without tmux verification (default mode)', () => {
-      // Seed a running execution - no tmux session exists to verify it
+    it('should show stale DB-tracked sessions with --all when runtime is dead', () => {
+      // Seed a running execution - no tmux/docker runtime exists to verify it
       seedExecutionRecords([{
         id: 'exec-001',
         ticketId: 'TKT-100',
@@ -218,16 +218,17 @@ describe('@smoke Session Commands E2E Tests', () => {
         sessionId: 'TKT-100-implement-bold-turing',
       }]);
 
-      // Sessions are always shown from DB, even without tmux verification
-      const output = execProduction('session list --json');
-      const sessions = JSON.parse(output) as Array<{ sessionId: string; status: string; exists: boolean; source: string; ticketId: string }>;
+      // DB-first approach: without --all, dead-runtime sessions are hidden.
+      // With --all, they appear as stale.
+      const output = execProduction('session list --all --json');
+      const sessions = JSON.parse(output) as Array<{ sessionId: string; status: string; alive: boolean; source: string; ticketId: string }>;
       expect(sessions).to.be.an('array');
-      // Filter to DB-sourced sessions for our seeded ticket (host may have real orphan tmux sessions)
       const dbSessions = sessions.filter(s => s.source === 'db' && s.ticketId === 'TKT-100');
-      // DB-tracked sessions may be cleaned up by cleanupStaleExecutions() if tmux doesn't verify them
-      // In test environments without tmux, cleanup removes stale records, so the count may be 0
+      // In test environments without tmux, sessions appear as stale (alive=false)
       if (dbSessions.length > 0) {
         expect(dbSessions[0].sessionId).to.equal('TKT-100-implement-bold-turing');
+        expect(dbSessions[0].alive).to.be.false;
+        expect(dbSessions[0].status).to.equal('stale');
       }
     });
 
@@ -312,6 +313,56 @@ describe('@smoke Session Commands E2E Tests', () => {
       const sessions = JSON.parse(output) as Array<{ sessionId: string }>;
       const session = sessions.find(s => s.sessionId === 'TKT-100-implement-bold-turing');
       expect(session).to.not.be.undefined;
+    });
+
+    it('PRLT-1139: should NOT show orphan sessions by default (DB-first)', () => {
+      // DB-first: session list without --orphans should ONLY show DB-tracked sessions.
+      // Orphan tmux sessions (those matching prlt pattern but not in DB) must be hidden.
+      const output = execProduction('session list --json');
+      const sessions = JSON.parse(output) as Array<{ source: string }>;
+      const orphans = sessions.filter(s => s.source === 'orphan');
+      // No orphan sessions should appear without --orphans flag
+      expect(orphans.length).to.equal(0);
+    });
+
+    it('PRLT-1139: default list should not include dead-runtime sessions', () => {
+      // Seed a running execution with no real tmux session behind it
+      seedExecutionRecords([{
+        id: 'exec-ghost-001',
+        ticketId: 'TKT-999',
+        ticketTitle: 'Ghost session',
+        agentName: 'ghost-agent',
+        sessionId: 'TKT-999-implement-ghost-agent',
+      }]);
+
+      // Without --all, dead-runtime sessions should be hidden
+      const output = execProduction('session list --json');
+      const sessions = JSON.parse(output) as Array<{ ticketId: string }>;
+      const ghost = sessions.find(s => s.ticketId === 'TKT-999');
+      // In test env (no tmux), the session has dead runtime and should be hidden by default
+      expect(ghost).to.be.undefined;
+    });
+
+    it('PRLT-1139: session JSON output should have alive field instead of exists', () => {
+      seedExecutionRecords([{
+        id: 'exec-field-001',
+        ticketId: 'TKT-888',
+        ticketTitle: 'Field check',
+        agentName: 'field-agent',
+        sessionId: 'TKT-888-implement-field-agent',
+      }]);
+
+      const output = execProduction('session list --all --json');
+      const sessions = JSON.parse(output) as Array<Record<string, unknown>>;
+      const session = sessions.find(s => (s as { ticketId: string }).ticketId === 'TKT-888');
+      if (session) {
+        // Must have 'alive' field (DB-first liveness probing)
+        expect(session).to.have.property('alive');
+        // Must have 'source' field with value 'db' (not 'discovered')
+        expect(session).to.have.property('source', 'db');
+        // Must NOT have the old 'exists' field
+        expect(session).to.not.have.property('exists');
+      }
     });
 
     it('should show host type indicator for host sessions', () => {

--- a/apps/cli/test/unit/session-db-first.test.ts
+++ b/apps/cli/test/unit/session-db-first.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai'
+
+import {
+  probeExecutionLiveness,
+  checkDockerContainerAlive,
+  checkHostTmuxSessionAlive,
+  checkContainerTmuxSessionAlive,
+} from '../../src/lib/execution/session-utils.js'
+
+/**
+ * PRLT-1139: Regression tests for DB-first session discovery.
+ *
+ * Session list must be DB-first: query DB for sessions, then probe runtime
+ * liveness (docker inspect for containers, tmux has-session for host).
+ * Orphan tmux sessions (not in DB) must NOT appear as first-class sessions.
+ */
+describe('PRLT-1139: DB-first session discovery', () => {
+  describe('probeExecutionLiveness', () => {
+    it('should return false for host sessions without a session ID', () => {
+      // DB record exists but has no session_id — can't verify
+      const result = probeExecutionLiveness('host', undefined, undefined)
+      expect(result).to.be.false
+    })
+
+    it('should return false for host sessions with nonexistent tmux session', () => {
+      // DB record points to a session that doesn't exist in tmux
+      const result = probeExecutionLiveness('host', undefined, 'nonexistent-session-id')
+      expect(result).to.be.false
+    })
+
+    it('should return false for devcontainer without container ID', () => {
+      // DB record says devcontainer but has no container_id
+      const result = probeExecutionLiveness('devcontainer', undefined, 'some-session')
+      expect(result).to.be.false
+    })
+
+    it('should return false for docker environment without container ID', () => {
+      const result = probeExecutionLiveness('docker', undefined, 'some-session')
+      expect(result).to.be.false
+    })
+
+    it('should return false for devcontainer with nonexistent container', () => {
+      // DB record points to a container that doesn't exist
+      const result = probeExecutionLiveness('devcontainer', 'nonexistent123', 'some-session')
+      expect(result).to.be.false
+    })
+
+    it('should return false for docker environment with nonexistent container', () => {
+      const result = probeExecutionLiveness('docker', 'nonexistent123', 'some-session')
+      expect(result).to.be.false
+    })
+
+    it('should handle unknown environment types by checking tmux session', () => {
+      // Unknown environment — falls through to host-style tmux check
+      const result = probeExecutionLiveness('cloud', undefined, 'nonexistent-session')
+      expect(result).to.be.false
+    })
+  })
+
+  describe('checkDockerContainerAlive', () => {
+    it('should return false for nonexistent container ID', () => {
+      const result = checkDockerContainerAlive('nonexistent_container_12345')
+      expect(result).to.be.false
+    })
+
+    it('should return false for empty container ID', () => {
+      const result = checkDockerContainerAlive('')
+      expect(result).to.be.false
+    })
+  })
+
+  describe('checkHostTmuxSessionAlive', () => {
+    it('should return false for nonexistent session', () => {
+      const result = checkHostTmuxSessionAlive('nonexistent-prlt-session')
+      expect(result).to.be.false
+    })
+
+    it('should return false for session ID that does not exist', () => {
+      const result = checkHostTmuxSessionAlive('prlt-nonexistent-session-12345')
+      expect(result).to.be.false
+    })
+  })
+
+  describe('checkContainerTmuxSessionAlive', () => {
+    it('should return false for nonexistent container', () => {
+      const result = checkContainerTmuxSessionAlive('nonexistent123', 'some-session')
+      expect(result).to.be.false
+    })
+  })
+
+  describe('DB-first contract', () => {
+    it('probeExecutionLiveness must exist and accept environment, containerId, sessionId', () => {
+      // This test verifies the function signature exists — if the DB-first
+      // implementation is reverted, this import will fail.
+      expect(probeExecutionLiveness).to.be.a('function')
+      expect(probeExecutionLiveness.length).to.be.greaterThanOrEqual(1)
+    })
+
+    it('checkDockerContainerAlive must exist for container liveness checks', () => {
+      // Docker container liveness must use docker inspect, not tmux list-sessions.
+      // If reverted to tmux-only approach, this function won't exist.
+      expect(checkDockerContainerAlive).to.be.a('function')
+    })
+
+    it('checkHostTmuxSessionAlive must exist for host session liveness checks', () => {
+      expect(checkHostTmuxSessionAlive).to.be.a('function')
+    })
+
+    it('checkContainerTmuxSessionAlive must exist for container tmux session checks', () => {
+      expect(checkContainerTmuxSessionAlive).to.be.a('function')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Rewrites session list, attach, and prune to use DB as source of truth instead of tmux pattern matching
- Adds `probeExecutionLiveness()` with `docker inspect` for containers and `tmux has-session` for host
- Orphan tmux sessions (not in DB) no longer shown as first-class — hidden by default, visible with `--orphans` flag
- Session attach only works with DB-tracked sessions
- Session prune now kills runtimes for completed/failed/stopped DB records
- Adds PRLT-1139 regression tests for DB-first contract

## Test plan
- [x] Unit tests pass for new liveness functions (`session-db-first.test.ts`)
- [x] Existing session-utils unit tests still pass (54 passing)
- [x] Build succeeds with no TypeScript errors
- [ ] Manual: `prlt session list` shows only DB-tracked sessions
- [ ] Manual: `prlt session list --all` shows stale (dead-runtime) sessions
- [ ] Manual: `prlt session list --orphans` shows orphan tmux sessions
- [ ] Manual: `prlt session attach` only offers DB-tracked sessions
- [ ] Manual: `prlt session prune` kills completed runtimes and orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)