### PR TITLE
feat(PRLT-1226): reviewer agents — spawn review agent on PR creation, post review comments

### DIFF
--- a/apps/cli/src/lib/events/events.ts
+++ b/apps/cli/src/lib/events/events.ts
@@ -175,6 +175,8 @@ export interface RuntimeEventMap {
   'on_agent_died': OrchestrateGenericEvent
   'on_agent_completed': OrchestrateGenericEvent
   'on_agent_idle': OrchestrateGenericEvent
+  'on_review_approved': OrchestrateGenericEvent
+  'on_changes_requested': OrchestrateGenericEvent
   'on_version_published': OrchestrateGenericEvent
 }
 

--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -159,6 +159,25 @@ const spawnFixAgent: ActionHandler = (ctx) => {
 }
 
 /**
+ * Spawn a review agent for a PR.
+ * Review agents are non-destructive — they read the diff and post comments.
+ * Uses --action review to launch in read-only mode with the review role prompt.
+ */
+const spawnReviewAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-review-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --action review --yes --display background`, { timeout: AGENT_SPAWN_TIMEOUT_MS, stdio: 'pipe' })
+    return { action: 'spawn-review-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-review-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
  * Health check / poke an idle agent.
  */
 const healthCheck: ActionHandler = (ctx) => {
@@ -221,6 +240,7 @@ export const ACTION_HANDLERS: Record<string, ActionHandler> = {
   'notify': notify,
   'cleanup-container': cleanupContainer,
   'spawn-fix-agent': spawnFixAgent,
+  'spawn-review-agent': spawnReviewAgent,
   'health-check': healthCheck,
   'resolve-conflict': resolveConflict,
 }

--- a/apps/cli/src/lib/orchestrate/poller.ts
+++ b/apps/cli/src/lib/orchestrate/poller.ts
@@ -13,7 +13,8 @@
 import { execSync } from 'node:child_process'
 import * as path from 'node:path'
 import type Database from 'better-sqlite3'
-import { isGHInstalled, isGHAuthenticated, listOpenPRs, getPRChecks, getPRByNumber } from '../pr/index.js'
+import { isGHInstalled, isGHAuthenticated, listOpenPRs, getPRChecks, getPRByNumber, getPRReviewDecision } from '../pr/index.js'
+import type { PRReviewDecision } from '../pr/index.js'
 import { runSyncCycle, type SyncReport } from '../sync/engine.js'
 import { SQLiteStorage } from '../pmo/storage-sqlite.js'
 import type { OrchestrateEngine } from './engine.js'
@@ -34,6 +35,7 @@ interface TrackedPR {
   number: number
   lastCIState: 'pending' | 'success' | 'failure' | 'unknown'
   lastMergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+  lastReviewDecision: PRReviewDecision
 }
 
 // =============================================================================
@@ -265,6 +267,30 @@ export class OrchestratePoller {
           }
         }
 
+        // --- Review Decision ---
+        const reviewDecision = getPRReviewDecision(pr.number, this.cwd)
+        if (tracked && reviewDecision && reviewDecision !== tracked.lastReviewDecision) {
+          if (reviewDecision === 'APPROVED') {
+            this.log(`[poll] Review approved: PR #${pr.number}`)
+            await this.engine.fireEvent('on_review_approved', {
+              event: 'on_review_approved',
+              pr: pr.number,
+              branch: pr.headBranch,
+              ticket: ticketId,
+              prUrl: pr.url,
+            })
+          } else if (reviewDecision === 'CHANGES_REQUESTED') {
+            this.log(`[poll] Changes requested: PR #${pr.number}`)
+            await this.engine.fireEvent('on_changes_requested', {
+              event: 'on_changes_requested',
+              pr: pr.number,
+              branch: pr.headBranch,
+              ticket: ticketId,
+              prUrl: pr.url,
+            })
+          }
+        }
+
         // --- Merge Conflicts ---
         let mergeable: TrackedPR['lastMergeable'] = 'UNKNOWN'
         try {
@@ -314,6 +340,7 @@ export class OrchestratePoller {
           number: pr.number,
           lastCIState: ciState,
           lastMergeable: mergeable,
+          lastReviewDecision: reviewDecision,
         })
       }
 

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -28,6 +28,7 @@ const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Re
   { event: 'on_ci_green', action: 'merge-pr' },
   { event: 'on_pr_merged', action: 'move-ticket', config: { target: 'done' } },
   { event: 'on_pr_opened', action: 'move-ticket', config: { target: 'review' } },
+  { event: 'on_pr_opened', action: 'spawn-review-agent' },
   { event: 'on_pr_merged', action: 'rebase-conflicting-prs' },
   { event: 'on_pr_conflicting', action: 'resolve-conflict' },
   // Ticket lifecycle
@@ -51,6 +52,9 @@ const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Re
  * Actions that spawn agents/containers (spawn-agent, respawn, spawn-fix-agent,
  * resolve-conflict) are NOT safe — they create external resources and must
  * require confirmation in supervised mode.
+ *
+ * Exception: spawn-review-agent IS safe because review agents are non-destructive
+ * — they only read diffs and post review comments (read-only permission mode).
  */
 const SAFE_ACTIONS = new Set([
   'move-ticket',
@@ -58,6 +62,7 @@ const SAFE_ACTIONS = new Set([
   'cleanup-container',
   'health-check',
   'rebase-conflicting-prs',
+  'spawn-review-agent',
 ])
 
 export const PRESETS: Record<PresetName, PresetDefinition> = {

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -41,6 +41,10 @@ const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Re
   { event: 'on_agent_died', action: 'respawn', config: { max_retries: 2 } },
   { event: 'on_agent_died', action: 'notify' },
   { event: 'on_agent_idle', action: 'health-check' },
+  // Review lifecycle
+  { event: 'on_review_approved', action: 'notify' },
+  { event: 'on_changes_requested', action: 'spawn-fix-agent' },
+  { event: 'on_changes_requested', action: 'notify' },
   // CI lifecycle
   { event: 'on_ci_failed', action: 'notify' },
   { event: 'on_ci_failed', action: 'spawn-fix-agent' },

--- a/apps/cli/src/lib/orchestrate/types.ts
+++ b/apps/cli/src/lib/orchestrate/types.ts
@@ -86,6 +86,7 @@ export type BuiltinAction =
   | 'notify'
   | 'cleanup-container'
   | 'spawn-fix-agent'
+  | 'spawn-review-agent'
   | 'health-check'
   | 'resolve-conflict'
 
@@ -99,6 +100,7 @@ export const BUILTIN_ACTIONS: BuiltinAction[] = [
   'notify',
   'cleanup-container',
   'spawn-fix-agent',
+  'spawn-review-agent',
   'health-check',
   'resolve-conflict',
 ]

--- a/apps/cli/src/lib/orchestrate/types.ts
+++ b/apps/cli/src/lib/orchestrate/types.ts
@@ -35,6 +35,8 @@ export type OrchestrateEvent =
   | 'on_agent_died'
   | 'on_agent_completed'
   | 'on_agent_idle'
+  | 'on_review_approved'
+  | 'on_changes_requested'
   | 'on_version_published'
 
 /** All valid orchestrate event names. */
@@ -57,6 +59,8 @@ export const ORCHESTRATE_EVENTS: OrchestrateEvent[] = [
   'on_agent_died',
   'on_agent_completed',
   'on_agent_idle',
+  'on_review_approved',
+  'on_changes_requested',
   'on_version_published',
 ]
 

--- a/apps/cli/src/lib/pr/index.ts
+++ b/apps/cli/src/lib/pr/index.ts
@@ -838,6 +838,35 @@ export function getPRChecks(prNumber: number, cwd?: string): PRCheck[] {
   }
 }
 
+/**
+ * Review decision state for a PR.
+ * Lightweight check that only fetches the review decision without full feedback.
+ */
+export type PRReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null;
+
+/**
+ * Get the review decision for a PR (lightweight — only fetches reviewDecision).
+ */
+export function getPRReviewDecision(prNumber: number, cwd?: string): PRReviewDecision {
+  try {
+    const result = execSync(
+      `gh pr view ${prNumber} --json reviewDecision -q .reviewDecision`,
+      {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ).trim();
+
+    if (result === 'APPROVED') return 'APPROVED';
+    if (result === 'CHANGES_REQUESTED') return 'CHANGES_REQUESTED';
+    if (result === 'REVIEW_REQUIRED') return 'REVIEW_REQUIRED';
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function formatPRFeedbackForPrompt(feedback: PRFeedback): string {
   const lines: string[] = [];
 

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -32,6 +32,8 @@ export type HookableEvent = Extract<
   | 'on_agent_died'
   | 'on_agent_completed'
   | 'on_agent_idle'
+  | 'on_review_approved'
+  | 'on_changes_requested'
   | 'on_version_published'
 >
 
@@ -54,6 +56,8 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
   'on_agent_died',
   'on_agent_completed',
   'on_agent_idle',
+  'on_review_approved',
+  'on_changes_requested',
   'on_version_published',
 ]
 

--- a/apps/cli/test/unit/orchestrate-actions.test.ts
+++ b/apps/cli/test/unit/orchestrate-actions.test.ts
@@ -27,6 +27,7 @@ describe('Orchestrate Built-in Actions', () => {
       'notify',
       'cleanup-container',
       'spawn-fix-agent',
+      'spawn-review-agent',
       'health-check',
       'resolve-conflict',
     ]
@@ -98,6 +99,12 @@ describe('Orchestrate Built-in Actions', () => {
 
     it('spawn-fix-agent should fail without ticket', () => {
       const result = executeBuiltinAction('spawn-fix-agent', { event: 'on_ci_failed' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket')
+    })
+
+    it('spawn-review-agent should fail without ticket', () => {
+      const result = executeBuiltinAction('spawn-review-agent', { event: 'on_pr_opened' })
       expect(result.success).to.be.false
       expect(result.error).to.include('No ticket')
     })
@@ -232,6 +239,15 @@ describe('Orchestrate Built-in Actions', () => {
       expect(result.error).to.include('prlt work start PRLT-400 --action revise --yes --display background')
     })
 
+    it('spawn-review-agent should use: prlt work start <ticket> --action review --yes --display background', () => {
+      const result = executeBuiltinAction('spawn-review-agent', {
+        event: 'on_pr_opened',
+        ticket: 'PRLT-450',
+      })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('prlt work start PRLT-450 --action review --yes --display background')
+    })
+
     it('health-check should use: prlt poke <agent> "..."', () => {
       const result = executeBuiltinAction('health-check', {
         event: 'on_agent_idle',
@@ -340,6 +356,7 @@ describe('Orchestrate Built-in Actions', () => {
         { name: 'spawn-agent', ctx: { event: 'test', ticket: 'TKT-1' } },
         { name: 'respawn', ctx: { event: 'test', ticket: 'TKT-1' } },
         { name: 'spawn-fix-agent', ctx: { event: 'test', ticket: 'TKT-1' } },
+        { name: 'spawn-review-agent', ctx: { event: 'test', ticket: 'TKT-1' } },
         { name: 'health-check', ctx: { event: 'test', agent: 'agent-1' } },
         { name: 'cleanup-container', ctx: { event: 'test', agent: 'agent-1' } },
         { name: 'resolve-conflict', ctx: { event: 'test', ticket: 'TKT-1' } },

--- a/apps/cli/test/unit/orchestrate-presets.test.ts
+++ b/apps/cli/test/unit/orchestrate-presets.test.ts
@@ -21,6 +21,7 @@ const SAFE_ACTIONS = new Set([
   'cleanup-container',
   'health-check',
   'rebase-conflicting-prs',
+  'spawn-review-agent',
 ])
 
 describe('Orchestrate Presets', () => {
@@ -142,19 +143,30 @@ describe('Orchestrate Presets', () => {
   // ===========================================================================
 
   describe('invariants', () => {
-    it('any action calling prlt work start MUST NOT be auto in supervised mode', () => {
-      // Actions that spawn agents/containers: spawn-agent, respawn, spawn-fix-agent, resolve-conflict
-      // These actions internally call `prlt work start` and MUST require confirmation
-      const spawnActions = new Set(['spawn-agent', 'respawn', 'spawn-fix-agent', 'resolve-conflict'])
+    it('code-modifying spawn actions MUST NOT be auto in supervised mode', () => {
+      // Actions that spawn code-modifying agents: spawn-agent, respawn, spawn-fix-agent, resolve-conflict
+      // These actions internally call `prlt work start` with code-modifying actions and MUST require confirmation.
+      // Exception: spawn-review-agent is safe (review agents are read-only, non-destructive).
+      const unsafeSpawnActions = new Set(['spawn-agent', 'respawn', 'spawn-fix-agent', 'resolve-conflict'])
       const supervised = getPreset('supervised')
 
       for (const hook of supervised.hooks) {
-        if (spawnActions.has(hook.action)) {
+        if (unsafeSpawnActions.has(hook.action)) {
           expect(hook.mode).to.equal(
             'confirm',
             `Action "${hook.action}" (event: ${hook.event}) calls prlt work start — must be confirm mode in supervised preset, not ${hook.mode}`
           )
         }
+      }
+    })
+
+    it('spawn-review-agent SHOULD be auto in supervised mode (non-destructive)', () => {
+      const supervised = getPreset('supervised')
+      const reviewHooks = supervised.hooks.filter(h => h.action === 'spawn-review-agent')
+
+      expect(reviewHooks.length).to.be.greaterThan(0, 'Should have at least one spawn-review-agent hook')
+      for (const hook of reviewHooks) {
+        expect(hook.mode).to.equal('auto', 'spawn-review-agent should be auto in supervised mode (review is read-only)')
       }
     })
 

--- a/apps/cli/test/unit/review-agent.test.ts
+++ b/apps/cli/test/unit/review-agent.test.ts
@@ -1,0 +1,217 @@
+import { expect } from 'chai'
+import { executeBuiltinAction, ACTION_HANDLERS } from '../../src/lib/orchestrate/actions.js'
+import { PRESETS, getPreset } from '../../src/lib/orchestrate/presets.js'
+import { BUILTIN_ACTIONS, ORCHESTRATE_EVENTS } from '../../src/lib/orchestrate/types.js'
+import { HOOKABLE_EVENTS } from '../../src/lib/work-lifecycle/hooks/types.js'
+import type { OrchestrateEventContext } from '../../src/lib/orchestrate/types.js'
+
+/**
+ * Regression tests for PRLT-1226: Reviewer Agents
+ *
+ * Tests cover:
+ * - spawn-review-agent action exists and works
+ * - Review events (on_review_approved, on_changes_requested) are defined
+ * - Presets wire on_pr_opened -> spawn-review-agent
+ * - Presets wire on_changes_requested -> spawn-fix-agent
+ * - Supervised preset: spawn-review-agent is auto (non-destructive)
+ * - Review flow: PR created -> review -> approve/changes
+ */
+
+describe('Reviewer Agents (PRLT-1226)', () => {
+  // ===========================================================================
+  // spawn-review-agent action
+  // ===========================================================================
+
+  describe('spawn-review-agent action', () => {
+    it('should be registered in ACTION_HANDLERS', () => {
+      expect(ACTION_HANDLERS).to.have.property('spawn-review-agent')
+      expect(ACTION_HANDLERS['spawn-review-agent']).to.be.a('function')
+    })
+
+    it('should be listed in BUILTIN_ACTIONS', () => {
+      expect(BUILTIN_ACTIONS).to.include('spawn-review-agent')
+    })
+
+    it('should fail without ticket in context', () => {
+      const result = executeBuiltinAction('spawn-review-agent', { event: 'on_pr_opened' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket')
+    })
+
+    it('should invoke prlt work start with --action review', () => {
+      const result = executeBuiltinAction('spawn-review-agent', {
+        event: 'on_pr_opened',
+        ticket: 'PRLT-1226',
+      })
+      // Will fail in test env since prlt isn't available, but error contains the command
+      expect(result.success).to.be.false
+      expect(result.error).to.include('prlt work start PRLT-1226 --action review --yes --display background')
+    })
+
+    it('should use --action review (not implement, not revise)', () => {
+      const result = executeBuiltinAction('spawn-review-agent', {
+        event: 'on_pr_opened',
+        ticket: 'TKT-TEST',
+      })
+      expect(result.error).to.include('--action review')
+      expect(result.error).to.not.include('--action implement')
+      expect(result.error).to.not.include('--action revise')
+    })
+  })
+
+  // ===========================================================================
+  // Review lifecycle events
+  // ===========================================================================
+
+  describe('review lifecycle events', () => {
+    it('on_review_approved should be a valid hookable event', () => {
+      expect(HOOKABLE_EVENTS).to.include('on_review_approved')
+    })
+
+    it('on_changes_requested should be a valid hookable event', () => {
+      expect(HOOKABLE_EVENTS).to.include('on_changes_requested')
+    })
+
+    it('on_review_approved should be a valid orchestrate event', () => {
+      expect(ORCHESTRATE_EVENTS).to.include('on_review_approved')
+    })
+
+    it('on_changes_requested should be a valid orchestrate event', () => {
+      expect(ORCHESTRATE_EVENTS).to.include('on_changes_requested')
+    })
+  })
+
+  // ===========================================================================
+  // Preset wiring
+  // ===========================================================================
+
+  describe('preset wiring', () => {
+    it('should wire on_pr_opened -> spawn-review-agent in all presets', () => {
+      for (const presetName of ['aggressive', 'conservative', 'supervised'] as const) {
+        const preset = getPreset(presetName)
+        const reviewHooks = preset.hooks.filter(
+          h => h.event === 'on_pr_opened' && h.action === 'spawn-review-agent'
+        )
+        expect(
+          reviewHooks.length,
+          `Preset "${presetName}" should have on_pr_opened -> spawn-review-agent hook`
+        ).to.equal(1)
+      }
+    })
+
+    it('should wire on_changes_requested -> spawn-fix-agent in all presets', () => {
+      for (const presetName of ['aggressive', 'conservative', 'supervised'] as const) {
+        const preset = getPreset(presetName)
+        const fixHooks = preset.hooks.filter(
+          h => h.event === 'on_changes_requested' && h.action === 'spawn-fix-agent'
+        )
+        expect(
+          fixHooks.length,
+          `Preset "${presetName}" should have on_changes_requested -> spawn-fix-agent hook`
+        ).to.equal(1)
+      }
+    })
+
+    it('should wire on_changes_requested -> notify in all presets', () => {
+      for (const presetName of ['aggressive', 'conservative', 'supervised'] as const) {
+        const preset = getPreset(presetName)
+        const notifyHooks = preset.hooks.filter(
+          h => h.event === 'on_changes_requested' && h.action === 'notify'
+        )
+        expect(
+          notifyHooks.length,
+          `Preset "${presetName}" should have on_changes_requested -> notify hook`
+        ).to.equal(1)
+      }
+    })
+
+    it('should wire on_review_approved -> notify in all presets', () => {
+      for (const presetName of ['aggressive', 'conservative', 'supervised'] as const) {
+        const preset = getPreset(presetName)
+        const notifyHooks = preset.hooks.filter(
+          h => h.event === 'on_review_approved' && h.action === 'notify'
+        )
+        expect(
+          notifyHooks.length,
+          `Preset "${presetName}" should have on_review_approved -> notify hook`
+        ).to.equal(1)
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Supervised mode: review agents are safe (auto)
+  // ===========================================================================
+
+  describe('supervised mode safety', () => {
+    it('spawn-review-agent should be auto in supervised preset (non-destructive)', () => {
+      const supervised = getPreset('supervised')
+      const reviewHooks = supervised.hooks.filter(h => h.action === 'spawn-review-agent')
+
+      expect(reviewHooks.length).to.be.greaterThan(0)
+      for (const hook of reviewHooks) {
+        expect(hook.mode).to.equal('auto',
+          'spawn-review-agent should be auto in supervised mode — review is read-only'
+        )
+      }
+    })
+
+    it('spawn-agent should still be confirm in supervised preset', () => {
+      const supervised = getPreset('supervised')
+      const spawnHooks = supervised.hooks.filter(h => h.action === 'spawn-agent')
+
+      expect(spawnHooks.length).to.be.greaterThan(0)
+      for (const hook of spawnHooks) {
+        expect(hook.mode).to.equal('confirm',
+          'spawn-agent should be confirm in supervised mode — implementation modifies code'
+        )
+      }
+    })
+
+    it('spawn-fix-agent should still be confirm in supervised preset', () => {
+      const supervised = getPreset('supervised')
+      const fixHooks = supervised.hooks.filter(h => h.action === 'spawn-fix-agent')
+
+      expect(fixHooks.length).to.be.greaterThan(0)
+      for (const hook of fixHooks) {
+        expect(hook.mode).to.equal('confirm',
+          'spawn-fix-agent should be confirm in supervised mode — fixes modify code'
+        )
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Full review flow validation
+  // ===========================================================================
+
+  describe('review flow', () => {
+    it('should have the complete review loop events wired in presets', () => {
+      // The review flow:
+      // 1. on_pr_opened -> spawn-review-agent (spawn reviewer)
+      // 2. on_review_approved -> notify (inform human)
+      // 3. on_changes_requested -> spawn-fix-agent (auto-fix)
+      // 4. on_changes_requested -> notify (inform human)
+
+      const preset = getPreset('aggressive')
+      const hookKeys = preset.hooks.map(h => `${h.event}:${h.action}`)
+
+      expect(hookKeys).to.include('on_pr_opened:spawn-review-agent')
+      expect(hookKeys).to.include('on_review_approved:notify')
+      expect(hookKeys).to.include('on_changes_requested:spawn-fix-agent')
+      expect(hookKeys).to.include('on_changes_requested:notify')
+    })
+
+    it('all review events should be valid RuntimeEventNames (no orphan events)', () => {
+      const reviewEvents = ['on_review_approved', 'on_changes_requested']
+      for (const event of reviewEvents) {
+        expect(HOOKABLE_EVENTS).to.include(event,
+          `Review event "${event}" must be a valid hookable event`
+        )
+        expect(ORCHESTRATE_EVENTS).to.include(event,
+          `Review event "${event}" must be a valid orchestrate event`
+        )
+      }
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "apps/cli": {
       "name": "@proletariat/cli",
-      "version": "0.3.102",
+      "version": "0.3.103",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Add `spawn-review-agent` built-in orchestrate action that spawns a read-only review agent via `prlt work start --action review`
- Add review lifecycle events (`on_review_approved`, `on_changes_requested`) to the event system and poller
- Wire `on_pr_opened → spawn-review-agent` in all presets; `on_changes_requested → spawn-fix-agent` for auto-fix loop
- In supervised mode, `spawn-review-agent` is auto (non-destructive: read-only, just posts comments) while code-modifying spawn actions remain confirm

## Review Flow

1. Implement agent creates PR → `on_pr_opened` fires
2. Daemon spawns review agent → reviews PR → posts comments via `gh pr review`
3. If approved → `on_review_approved` fires → notify hook
4. If changes requested → `on_changes_requested` fires → `spawn-fix-agent` + notify

## Test Plan

- [x] 18 dedicated regression tests in `review-agent.test.ts`
- [x] All 118 existing orchestrate tests pass
- [x] Build passes
- [x] CLI invocation string validated: `prlt work start <ticket> --action review --yes --display background`
- [x] Preset invariants validated (BUILTIN_ACTIONS ↔ ACTION_HANDLERS ↔ presets)

Resolves PRLT-1226