### PR TITLE
feat(PRLT-1162): enforce prlt work commands over raw gh/git commands in agent prompts

### DIFF
--- a/apps/cli/src/lib/execution/runners/prompt-builder.ts
+++ b/apps/cli/src/lib/execution/runners/prompt-builder.ts
@@ -138,10 +138,12 @@ const ORCHESTRATOR_COMMAND_REGISTRY: CommandCategory[] = [
   {
     title: 'PR Workflow',
     commands: [
+      { cmd: 'prlt work ship <ticket-id>', desc: 'Merge PR and move ticket to Done', checkPath: 'work/ship' },
+      { cmd: 'prlt work ship <ticket-id> --when-green', desc: 'Auto-merge when CI passes', checkPath: 'work/ship' },
+      { cmd: 'prlt pr checks', desc: 'Check CI status for current PR', checkPath: 'pr/checks' },
       { cmd: 'gh pr list', desc: 'List open PRs' },
       { cmd: 'gh pr view <num>', desc: 'View PR details' },
       { cmd: 'gh pr checks <num>', desc: 'Check CI status' },
-      { cmd: 'gh pr merge <num> --squash', desc: 'Merge PR (squash only)' },
     ],
   },
 ]
@@ -153,6 +155,8 @@ interface AntiPatternDef {
 }
 
 const ORCHESTRATOR_ANTI_PATTERNS: AntiPatternDef[] = [
+  { bad: 'gh pr merge', good: 'prlt work ship <ticket-id>', checkPath: 'work/ship' },
+  { bad: 'gh pr create', good: 'prlt pr create or prlt work propose <ticket-id>', checkPath: 'pr/create' },
   { bad: 'docker exec <container> ...', good: 'prlt session exec', checkPath: 'session/exec' },
   { bad: 'tmux send-keys ...', good: 'prlt session poke', checkPath: 'session/poke' },
   { bad: 'tmux capture-pane ...', good: 'prlt session peek', checkPath: 'session/peek' },
@@ -223,7 +227,7 @@ function buildOrchestratorBody(hqName: string, context: ExecutionContext): strin
   prompt += `- Plan and prioritize work — decide what to tackle next and in what order\n`
   prompt += `- Delegate implementation to agents via \`prlt work start\`\n`
   prompt += `- Monitor agent progress via sessions and review completed work\n`
-  prompt += `- Review and merge completed PRs via \`gh pr merge --squash\`\n`
+  prompt += `- Review and merge completed PRs via \`prlt work ship <ticket-id>\`\n`
   prompt += `- Coordinate parallel agents — handle rebases after merges\n`
   prompt += `- Never write code or make changes to source files yourself\n\n`
   prompt += `## Command Reference\n\n`
@@ -236,7 +240,9 @@ function buildOrchestratorBody(hqName: string, context: ExecutionContext): strin
   prompt += buildOrchestratorAntiPatterns()
   prompt += buildIntegrationCommandsSection(context.connectedIntegrations)
   prompt += `## Workflow\n`
-  prompt += `- Squash merge only: \`gh pr merge --squash\`\n`
+  prompt += `- Merge PRs: \`prlt work ship <ticket-id>\` (squash-merges and moves ticket to Done)\n`
+  prompt += `- Auto-merge when CI passes: \`prlt work ship <ticket-id> --when-green\`\n`
+  prompt += `- **NEVER use \`gh pr merge\`** — it skips ticket state transitions and breaks board/Linear sync\n`
   prompt += `- After merging: subsequent PRs from parallel agents will need rebase\n`
   prompt += `- Kill stale sessions after their PRs are merged\n\n`
 
@@ -411,6 +417,10 @@ export function buildPrompt(context: ExecutionContext): string {
     if (context.modifiesCode) {
       const reviewGate = context.reviewGate || 'required'
 
+      const forbiddenBlock = `\n\n**NEVER use these commands — they skip ticket lifecycle updates and break board sync:**\n` +
+        `- \`gh pr create\` → use \`prlt work propose ${context.ticketId}\` instead\n` +
+        `- \`gh pr merge\` → use \`prlt work ship ${context.ticketId}\` instead`
+
       if (reviewGate === 'auto') {
         // Auto mode: agent ships directly to main, no PR needed
         prompt += `1. **Commit your work** in each repository directory you modified:\n`
@@ -425,6 +435,7 @@ export function buildPrompt(context: ExecutionContext): string {
         prompt += `   \`\`\`bash\n   prlt work ready ${context.ticketId} --no-pr\n   \`\`\`\n`
         prompt += `   This moves the ticket to done. No PR is needed — your work ships directly.\n`
         prompt += `\n**IMPORTANT:** Use the global \`prlt\` command (just type \`prlt\`). Do NOT use \`./bin/run.js\` or any local path.`
+        prompt += forbiddenBlock
       } else if (reviewGate === 'post') {
         // Post mode: agent creates and merges its own PR, human reviews after
         prompt += `1. **Commit your work** in each repository directory you modified:\n`
@@ -440,6 +451,7 @@ export function buildPrompt(context: ExecutionContext): string {
         prompt += `   This creates a pull request and moves the ticket to review. The PR will be auto-merged — a human will review post-merge.\n`
         prompt += `\n**IMPORTANT:** Use \`prlt work propose\` — do NOT use \`gh pr create\` directly, as that skips ticket state transitions.`
         prompt += `\n**IMPORTANT:** Use the global \`prlt\` command (just type \`prlt\`). Do NOT use \`./bin/run.js\` or any local path.`
+        prompt += forbiddenBlock
       } else {
         // Required mode (default): agent creates PR, human approves before it lands
         prompt += `1. **Commit your work** in each repository directory you modified:\n`
@@ -461,6 +473,7 @@ export function buildPrompt(context: ExecutionContext): string {
           prompt += `   This moves the ticket to review.\n`
         }
         prompt += `\n**IMPORTANT:** Use the global \`prlt\` command (just type \`prlt\`). Do NOT use \`./bin/run.js\` or any local path.`
+        prompt += forbiddenBlock
       }
     } else {
       prompt += `When you have completed the task, provide a summary of what you did.`

--- a/apps/cli/src/lib/pmo/storage/base.ts
+++ b/apps/cli/src/lib/pmo/storage/base.ts
@@ -589,7 +589,22 @@ Use these commands to interact with the ticket system. Always use the global \`p
 const PRLT_COMMANDS_CODE = `
 | \`prlt commit "message"\` | Create a commit with ticket ID from branch name |
 | \`prlt work propose <id>\` | Create a PR and move ticket to Review (preferred for agents) |
-| \`prlt work ready <id> --pr\` | Mark ticket ready for review and create a PR |`
+| \`prlt work ready <id> --pr\` | Mark ticket ready for review and create a PR |
+| \`prlt work ship <id>\` | Merge PR and move ticket to Done |
+| \`prlt work complete <id>\` | Mark ticket as complete (move to Done) |
+| \`prlt pr create\` | Create a PR with ticket context (use \`prlt work propose\` instead when possible) |
+
+### Forbidden Commands — NEVER Use These
+
+These raw commands bypass ticket state transitions and break board/Linear sync:
+
+| Forbidden Command | Use Instead |
+|-------------------|-------------|
+| \`gh pr create\` | \`prlt work propose <id>\` or \`prlt pr create\` |
+| \`gh pr merge\` | \`prlt work ship <id>\` |
+| \`git push origin HEAD && gh pr create\` | \`prlt work propose <id>\` (handles push + PR + state) |
+
+**Why:** \`prlt\` commands update ticket state (In Progress → Review → Done) and sync with Linear/Jira. Raw \`gh\` commands skip all of this, leaving the board stale.`
 
 const PRLT_COMMANDS_REVIEW = `
 | \`prlt ticket move <id>\` | Move ticket to a different column |
@@ -837,7 +852,12 @@ ${PRLT_COMMANDS_CODE}`,
    This creates a pull request and moves the ticket to Review automatically.
 
 **IMPORTANT:** Use \`prlt work propose\` — do NOT use \`gh pr create\` directly, as that skips ticket state transitions.
-**IMPORTANT:** Use the global \`prlt\` command (just type \`prlt\`). Do NOT use \`./bin/run.js\` or any local path.`,
+**IMPORTANT:** Use the global \`prlt\` command (just type \`prlt\`). Do NOT use \`./bin/run.js\` or any local path.
+
+**NEVER use these commands:**
+- \`gh pr create\` → use \`prlt work propose {{TICKET_ID}}\` instead
+- \`gh pr merge\` → use \`prlt work ship {{TICKET_ID}}\` instead
+- These raw commands skip ticket lifecycle updates and break board sync.`,
       fromState: 'Todo',
       toState: 'In Progress',
       executor: 'claude',
@@ -976,7 +996,7 @@ Merge this ticket's pull request after verifying it is ready:
 
 1. **Check CI status** — ensure all checks are passing:
    \`\`\`bash
-   gh pr checks
+   prlt pr checks
    \`\`\`
 
 2. **Verify approval** — ensure the PR has been approved:
@@ -984,36 +1004,38 @@ Merge this ticket's pull request after verifying it is ready:
    gh pr view --json reviews
    \`\`\`
 
-3. **Merge the PR** — use squash merge by default:
+3. **Merge the PR** using prlt:
    \`\`\`bash
-   gh pr merge --squash --delete-branch
+   prlt work ship {{TICKET_ID}}
+   \`\`\`
+   This squash-merges the PR, deletes the branch, and moves the ticket to Done.
+
+   If CI is not yet green, use \`--when-green\` to auto-merge once checks pass:
+   \`\`\`bash
+   prlt work ship {{TICKET_ID}} --when-green
    \`\`\`
 
-4. **Clean up** — the \`--delete-branch\` flag handles remote branch deletion.
-   Locally, prune stale tracking branches:
-   \`\`\`bash
-   git fetch --prune
-   \`\`\`
+4. **Clean up** — \`prlt work ship\` handles branch deletion automatically.
 
 ## Important Rules
-- Do NOT merge if CI checks are failing — report the failures instead
+- Do NOT merge if CI checks are failing — report the failures or use \`--when-green\`
 - Do NOT merge if the PR has not been approved — report the status instead
 - Do NOT force-merge or bypass required checks
 - If merge conflicts exist, report them — do NOT attempt to resolve them in this action
+- **NEVER use \`gh pr merge\`** — always use \`prlt work ship\` (it updates ticket state and syncs with Linear/Jira)
 
 ${PRLT_COMMANDS_COMMON}
-${PRLT_COMMANDS_REVIEW}`,
+${PRLT_COMMANDS_CODE}`,
       endPrompt: `After merging:
 
-1. **If merge was successful**, mark the ticket as complete:
-   \`\`\`bash
-   prlt work complete {{TICKET_ID}}
-   \`\`\`
+1. **If merge was successful** via \`prlt work ship\`, the ticket is automatically moved to Done — no further action needed.
 
 2. **If merge failed** (CI failures, conflicts, missing approval), report the issue:
    \`\`\`bash
    prlt ticket edit {{TICKET_ID}} --add-subtask "Fix: <description of merge blocker>"
    \`\`\`
+
+**IMPORTANT:** NEVER use \`gh pr merge\` — always use \`prlt work ship {{TICKET_ID}}\`.
 
 **STOP:** After completing the above, your task is done. Do not take any further actions.`,
       fromState: 'Review',

--- a/apps/cli/test/unit/work-propose.test.ts
+++ b/apps/cli/test/unit/work-propose.test.ts
@@ -65,7 +65,8 @@ describe('@smoke PRLT-1129: Agent prompt + stop hook routing', () => {
         reviewGate: 'required',
       }))
       expect(prompt).to.include('prlt work ready TKT-900 --no-pr')
-      expect(prompt).to.not.include('prlt work propose')
+      // Primary instruction should NOT be prlt work propose (it may appear in forbidden commands context)
+      expect(prompt).to.not.match(/```bash\n\s*prlt work propose/)
     })
 
     it('should use prlt work ready --no-pr in auto review gate mode', () => {
@@ -74,7 +75,8 @@ describe('@smoke PRLT-1129: Agent prompt + stop hook routing', () => {
         reviewGate: 'auto',
       }))
       expect(prompt).to.include('prlt work ready TKT-900 --no-pr')
-      expect(prompt).to.not.include('prlt work propose')
+      // Primary instruction should NOT be prlt work propose (it may appear in forbidden commands context)
+      expect(prompt).to.not.match(/```bash\n\s*prlt work propose/)
     })
 
     it('should warn against using gh pr create directly', () => {
@@ -103,6 +105,61 @@ describe('@smoke PRLT-1129: Agent prompt + stop hook routing', () => {
         createPR: true,
       }))
       expect(prompt).to.include('prlt work propose TKT-900')
+    })
+  })
+
+  // =========================================================================
+  // Layer 1b: PRLT-1162 — Forbidden commands enforcement
+  // =========================================================================
+  describe('Layer 1b: PRLT-1162 — Forbidden commands in all modes', () => {
+    it('should warn against gh pr merge in required mode', () => {
+      const prompt = buildPrompt(makeContext({
+        modifiesCode: true,
+        createPR: true,
+        reviewGate: 'required',
+      }))
+      expect(prompt).to.include('`gh pr merge`')
+      expect(prompt).to.include('prlt work ship')
+    })
+
+    it('should warn against gh pr create in required mode', () => {
+      const prompt = buildPrompt(makeContext({
+        modifiesCode: true,
+        createPR: true,
+        reviewGate: 'required',
+      }))
+      expect(prompt).to.include('`gh pr create`')
+      expect(prompt).to.include('prlt work propose')
+    })
+
+    it('should warn against gh pr merge in post mode', () => {
+      const prompt = buildPrompt(makeContext({
+        modifiesCode: true,
+        createPR: true,
+        reviewGate: 'post',
+      }))
+      expect(prompt).to.include('`gh pr merge`')
+      expect(prompt).to.include('prlt work ship')
+    })
+
+    it('should warn against gh pr merge in auto mode', () => {
+      const prompt = buildPrompt(makeContext({
+        modifiesCode: true,
+        reviewGate: 'auto',
+      }))
+      expect(prompt).to.include('`gh pr merge`')
+      expect(prompt).to.include('prlt work ship')
+    })
+
+    it('should include forbidden commands block when createPR=false', () => {
+      const prompt = buildPrompt(makeContext({
+        modifiesCode: true,
+        createPR: false,
+        reviewGate: 'required',
+      }))
+      expect(prompt).to.include('NEVER use these commands')
+      expect(prompt).to.include('`gh pr create`')
+      expect(prompt).to.include('`gh pr merge`')
     })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "apps/cli": {
       "name": "@proletariat/cli",
-      "version": "0.3.94",
+      "version": "0.3.95",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Add explicit "Forbidden Commands" section to agent prompts listing `gh pr create` and `gh pr merge` as banned, with `prlt work propose` and `prlt work ship` as required replacements
- Update orchestrator prompt to use `prlt work ship` instead of `gh pr merge --squash` in commands, workflow, and anti-patterns
- Update merge action to use `prlt work ship` instead of `gh pr merge --squash --delete-branch`
- Expand `PRLT_COMMANDS_CODE` reference table with `prlt work ship`, `prlt work complete`, and `prlt pr create`
- Update and add regression tests for forbidden commands enforcement across all review gate modes

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Existing PRLT-1129 tests updated and passing
- [x] New PRLT-1162 tests verify forbidden commands block appears in all modes (required, post, auto, createPR=false)
- [x] Pre-existing test failures (ci-merge-check, db-safety) unrelated to this change

## Files changed

- `apps/cli/src/lib/pmo/storage/base.ts` — Updated `PRLT_COMMANDS_CODE`, implement endPrompt, merge action prompt/endPrompt
- `apps/cli/src/lib/execution/runners/prompt-builder.ts` — Updated orchestrator commands, anti-patterns, workflow section, and "When Complete" forbidden block
- `apps/cli/test/unit/work-propose.test.ts` — Updated tests + added PRLT-1162 forbidden commands tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)