### PR TITLE
feat(PRLT-1117): exclude running agents from session prune cleanup list

### DIFF
--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -1367,17 +1367,21 @@ export function getCleanableAgents(
   workspaceInfo: WorkspaceInfo,
   checkRunning: boolean = true
 ): Agent[] {
-  // Get ephemeral agents in active lifecycle states
-  const ephemeralAgents = workspaceInfo.agents.filter(
-    a => a.type === 'ephemeral' && (a.status === 'active' || a.status === 'running')
-  );
-
   if (!checkRunning) {
-    return ephemeralAgents;
+    // Return all ephemeral agents in active lifecycle states (including running)
+    return workspaceInfo.agents.filter(
+      a => a.type === 'ephemeral' && (a.status === 'active' || a.status === 'running')
+    );
   }
 
-  // Filter out agents with active tmux sessions
-  return ephemeralAgents.filter(agent => {
+  // Exclude agents with 'running' DB status — they are actively working
+  const idleAgents = workspaceInfo.agents.filter(
+    a => a.type === 'ephemeral' && a.status === 'active'
+  );
+
+  // Additionally filter out agents with active tmux sessions (safety net
+  // for agents that are running but whose DB status wasn't updated)
+  return idleAgents.filter(agent => {
     const sessions = getAgentTmuxSessions(agent.name);
     return sessions.length === 0;
   });

--- a/apps/cli/test/unit/session-prune-running-agents.test.ts
+++ b/apps/cli/test/unit/session-prune-running-agents.test.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai'
+import { getCleanableAgents, WorkspaceInfo } from '../../src/lib/agents/commands.js'
+import type { Agent } from '../../src/lib/database/agents.js'
+
+/**
+ * Regression test for PRLT-1117: session prune includes actively running agents
+ *
+ * getCleanableAgents was including agents with status='running' in the cleanable
+ * list. When those agents ran inside containers (where host tmux can't detect
+ * their sessions), they appeared as candidates for cleanup. The fix ensures
+ * agents with DB status 'running' are excluded when checkRunning=true.
+ */
+describe('@smoke getCleanableAgents excludes running agents (PRLT-1117)', () => {
+  function makeAgent(overrides: Partial<Agent> & { name: string }): Agent {
+    return {
+      type: 'ephemeral',
+      status: 'active',
+      base_name: null,
+      theme_id: null,
+      worktree_path: null,
+      mount_mode: 'worktree',
+      created_at: new Date().toISOString(),
+      cleaned_at: null,
+      ...overrides,
+    }
+  }
+
+  function makeWorkspaceInfo(agents: Agent[]): WorkspaceInfo {
+    return {
+      path: '/tmp/test-workspace',
+      type: 'hq',
+      workspaceName: 'test',
+      hasPMO: false,
+      agents,
+      repositories: [],
+      agentsPath: '/tmp/test-workspace/temp',
+      activeThemeId: null,
+      persistentAgentsDir: 'staff',
+      ephemeralAgentsDir: 'temp',
+    }
+  }
+
+  it('excludes agents with status=running when checkRunning=true', () => {
+    const agents = [
+      makeAgent({ name: 'idle-agent-1', status: 'active' }),
+      makeAgent({ name: 'busy-agent-1', status: 'running' }),
+      makeAgent({ name: 'idle-agent-2', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+
+    // checkRunning=true — running agents should be excluded
+    const cleanable = getCleanableAgents(workspace, true)
+    const names = cleanable.map(a => a.name)
+
+    expect(names).to.include('idle-agent-1')
+    expect(names).to.include('idle-agent-2')
+    expect(names).to.not.include('busy-agent-1')
+  })
+
+  it('includes agents with status=running when checkRunning=false', () => {
+    const agents = [
+      makeAgent({ name: 'idle-agent-1', status: 'active' }),
+      makeAgent({ name: 'busy-agent-1', status: 'running' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+
+    // checkRunning=false — all active/running agents returned
+    const cleanable = getCleanableAgents(workspace, false)
+    const names = cleanable.map(a => a.name)
+
+    expect(names).to.include('idle-agent-1')
+    expect(names).to.include('busy-agent-1')
+  })
+
+  it('excludes persistent agents regardless of status', () => {
+    const agents = [
+      makeAgent({ name: 'persistent-1', type: 'persistent', status: 'active' }),
+      makeAgent({ name: 'ephemeral-1', type: 'ephemeral', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+
+    const cleanable = getCleanableAgents(workspace, true)
+    const names = cleanable.map(a => a.name)
+
+    expect(names).to.not.include('persistent-1')
+    expect(names).to.include('ephemeral-1')
+  })
+
+  it('excludes completed/dead/cleaned agents', () => {
+    const agents = [
+      makeAgent({ name: 'done-agent', status: 'completed' }),
+      makeAgent({ name: 'dead-agent', status: 'dead' }),
+      makeAgent({ name: 'cleaned-agent', status: 'cleaned' }),
+      makeAgent({ name: 'active-agent', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+
+    const cleanable = getCleanableAgents(workspace, true)
+    const names = cleanable.map(a => a.name)
+
+    expect(names).to.deep.equal(['active-agent'])
+  })
+
+  it('returns empty array when all ephemeral agents are running', () => {
+    const agents = [
+      makeAgent({ name: 'busy-1', status: 'running' }),
+      makeAgent({ name: 'busy-2', status: 'running' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+
+    const cleanable = getCleanableAgents(workspace, true)
+    expect(cleanable).to.have.length(0)
+  })
+})


### PR DESCRIPTION
## Summary

- **Bug**: `prlt session prune` was listing agents with `running` DB status and active container tmux sessions as candidates for cleanup
- **Root cause**: `getCleanableAgents()` included `running` agents in the initial pool, relying on host tmux detection to filter them out — but container-based agents' tmux sessions aren't visible from the host
- **Fix**: When `checkRunning=true`, exclude agents with `status=running` at the DB level before the tmux safety-net check

## Test plan
- [x] Regression test: 5 unit tests covering all status combinations
- [x] Build passes
- [ ] Verify running agents no longer appear in `prlt session prune --dry-run` output