### PR TITLE
fix(PRLT-1221): increase agent spawn timeout from 60s to 180s

### DIFF
--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -14,6 +14,13 @@ import type { OrchestrateEventContext, OrchestrateActionResult } from './types.j
 type ActionHandler = (ctx: OrchestrateEventContext, config?: Record<string, unknown>) => OrchestrateActionResult
 
 /**
+ * Timeout for actions that spawn agents via `prlt work start`.
+ * Container creation + clone + setup regularly exceeds 60s,
+ * so we allow 180s to avoid ETIMEDOUT on the execSync call.
+ */
+export const AGENT_SPAWN_TIMEOUT_MS = 180_000
+
+/**
  * Merge a PR via `prlt work ship`.
  */
 const mergePr: ActionHandler = (ctx, config) => {
@@ -76,7 +83,7 @@ const spawnAgent: ActionHandler = (ctx) => {
       return { action: 'spawn-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
     }
 
-    execSync(`prlt work start ${ctx.ticket} --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    execSync(`prlt work start ${ctx.ticket} --yes --display background`, { timeout: AGENT_SPAWN_TIMEOUT_MS, stdio: 'pipe' })
     return { action: 'spawn-agent', success: true, durationMs: Date.now() - start }
   } catch (err) {
     return { action: 'spawn-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
@@ -93,7 +100,7 @@ const respawn: ActionHandler = (ctx, config) => {
       return { action: 'respawn', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
     }
 
-    execSync(`prlt work start ${ctx.ticket} --yes --display background --force`, { timeout: 60_000, stdio: 'pipe' })
+    execSync(`prlt work start ${ctx.ticket} --yes --display background --force`, { timeout: AGENT_SPAWN_TIMEOUT_MS, stdio: 'pipe' })
     return { action: 'respawn', success: true, durationMs: Date.now() - start }
   } catch (err) {
     return { action: 'respawn', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
@@ -144,7 +151,7 @@ const spawnFixAgent: ActionHandler = (ctx) => {
       return { action: 'spawn-fix-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
     }
 
-    execSync(`prlt work start ${ctx.ticket} --action revise --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    execSync(`prlt work start ${ctx.ticket} --action revise --yes --display background`, { timeout: AGENT_SPAWN_TIMEOUT_MS, stdio: 'pipe' })
     return { action: 'spawn-fix-agent', success: true, durationMs: Date.now() - start }
   } catch (err) {
     return { action: 'spawn-fix-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
@@ -191,7 +198,7 @@ const resolveConflict: ActionHandler = (ctx) => {
     }
 
     // Respawn the agent with resolve action
-    execSync(`prlt work start ${ctx.ticket} --action resolve --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    execSync(`prlt work start ${ctx.ticket} --action resolve --yes --display background`, { timeout: AGENT_SPAWN_TIMEOUT_MS, stdio: 'pipe' })
     return { action: 'resolve-conflict', success: true, durationMs: Date.now() - start }
   } catch (err) {
     return { action: 'resolve-conflict', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }

--- a/apps/cli/test/unit/orchestrate-actions.test.ts
+++ b/apps/cli/test/unit/orchestrate-actions.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { executeBuiltinAction, ACTION_HANDLERS } from '../../src/lib/orchestrate/actions.js'
+import { executeBuiltinAction, ACTION_HANDLERS, AGENT_SPAWN_TIMEOUT_MS } from '../../src/lib/orchestrate/actions.js'
 import type { OrchestrateEventContext } from '../../src/lib/orchestrate/types.js'
 
 /**
@@ -156,6 +156,17 @@ describe('Orchestrate Built-in Actions', () => {
     it('should include the action name in the error', () => {
       const result = executeBuiltinAction('does-not-exist', { event: 'on_ci_green' })
       expect(result.error).to.include('does-not-exist')
+    })
+  })
+
+  // ===========================================================================
+  // Agent Spawn Timeout (PRLT-1221 regression)
+  // ===========================================================================
+
+  describe('agent spawn timeout', () => {
+    it('should export AGENT_SPAWN_TIMEOUT_MS >= 120s to avoid ETIMEDOUT on container setup', () => {
+      expect(AGENT_SPAWN_TIMEOUT_MS).to.be.a('number')
+      expect(AGENT_SPAWN_TIMEOUT_MS).to.be.at.least(120_000)
     })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "apps/cli": {
       "name": "@proletariat/cli",
-      "version": "0.3.100",
+      "version": "0.3.101",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Increases execSync timeout for agent-spawning orchestrate actions from 60s to 180s
- Affects `spawn-agent`, `respawn`, `spawn-fix-agent`, and `resolve-conflict` actions
- Extracts timeout into exported `AGENT_SPAWN_TIMEOUT_MS` constant for consistency

## Problem
The `resolve-conflict` action (and other agent-spawning actions) used a 60s timeout for `prlt work start`. Container creation + clone + setup regularly exceeds 60s, causing ETIMEDOUT at ~99s and reporting the action as failed even though the container was created.

## Test plan
- [x] Regression test verifies `AGENT_SPAWN_TIMEOUT_MS >= 120_000`
- [x] All existing orchestrate-actions tests pass
- [x] Build passes

Closes PRLT-1221