### PR TITLE
fix(PRLT-1235): work start ticket lookup regression from PRLT-1231

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -747,6 +747,7 @@ export default class WorkStart extends PMOCommand {
           linkedTicket = await this.createOrUpdateLinkedTicket(projectId, envelope, db)
           await autoExportToBoard(this.pmoPath, this.storage)
         } else if (existingLinkedTicket) {
+          envelopeTicket = existingLinkedTicket
           // Existing PMO ticket found — use it (backward compat)
           linkedTicket = existingLinkedTicket
         } else {


### PR DESCRIPTION
## Summary
- PRLT-1231 (live from provider) broke `prlt work start` for tickets that had existing PMO entries in the local DB
- The `existingLinkedTicket` branch didn't set `envelopeTicket`, so the later `tp.getTicket()` tried to look up a local `TKT-xxx` ID in Linear, which always returns null → `TICKET_NOT_FOUND`
- Fix: set `envelopeTicket` in the `existingLinkedTicket` branch so the provider lookup is skipped (ticket data already available)
- **P0**: This blocks all agent spawning

## Test plan
- [ ] `prlt work start PRLT-1235` succeeds (previously failed with TICKET_NOT_FOUND)
- [ ] `prlt work start` interactive menu still works
- [ ] `prlt work start --from linear:PRLT-XXX` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)