### PR TITLE
fix(PRLT-1211): override process.exit(0) in daemon mode to prevent oclif from killing orchestrate

### DIFF
--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -217,6 +217,17 @@ export default class Orchestrate extends PromptCommand {
       }
 
       // Daemon mode: start the engine and run until stopped
+      //
+      // PRLT-1211: Override process.exit to prevent oclif from killing the daemon.
+      // After run() returns, oclif's error handler calls process.exit(0) via
+      // @oclif/core/lib/errors/handle.js → Exit.exit(). We intercept exit(0)
+      // so the daemon stays alive; non-zero exits still terminate immediately.
+      const originalExit = process.exit
+      process.exit = ((code: number) => {
+        if (code === 0) return  // swallow oclif's clean-exit call
+        originalExit(code)
+      }) as never
+
       engine.start()
 
       if (jsonMode) {
@@ -273,6 +284,8 @@ export default class Orchestrate extends PromptCommand {
           engine.stop()
           if (pollTimer) clearInterval(pollTimer)
           if (rl) { rl.close(); rl = null }
+          // Restore original process.exit so the process can terminate after cleanup
+          process.exit = originalExit
           this.log(styles.muted('\n  Orchestrate daemon stopped'))
           resolve()
         }

--- a/apps/cli/test/unit/orchestrate-daemon-keepalive.test.ts
+++ b/apps/cli/test/unit/orchestrate-daemon-keepalive.test.ts
@@ -96,6 +96,126 @@ describe('orchestrate daemon keepalive (PRLT-1202)', () => {
     try { unlinkSync(join(tmpDir, 'no-keepalive.mjs')) } catch {}
     try { unlinkSync(join(tmpDir, 'with-keepalive.mjs')) } catch {}
     try { unlinkSync(join(tmpDir, 'sigterm-cleanup.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-override.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-override-nonzero.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-override-restore.mjs')) } catch {}
+  })
+})
+
+/**
+ * Regression test for PRLT-1211: oclif force-calls process.exit(0) despite keepalive timer.
+ *
+ * The bug: after the orchestrate command's run() method returns, oclif's error
+ * handler calls process.exit(0) via @oclif/core/lib/errors/handle.js, which
+ * kills the daemon even though it has an active keepalive timer.
+ *
+ * The fix: override process.exit in daemon mode so exit(0) is a no-op.
+ * Non-zero exits still terminate immediately. The original is restored during
+ * cleanup so the process can exit after shutdown.
+ */
+describe('orchestrate process.exit override (PRLT-1211)', () => {
+  let tmpDir: string
+
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'prlt-exit-override-test-'))
+  })
+
+  it('process stays alive when process.exit(0) is called with override active', async () => {
+    // Simulates oclif calling process.exit(0) after run() returns.
+    // With the override, exit(0) is swallowed and the daemon stays alive.
+    const script = join(tmpDir, 'exit-override.mjs')
+    writeFileSync(script, `
+      const keepAlive = setInterval(() => {}, 60000)
+
+      // Override process.exit — same pattern as the orchestrate command fix
+      const originalExit = process.exit
+      process.exit = ((code) => {
+        if (code === 0) return
+        originalExit(code)
+      })
+
+      // Simulate oclif calling process.exit(0) after command completes
+      setTimeout(() => { process.exit(0) }, 200)
+
+      await new Promise((resolve) => {
+        const cleanup = () => {
+          clearInterval(keepAlive)
+          process.exit = originalExit
+          resolve()
+        }
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+    `)
+
+    const exitCode = await runWithTimeout(script, 2000)
+    expect(exitCode).to.equal('timeout', 'process.exit(0) should be swallowed — daemon stays alive')
+  })
+
+  it('process still exits on non-zero exit code', async () => {
+    // Non-zero exit codes must still terminate the process
+    const script = join(tmpDir, 'exit-override-nonzero.mjs')
+    writeFileSync(script, `
+      const keepAlive = setInterval(() => {}, 60000)
+
+      const originalExit = process.exit
+      process.exit = ((code) => {
+        if (code === 0) return
+        originalExit(code)
+      })
+
+      // Non-zero exit should still work
+      setTimeout(() => { process.exit(1) }, 200)
+
+      await new Promise((resolve) => {
+        process.on('SIGINT', () => { clearInterval(keepAlive); resolve() })
+        process.on('SIGTERM', () => { clearInterval(keepAlive); resolve() })
+      })
+    `)
+
+    const exitCode = await runWithTimeout(script, 2000)
+    expect(exitCode).to.equal('1', 'Non-zero exit codes should still terminate the process')
+  })
+
+  it('process exits normally after cleanup restores original process.exit', async () => {
+    // After SIGTERM, cleanup restores original process.exit, so exit(0) works
+    const script = join(tmpDir, 'exit-override-restore.mjs')
+    writeFileSync(script, `
+      const keepAlive = setInterval(() => {}, 60000)
+
+      const originalExit = process.exit
+      process.exit = ((code) => {
+        if (code === 0) return
+        originalExit(code)
+      })
+
+      await new Promise((resolve) => {
+        const cleanup = () => {
+          clearInterval(keepAlive)
+          process.exit = originalExit
+          resolve()
+        }
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+      // After cleanup restores process.exit, exit(0) terminates as expected
+      process.exit(0)
+    `)
+
+    const exitCode = await new Promise((resolve) => {
+      const child = fork(script, [], { stdio: 'ignore' })
+      setTimeout(() => { child.kill('SIGTERM') }, 500)
+      child.on('exit', (code) => resolve(code))
+      setTimeout(() => { child.kill('SIGKILL'); resolve(null) }, 5000)
+    })
+
+    expect(exitCode).to.equal(0, 'After cleanup, process.exit(0) should terminate normally')
+  })
+
+  after(() => {
+    try { unlinkSync(join(tmpDir, 'exit-override.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-override-nonzero.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-override-restore.mjs')) } catch {}
   })
 })
 


### PR DESCRIPTION
## Problem

The orchestrate daemon exits immediately because oclif's error handler calls process.exit(0) after the command's run() method. The keepalive timer from PRLT-1202 keeps Node's event loop alive, but oclif bypasses it by calling process.exit(0) directly.

## Fix

- Override process.exit in daemon mode: exit(0) becomes a no-op, non-zero exits still terminate
- Restore original process.exit during cleanup so shutdown works normally

## Test plan

- [x] Regression test: process stays alive when process.exit(0) called with override
- [x] Regression test: non-zero exit codes still terminate
- [x] Regression test: cleanup restores original exit so shutdown works
- [x] Build passes
- [x] All 6 keepalive/exit-override tests pass