### PR TITLE
feat(PRLT-1183): graceful degradation for read-only HQ mount in agent containers

### DIFF
--- a/apps/cli/src/commands/work/complete.ts
+++ b/apps/cli/src/commands/work/complete.ts
@@ -141,14 +141,18 @@ export default class WorkComplete extends PMOCommand {
       // Mark any running executions for this ticket as completed
       const runningExecution = executionStorage.getRunningExecution(ticketId!);
       if (runningExecution) {
-        executionStorage.updateStatus(runningExecution.id, 'completed');
+        const updated = executionStorage.tryUpdateStatus(runningExecution.id, 'completed');
 
-        // Track work completion analytics
-        const startTime = runningExecution.startedAt ? new Date(runningExecution.startedAt).getTime() : 0;
-        const durationMs = startTime > 0 ? Date.now() - startTime : 0;
-        trackWorkCompleted({ durationMs, prCreated: false });
+        if (updated) {
+          // Track work completion analytics
+          const startTime = runningExecution.startedAt ? new Date(runningExecution.startedAt).getTime() : 0;
+          const durationMs = startTime > 0 ? Date.now() - startTime : 0;
+          trackWorkCompleted({ durationMs, prCreated: false });
 
-        this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+          this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+        } else {
+          this.log(styles.muted(`   Execution ${runningExecution.id} status update skipped (read-only database)`));
+        }
 
         // PRLT-984: Commit validation — warn if no meaningful code was committed
         if (runningExecution.branch && runningExecution.agentName) {

--- a/apps/cli/src/commands/work/ready.ts
+++ b/apps/cli/src/commands/work/ready.ts
@@ -179,8 +179,12 @@ export default class WorkReady extends PMOCommand {
       // Mark any running executions for this ticket as completed
       const runningExecution = executionStorage.getRunningExecution(ticketId!);
       if (runningExecution) {
-        executionStorage.updateStatus(runningExecution.id, 'completed');
-        this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+        const updated = executionStorage.tryUpdateStatus(runningExecution.id, 'completed');
+        if (updated) {
+          this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+        } else {
+          this.log(styles.muted(`   Execution ${runningExecution.id} status update skipped (read-only database)`));
+        }
       }
 
       // PRLT-984: Commit validation — warn if no meaningful code was committed
@@ -272,9 +276,17 @@ export default class WorkReady extends PMOCommand {
           if (prResult.number) {
             prMetadata.pr_number = String(prResult.number);
           }
-          await this.storage.updateTicket(ticketId!, {
-            metadata: prMetadata,
-          });
+          try {
+            await this.storage.updateTicket(ticketId!, {
+              metadata: prMetadata,
+            });
+          } catch (err) {
+            if ((err as { code?: string }).code === 'SQLITE_READONLY') {
+              this.log(styles.muted('   PR metadata update skipped (read-only database)'));
+            } else {
+              throw err;
+            }
+          }
         }
       }
 

--- a/apps/cli/src/commands/work/ship.ts
+++ b/apps/cli/src/commands/work/ship.ts
@@ -423,13 +423,21 @@ export default class WorkShip extends PMOCommand {
 
       if (ticket && ticketId) {
         // Update PR metadata
-        await this.storage.updateTicket(ticketId, {
-          metadata: {
-            ...ticket.metadata,
-            pr_state: 'MERGED',
-            merged_at: new Date().toISOString(),
-          },
-        });
+        try {
+          await this.storage.updateTicket(ticketId, {
+            metadata: {
+              ...ticket.metadata,
+              pr_state: 'MERGED',
+              merged_at: new Date().toISOString(),
+            },
+          });
+        } catch (err) {
+          if ((err as { code?: string }).code === 'SQLITE_READONLY') {
+            this.log(styles.muted('   PR metadata update skipped (read-only database)'));
+          } else {
+            throw err;
+          }
+        }
 
         if (!flags['no-transition']) {
           try {
@@ -459,8 +467,12 @@ export default class WorkShip extends PMOCommand {
         // Mark execution as completed
         const runningExecution = executionStorage.getRunningExecution(ticketId);
         if (runningExecution) {
-          executionStorage.updateStatus(runningExecution.id, 'completed');
-          this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+          const updated = executionStorage.tryUpdateStatus(runningExecution.id, 'completed');
+          if (updated) {
+            this.log(styles.muted(`   Execution ${runningExecution.id} marked as completed`));
+          } else {
+            this.log(styles.muted(`   Execution ${runningExecution.id} status update skipped (read-only database)`));
+          }
         }
       }
 

--- a/apps/cli/src/lib/execution/storage.ts
+++ b/apps/cli/src/lib/execution/storage.ts
@@ -197,6 +197,24 @@ export class ExecutionStorage {
   }
 
   /**
+   * Try to update execution status, gracefully handling read-only databases.
+   * Returns true if the update succeeded, false if skipped due to read-only DB.
+   * Use this in container environments where the HQ database is mounted read-only.
+   */
+  tryUpdateStatus(id: string, status: ExecutionStatus, exitCode?: number, errorMessage?: string): boolean {
+    try {
+      this.updateStatus(id, status, exitCode, errorMessage)
+      return true
+    } catch (error: unknown) {
+      const code = (error as { code?: string }).code
+      if (code === 'SQLITE_READONLY') {
+        return false
+      }
+      throw error
+    }
+  }
+
+  /**
    * Update execution status
    */
   updateStatus(id: string, status: ExecutionStatus, exitCode?: number, errorMessage?: string): void {

--- a/apps/cli/src/lib/pmo/storage/index.ts
+++ b/apps/cli/src/lib/pmo/storage/index.ts
@@ -9,8 +9,10 @@
  */
 
 import Database from 'better-sqlite3'
+import * as path from 'node:path'
 import { createDrizzleConnection, DrizzleDB } from '../../database/drizzle.js'
 import { type DatabaseDriver, BetterSqlite3Driver } from '../../database/driver.js'
+import { isReadOnlyHQMount } from '../../container.js'
 import {
   AcceptanceCriterion,
   Board,
@@ -91,8 +93,14 @@ export class SQLiteStorage implements PMOStorage {
   constructor(dbPath: string) {
     this.dbPath = dbPath
 
-    // Open database (creates if doesn't exist)
-    this.db = new Database(dbPath)
+    // Auto-detect read-only mode for container environments (PRLT-1183).
+    // The dbPath lives under .proletariat/ — derive the workspace root (grandparent)
+    // and check if it sits on a read-only HQ mount.
+    const workspaceRoot = path.dirname(path.dirname(dbPath))
+    const readOnly = isReadOnlyHQMount(workspaceRoot)
+
+    // Open database — read-only in container environments to prevent SQLITE_READONLY crashes
+    this.db = new Database(dbPath, readOnly ? { readonly: true } : undefined)
     this.db.pragma('foreign_keys = ON')
 
     // Create DatabaseDriver abstraction
@@ -106,7 +114,9 @@ export class SQLiteStorage implements PMOStorage {
       db: this.db,
       driver: this.driver,
       drizzle: this.drizzle,
-      updateBoardTimestamp: (projectId: string) => updateBoardTimestamp(this.db, projectId),
+      updateBoardTimestamp: readOnly
+        ? () => {} // No-op in read-only mode
+        : (projectId: string) => updateBoardTimestamp(this.db, projectId),
     }
 
     // Initialize domain-specific storage modules
@@ -122,8 +132,10 @@ export class SQLiteStorage implements PMOStorage {
     this.actionStorage = new ActionStorage(ctx)
     this.workflowRuleStorage = new WorkflowRuleStorage(ctx)
 
-    // Ensure PMO tables exist
-    this.ensurePMOTables()
+    // Ensure PMO tables exist — skip in read-only mode (tables already exist on HQ)
+    if (!readOnly) {
+      this.ensurePMOTables()
+    }
   }
 
   /**

--- a/apps/cli/src/lib/work-lifecycle/transition.ts
+++ b/apps/cli/src/lib/work-lifecycle/transition.ts
@@ -137,25 +137,36 @@ export async function moveTicketByIntent(opts: {
   }
 
   // Move in local PMO
+  let localMoveSucceeded = false
   try {
     await storage.moveTicket(ticket.projectId, ticket.id, targetColumn)
+    localMoveSucceeded = true
   } catch (error) {
-    return {
-      moved: false,
-      targetColumn,
-      previousColumn,
-      message: `Failed to move: ${error instanceof Error ? error.message : String(error)}`,
+    const code = (error as { code?: string }).code
+    if (code === 'SQLITE_READONLY') {
+      // PRLT-1183: In container environments the HQ database is mounted read-only.
+      // Skip local PMO write but still sync to external provider below.
+      if (log) log('Local PMO update skipped (read-only database)')
+    } else {
+      return {
+        moved: false,
+        targetColumn,
+        previousColumn,
+        message: `Failed to move: ${error instanceof Error ? error.message : String(error)}`,
+      }
     }
   }
 
-  // Sync to external provider
+  // Sync to external provider (e.g. Linear)
+  let externalSyncSucceeded = false
   if (resolveProvider) {
     try {
       const provider = await resolveProvider(ticket.id, ticket.projectId)
       if (provider.name !== 'pmo') {
         const result = await provider.moveTicket(ticket.id, targetColumn)
-        if (result.success && log) {
-          log(`Synced to ${result.provider}: ${targetColumn}`)
+        if (result.success) {
+          externalSyncSucceeded = true
+          if (log) log(`Synced to ${result.provider}: ${targetColumn}`)
         }
       }
     } catch {
@@ -164,7 +175,7 @@ export async function moveTicketByIntent(opts: {
   }
 
   return {
-    moved: true,
+    moved: localMoveSucceeded || externalSyncSucceeded,
     targetColumn,
     previousColumn,
   }

--- a/apps/cli/test/unit/regression-prlt1183-readonly-lifecycle.test.ts
+++ b/apps/cli/test/unit/regression-prlt1183-readonly-lifecycle.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression test for PRLT-1183
+ *
+ * Verifies that lifecycle commands (work propose/ready/ship/complete) work
+ * in container environments where the HQ database is mounted read-only.
+ *
+ * Root causes fixed:
+ * 1. SQLiteStorage opened workspace.db in read-write mode in containers,
+ *    crashing even read-only commands like `ticket show`.
+ * 2. ExecutionStorage.updateStatus() crashed with SQLITE_READONLY when
+ *    lifecycle commands tried to mark executions as completed.
+ * 3. moveTicketByIntent() failed entirely on SQLITE_READONLY instead of
+ *    falling through to the external provider sync.
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { runDrizzleMigrations } from '../../src/lib/database/migrator.js'
+import { ALL_MIGRATIONS } from '../../src/lib/database/migrations/index.js'
+import { ExecutionStorage } from '../../src/lib/execution/storage.js'
+import { PMO_SCHEMA_SQL } from '../../src/lib/pmo/schema.js'
+import { SQLiteStorage } from '../../src/lib/pmo/storage/index.js'
+
+describe('PRLT-1183: read-only HQ mount graceful degradation', () => {
+  const originalEnv = { ...process.env }
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-1183-'))
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Create a test workspace with workspace.db and PMO tables.
+   */
+  function createTestWorkspace(workspacePath: string): void {
+    const proletariatDir = path.join(workspacePath, '.proletariat')
+    fs.mkdirSync(proletariatDir, { recursive: true })
+
+    const dbPath = path.join(proletariatDir, 'workspace.db')
+    const db = new Database(dbPath)
+    db.pragma('journal_mode = WAL')
+    db.pragma('foreign_keys = ON')
+    runDrizzleMigrations(db, ALL_MIGRATIONS)
+
+    // Insert workspace config
+    db.exec(`
+      INSERT OR IGNORE INTO workspace (id, type, workspace_name, has_pmo, created_at)
+      VALUES (1, 'hq', 'test-hq', 1, datetime('now'))
+    `)
+
+    // Create PMO tables
+    db.exec(PMO_SCHEMA_SQL)
+
+    // Create a test execution record
+    db.exec(`
+      INSERT INTO agent_work (id, ticket_id, agent_name, executor, environment, display_mode, permission_mode, status, started_at)
+      VALUES ('WORK-TEST0001', 'TKT-001', 'test-agent', 'claude-code', 'docker', 'terminal', 'safe', 'running', ${Date.now()})
+    `)
+
+    // Checkpoint WAL so read-only opens work
+    db.pragma('wal_checkpoint(TRUNCATE)')
+    db.close()
+
+    // Write config.json
+    fs.writeFileSync(
+      path.join(proletariatDir, 'config.json'),
+      JSON.stringify({ version: '1.0.0', type: 'hq', schemaVersion: 1 })
+    )
+  }
+
+  function simulateContainer(hqPath: string): void {
+    process.env.PRLT_AGENT_NAME = 'test-agent-1'
+    process.env.DEVCONTAINER = 'true'
+    process.env.PRLT_HQ_PATH = hqPath
+  }
+
+  // =========================================================================
+  // SQLiteStorage: read-only container support
+  // =========================================================================
+
+  describe('SQLiteStorage read-only mode', () => {
+    it('should open PMO storage in read-only mode in container environments', () => {
+      createTestWorkspace(tmpDir)
+      simulateContainer(tmpDir)
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+      const storage = new SQLiteStorage(dbPath)
+
+      // Should be able to read via the database
+      const db = storage.getDatabase()
+      const row = db.prepare('SELECT workspace_name FROM workspace WHERE id = 1').get() as { workspace_name: string }
+      expect(row.workspace_name).to.equal('test-hq')
+
+      db.close()
+    })
+
+    it('should skip ensurePMOTables in read-only mode (no crash)', () => {
+      createTestWorkspace(tmpDir)
+      simulateContainer(tmpDir)
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+
+      // This should NOT throw — ensurePMOTables is skipped in readonly mode
+      expect(() => new SQLiteStorage(dbPath)).not.to.throw()
+    })
+
+    it('should open PMO storage in read-write mode when not in container', () => {
+      createTestWorkspace(tmpDir)
+      delete process.env.PRLT_AGENT_NAME
+      delete process.env.DEVCONTAINER
+      delete process.env.PRLT_HQ_PATH
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+      const storage = new SQLiteStorage(dbPath)
+      const db = storage.getDatabase()
+
+      // Should be able to write
+      expect(() => {
+        db.exec("UPDATE workspace SET workspace_name = 'modified' WHERE id = 1")
+      }).not.to.throw()
+
+      db.close()
+    })
+  })
+
+  // =========================================================================
+  // ExecutionStorage.tryUpdateStatus: graceful read-only handling
+  // =========================================================================
+
+  describe('ExecutionStorage.tryUpdateStatus', () => {
+    it('should return true when update succeeds on writable database', () => {
+      createTestWorkspace(tmpDir)
+      delete process.env.PRLT_AGENT_NAME
+      delete process.env.DEVCONTAINER
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+      const db = new Database(dbPath)
+      const storage = new ExecutionStorage(db)
+
+      const result = storage.tryUpdateStatus('WORK-TEST0001', 'completed')
+      expect(result).to.be.true
+
+      // Verify the update actually happened
+      const row = db.prepare('SELECT status FROM agent_work WHERE id = ?').get('WORK-TEST0001') as { status: string }
+      expect(row.status).to.equal('completed')
+
+      db.close()
+    })
+
+    it('should return false when database is read-only (no crash)', () => {
+      createTestWorkspace(tmpDir)
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+      const db = new Database(dbPath, { readonly: true })
+      const storage = new ExecutionStorage(db)
+
+      // tryUpdateStatus should NOT throw — it returns false
+      const result = storage.tryUpdateStatus('WORK-TEST0001', 'completed')
+      expect(result).to.be.false
+
+      db.close()
+    })
+
+    it('should still throw non-readonly errors', () => {
+      createTestWorkspace(tmpDir)
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+      const db = new Database(dbPath)
+      const storage = new ExecutionStorage(db)
+
+      // Drop the table to cause a different error
+      db.exec('DROP TABLE agent_work')
+
+      expect(() => {
+        storage.tryUpdateStatus('WORK-TEST0001', 'completed')
+      }).to.throw()
+
+      db.close()
+    })
+  })
+
+  // =========================================================================
+  // moveTicketByIntent: read-only graceful degradation
+  // =========================================================================
+
+  describe('moveTicketByIntent read-only handling', () => {
+    it('should not crash when storage.moveTicket fails with SQLITE_READONLY', async () => {
+      // This test verifies that moveTicketByIntent catches SQLITE_READONLY
+      // and continues to the external provider sync
+      const { moveTicketByIntent } = await import('../../src/lib/work-lifecycle/transition.js')
+
+      createTestWorkspace(tmpDir)
+
+      const dbPath = path.join(tmpDir, '.proletariat', 'workspace.db')
+      const db = new Database(dbPath)
+
+      // Create a project and board so column resolution works
+      db.exec(`
+        INSERT OR IGNORE INTO pmo_projects (id, name, created_at, updated_at)
+        VALUES ('PROJ-001', 'Test Project', datetime('now'), datetime('now'))
+      `)
+      db.exec(`
+        INSERT OR IGNORE INTO pmo_workflows (id, name, description, is_builtin, created_at)
+        VALUES ('default', 'Default', 'Default workflow', 1, datetime('now'))
+      `)
+      db.exec(`
+        INSERT OR IGNORE INTO pmo_workflow_statuses (id, workflow_id, name, category, position, created_at)
+        VALUES
+          ('ws-todo', 'default', 'To Do', 'planned', 0, datetime('now')),
+          ('ws-done', 'default', 'Done', 'completed', 2, datetime('now'))
+      `)
+      db.close()
+
+      // Reopen as read-only to simulate container
+      const rodb = new Database(dbPath, { readonly: true })
+
+      // Create a mock storage that throws SQLITE_READONLY on moveTicket
+      const mockStorage = {
+        getProjectBoard: async (_projectId: string) => ({
+          columns: [{ name: 'To Do' }, { name: 'Done' }],
+        }),
+        moveTicket: async () => {
+          const err = new Error('attempt to write a readonly database')
+          ;(err as { code?: string }).code = 'SQLITE_READONLY'
+          throw err
+        },
+      }
+
+      const logs: string[] = []
+      const result = await moveTicketByIntent({
+        db: rodb,
+        storage: mockStorage as never,
+        ticket: { id: 'TKT-001', projectId: 'PROJ-001', statusName: 'To Do' },
+        intent: 'completed',
+        providerName: 'pmo',
+        log: (msg) => logs.push(msg),
+      })
+
+      // Should not crash, and should report the readonly skip
+      expect(logs.some(l => l.includes('read-only'))).to.be.true
+      // moved is false because local write failed and no external provider was given
+      expect(result.targetColumn).to.equal('Done')
+
+      rodb.close()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes read-only HQ mount breaking `prlt` lifecycle commands inside agent containers. Three root causes addressed:

- **SQLiteStorage bypassed container detection** — opened `workspace.db` directly via `new Database(dbPath)` without checking `isReadOnlyHQMount()`. Even read-only commands like `ticket show` crashed with SQLITE_READONLY.
- **Lifecycle commands crashed on status writes** — `ExecutionStorage.updateStatus()` threw SQLITE_READONLY when `work ready/ship/complete` tried to mark executions as completed.
- **moveTicketByIntent short-circuited** — returned early on SQLITE_READONLY without reaching the external provider sync (Linear), so board state never updated.

## Changes

- `SQLiteStorage`: auto-detect container environment via `isReadOnlyHQMount()`, open DB read-only, skip `ensurePMOTables()` and `updateBoardTimestamp` writes
- `ExecutionStorage`: add `tryUpdateStatus()` that returns `false` on SQLITE_READONLY instead of throwing
- `moveTicketByIntent`: catch SQLITE_READONLY on local PMO write and fall through to external provider sync
- `work ready/ship/complete`: use `tryUpdateStatus` and wrap `storage.updateTicket` writes with SQLITE_READONLY handling
- 7 regression tests covering all three fix paths

## Test plan

- [x] All 7 new regression tests pass (`test/unit/regression-prlt1183-readonly-lifecycle.test.ts`)
- [x] All 7 existing PRLT-1090 container readonly tests still pass
- [x] All 4 existing PRLT-1163 readonly HQ mount tests still pass
- [x] All 81 related unit tests pass (execution storage, work lifecycle)
- [x] Build passes (`pnpm build`)
- [ ] Manual verification: agent container can run `prlt ticket show`, `prlt work propose`, `prlt work ship` without SQLITE_READONLY crashes

Closes PRLT-1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)