### PR TITLE
fix(PRLT-1220): use positional args for daemon move-ticket action

### DIFF
--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -46,7 +46,7 @@ const moveTicket: ActionHandler = (ctx, config) => {
       return { action: 'move-ticket', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
     }
 
-    execSync(`prlt ticket move ${ctx.ticket} --to "${target}" --yes`, { timeout: 30_000, stdio: 'pipe' })
+    execSync(`prlt ticket move ${ctx.ticket} "${target}"`, { timeout: 30_000, stdio: 'pipe' })
     return { action: 'move-ticket', success: true, durationMs: Date.now() - start }
   } catch (err) {
     return { action: 'move-ticket', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }

--- a/apps/cli/test/unit/orchestrate-actions.test.ts
+++ b/apps/cli/test/unit/orchestrate-actions.test.ts
@@ -143,6 +143,39 @@ describe('Orchestrate Built-in Actions', () => {
   })
 
   // ===========================================================================
+  // Move-ticket CLI flag regression (PRLT-1220)
+  // ===========================================================================
+
+  describe('move-ticket command format (PRLT-1220)', () => {
+    it('should use positional args, not --to or --yes flags', () => {
+      const ctx: OrchestrateEventContext = {
+        event: 'on_pr_merged',
+        ticket: 'TKT-012',
+      }
+      const result = executeBuiltinAction('move-ticket', ctx, { target: 'in-progress' })
+      // The action will fail because prlt is not available in test, but the
+      // error message contains the exact command that was attempted.
+      expect(result.success).to.be.false
+      expect(result.error).to.be.a('string')
+      // Must use positional args: prlt ticket move TICKETID COLUMN
+      expect(result.error).to.include('prlt ticket move TKT-012 "in-progress"')
+      // Must NOT use the old --to / --yes flags
+      expect(result.error).to.not.include('--to')
+      expect(result.error).to.not.include('--yes')
+    })
+
+    it('should default target to "done" when no config provided', () => {
+      const ctx: OrchestrateEventContext = {
+        event: 'on_pr_merged',
+        ticket: 'TKT-099',
+      }
+      const result = executeBuiltinAction('move-ticket', ctx)
+      expect(result.success).to.be.false
+      expect(result.error).to.include('prlt ticket move TKT-099 "done"')
+    })
+  })
+
+  // ===========================================================================
   // Unknown Action
   // ===========================================================================
 


### PR DESCRIPTION
## Summary
- Fixed `move-ticket` action in orchestrate/actions.ts to use positional arguments instead of non-existent `--to` and `--yes` flags
- Changed `prlt ticket move ${ticket} --to "${target}" --yes` → `prlt ticket move ${ticket} "${target}"`
- Added regression tests that verify the correct command format

## Test plan
- [x] Regression test verifies positional args are used (not `--to`/`--yes`)
- [x] Regression test verifies default target is "done"
- [x] Existing unit tests still pass
- [x] Build passes

Fixes: https://linear.app/proletariat/issue/PRLT-1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)