### PR TITLE
chore: bump version to 0.3.98

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.97",
+  "version": "0.3.98",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
12 commits since 0.3.97 including: daemon keepalive fix, test fixes, full CI on PRs, poller MVP, Jira/Notion/Asana/GitHub Issues providers, intent-based transitions, GC fixes.