### PR TITLE
feat(PRLT-1163): mount HQ .proletariat read-only to prevent DB corruption

### DIFF
--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -109,7 +109,7 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
     // to avoid corruption from concurrent writes by multiple containers
     // NOTE: SSH agent socket mounting doesn't work reliably on Docker Desktop for Mac
     // So we use HTTPS + token approach instead. The token is fetched fresh at spawn time.
-    'source=${localEnv:PRLT_HQ_PATH}/.proletariat,target=/hq/.proletariat,type=bind,consistency=cached',
+    'source=${localEnv:PRLT_HQ_PATH}/.proletariat,target=/hq/.proletariat,type=bind,readonly,consistency=cached',
     // PMO path can be anywhere (e.g., /hq/pmo or /hq/repos/myrepo/pmo)
     // Use PRLT_PMO_PATH env var to mount the actual location to /hq/pmo
     'source=${localEnv:PRLT_PMO_PATH},target=/hq/pmo,type=bind,consistency=cached',

--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -244,17 +244,18 @@ export function imageExists(imageName: string): boolean {
 /**
  * Create and start a Docker container for an agent.
  */
-export function createDockerContainer(
+/**
+ * Build the Docker volume mount flags for an agent container.
+ * PRLT-1163: HQ .proletariat is mounted read-only to prevent SQLite corruption
+ * from concurrent container writes.
+ */
+export function buildContainerMounts(
   context: ExecutionContext,
-  containerName: string,
-  imageName: string,
-  config: ExecutionConfig,
   executor: ExecutorType = 'claude-code',
-  prltInfo?: { registry: string; version: string }
-): boolean {
-  const mounts: string[] = [
+): string[] {
+  return [
     `-v "${context.agentDir}:/workspace:cached"`,
-    ...(context.hqPath ? [`-v "${context.hqPath}/.proletariat:/hq/.proletariat:cached"`] : []),
+    ...(context.hqPath ? [`-v "${context.hqPath}/.proletariat:/hq/.proletariat:ro"`] : []),
     ...(context.pmoPath ? [`-v "${context.pmoPath}:/hq/pmo:cached"`] : []),
     ...(context.repoWorktrees || []).map(
       repoName => `-v "${context.hqPath}/repos/${repoName}:/hq/repos/${repoName}:cached"`
@@ -264,6 +265,20 @@ export function createDockerContainer(
     // If the cache volume doesn't exist, Docker creates an empty one (harmless).
     ...(pnpmStoreCacheExists() ? [`-v "${PNPM_STORE_CACHE_VOLUME}:/tmp/pnpm-store-cache:ro"`] : []),
   ]
+}
+
+/**
+ * Create and start a Docker container for an agent.
+ */
+export function createDockerContainer(
+  context: ExecutionContext,
+  containerName: string,
+  imageName: string,
+  config: ExecutionConfig,
+  executor: ExecutorType = 'claude-code',
+  prltInfo?: { registry: string; version: string }
+): boolean {
+  const mounts = buildContainerMounts(context, executor)
 
   const hasWorktrees = context.repoWorktrees && context.repoWorktrees.length > 0
   // Merge workspace-level and action-level network allowlists (PRLT-1079)

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -351,6 +351,7 @@ export {
   getContainerId,
   buildDockerImage,
   imageExists,
+  buildContainerMounts,
   createDockerContainer,
   runContainerSetup,
   ensureDockerContainer,

--- a/apps/cli/test/unit/regression-prlt1163-readonly-hq-mount.test.ts
+++ b/apps/cli/test/unit/regression-prlt1163-readonly-hq-mount.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test for PRLT-1163
+ *
+ * Verifies that the HQ .proletariat directory is mounted read-only into
+ * agent containers to prevent SQLite corruption from concurrent writers.
+ */
+import { expect } from 'chai'
+import {
+  buildContainerMounts,
+} from '../../src/lib/execution/runners/docker-management.js'
+import {
+  generateDevcontainerJson,
+} from '../../src/lib/execution/devcontainer.js'
+import type { ExecutionContext } from '../../src/lib/execution/types.js'
+
+describe('PRLT-1163: HQ .proletariat mount must be read-only', () => {
+  // =========================================================================
+  // Docker management (raw docker run path)
+  // =========================================================================
+  describe('buildContainerMounts (docker-management)', () => {
+    function makeContext(overrides: Partial<ExecutionContext> = {}): ExecutionContext {
+      return {
+        ticketId: 'TKT-001',
+        ticketTitle: 'Test ticket',
+        agentName: 'test-agent',
+        agentDir: '/path/to/agent',
+        worktreePath: '/path/to/worktree',
+        branch: 'main',
+        hqPath: '/path/to/hq',
+        ...overrides,
+      }
+    }
+
+    it('should mount .proletariat as read-only (:ro)', () => {
+      const mounts = buildContainerMounts(makeContext())
+      const hqMount = mounts.find(m => m.includes('.proletariat:/hq/.proletariat'))
+      expect(hqMount).to.exist
+      expect(hqMount).to.include(':ro')
+      // Must NOT use :cached without :ro — that's the bug this ticket fixes
+      expect(hqMount).to.not.include(':cached')
+    })
+
+    it('should not include .proletariat mount when hqPath is not set', () => {
+      const mounts = buildContainerMounts(makeContext({ hqPath: undefined }))
+      const hqMount = mounts.find(m => m.includes('.proletariat:/hq/.proletariat'))
+      expect(hqMount).to.not.exist
+    })
+
+    it('should still mount workspace as read-write (cached)', () => {
+      const mounts = buildContainerMounts(makeContext())
+      const wsMount = mounts.find(m => m.includes('/workspace:'))
+      expect(wsMount).to.exist
+      expect(wsMount).to.include(':cached')
+    })
+  })
+
+  // =========================================================================
+  // Devcontainer JSON (devcontainer CLI path)
+  // =========================================================================
+  describe('generateDevcontainerJson', () => {
+    it('should mount .proletariat as readonly in devcontainer config', () => {
+      const result = generateDevcontainerJson({
+        agentName: 'test-agent',
+        agentDir: '/path/to/agents/staff/test-agent',
+      })
+      const hqMount = result.mounts.find((m: string) =>
+        m.includes('.proletariat') && m.includes('/hq/.proletariat')
+      )
+      expect(hqMount).to.exist
+      expect(hqMount).to.include('readonly')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Changed `.proletariat` mount from `:cached` (read-write) to `:ro` (read-only) in `docker-management.ts` for raw Docker containers
- Added `readonly` flag to the `.proletariat` bind mount in `devcontainer.ts` for devcontainer-based containers
- Extracted `buildContainerMounts()` as a testable function from `createDockerContainer()`
- Added 4 regression tests verifying the mount is read-only in both Docker and devcontainer paths

## Problem

Agent containers were mounted with `-v .proletariat:/hq/.proletariat:cached` (read-write). When multiple containers ran simultaneously, they all wrote to the same SQLite database, causing corruption (`SQLITE_CORRUPT`, `SQLITE_IOERR_SHORT_READ`).

## Fix

Option A from the ticket: read-only mount. Agents can still read config (Linear API key, repo settings) but cannot write to the HQ database. State mutations go through `prlt` CLI commands on the host.

## Test plan

- [x] Regression test verifies `:ro` flag on docker-management mount
- [x] Regression test verifies `readonly` flag on devcontainer mount
- [x] All 150 existing Docker/devcontainer/PRLT-1090 tests still pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)