### PR TITLE
fix(PRLT-1222): move resolve-conflict to confirm mode and add conflict dedup

### DIFF
--- a/apps/cli/src/lib/orchestrate/poller.ts
+++ b/apps/cli/src/lib/orchestrate/poller.ts
@@ -52,6 +52,9 @@ export class OrchestratePoller {
   /** Track which tickets we've already fired on_ticket_ready for. */
   private firedReadyTickets = new Set<string>()
 
+  /** Track tickets with active conflict resolution to prevent duplicate agent spawns. */
+  private activeConflictResolutions = new Set<string>()
+
   /** Track known agent lifecycle states. */
   private lastAgentStates = new Map<string, string>()
 
@@ -275,20 +278,35 @@ export class OrchestratePoller {
             mergeable = 'MERGEABLE'
           }
         } catch {
-          // gh command failed
+          // gh command failed — preserve previous mergeable state to avoid
+          // CONFLICTING→UNKNOWN→CONFLICTING re-fire cycles
+          mergeable = tracked?.lastMergeable ?? 'UNKNOWN'
+        }
+
+        // Clear conflict resolution tracking when PR becomes mergeable
+        if (mergeable === 'MERGEABLE' && ticketId) {
+          this.activeConflictResolutions.delete(ticketId)
         }
 
         // Fire on_pr_conflicting on first observation or when transitioning to CONFLICTING
         const isNewConflict = mergeable === 'CONFLICTING' && (!tracked || tracked.lastMergeable !== 'CONFLICTING')
         if (isNewConflict) {
-          this.log(`[poll] PR conflicting: PR #${pr.number}`)
-          await this.engine.fireEvent('on_pr_conflicting', {
-            event: 'on_pr_conflicting',
-            pr: pr.number,
-            branch: pr.headBranch,
-            ticket: ticketId,
-            prUrl: pr.url,
-          })
+          // Dedup: skip if we already have an active conflict resolution for this ticket
+          if (ticketId && this.activeConflictResolutions.has(ticketId)) {
+            this.log(`[poll] PR #${pr.number} conflicting but resolution already active for ${ticketId}, skipping`)
+          } else {
+            if (ticketId) {
+              this.activeConflictResolutions.add(ticketId)
+            }
+            this.log(`[poll] PR conflicting: PR #${pr.number}`)
+            await this.engine.fireEvent('on_pr_conflicting', {
+              event: 'on_pr_conflicting',
+              pr: pr.number,
+              branch: pr.headBranch,
+              ticket: ticketId,
+              prUrl: pr.url,
+            })
+          }
         }
 
         // Update tracking

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -39,14 +39,19 @@ const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Re
   { event: 'on_agent_spawned', action: 'move-ticket', config: { target: 'in-progress' } },
 ]
 
-/** Safe actions that can be auto-executed even in supervised mode. */
+/**
+ * Safe actions that can be auto-executed even in supervised mode.
+ *
+ * Actions that spawn agents/containers (spawn-agent, respawn, spawn-fix-agent,
+ * resolve-conflict) are NOT safe — they create external resources and must
+ * require confirmation in supervised mode.
+ */
 const SAFE_ACTIONS = new Set([
   'move-ticket',
   'notify',
   'cleanup-container',
   'health-check',
   'rebase-conflicting-prs',
-  'resolve-conflict',
 ])
 
 export const PRESETS: Record<PresetName, PresetDefinition> = {

--- a/apps/cli/test/unit/orchestrate-poller.test.ts
+++ b/apps/cli/test/unit/orchestrate-poller.test.ts
@@ -200,6 +200,20 @@ describe('OrchestratePoller', () => {
   })
 
   // ===========================================================================
+  // Conflict Resolution Dedup (PRLT-1222)
+  // ===========================================================================
+
+  describe('PRLT-1222: conflict resolution deduplication', () => {
+    it('should expose activeConflictResolutions set for tracking', () => {
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      // The poller should have the activeConflictResolutions tracking
+      // This is a structural test — the set is private, so we verify
+      // the poller can be created without errors
+      expect(poller).to.be.instanceOf(OrchestratePoller)
+    })
+  })
+
+  // ===========================================================================
   // Error Handling
   // ===========================================================================
 

--- a/apps/cli/test/unit/orchestrate-presets.test.ts
+++ b/apps/cli/test/unit/orchestrate-presets.test.ts
@@ -19,7 +19,6 @@ const SAFE_ACTIONS = new Set([
   'cleanup-container',
   'health-check',
   'rebase-conflicting-prs',
-  'resolve-conflict',
 ])
 
 describe('Orchestrate Presets', () => {

--- a/apps/cli/test/unit/resolve-conflict.test.ts
+++ b/apps/cli/test/unit/resolve-conflict.test.ts
@@ -6,15 +6,17 @@ import { PRESETS } from '../../src/lib/orchestrate/presets.js'
 
 /**
  * Regression tests for PRLT-1161: Daemon auto-detect and resolve merge conflicts.
+ * Updated for PRLT-1222: resolve-conflict moved to confirm mode + dedup fixes.
  *
  * Tests cover:
  * - resolve-conflict action is registered and wired
  * - Skips PRs with no associated ticket (AC: no action on unassociated PRs)
  * - on_pr_conflicting event triggers resolve-conflict in presets
- * - resolve-conflict is classified as a safe action in supervised preset
+ * - resolve-conflict requires confirmation in supervised preset (PRLT-1222)
+ * - Agent-spawning actions are NOT classified as safe (PRLT-1222)
  */
 
-describe('Merge Conflict Resolution (PRLT-1161)', () => {
+describe('Merge Conflict Resolution (PRLT-1161, PRLT-1222)', () => {
   // ===========================================================================
   // Action Registration
   // ===========================================================================
@@ -111,12 +113,12 @@ describe('Merge Conflict Resolution (PRLT-1161)', () => {
       expect(hook!.mode).to.equal('auto')
     })
 
-    it('should auto-execute resolve-conflict in supervised preset (safe action)', () => {
+    it('should require confirmation for resolve-conflict in supervised preset (spawns agents)', () => {
       const hook = PRESETS.supervised.hooks.find(
         h => h.event === 'on_pr_conflicting' && h.action === 'resolve-conflict'
       )
       expect(hook).to.exist
-      expect(hook!.mode).to.equal('auto')
+      expect(hook!.mode).to.equal('confirm')
     })
 
     it('should require confirmation for resolve-conflict in conservative preset', () => {
@@ -140,6 +142,43 @@ describe('Merge Conflict Resolution (PRLT-1161)', () => {
       expect(result).to.have.property('action', 'resolve-conflict')
       expect(result).to.have.property('success')
       expect(result).to.have.property('durationMs')
+    })
+  })
+
+  // ===========================================================================
+  // PRLT-1222 Regression: agent-spawning actions must not be safe
+  // ===========================================================================
+
+  describe('PRLT-1222: agent-spawning actions are destructive', () => {
+    const AGENT_SPAWNING_ACTIONS = ['spawn-agent', 'respawn', 'spawn-fix-agent', 'resolve-conflict']
+
+    it('should NOT classify any agent-spawning action as safe in supervised preset', () => {
+      const supervised = PRESETS.supervised
+      for (const action of AGENT_SPAWNING_ACTIONS) {
+        const hooks = supervised.hooks.filter(h => h.action === action)
+        for (const hook of hooks) {
+          expect(hook.mode).to.equal(
+            'confirm',
+            `Agent-spawning action "${action}" (event: ${hook.event}) must be confirm in supervised preset, not ${hook.mode}`
+          )
+        }
+      }
+    })
+
+    it('should classify resolve-conflict as confirm in supervised preset', () => {
+      const hook = PRESETS.supervised.hooks.find(
+        h => h.action === 'resolve-conflict'
+      )
+      expect(hook).to.exist
+      expect(hook!.mode).to.equal('confirm')
+    })
+
+    it('should still allow resolve-conflict as auto in aggressive preset', () => {
+      const hook = PRESETS.aggressive.hooks.find(
+        h => h.action === 'resolve-conflict'
+      )
+      expect(hook).to.exist
+      expect(hook!.mode).to.equal('auto')
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes P0 bug where `resolve-conflict` was classified as a safe auto-mode action in the supervised preset, but it spawns agents via `prlt work start` — causing runaway container creation (28 zombie containers in ~35 minutes).

### Changes

- **Move resolve-conflict to confirm mode in supervised preset**: Removed `resolve-conflict` from `SAFE_ACTIONS` set. Actions that spawn agents/containers (spawn-agent, respawn, spawn-fix-agent, resolve-conflict) are now all classified as destructive and require confirmation in supervised mode.

- **Add conflict resolution deduplication**: Added `activeConflictResolutions` tracking set in the poller. Before firing `on_pr_conflicting`, checks if a resolution is already active for that ticket. Clears tracking when PR becomes mergeable.

- **Fix UNKNOWN→CONFLICTING re-fire bug**: When `gh pr view` fails, preserve the previous mergeable state instead of resetting to UNKNOWN. This prevents the cycle where a transient gh failure causes the state to flip CONFLICTING→UNKNOWN→CONFLICTING, re-triggering the event on every other poll cycle.

### Files changed
- `apps/cli/src/lib/orchestrate/presets.ts` — Remove resolve-conflict from SAFE_ACTIONS
- `apps/cli/src/lib/orchestrate/poller.ts` — Add dedup set + fix UNKNOWN re-fire + clear on mergeable
- `apps/cli/test/unit/resolve-conflict.test.ts` — Update supervised preset assertion, add PRLT-1222 regression tests
- `apps/cli/test/unit/orchestrate-presets.test.ts` — Align test SAFE_ACTIONS with source
- `apps/cli/test/unit/orchestrate-poller.test.ts` — Add dedup structural test

## Test plan
- [x] Build passes (`pnpm build`)
- [x] All 24 related unit tests pass
- [x] Regression test: resolve-conflict is confirm in supervised preset
- [x] Regression test: no agent-spawning action is classified as safe
- [x] Regression test: resolve-conflict remains auto in aggressive preset
- [ ] Manual: apply supervised preset and verify resolve-conflict requires confirmation

Closes PRLT-1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)