### PR TITLE
fix(PRLT-1211): override process.exit to prevent oclif from killing orchestrate daemon

### DIFF
--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -219,6 +219,16 @@ export default class Orchestrate extends PromptCommand {
       // Daemon mode: start the engine and run until stopped
       engine.start()
 
+      // Prevent oclif from killing the daemon — oclif's error handler calls
+      // process.exit(0) after run() resolves, which terminates the daemon.
+      // Override process.exit to ignore clean exits while the daemon is running.
+      const originalExit = process.exit
+      let daemonRunning = true
+      process.exit = ((code?: number) => {
+        if (daemonRunning && (code === 0 || code === undefined)) return
+        originalExit(code as number)
+      }) as never
+
       if (jsonMode) {
         outputSuccessAsJson(
           { status: 'running', mode: 'daemon' },
@@ -270,6 +280,8 @@ export default class Orchestrate extends PromptCommand {
       await new Promise<void>((resolve) => {
         const cleanup = () => {
           clearInterval(keepAlive)
+          daemonRunning = false
+          process.exit = originalExit
           engine.stop()
           if (pollTimer) clearInterval(pollTimer)
           if (rl) { rl.close(); rl = null }

--- a/apps/cli/test/unit/orchestrate-daemon-keepalive.test.ts
+++ b/apps/cli/test/unit/orchestrate-daemon-keepalive.test.ts
@@ -5,17 +5,17 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
 /**
- * Regression test for PRLT-1202: orchestrate daemon exits immediately.
+ * Regression tests for PRLT-1202 and PRLT-1211: orchestrate daemon exits.
  *
- * The bug: process.on('SIGINT'/'SIGTERM') signal listeners alone don't keep
- * the Node.js event loop alive. Without an active handle (like setInterval),
- * Node exits immediately after printing "Engine started."
+ * PRLT-1202: signal listeners alone don't keep the Node.js event loop alive.
+ * Fix: keepalive setInterval keeps the event loop running.
  *
- * The fix: a keepalive setInterval that keeps the event loop alive until
- * cleanup is called via SIGINT/SIGTERM.
+ * PRLT-1211: oclif's error handler calls process.exit(0) after run() resolves,
+ * killing the daemon even with the keepalive timer.
+ * Fix: override process.exit to ignore code-0 exits while daemon is running.
  */
 
-describe('orchestrate daemon keepalive (PRLT-1202)', () => {
+describe('orchestrate daemon keepalive (PRLT-1202, PRLT-1211)', () => {
   let tmpDir: string
 
   before(() => {
@@ -23,7 +23,6 @@ describe('orchestrate daemon keepalive (PRLT-1202)', () => {
   })
 
   it('process exits immediately when only signal listeners keep the loop (old behavior)', async () => {
-    // This script reproduces the bug: signal listeners alone don't keep Node alive
     const script = join(tmpDir, 'no-keepalive.mjs')
     writeFileSync(script, `
       await new Promise((resolve) => {
@@ -33,12 +32,10 @@ describe('orchestrate daemon keepalive (PRLT-1202)', () => {
     `)
 
     const exitCode = await runWithTimeout(script, 2000)
-    // Node exits immediately (code 0) because nothing keeps the event loop alive
     expect(exitCode).to.not.equal('timeout', 'Without keepalive, process should exit immediately')
   })
 
   it('process stays alive with keepalive timer (new behavior)', async () => {
-    // This script uses the fix: a setInterval keeps the event loop alive
     const script = join(tmpDir, 'with-keepalive.mjs')
     writeFileSync(script, `
       const keepAlive = setInterval(() => {}, 60000)
@@ -54,18 +51,90 @@ describe('orchestrate daemon keepalive (PRLT-1202)', () => {
     `)
 
     const exitCode = await runWithTimeout(script, 2000)
-    // Process should still be running after 2s (we killed it via timeout)
     expect(exitCode).to.equal('timeout', 'With keepalive, process should stay alive until signaled')
+  })
+
+  it('process survives process.exit(0) when exit is overridden (PRLT-1211)', async () => {
+    // Reproduces the oclif bug: after run() resolves, oclif calls process.exit(0)
+    const script = join(tmpDir, 'exit-override.mjs')
+    writeFileSync(script, `
+      const originalExit = process.exit
+      let daemonRunning = true
+      process.exit = ((code) => {
+        if (daemonRunning && (code === 0 || code === undefined)) return
+        originalExit(code)
+      })
+
+      const keepAlive = setInterval(() => {}, 60000)
+
+      // Simulate oclif calling process.exit(0) after run() completes
+      setTimeout(() => { process.exit(0) }, 200)
+
+      await new Promise((resolve) => {
+        const cleanup = () => {
+          clearInterval(keepAlive)
+          daemonRunning = false
+          process.exit = originalExit
+          resolve()
+        }
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+    `)
+
+    const exitCode = await runWithTimeout(script, 2000)
+    expect(exitCode).to.equal('timeout', 'With exit override, process.exit(0) should be intercepted')
+  })
+
+  it('process exits on non-zero exit code even with override', async () => {
+    const script = join(tmpDir, 'exit-nonzero.mjs')
+    writeFileSync(script, `
+      const originalExit = process.exit
+      let daemonRunning = true
+      process.exit = ((code) => {
+        if (daemonRunning && (code === 0 || code === undefined)) return
+        originalExit(code)
+      })
+
+      const keepAlive = setInterval(() => {}, 60000)
+
+      // Non-zero exits should still terminate
+      setTimeout(() => { process.exit(1) }, 200)
+
+      await new Promise((resolve) => {
+        const cleanup = () => {
+          clearInterval(keepAlive)
+          daemonRunning = false
+          process.exit = originalExit
+          resolve()
+        }
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+    `)
+
+    const exitCode = await runWithTimeout(script, 2000)
+    expect(exitCode).to.not.equal('timeout', 'Non-zero exit should still terminate')
+    expect(exitCode).to.equal('1', 'Should exit with code 1')
   })
 
   it('process exits cleanly on SIGTERM with keepalive timer', async () => {
     const script = join(tmpDir, 'sigterm-cleanup.mjs')
     writeFileSync(script, `
+      const originalExit = process.exit
+      let daemonRunning = true
+      process.exit = ((code) => {
+        if (daemonRunning && (code === 0 || code === undefined)) return
+        originalExit(code)
+      })
+
       const keepAlive = setInterval(() => {}, 60000)
 
       await new Promise((resolve) => {
         const cleanup = () => {
           clearInterval(keepAlive)
+          daemonRunning = false
+          process.exit = originalExit
           resolve()
         }
         process.on('SIGINT', cleanup)
@@ -76,12 +145,8 @@ describe('orchestrate daemon keepalive (PRLT-1202)', () => {
 
     const exitCode = await new Promise<number | null>((resolve) => {
       const child = fork(script, [], { stdio: 'ignore' })
-      // Send SIGTERM after 500ms
-      setTimeout(() => {
-        child.kill('SIGTERM')
-      }, 500)
+      setTimeout(() => { child.kill('SIGTERM') }, 500)
       child.on('exit', (code) => resolve(code))
-      // Safety timeout
       setTimeout(() => {
         child.kill('SIGKILL')
         resolve(null)
@@ -92,17 +157,14 @@ describe('orchestrate daemon keepalive (PRLT-1202)', () => {
   })
 
   after(() => {
-    // Clean up temp files
     try { unlinkSync(join(tmpDir, 'no-keepalive.mjs')) } catch {}
     try { unlinkSync(join(tmpDir, 'with-keepalive.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-override.mjs')) } catch {}
+    try { unlinkSync(join(tmpDir, 'exit-nonzero.mjs')) } catch {}
     try { unlinkSync(join(tmpDir, 'sigterm-cleanup.mjs')) } catch {}
   })
 })
 
-/**
- * Run a script with a timeout. Returns 'timeout' if the process doesn't exit
- * within the timeout, or the exit code as a string.
- */
 function runWithTimeout(scriptPath: string, timeoutMs: number): Promise<string> {
   return new Promise((resolve) => {
     const child = fork(scriptPath, [], { stdio: 'ignore' })


### PR DESCRIPTION
## Summary

- Override `process.exit` in daemon mode to prevent oclif's error handler from calling `process.exit(0)` after `run()` resolves, which kills the orchestrate daemon
- Non-zero exit codes still terminate immediately (only code-0 exits are intercepted while daemon is running)
- `process.exit` is restored to original during cleanup (SIGINT/SIGTERM)

Fixes PRLT-1211. Reopens and completes the fix started in PRLT-1202.

## Test plan

- [x] Regression test: process survives `process.exit(0)` when override is active (PRLT-1211 scenario)
- [x] Regression test: process exits on non-zero exit code even with override
- [x] Regression test: process exits cleanly on SIGTERM after override is restored
- [x] Existing keepalive timer tests (PRLT-1202) still pass
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)