### PR TITLE
PRLT-1191: Implement Notion ticket provider — use Notion databases as kanban boards

### DIFF
--- a/apps/cli/src/lib/external-issues/notion.ts
+++ b/apps/cli/src/lib/external-issues/notion.ts
@@ -1,0 +1,398 @@
+/**
+ * Notion External Issue Adapter
+ *
+ * Normalizes Notion database pages into the canonical IssueEnvelope format
+ * for use with the external issue pipeline.
+ */
+
+import {
+  ExternalIssueAdapterError,
+  toNormalizedEnvelope,
+  type IssueEnvelope,
+  type NormalizedIssueEnvelope,
+} from './types.js'
+
+export interface NotionAdapterConfig {
+  apiKey?: string
+  databaseId?: string
+}
+
+interface NotionPagePayload {
+  id?: string
+  url?: string
+  created_time?: string
+  last_edited_time?: string
+  archived?: boolean
+  properties?: Record<string, NotionPropertyPayload>
+}
+
+type NotionPropertyPayload =
+  | { type: 'title'; title: Array<{ plain_text: string }> }
+  | { type: 'rich_text'; rich_text: Array<{ plain_text: string }> }
+  | { type: 'status'; status: { id: string; name: string; color: string } | null }
+  | { type: 'select'; select: { id: string; name: string; color: string } | null }
+  | { type: 'multi_select'; multi_select: Array<{ id: string; name: string; color: string }> }
+  | { type: 'people'; people: Array<{ id: string; name?: string }> }
+
+const NOTION_API_VERSION = '2022-06-28'
+
+function ensureNotionConfig(
+  config: NotionAdapterConfig,
+): { apiKey: string; databaseId?: string } {
+  const apiKey = config.apiKey || process.env.PRLT_NOTION_API_KEY || process.env.NOTION_API_KEY
+  const databaseId = config.databaseId || process.env.PRLT_NOTION_DATABASE_ID
+
+  if (!apiKey) {
+    throw new ExternalIssueAdapterError(
+      'MISSING_CONFIG',
+      'Missing Notion API key. Set NOTION_API_KEY or PRLT_NOTION_API_KEY, or run "prlt notion configure".',
+    )
+  }
+
+  return { apiKey, databaseId: databaseId || undefined }
+}
+
+function extractPageTitle(page: NotionPagePayload): string {
+  if (!page.properties) return 'Untitled'
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'title' && 'title' in prop && prop.title.length > 0) {
+      return prop.title.map(t => t.plain_text).join('')
+    }
+  }
+  return 'Untitled'
+}
+
+function extractPageDescription(page: NotionPagePayload): string {
+  if (!page.properties) return ''
+  const desc = page.properties['Description']
+  if (desc && desc.type === 'rich_text' && 'rich_text' in desc) {
+    return desc.rich_text.map(t => t.plain_text).join('')
+  }
+  return ''
+}
+
+function extractPageStatus(page: NotionPagePayload): string {
+  if (!page.properties) return 'Unknown'
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'status' && 'status' in prop && prop.status) {
+      return prop.status.name
+    }
+  }
+  return page.archived ? 'Archived' : 'Unknown'
+}
+
+function extractPageLabels(page: NotionPagePayload): string[] {
+  if (!page.properties) return []
+  const labels: string[] = []
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'multi_select' && 'multi_select' in prop) {
+      for (const item of prop.multi_select) {
+        labels.push(item.name)
+      }
+    }
+  }
+  return labels
+}
+
+function extractPageAssignee(page: NotionPagePayload): string | null {
+  if (!page.properties) return null
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'people' && 'people' in prop && prop.people.length > 0) {
+      return prop.people[0].name || null
+    }
+  }
+  return null
+}
+
+function derivePriority(labels: string[]): string | null {
+  const priorityLabel = labels.find(l => /^P[0-3]$/i.test(l))
+  return priorityLabel ? priorityLabel.toUpperCase() : null
+}
+
+function ensurePageShape(page: NotionPagePayload): asserts page is Required<Pick<NotionPagePayload, 'id' | 'url'>> & NotionPagePayload {
+  if (!page.id || !page.url) {
+    throw new ExternalIssueAdapterError(
+      'BAD_PAYLOAD',
+      'Notion page payload is missing required fields (id, url).',
+      page,
+    )
+  }
+}
+
+/**
+ * Normalize a raw Notion page into a canonical IssueEnvelope.
+ */
+export function normalizeNotionPage(rawPage: unknown): IssueEnvelope {
+  if (!rawPage || typeof rawPage !== 'object') {
+    throw new ExternalIssueAdapterError('BAD_PAYLOAD', 'Notion page payload is invalid.', rawPage)
+  }
+
+  const page = rawPage as NotionPagePayload
+  ensurePageShape(page)
+
+  const labels = extractPageLabels(page)
+
+  return {
+    source: 'notion',
+    external_id: page.id,
+    external_key: page.id,
+    title: extractPageTitle(page),
+    description: extractPageDescription(page),
+    labels,
+    priority: derivePriority(labels),
+    status: extractPageStatus(page),
+    url: page.url,
+    project_key: 'DEFAULT',
+    assignee: extractPageAssignee(page),
+    item_type: 'page',
+    raw: rawPage as Record<string, unknown>,
+  }
+}
+
+/**
+ * Normalize a raw Notion page into a PMO-ready NormalizedIssueEnvelope.
+ */
+export function normalizeNotionPageToEnvelope(rawPage: unknown): NormalizedIssueEnvelope {
+  const envelope = normalizeNotionPage(rawPage)
+  return toNormalizedEnvelope(envelope, 'feature')
+}
+
+/**
+ * Build a PMO ticket description from a NormalizedIssueEnvelope.
+ */
+export function buildNotionTicketDescription(envelope: NormalizedIssueEnvelope): string {
+  const body = envelope.description.trim()
+  const metadataLines = [
+    `- Source: ${envelope.source.name}`,
+    `- External key: ${envelope.source.externalKey}`,
+    `- External id: ${envelope.source.externalId}`,
+    `- URL: ${envelope.source.url}`,
+    `- Status: ${envelope.status}`,
+    `- Priority: ${envelope.priority || 'Unset'}`,
+    `- Labels: ${envelope.labels.length > 0 ? envelope.labels.join(', ') : 'None'}`,
+  ]
+
+  const parts = [
+    body,
+    '## External Issue Context',
+    metadataLines.join('\n'),
+  ].filter(Boolean)
+
+  return parts.join('\n\n')
+}
+
+/**
+ * Build ticket metadata from a NormalizedIssueEnvelope for traceability.
+ */
+export function buildNotionMetadata(envelope: NormalizedIssueEnvelope): Record<string, string> {
+  return {
+    external_source: envelope.source.name,
+    external_key: envelope.source.externalKey,
+    external_id: envelope.source.externalId,
+    external_url: envelope.source.url,
+    external_raw: JSON.stringify(envelope.source.raw),
+  }
+}
+
+/**
+ * Build a spawn context message from a NormalizedIssueEnvelope.
+ */
+export function buildNotionSpawnContextMessage(
+  envelope: NormalizedIssueEnvelope,
+  additionalMessage?: string,
+): string {
+  const lines = [
+    `External issue source: ${envelope.source.name}`,
+    `External issue key: ${envelope.source.externalKey}`,
+    `External issue id: ${envelope.source.externalId}`,
+    `External issue URL: ${envelope.source.url}`,
+  ]
+
+  if (additionalMessage?.trim()) {
+    lines.push('', additionalMessage.trim())
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Check if Notion is configured via environment variables.
+ */
+export function isNotionConfiguredFromEnv(config?: NotionAdapterConfig): boolean {
+  const apiKey = config?.apiKey
+    || process.env.PRLT_NOTION_API_KEY
+    || process.env.NOTION_API_KEY
+
+  return Boolean(apiKey)
+}
+
+/**
+ * Fetch a single Notion page by its ID and normalize it.
+ */
+export async function getNotionPageById(
+  configInput: NotionAdapterConfig,
+  pageId: string,
+  options?: { fetchImpl?: typeof fetch },
+): Promise<NormalizedIssueEnvelope | null> {
+  const config = ensureNotionConfig(configInput)
+  const fetchImpl = options?.fetchImpl || fetch
+
+  const url = `https://api.notion.com/v1/pages/${encodeURIComponent(pageId)}`
+
+  const response = await fetchImpl(url, {
+    headers: {
+      'Authorization': `Bearer ${config.apiKey}`,
+      'Notion-Version': NOTION_API_VERSION,
+    },
+  })
+
+  if (response.status === 401 || response.status === 403) {
+    throw new ExternalIssueAdapterError(
+      'AUTH_FAILED',
+      'Notion authentication failed. Verify your integration token.',
+    )
+  }
+
+  if (response.status === 429) {
+    throw new ExternalIssueAdapterError(
+      'RATE_LIMITED',
+      'Notion API rate limit exceeded. Wait a moment and try again.',
+    )
+  }
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    throw new ExternalIssueAdapterError(
+      'REQUEST_FAILED',
+      `Notion request failed with status ${response.status}.`,
+    )
+  }
+
+  const payload = await response.json() as NotionPagePayload
+  return normalizeNotionPageToEnvelope(payload)
+}
+
+/**
+ * Fetch and normalize Notion pages from a database into NormalizedIssueEnvelopes.
+ */
+export async function listNotionPages(
+  configInput: NotionAdapterConfig,
+  options?: {
+    limit?: number
+    query?: string
+    fetchImpl?: typeof fetch
+  },
+): Promise<NormalizedIssueEnvelope[]> {
+  const config = ensureNotionConfig(configInput)
+  const fetchImpl = options?.fetchImpl || fetch
+  const limit = Math.max(1, Math.min(options?.limit ?? 20, 100))
+
+  if (!config.databaseId) {
+    throw new ExternalIssueAdapterError(
+      'MISSING_CONFIG',
+      'Missing Notion database ID. Run "prlt notion configure" and select a database, or set PRLT_NOTION_DATABASE_ID.',
+    )
+  }
+
+  const url = `https://api.notion.com/v1/databases/${encodeURIComponent(config.databaseId)}/query`
+
+  const body: Record<string, unknown> = { page_size: limit }
+
+  // If there's a text query, we use Notion's filter on title
+  if (options?.query) {
+    body.filter = {
+      property: 'Name',
+      title: { contains: options.query },
+    }
+  }
+
+  const response = await fetchImpl(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${config.apiKey}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': NOTION_API_VERSION,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (response.status === 401 || response.status === 403) {
+    throw new ExternalIssueAdapterError('AUTH_FAILED', 'Notion authentication failed. Verify your integration token.')
+  }
+
+  if (!response.ok) {
+    throw new ExternalIssueAdapterError('REQUEST_FAILED', `Notion request failed with status ${response.status}.`)
+  }
+
+  const payload = await response.json() as { results?: NotionPagePayload[] }
+  const pages = payload.results ?? []
+
+  return pages.slice(0, limit).map(page => normalizeNotionPageToEnvelope(page))
+}
+
+/**
+ * Import a Notion page into PMO as a linked ticket.
+ */
+export async function importNotionPageToPmo(
+  storage: {
+    listTickets(projectId: string): Promise<Array<{ id: string; metadata?: Record<string, string> }>>,
+    createTicket(projectId: string, input: {
+      title: string
+      description: string
+      priority?: string
+      category?: string
+      labels: string[]
+      metadata: Record<string, string>
+    }): Promise<{ id: string }>,
+    updateTicket(ticketId: string, input: {
+      title: string
+      description: string
+      priority?: string
+      category?: string
+      labels: string[]
+      metadata: Record<string, string>
+    }): Promise<{ id: string }>,
+  },
+  projectId: string,
+  envelope: NormalizedIssueEnvelope,
+): Promise<{ ticketId: string; created: boolean }> {
+  const tickets = await storage.listTickets(projectId)
+  const existing = tickets.find((ticket) => {
+    const source = ticket.metadata?.external_source
+    const key = ticket.metadata?.external_key
+    const id = ticket.metadata?.external_id
+    return source === 'notion'
+      && (key === envelope.source.externalKey || id === envelope.source.externalId)
+  })
+
+  const description = buildNotionTicketDescription(envelope)
+  const metadata = buildNotionMetadata(envelope)
+
+  if (existing) {
+    await storage.updateTicket(existing.id, {
+      title: envelope.title,
+      description,
+      priority: envelope.priority ?? undefined,
+      category: envelope.category ?? undefined,
+      labels: envelope.labels,
+      metadata: {
+        ...existing.metadata,
+        ...metadata,
+      },
+    })
+    return { ticketId: existing.id, created: false }
+  }
+
+  const ticket = await storage.createTicket(projectId, {
+    title: envelope.title,
+    description,
+    priority: envelope.priority ?? undefined,
+    category: envelope.category ?? undefined,
+    labels: envelope.labels,
+    metadata,
+  })
+  return { ticketId: ticket.id, created: true }
+}

--- a/apps/cli/src/lib/external-issues/types.ts
+++ b/apps/cli/src/lib/external-issues/types.ts
@@ -14,17 +14,17 @@
  * Supported external issue sources.
  *
  */
-export type IssueSource = 'linear' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'clickup'
+export type IssueSource = 'linear' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'clickup' | 'notion'
 
 /**
  * All valid issue sources as a const array.
  */
-export const ISSUE_SOURCES = ['linear', 'jira', 'asana', 'shortcut', 'trello', 'clickup'] as const
+export const ISSUE_SOURCES = ['linear', 'jira', 'asana', 'shortcut', 'trello', 'clickup', 'notion'] as const
 
 /**
  * Providers supported by the external execution mapping store.
  */
-export type ExternalMappingProvider = 'linear' | 'jira' | 'shortcut' | 'asana' | 'trello' | 'monday' | 'clickup' | 'pmo'
+export type ExternalMappingProvider = 'linear' | 'jira' | 'shortcut' | 'asana' | 'trello' | 'monday' | 'clickup' | 'notion' | 'pmo'
 
 // =============================================================================
 // IssueEnvelope - Canonical External Issue Format

--- a/apps/cli/src/lib/notion/client.ts
+++ b/apps/cli/src/lib/notion/client.ts
@@ -1,0 +1,210 @@
+/**
+ * Notion API Client
+ *
+ * Lightweight wrapper around the Notion REST API.
+ * Uses the Notion API with Bearer token authentication.
+ */
+
+import type {
+  NotionDatabase,
+  NotionPage,
+  NotionUser,
+  NotionDatabaseQueryResponse,
+} from './types.js'
+
+const NOTION_API_VERSION = '2022-06-28'
+
+export class NotionClient {
+  private readonly baseUrl = 'https://api.notion.com/v1'
+
+  constructor(private apiKey: string) {}
+
+  private async request<T>(
+    path: string,
+    init: {
+      method?: 'GET' | 'POST' | 'PATCH' | 'DELETE'
+      body?: unknown
+      query?: Record<string, string | undefined>
+    } = {},
+  ): Promise<T> {
+    const url = new URL(`${this.baseUrl}${path}`)
+
+    if (init.query) {
+      for (const [key, value] of Object.entries(init.query)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, value)
+        }
+      }
+    }
+
+    const response = await fetch(url, {
+      method: init.method ?? 'GET',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': NOTION_API_VERSION,
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined,
+    })
+
+    if (response.status === 401) {
+      throw new Error('Notion authentication failed. Verify your integration token.')
+    }
+
+    if (response.status === 429) {
+      throw new Error('Notion API rate limit exceeded. Wait a moment and try again.')
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`Notion API request failed (${response.status}): ${text}`)
+    }
+
+    return response.json() as Promise<T>
+  }
+
+  /**
+   * Verify the integration token by fetching the bot user.
+   */
+  async verify(): Promise<NotionUser> {
+    const result = await this.request<{ bot: { owner: { type: string } }; id: string; name?: string }>('/users/me')
+    return { id: result.id, name: result.name, type: 'bot' }
+  }
+
+  /**
+   * Get a database by ID.
+   */
+  async getDatabase(databaseId: string): Promise<NotionDatabase | null> {
+    try {
+      return await this.request<NotionDatabase>(`/databases/${databaseId}`)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Query a database for pages, optionally with a filter.
+   */
+  async queryDatabase(
+    databaseId: string,
+    options?: {
+      filter?: unknown
+      sorts?: unknown
+      startCursor?: string
+      pageSize?: number
+    },
+  ): Promise<NotionDatabaseQueryResponse> {
+    const body: Record<string, unknown> = {}
+    if (options?.filter) body.filter = options.filter
+    if (options?.sorts) body.sorts = options.sorts
+    if (options?.startCursor) body.start_cursor = options.startCursor
+    if (options?.pageSize) body.page_size = Math.min(options.pageSize, 100)
+
+    return this.request<NotionDatabaseQueryResponse>(`/databases/${databaseId}/query`, {
+      method: 'POST',
+      body,
+    })
+  }
+
+  /**
+   * Get a page by ID.
+   */
+  async getPage(pageId: string): Promise<NotionPage | null> {
+    try {
+      return await this.request<NotionPage>(`/pages/${pageId}`)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Create a page in a database.
+   */
+  async createPage(
+    databaseId: string,
+    properties: Record<string, unknown>,
+  ): Promise<NotionPage> {
+    return this.request<NotionPage>('/pages', {
+      method: 'POST',
+      body: {
+        parent: { database_id: databaseId },
+        properties,
+      },
+    })
+  }
+
+  /**
+   * Update a page's properties.
+   */
+  async updatePage(
+    pageId: string,
+    properties: Record<string, unknown>,
+  ): Promise<NotionPage> {
+    return this.request<NotionPage>(`/pages/${pageId}`, {
+      method: 'PATCH',
+      body: { properties },
+    })
+  }
+
+  /**
+   * Archive (soft-delete) a page.
+   */
+  async archivePage(pageId: string): Promise<NotionPage> {
+    return this.request<NotionPage>(`/pages/${pageId}`, {
+      method: 'PATCH',
+      body: { archived: true },
+    })
+  }
+
+  /**
+   * Search for pages and databases.
+   */
+  async search(
+    query: string,
+    options?: { filter?: { property: string; value: string }; pageSize?: number },
+  ): Promise<{ results: NotionPage[] }> {
+    const body: Record<string, unknown> = { query }
+    if (options?.filter) body.filter = options.filter
+    if (options?.pageSize) body.page_size = Math.min(options.pageSize, 100)
+
+    return this.request<{ results: NotionPage[] }>('/search', {
+      method: 'POST',
+      body,
+    })
+  }
+
+  /**
+   * Retrieve the status property options from a database schema.
+   * Returns the status groups and options if a status property exists.
+   */
+  async getDatabaseStatuses(databaseId: string): Promise<Array<{ id: string; name: string; color: string }>> {
+    const db = await this.getDatabase(databaseId)
+    if (!db) return []
+
+    const props = (db as unknown as { properties: Record<string, unknown> }).properties
+    if (!props) return []
+
+    for (const prop of Object.values(props)) {
+      const p = prop as Record<string, unknown>
+      if (p.type === 'status') {
+        const statusConfig = p.status as { options?: Array<{ id: string; name: string; color: string }> } | undefined
+        return statusConfig?.options ?? []
+      }
+    }
+
+    return []
+  }
+
+  /**
+   * Add a comment to a page.
+   */
+  async addComment(pageId: string, text: string): Promise<void> {
+    await this.request('/comments', {
+      method: 'POST',
+      body: {
+        parent: { page_id: pageId },
+        rich_text: [{ type: 'text', text: { content: text } }],
+      },
+    })
+  }
+}

--- a/apps/cli/src/lib/notion/config.ts
+++ b/apps/cli/src/lib/notion/config.ts
@@ -1,0 +1,112 @@
+/**
+ * Notion Configuration Storage
+ *
+ * Stores Notion credentials and preferences in the workspace_settings table.
+ */
+
+import type Database from 'better-sqlite3'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
+import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
+import type { NotionConfig } from './types.js'
+
+const NOTION_CONFIG_KEYS = {
+  apiKey: 'notion.api_key',
+  databaseId: 'notion.database_id',
+  databaseName: 'notion.database_name',
+} as const
+
+/**
+ * Check if Notion is configured.
+ */
+export function isNotionConfigured(db: Database.Database): boolean {
+  const hasDbConfig = hasCredential(db, NOTION_CONFIG_KEYS.apiKey)
+  if (hasDbConfig) return true
+
+  return !!(process.env.PRLT_NOTION_API_KEY || process.env.NOTION_API_KEY)
+}
+
+/**
+ * Load Notion configuration from the database + environment.
+ */
+export function loadNotionConfig(db: Database.Database): NotionConfig | null {
+  const settings = new SettingsStore(db)
+  const apiKey = getCredential(db, NOTION_CONFIG_KEYS.apiKey)
+    || process.env.PRLT_NOTION_API_KEY
+    || process.env.NOTION_API_KEY
+
+  if (!apiKey) return null
+
+  return {
+    apiKey,
+    databaseId: settings.get(NOTION_CONFIG_KEYS.databaseId)
+      || process.env.PRLT_NOTION_DATABASE_ID
+      || undefined,
+    databaseName: settings.get(NOTION_CONFIG_KEYS.databaseName) || undefined,
+  }
+}
+
+/**
+ * Save Notion configuration to the database.
+ */
+export function saveNotionConfig(db: Database.Database, config: NotionConfig): void {
+  const settings = new SettingsStore(db)
+  setCredential(db, NOTION_CONFIG_KEYS.apiKey, config.apiKey)
+  if (config.databaseId) {
+    settings.set(NOTION_CONFIG_KEYS.databaseId, config.databaseId)
+  }
+  if (config.databaseName) {
+    settings.set(NOTION_CONFIG_KEYS.databaseName, config.databaseName)
+  }
+}
+
+export function saveNotionApiKey(db: Database.Database, apiKey: string): void {
+  setCredential(db, NOTION_CONFIG_KEYS.apiKey, apiKey)
+}
+
+export function saveNotionDatabase(db: Database.Database, databaseId: string, databaseName: string): void {
+  const settings = new SettingsStore(db)
+  settings.set(NOTION_CONFIG_KEYS.databaseId, databaseId)
+  settings.set(NOTION_CONFIG_KEYS.databaseName, databaseName)
+}
+
+export function clearNotionConfig(db: Database.Database): void {
+  const settings = new SettingsStore(db)
+  for (const key of Object.values(NOTION_CONFIG_KEYS)) {
+    if (key === NOTION_CONFIG_KEYS.apiKey) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
+  }
+}
+
+/**
+ * Get the Notion API key using the provider-sources resolution chain.
+ *
+ * Resolution order:
+ * 1. If a Notion provider source is configured, resolve its apiKeyRef
+ * 2. Legacy fallback: PRLT_NOTION_API_KEY or NOTION_API_KEY environment variables
+ * 3. Legacy fallback: credential store key 'notion.api_key'
+ */
+export function getNotionApiKey(db: Database.Database): string | null {
+  // 1. Try provider sources (supports custom apiKeyRef per source)
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'notion') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch {
+    // Provider sources table may not exist in older databases
+  }
+
+  // 2. Legacy: environment variables
+  const envKey = process.env.PRLT_NOTION_API_KEY || process.env.NOTION_API_KEY
+  if (envKey) return envKey
+
+  // 3. Legacy: stored credential
+  return getCredential(db, NOTION_CONFIG_KEYS.apiKey)
+}

--- a/apps/cli/src/lib/notion/mapper.ts
+++ b/apps/cli/src/lib/notion/mapper.ts
@@ -1,0 +1,99 @@
+/**
+ * Notion Page ↔ PMO Ticket Mapper
+ *
+ * Stores bidirectional mapping between PMO ticket IDs and Notion page IDs.
+ */
+
+import type Database from 'better-sqlite3'
+import { PMO_TABLES } from '../pmo/schema.js'
+import type { NotionPageMap } from './types.js'
+import { type DatabaseDriver, wrapDatabase } from '../database/driver.js'
+
+function toDriver(dbOrDriver: DatabaseDriver | Database.Database): DatabaseDriver {
+  if ('prepare' in dbOrDriver && 'pragma' in dbOrDriver && !('raw' in dbOrDriver)) {
+    return wrapDatabase(dbOrDriver as Database.Database)
+  }
+  return dbOrDriver as DatabaseDriver
+}
+
+export class NotionMapper {
+  private driver: DatabaseDriver
+
+  constructor(dbOrDriver: DatabaseDriver | Database.Database) {
+    this.driver = toDriver(dbOrDriver)
+    this.ensureTable()
+  }
+
+  private ensureTable(): void {
+    this.driver.exec(`
+      CREATE TABLE IF NOT EXISTS ${PMO_TABLES.notion_page_map} (
+        pmo_ticket_id TEXT NOT NULL REFERENCES ${PMO_TABLES.tickets}(id) ON DELETE CASCADE,
+        notion_page_id TEXT NOT NULL,
+        notion_database_id TEXT,
+        last_synced_at TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (pmo_ticket_id),
+        UNIQUE (notion_page_id)
+      )
+    `)
+
+    this.driver.exec(`
+      CREATE INDEX IF NOT EXISTS idx_pmo_notion_page_map_page_id
+        ON ${PMO_TABLES.notion_page_map}(notion_page_id)
+    `)
+  }
+
+  createOrUpdateMapping(pmoTicketId: string, notionPageId: string, notionDatabaseId?: string): void {
+    this.driver.prepare(`
+      INSERT INTO ${PMO_TABLES.notion_page_map}
+        (pmo_ticket_id, notion_page_id, notion_database_id, last_synced_at, created_at)
+      VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      ON CONFLICT(pmo_ticket_id) DO UPDATE SET
+        notion_page_id = excluded.notion_page_id,
+        notion_database_id = excluded.notion_database_id,
+        last_synced_at = CURRENT_TIMESTAMP
+    `).run(pmoTicketId, notionPageId, notionDatabaseId ?? null)
+  }
+
+  getByTicketId(ticketId: string): NotionPageMap | null {
+    const row = this.driver.prepare<Record<string, unknown>>(`
+      SELECT * FROM ${PMO_TABLES.notion_page_map} WHERE pmo_ticket_id = ?
+    `).get(ticketId)
+
+    return row ? this.rowToMap(row) : null
+  }
+
+  getByPageId(notionPageId: string): NotionPageMap | null {
+    const row = this.driver.prepare<Record<string, unknown>>(`
+      SELECT * FROM ${PMO_TABLES.notion_page_map} WHERE notion_page_id = ?
+    `).get(notionPageId)
+
+    return row ? this.rowToMap(row) : null
+  }
+
+  listMappings(): NotionPageMap[] {
+    const rows = this.driver.prepare<Record<string, unknown>>(`
+      SELECT * FROM ${PMO_TABLES.notion_page_map} ORDER BY created_at DESC
+    `).all()
+
+    return rows.map((row) => this.rowToMap(row))
+  }
+
+  updateSyncTimestamp(ticketId: string): void {
+    this.driver.prepare(`
+      UPDATE ${PMO_TABLES.notion_page_map}
+      SET last_synced_at = CURRENT_TIMESTAMP
+      WHERE pmo_ticket_id = ?
+    `).run(ticketId)
+  }
+
+  private rowToMap(row: Record<string, unknown>): NotionPageMap {
+    return {
+      pmoTicketId: row.pmo_ticket_id as string,
+      notionPageId: row.notion_page_id as string,
+      notionDatabaseId: (row.notion_database_id as string | null) ?? undefined,
+      lastSyncedAt: row.last_synced_at ? new Date(row.last_synced_at as string) : undefined,
+      createdAt: new Date(row.created_at as string),
+    }
+  }
+}

--- a/apps/cli/src/lib/notion/types.ts
+++ b/apps/cli/src/lib/notion/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Notion Integration Types
+ *
+ * Types for Notion API responses and internal mappings.
+ */
+
+export interface NotionConfig {
+  apiKey: string
+  databaseId?: string
+  databaseName?: string
+}
+
+export interface NotionDatabase {
+  id: string
+  title: Array<{ plain_text: string }>
+  url: string
+}
+
+export interface NotionUser {
+  id: string
+  name?: string
+  type: 'person' | 'bot'
+}
+
+export interface NotionSelectOption {
+  id: string
+  name: string
+  color?: string
+}
+
+export interface NotionStatusProperty {
+  id: string
+  name: string
+  color?: string
+  /** Status group (e.g., "To-do", "In progress", "Complete") */
+  group?: { id: string; name: string; color: string }
+}
+
+export interface NotionPage {
+  id: string
+  url: string
+  created_time: string
+  last_edited_time: string
+  archived: boolean
+  properties: Record<string, NotionPropertyValue>
+}
+
+export type NotionPropertyValue =
+  | { type: 'title'; title: Array<{ plain_text: string }> }
+  | { type: 'rich_text'; rich_text: Array<{ plain_text: string }> }
+  | { type: 'status'; status: { id: string; name: string; color: string } | null }
+  | { type: 'select'; select: { id: string; name: string; color: string } | null }
+  | { type: 'multi_select'; multi_select: Array<{ id: string; name: string; color: string }> }
+  | { type: 'people'; people: Array<{ id: string; name?: string }> }
+  | { type: 'url'; url: string | null }
+  | { type: 'date'; date: { start: string; end?: string | null } | null }
+  | { type: 'checkbox'; checkbox: boolean }
+  | { type: 'number'; number: number | null }
+
+export interface NotionPageMap {
+  pmoTicketId: string
+  notionPageId: string
+  notionDatabaseId?: string
+  lastSyncedAt?: Date
+  createdAt: Date
+}
+
+export interface NotionQueryFilter {
+  property?: string
+  status?: { equals: string }
+  title?: { contains: string }
+}
+
+export interface NotionDatabaseQueryResponse {
+  results: NotionPage[]
+  has_more: boolean
+  next_cursor: string | null
+}

--- a/apps/cli/src/lib/pmo/schema.ts
+++ b/apps/cli/src/lib/pmo/schema.ts
@@ -63,6 +63,8 @@ export const PMO_TABLES = {
   asana_task_map: 'pmo_asana_task_map',  // Asana task ↔ PMO ticket mapping
   // Trello integration tables
   trello_card_map: 'pmo_trello_card_map',  // Trello card ↔ PMO ticket mapping
+  // Notion integration tables
+  notion_page_map: 'pmo_notion_page_map',  // Notion page ↔ PMO ticket mapping
   // Work lifecycle hooks
   work_hooks: 'pmo_work_hooks',  // Configurable event-driven actions for work events
   // Legacy tables (deprecated, kept for migration)

--- a/apps/cli/src/lib/providers/index.ts
+++ b/apps/cli/src/lib/providers/index.ts
@@ -26,6 +26,7 @@ export { LinearTicketProvider } from './linear-provider.js'
 export { TrelloTicketProvider } from './trello-provider.js'
 export { GitHubIssuesTicketProvider } from './github-provider.js'
 export { JiraTicketProvider } from './jira-provider.js'
+export { NotionTicketProvider } from './notion-provider.js'
 export { EventEmittingProvider, type StatusResolver } from './event-emitting-provider.js'
 export { ProviderStatusMappingStore, type StatusMapping } from './status-mapping.js'
 export {

--- a/apps/cli/src/lib/providers/notion-provider.ts
+++ b/apps/cli/src/lib/providers/notion-provider.ts
@@ -1,0 +1,518 @@
+/**
+ * Notion Ticket Provider
+ *
+ * Writes ticket operations directly to Notion via API,
+ * then updates local PMO to keep it in sync.
+ *
+ * Follows the same pattern as TrelloTicketProvider:
+ * Notion is the source of truth, PMO is best-effort mirror.
+ *
+ * Notion databases act as kanban boards — pages are tickets,
+ * and the Status property maps to board columns.
+ */
+
+import type Database from 'better-sqlite3'
+import { NotionClient } from '../notion/client.js'
+import { NotionMapper } from '../notion/mapper.js'
+import { getNotionApiKey, loadNotionConfig } from '../notion/config.js'
+import type { NotionPage, NotionPropertyValue } from '../notion/types.js'
+import type { Ticket, TicketFilter, CreateTicketInput, UpdateTicketInput } from '../pmo/types.js'
+import type {
+  TicketProvider,
+  ProviderMoveResult,
+  ProviderDeleteResult,
+  ProviderListResult,
+  ProviderCreateResult,
+  ProviderGetResult,
+  ProviderUpdateResult,
+  ProviderAssignResult,
+  ProviderStorage,
+} from './types.js'
+
+export class NotionTicketProvider implements TicketProvider {
+  readonly name = 'notion' as const
+
+  constructor(
+    private db: Database.Database,
+    private storage: ProviderStorage,
+    private projectId: string,
+  ) {}
+
+  private getApiKeyOrFail(): string {
+    const apiKey = getNotionApiKey(this.db)
+    if (!apiKey) throw new Error('Notion API key not configured')
+    return apiKey
+  }
+
+  async moveTicket(ticketId: string, newState: string): Promise<ProviderMoveResult> {
+    // 1. Get Notion credentials
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion credentials not configured' }
+    }
+
+    // 2. Look up Notion mapping for this PMO ticket
+    const mapper = new NotionMapper(this.db)
+    const mapping = mapper.getByTicketId(ticketId)
+    if (!mapping) {
+      return { success: false, provider: 'notion', error: `No Notion mapping for ticket ${ticketId}` }
+    }
+
+    const client = new NotionClient(apiKey)
+
+    // 3. Get the page to find its Status property
+    const page = await client.getPage(mapping.notionPageId)
+    if (!page) {
+      return { success: false, provider: 'notion', error: `Notion page ${mapping.notionPageId} not found` }
+    }
+
+    // 4. Find the Status property name on this page
+    const statusPropName = findStatusPropertyName(page)
+    if (!statusPropName) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: 'No Status property found on Notion page. Ensure the database has a Status property.',
+      }
+    }
+
+    // 5. Update the page's Status property
+    try {
+      await client.updatePage(mapping.notionPageId, {
+        [statusPropName]: { status: { name: newState } },
+      })
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: `Failed to update Notion page status: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+
+    // 6. Update local PMO mirror (best-effort)
+    try {
+      await this.storage.moveTicket(this.projectId, ticketId, newState)
+    } catch {
+      // Non-fatal: Notion is the source of truth
+    }
+
+    // 7. Post a comment about the status change (best-effort)
+    try {
+      await client.addComment(
+        mapping.notionPageId,
+        `Status updated to ${newState} (via prlt)`,
+      )
+    } catch {
+      // Non-fatal: comment is informational
+    }
+
+    // 8. Update sync timestamp (best-effort)
+    try {
+      mapper.updateSyncTimestamp(ticketId)
+    } catch {
+      // Non-fatal
+    }
+
+    return { success: true, provider: 'notion' }
+  }
+
+  async deleteTicket(ticketId: string): Promise<ProviderDeleteResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion credentials not configured' }
+    }
+
+    // Look up Notion mapping
+    const mapper = new NotionMapper(this.db)
+    const mapping = mapper.getByTicketId(ticketId)
+
+    if (mapping) {
+      // Archive the page in Notion
+      const client = new NotionClient(apiKey)
+      try {
+        await client.archivePage(mapping.notionPageId)
+      } catch (error) {
+        return {
+          success: false,
+          provider: 'notion',
+          error: `Failed to archive Notion page: ${error instanceof Error ? error.message : String(error)}`,
+        }
+      }
+    }
+
+    // Delete the local PMO mirror
+    try {
+      await this.storage.deleteTicket(ticketId)
+    } catch {
+      // Non-fatal if Notion archive succeeded
+    }
+
+    return { success: true, provider: 'notion' }
+  }
+
+  async listTickets(_projectId?: string, filter?: TicketFilter): Promise<ProviderListResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', tickets: [], error: 'Notion credentials not configured' }
+    }
+
+    const notionConfig = loadNotionConfig(this.db)
+    const databaseId = notionConfig?.databaseId || process.env.PRLT_NOTION_DATABASE_ID
+
+    if (!databaseId) {
+      return {
+        success: false,
+        provider: 'notion',
+        tickets: [],
+        error: 'Notion database ID is required. Run "prlt notion configure" or set PRLT_NOTION_DATABASE_ID.',
+      }
+    }
+
+    const client = new NotionClient(apiKey)
+
+    try {
+      // Build Notion filter if we have a status/column filter
+      let notionFilter: unknown | undefined
+      if (filter?.column) {
+        notionFilter = {
+          property: 'Status',
+          status: { equals: filter.column },
+        }
+      }
+
+      const response = await client.queryDatabase(databaseId, {
+        filter: notionFilter,
+        pageSize: 50,
+      })
+
+      let tickets: Ticket[] = response.results.map(page => notionPageToTicket(page, databaseId))
+
+      // Apply client-side filters
+      if (filter?.priority) {
+        tickets = tickets.filter(t => t.priority === filter.priority)
+      }
+      if (filter?.category) {
+        tickets = tickets.filter(t => t.category === filter.category)
+      }
+      if (filter?.search) {
+        const term = filter.search.toLowerCase()
+        tickets = tickets.filter(t =>
+          t.title.toLowerCase().includes(term) ||
+          (t.description || '').toLowerCase().includes(term),
+        )
+      }
+      if (filter?.label) {
+        const label = filter.label.toLowerCase()
+        tickets = tickets.filter(t => t.labels.some(l => l.toLowerCase() === label))
+      }
+
+      return { success: true, provider: 'notion', tickets }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        tickets: [],
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async createTicket(projectId: string, input: CreateTicketInput): Promise<ProviderCreateResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion credentials not configured' }
+    }
+
+    const notionConfig = loadNotionConfig(this.db)
+    const databaseId = notionConfig?.databaseId || process.env.PRLT_NOTION_DATABASE_ID
+
+    if (!databaseId) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: 'Notion database ID is required. Run "prlt notion configure" or set PRLT_NOTION_DATABASE_ID.',
+      }
+    }
+
+    const client = new NotionClient(apiKey)
+
+    try {
+      // Build Notion properties
+      const properties: Record<string, unknown> = {
+        Name: { title: [{ text: { content: input.title } }] },
+      }
+
+      if (input.description) {
+        properties['Description'] = {
+          rich_text: [{ text: { content: input.description } }],
+        }
+      }
+
+      // Create the page in Notion
+      const page = await client.createPage(databaseId, properties)
+
+      // Create local PMO mirror ticket
+      const mirrorDescription = [
+        input.description || '',
+        '',
+        '---',
+        `_Created in Notion: [${input.title}](${page.url})_`,
+      ].join('\n').trim()
+
+      const pmoTicket = await this.storage.createTicket(projectId, {
+        ...input,
+        description: mirrorDescription,
+        metadata: {
+          ...input.metadata,
+          'external_source': 'notion',
+          'external_id': page.id,
+          'external_key': page.id,
+          'external_url': page.url,
+        },
+      })
+
+      // Create mapping record for sync operations
+      const mapper = new NotionMapper(this.db)
+      mapper.createOrUpdateMapping(pmoTicket.id, page.id, databaseId)
+
+      return { success: true, provider: 'notion', ticket: pmoTicket }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async getTicket(ticketId: string): Promise<ProviderGetResult> {
+    // Use local PMO mirror to avoid unnecessary API calls (same pattern as Linear/Trello)
+    try {
+      const ticket = await this.storage.getTicket(ticketId)
+      return { success: true, provider: 'notion', ticket }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async updateTicket(ticketId: string, input: UpdateTicketInput): Promise<ProviderUpdateResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion credentials not configured' }
+    }
+
+    // Look up Notion mapping for this PMO ticket
+    const mapper = new NotionMapper(this.db)
+    const mapping = mapper.getByTicketId(ticketId)
+
+    if (mapping) {
+      // Build Notion update payload from input fields
+      const properties: Record<string, unknown> = {}
+      if (input.title !== undefined) {
+        properties['Name'] = { title: [{ text: { content: input.title } }] }
+      }
+      if (input.description !== undefined) {
+        properties['Description'] = {
+          rich_text: [{ text: { content: input.description ?? '' } }],
+        }
+      }
+
+      // Only call Notion API if there are Notion-relevant fields
+      if (Object.keys(properties).length > 0) {
+        const client = new NotionClient(apiKey)
+        try {
+          await client.updatePage(mapping.notionPageId, properties)
+        } catch (error) {
+          return {
+            success: false,
+            provider: 'notion',
+            error: `Failed to update Notion page: ${error instanceof Error ? error.message : String(error)}`,
+          }
+        }
+      }
+
+      // Update sync timestamp (best-effort)
+      try {
+        mapper.updateSyncTimestamp(ticketId)
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    // Also update local PMO mirror
+    try {
+      const ticket = await this.storage.updateTicket(ticketId, input as Partial<Ticket>)
+      return { success: true, provider: 'notion', ticket }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async assignTicket(ticketId: string, assignee: string): Promise<ProviderAssignResult> {
+    // Notion assignee is via People property — best-effort on Notion side,
+    // always update local PMO mirror
+    try {
+      await this.storage.updateTicket(ticketId, { assignee } as Partial<Ticket>)
+      return { success: true, provider: 'notion' }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Find the Status property name on a Notion page.
+ * Looks for a property with type 'status'.
+ */
+function findStatusPropertyName(page: NotionPage): string | null {
+  for (const [name, prop] of Object.entries(page.properties)) {
+    if (prop.type === 'status') {
+      return name
+    }
+  }
+  return null
+}
+
+/**
+ * Extract the title from a Notion page's properties.
+ */
+function extractTitle(page: NotionPage): string {
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'title' && prop.title.length > 0) {
+      return prop.title.map(t => t.plain_text).join('')
+    }
+  }
+  return 'Untitled'
+}
+
+/**
+ * Extract a rich text property value.
+ */
+function extractRichText(prop: NotionPropertyValue | undefined): string | undefined {
+  if (!prop || prop.type !== 'rich_text') return undefined
+  if (prop.rich_text.length === 0) return undefined
+  return prop.rich_text.map(t => t.plain_text).join('')
+}
+
+/**
+ * Extract the status name from a Notion page.
+ */
+function extractStatus(page: NotionPage): string {
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'status' && prop.status) {
+      return prop.status.name
+    }
+  }
+  return 'Unknown'
+}
+
+/**
+ * Extract labels from multi_select properties.
+ */
+function extractLabels(page: NotionPage): string[] {
+  const labels: string[] = []
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'multi_select') {
+      for (const item of prop.multi_select) {
+        labels.push(item.name)
+      }
+    }
+  }
+  return labels
+}
+
+/**
+ * Extract the assignee from People properties.
+ */
+function extractAssignee(page: NotionPage): string | undefined {
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === 'people' && prop.people.length > 0) {
+      return prop.people[0].name || undefined
+    }
+  }
+  return undefined
+}
+
+/**
+ * Convert a Notion page to a Ticket shape for listing.
+ */
+function notionPageToTicket(page: NotionPage, databaseId: string): Ticket {
+  const title = extractTitle(page)
+  const status = extractStatus(page)
+  const labels = extractLabels(page)
+  const assignee = extractAssignee(page)
+  const description = extractRichText(page.properties['Description'])
+
+  return {
+    id: page.id,
+    title,
+    description,
+    projectId: databaseId,
+    projectName: databaseId,
+    statusId: status,
+    statusName: status,
+    owner: assignee,
+    assignee,
+    subtasks: [],
+    labels,
+    metadata: {
+      external_source: 'notion',
+      external_key: page.id,
+      external_id: page.id,
+      external_url: page.url,
+    },
+    createdAt: new Date(page.created_time),
+    updatedAt: new Date(page.last_edited_time),
+  }
+}
+
+/**
+ * Find the best matching Notion status for a target state name.
+ * Uses case-insensitive exact match first, then substring match.
+ */
+export function findMatchingNotionStatus(
+  statuses: Array<{ id: string; name: string }>,
+  targetState: string,
+): { id: string; name: string } | null {
+  const lower = targetState.toLowerCase()
+
+  // 1. Exact match (case-insensitive)
+  const exact = statuses.find(s => s.name.toLowerCase() === lower)
+  if (exact) return exact
+
+  // 2. Status name contains the target state
+  const contains = statuses.find(s => s.name.toLowerCase().includes(lower))
+  if (contains) return contains
+
+  // 3. Target state contains the status name
+  const reverseContains = statuses.find(s => lower.includes(s.name.toLowerCase()))
+  if (reverseContains) return reverseContains
+
+  return null
+}

--- a/apps/cli/src/lib/providers/resolver.ts
+++ b/apps/cli/src/lib/providers/resolver.ts
@@ -26,6 +26,8 @@ import { isJiraConfigured } from '../jira/config.js'
 import { LinearMapper } from '../linear/mapper.js'
 import { isTrelloConfigured } from '../trello/config.js'
 import { TrelloMapper } from '../trello/mapper.js'
+import { isNotionConfigured } from '../notion/config.js'
+import { NotionMapper } from '../notion/mapper.js'
 import type { StateCategory } from '../pmo/types.js'
 import type { TicketProvider, ProviderStorage } from './types.js'
 import { PMOTicketProvider } from './pmo-provider.js'
@@ -34,6 +36,7 @@ import { ClickUpTicketProvider } from './clickup-provider.js'
 import { TrelloTicketProvider } from './trello-provider.js'
 import { GitHubIssuesTicketProvider } from './github-provider.js'
 import { JiraTicketProvider } from './jira-provider.js'
+import { NotionTicketProvider } from './notion-provider.js'
 import { EventEmittingProvider, type StatusResolver } from './event-emitting-provider.js'
 
 /**
@@ -189,6 +192,17 @@ export function resolveTicketProvider(
     return wrapWithEvents(inner, db, storage, projectId)
   }
 
+  // Check Notion
+  if (externalSource === 'notion' && isNotionConfigured(db)) {
+    const mapper = new NotionMapper(db)
+    const mapping = mapper.getByTicketId(ticketId)
+
+    if (mapping) {
+      const inner = new NotionTicketProvider(db, storage, projectId)
+      return wrapWithEvents(inner, db, storage, projectId)
+    }
+  }
+
   // Default: local PMO
   const inner = new PMOTicketProvider(storage, projectId)
   return wrapWithEvents(inner, db, storage, projectId)
@@ -242,6 +256,11 @@ export function resolveProjectProvider(
 
   if (source === 'jira') {
     const inner = new JiraTicketProvider(db, storage, projectId)
+    return wrapWithEvents(inner, db, storage, projectId)
+  }
+
+  if (source === 'notion') {
+    const inner = new NotionTicketProvider(db, storage, projectId)
     return wrapWithEvents(inner, db, storage, projectId)
   }
 

--- a/apps/cli/src/lib/providers/types.ts
+++ b/apps/cli/src/lib/providers/types.ts
@@ -14,7 +14,7 @@ import type { StateCategory, Ticket, TicketFilter, CreateTicketInput, UpdateTick
 /**
  * Supported provider names for ticket operations.
  */
-export type TicketProviderName = 'pmo' | 'linear' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'clickup' | 'github'
+export type TicketProviderName = 'pmo' | 'linear' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'clickup' | 'github' | 'notion'
 
 /**
  * Generic result of a provider operation.

--- a/apps/cli/src/lib/work-lifecycle/events.ts
+++ b/apps/cli/src/lib/work-lifecycle/events.ts
@@ -15,7 +15,7 @@ import type { StateCategory } from '../pmo/types.js'
  * Sources that can emit work-lifecycle events.
  * PMO is just another provider, not the central hub.
  */
-export type WorkEventSource = 'pmo' | 'linear' | 'github' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'monday' | 'clickup'
+export type WorkEventSource = 'pmo' | 'linear' | 'github' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'monday' | 'clickup' | 'notion'
 
 /** Emitted when work begins on a work item (status moved to 'started' category). */
 export interface WorkStartedEvent {

--- a/apps/cli/src/lib/work-source/config.ts
+++ b/apps/cli/src/lib/work-source/config.ts
@@ -14,7 +14,7 @@ const DEFAULT_SOURCE_KEY = 'work.default_source'
 /** @deprecated Old key kept for migration — use DEFAULT_SOURCE_KEY */
 const LEGACY_ACTIVE_SOURCE_KEY = 'work.active_source'
 
-export const WORK_SOURCE_PROVIDERS = ['pmo', 'linear', 'jira', 'shortcut', 'asana', 'trello', 'monday', 'clickup', 'github'] as const
+export const WORK_SOURCE_PROVIDERS = ['pmo', 'linear', 'jira', 'shortcut', 'asana', 'trello', 'monday', 'clickup', 'github', 'notion'] as const
 export type WorkSourceProvider = typeof WORK_SOURCE_PROVIDERS[number]
 
 export interface WorkSourceRef {

--- a/apps/cli/test/unit/external-issues.test.ts
+++ b/apps/cli/test/unit/external-issues.test.ts
@@ -376,10 +376,11 @@ describe('External Issues', () => {
     it('contains currently supported sources', () => {
       expect(ISSUE_SOURCES).to.include('linear');
       expect(ISSUE_SOURCES).to.include('jira');
+      expect(ISSUE_SOURCES).to.include('notion');
     });
 
-    it('has exactly 6 known sources', () => {
-      expect(ISSUE_SOURCES).to.have.length(6);
+    it('has exactly 7 known sources', () => {
+      expect(ISSUE_SOURCES).to.have.length(7);
     });
   });
 

--- a/apps/cli/test/unit/notion-provider.test.ts
+++ b/apps/cli/test/unit/notion-provider.test.ts
@@ -1,0 +1,647 @@
+import { expect } from 'chai'
+import type { ProviderStorage } from '../../src/lib/providers/types.js'
+import type { StateCategory, Ticket, TicketFilter, CreateTicketInput } from '../../src/lib/pmo/types.js'
+import { NotionTicketProvider } from '../../src/lib/providers/notion-provider.js'
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface MockTicket {
+  id: string
+  projectId?: string
+  statusName?: string
+  statusCategory?: StateCategory | null
+  metadata?: Record<string, string> | null
+}
+
+function createMockStorage(overrides?: {
+  ticket?: MockTicket | null
+  tickets?: Ticket[]
+  board?: { columns: Array<{ name: string }> } | null
+  moveError?: Error
+  deleteError?: Error
+  createError?: Error
+  updateError?: Error
+  moveCalls?: Array<{ projectId: string; ticketId: string; columnName: string }>
+  deleteCalls?: string[]
+  createCalls?: Array<{ projectId: string; input: CreateTicketInput }>
+  updateCalls?: Array<{ id: string; changes: Partial<Ticket> }>
+}): ProviderStorage {
+  const moveCalls = overrides?.moveCalls ?? []
+  const deleteCalls = overrides?.deleteCalls ?? []
+  const createCalls = overrides?.createCalls ?? []
+  const updateCalls = overrides?.updateCalls ?? []
+
+  return {
+    getTicket: async (id: string) => {
+      if (overrides?.ticket === null) return null
+      const ticket = overrides?.ticket ?? {
+        id,
+        projectId: 'test-project',
+        statusName: 'In Progress',
+        statusCategory: 'started' as StateCategory,
+        metadata: {},
+      }
+      return {
+        ...ticket,
+        title: 'Test ticket',
+        statusId: ticket.statusName || 'backlog',
+        subtasks: [],
+        labels: [],
+        metadata: ticket.metadata || {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    getProjectBoard: async () => {
+      if (overrides?.board === null) return null
+      return overrides?.board ?? {
+        columns: [
+          { name: 'Backlog' },
+          { name: 'In Progress' },
+          { name: 'Review' },
+          { name: 'Done' },
+        ],
+      }
+    },
+    moveTicket: async (projectId: string, ticketId: string, columnName: string) => {
+      if (overrides?.moveError) throw overrides.moveError
+      moveCalls.push({ projectId, ticketId, columnName })
+      return {
+        id: ticketId,
+        title: 'Test ticket',
+        projectId,
+        statusId: columnName,
+        statusName: columnName,
+        subtasks: [],
+        labels: [],
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    deleteTicket: async (id: string) => {
+      if (overrides?.deleteError) throw overrides.deleteError
+      deleteCalls.push(id)
+    },
+    listTickets: async (_projectId: string | undefined, _filter?: TicketFilter) => {
+      return overrides?.tickets ?? []
+    },
+    createTicket: async (projectId: string, input: CreateTicketInput) => {
+      if (overrides?.createError) throw overrides.createError
+      createCalls.push({ projectId, input })
+      return {
+        id: input.id || 'TKT-NEW',
+        title: input.title,
+        projectId,
+        statusId: input.statusName || 'backlog',
+        statusName: input.statusName || 'Backlog',
+        subtasks: [],
+        labels: input.labels || [],
+        metadata: input.metadata || {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    updateTicket: async (id: string, changes: Partial<Ticket>) => {
+      if (overrides?.updateError) throw overrides.updateError
+      updateCalls.push({ id, changes })
+      const ticket = overrides?.ticket ?? { id, projectId: 'test-project', statusName: 'In Progress' }
+      return {
+        ...ticket,
+        ...changes,
+        id,
+        title: (changes.title as string) || 'Test ticket',
+        statusId: ticket.statusName || 'backlog',
+        subtasks: [],
+        labels: [],
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    getDatabase: () => ({
+      prepare: () => ({ get: () => undefined, all: () => [], run: () => {} }),
+      exec: () => {},
+      pragma: () => {},
+    }) as any,
+  }
+}
+
+/**
+ * Create a mock database that simulates Notion configuration.
+ * The NotionTicketProvider calls getNotionApiKey which
+ * checks provider sources, env vars, and credential store. We mock via env vars.
+ */
+function withNotionEnv(fn: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    const origKey = process.env.PRLT_NOTION_API_KEY
+    const origDb = process.env.PRLT_NOTION_DATABASE_ID
+    process.env.PRLT_NOTION_API_KEY = 'ntn_test-notion-key'
+    process.env.PRLT_NOTION_DATABASE_ID = 'test-database-id'
+    try {
+      await fn()
+    } finally {
+      if (origKey === undefined) delete process.env.PRLT_NOTION_API_KEY
+      else process.env.PRLT_NOTION_API_KEY = origKey
+      if (origDb === undefined) delete process.env.PRLT_NOTION_DATABASE_ID
+      else process.env.PRLT_NOTION_DATABASE_ID = origDb
+    }
+  }
+}
+
+function createMockDb(): any {
+  return {
+    prepare: (sql: string) => ({
+      get: (..._args: any[]) => undefined,
+      all: (..._args: any[]) => [],
+      run: (..._args: any[]) => ({ changes: 0 }),
+    }),
+    exec: (_sql: string) => {},
+    pragma: () => {},
+  }
+}
+
+// =============================================================================
+// NotionTicketProvider Tests
+// =============================================================================
+
+describe('NotionTicketProvider', () => {
+  it('has name set to "notion"', () => {
+    const storage = createMockStorage()
+    const db = createMockDb()
+    const provider = new NotionTicketProvider(db, storage, 'test-project')
+    expect(provider.name).to.equal('notion')
+  })
+
+  // ---------------------------------------------------------------------------
+  // getTicket — reads from local PMO mirror
+  // ---------------------------------------------------------------------------
+  describe('getTicket', () => {
+    it('reads from local PMO storage', async () => {
+      const storage = createMockStorage({
+        ticket: { id: 'TKT-100', projectId: 'test-project', statusName: 'Open' },
+      })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.getTicket('TKT-100')
+
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(result.ticket).to.not.be.null
+      expect(result.ticket!.id).to.equal('TKT-100')
+    })
+
+    it('returns null ticket when not found', async () => {
+      const storage = createMockStorage({ ticket: null })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.getTicket('TKT-MISSING')
+
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(result.ticket).to.be.null
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // assignTicket — updates local PMO mirror
+  // ---------------------------------------------------------------------------
+  describe('assignTicket', () => {
+    it('updates assignee in local PMO storage', async () => {
+      const updateCalls: Array<{ id: string; changes: Partial<Ticket> }> = []
+      const storage = createMockStorage({ updateCalls })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.assignTicket('TKT-100', 'alice')
+
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(updateCalls).to.have.lengthOf(1)
+      expect(updateCalls[0].id).to.equal('TKT-100')
+      expect(updateCalls[0].changes).to.deep.include({ assignee: 'alice' })
+    })
+
+    it('returns error when storage fails', async () => {
+      const storage = createMockStorage({ updateError: new Error('storage down') })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.assignTicket('TKT-100', 'alice')
+
+      expect(result.success).to.be.false
+      expect(result.provider).to.equal('notion')
+      expect(result.error).to.include('storage down')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // moveTicket — requires Notion credentials
+  // ---------------------------------------------------------------------------
+  describe('moveTicket', () => {
+    it('returns error when Notion credentials not configured', async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      // Ensure env vars are not set
+      const origKey = process.env.PRLT_NOTION_API_KEY
+      delete process.env.PRLT_NOTION_API_KEY
+      delete process.env.NOTION_API_KEY
+
+      try {
+        const result = await provider.moveTicket('TKT-100', 'Done')
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.error).to.include('not configured')
+      } finally {
+        if (origKey) process.env.PRLT_NOTION_API_KEY = origKey
+      }
+    })
+
+    it('returns error when no Notion mapping exists', withNotionEnv(async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.moveTicket('TKT-UNMAPPED', 'Done')
+
+      expect(result.success).to.be.false
+      expect(result.provider).to.equal('notion')
+      expect(result.error).to.include('No Notion mapping')
+    }))
+  })
+
+  // ---------------------------------------------------------------------------
+  // deleteTicket — archives page in Notion
+  // ---------------------------------------------------------------------------
+  describe('deleteTicket', () => {
+    it('returns error when Notion credentials not configured', async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const origKey = process.env.PRLT_NOTION_API_KEY
+      delete process.env.PRLT_NOTION_API_KEY
+      delete process.env.NOTION_API_KEY
+
+      try {
+        const result = await provider.deleteTicket('TKT-100')
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.error).to.include('not configured')
+      } finally {
+        if (origKey) process.env.PRLT_NOTION_API_KEY = origKey
+      }
+    })
+
+    it('deletes local PMO mirror when no Notion mapping exists', withNotionEnv(async () => {
+      const deleteCalls: string[] = []
+      const storage = createMockStorage({ deleteCalls })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.deleteTicket('TKT-NO-MAP')
+
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(deleteCalls).to.include('TKT-NO-MAP')
+    }))
+  })
+
+  // ---------------------------------------------------------------------------
+  // listTickets — fetches from Notion API
+  // ---------------------------------------------------------------------------
+  describe('listTickets', () => {
+    it('returns error when Notion credentials not configured', async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const origKey = process.env.PRLT_NOTION_API_KEY
+      delete process.env.PRLT_NOTION_API_KEY
+      delete process.env.NOTION_API_KEY
+
+      try {
+        const result = await provider.listTickets()
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.tickets).to.deep.equal([])
+        expect(result.error).to.include('not configured')
+      } finally {
+        if (origKey) process.env.PRLT_NOTION_API_KEY = origKey
+      }
+    })
+
+    it('returns error when database ID is missing', withNotionEnv(async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      // Remove the database ID
+      const origDb = process.env.PRLT_NOTION_DATABASE_ID
+      delete process.env.PRLT_NOTION_DATABASE_ID
+
+      try {
+        const result = await provider.listTickets()
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.error).to.include('database ID is required')
+      } finally {
+        if (origDb) process.env.PRLT_NOTION_DATABASE_ID = origDb
+      }
+    }))
+  })
+
+  // ---------------------------------------------------------------------------
+  // createTicket — creates page in Notion
+  // ---------------------------------------------------------------------------
+  describe('createTicket', () => {
+    it('returns error when Notion credentials not configured', async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const origKey = process.env.PRLT_NOTION_API_KEY
+      delete process.env.PRLT_NOTION_API_KEY
+      delete process.env.NOTION_API_KEY
+
+      try {
+        const result = await provider.createTicket('test-project', {
+          title: 'New page',
+          description: 'Description',
+          labels: [],
+        })
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.error).to.include('not configured')
+      } finally {
+        if (origKey) process.env.PRLT_NOTION_API_KEY = origKey
+      }
+    })
+
+    it('returns error when database ID is missing', withNotionEnv(async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const origDb = process.env.PRLT_NOTION_DATABASE_ID
+      delete process.env.PRLT_NOTION_DATABASE_ID
+
+      try {
+        const result = await provider.createTicket('test-project', {
+          title: 'New page',
+          description: 'Description',
+          labels: [],
+        })
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.error).to.include('database ID is required')
+      } finally {
+        if (origDb) process.env.PRLT_NOTION_DATABASE_ID = origDb
+      }
+    }))
+  })
+
+  // ---------------------------------------------------------------------------
+  // updateTicket — updates page in Notion + PMO mirror
+  // ---------------------------------------------------------------------------
+  describe('updateTicket', () => {
+    it('returns error when Notion credentials not configured', async () => {
+      const storage = createMockStorage()
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const origKey = process.env.PRLT_NOTION_API_KEY
+      delete process.env.PRLT_NOTION_API_KEY
+      delete process.env.NOTION_API_KEY
+
+      try {
+        const result = await provider.updateTicket('TKT-100', { title: 'Updated' })
+
+        expect(result.success).to.be.false
+        expect(result.provider).to.equal('notion')
+        expect(result.error).to.include('not configured')
+      } finally {
+        if (origKey) process.env.PRLT_NOTION_API_KEY = origKey
+      }
+    })
+
+    it('updates local PMO mirror when no Notion mapping exists', withNotionEnv(async () => {
+      const updateCalls: Array<{ id: string; changes: Partial<Ticket> }> = []
+      const storage = createMockStorage({ updateCalls })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.updateTicket('TKT-NO-MAP', { title: 'Updated title' })
+
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(updateCalls).to.have.lengthOf(1)
+      expect(updateCalls[0].id).to.equal('TKT-NO-MAP')
+    }))
+
+    it('returns error when storage update fails', withNotionEnv(async () => {
+      const storage = createMockStorage({ updateError: new Error('storage failure') })
+      const db = createMockDb()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.updateTicket('TKT-100', { title: 'Updated' })
+
+      expect(result.success).to.be.false
+      expect(result.provider).to.equal('notion')
+      expect(result.error).to.include('storage failure')
+    }))
+  })
+})
+
+// =============================================================================
+// findMatchingNotionStatus (exported helper)
+// =============================================================================
+
+import { findMatchingNotionStatus } from '../../src/lib/providers/notion-provider.js'
+
+describe('findMatchingNotionStatus', () => {
+  const statuses = [
+    { id: '1', name: 'Not started' },
+    { id: '2', name: 'In progress' },
+    { id: '3', name: 'Done' },
+    { id: '4', name: 'Review' },
+  ]
+
+  it('finds exact match (case-insensitive)', () => {
+    const result = findMatchingNotionStatus(statuses, 'done')
+    expect(result).to.not.be.null
+    expect(result!.name).to.equal('Done')
+  })
+
+  it('finds exact match with different case', () => {
+    const result = findMatchingNotionStatus(statuses, 'IN PROGRESS')
+    expect(result).to.not.be.null
+    expect(result!.name).to.equal('In progress')
+  })
+
+  it('finds match when status name contains target', () => {
+    const result = findMatchingNotionStatus(statuses, 'progress')
+    expect(result).to.not.be.null
+    expect(result!.name).to.equal('In progress')
+  })
+
+  it('finds match when target contains status name', () => {
+    const result = findMatchingNotionStatus(statuses, 'code review needed')
+    expect(result).to.not.be.null
+    expect(result!.name).to.equal('Review')
+  })
+
+  it('returns null when no match found', () => {
+    const result = findMatchingNotionStatus(statuses, 'Cancelled')
+    expect(result).to.be.null
+  })
+})
+
+// =============================================================================
+// External issues adapter
+// =============================================================================
+
+import {
+  normalizeNotionPage,
+  normalizeNotionPageToEnvelope,
+  buildNotionTicketDescription,
+  buildNotionMetadata,
+  isNotionConfiguredFromEnv,
+} from '../../src/lib/external-issues/notion.js'
+
+describe('Notion external issues adapter', () => {
+  describe('normalizeNotionPage', () => {
+    it('normalizes a valid Notion page into an IssueEnvelope', () => {
+      const rawPage = {
+        id: 'page-123',
+        url: 'https://notion.so/page-123',
+        created_time: '2024-01-01T00:00:00.000Z',
+        last_edited_time: '2024-01-02T00:00:00.000Z',
+        archived: false,
+        properties: {
+          Name: { type: 'title', title: [{ plain_text: 'Test Page' }] },
+          Description: { type: 'rich_text', rich_text: [{ plain_text: 'A test description' }] },
+          Status: { type: 'status', status: { id: 's1', name: 'In progress', color: 'blue' } },
+          Tags: { type: 'multi_select', multi_select: [{ id: 't1', name: 'P1', color: 'red' }] },
+        },
+      }
+
+      const envelope = normalizeNotionPage(rawPage)
+
+      expect(envelope.source).to.equal('notion')
+      expect(envelope.external_id).to.equal('page-123')
+      expect(envelope.title).to.equal('Test Page')
+      expect(envelope.description).to.equal('A test description')
+      expect(envelope.status).to.equal('In progress')
+      expect(envelope.labels).to.deep.equal(['P1'])
+      expect(envelope.priority).to.equal('P1')
+      expect(envelope.item_type).to.equal('page')
+    })
+
+    it('handles missing description', () => {
+      const rawPage = {
+        id: 'page-456',
+        url: 'https://notion.so/page-456',
+        properties: {
+          Name: { type: 'title', title: [{ plain_text: 'No Desc Page' }] },
+        },
+      }
+
+      const envelope = normalizeNotionPage(rawPage)
+      expect(envelope.description).to.equal('')
+    })
+
+    it('throws for invalid payload', () => {
+      expect(() => normalizeNotionPage(null)).to.throw('invalid')
+      expect(() => normalizeNotionPage({})).to.throw('missing required fields')
+    })
+  })
+
+  describe('normalizeNotionPageToEnvelope', () => {
+    it('produces a NormalizedIssueEnvelope', () => {
+      const rawPage = {
+        id: 'page-789',
+        url: 'https://notion.so/page-789',
+        properties: {
+          Name: { type: 'title', title: [{ plain_text: 'Normalized Page' }] },
+          Status: { type: 'status', status: { id: 's1', name: 'Done', color: 'green' } },
+        },
+      }
+
+      const envelope = normalizeNotionPageToEnvelope(rawPage)
+      expect(envelope.source.name).to.equal('notion')
+      expect(envelope.source.externalId).to.equal('page-789')
+      expect(envelope.title).to.equal('Normalized Page')
+      expect(envelope.status).to.equal('Done')
+      expect(envelope.category).to.equal('feature')
+    })
+  })
+
+  describe('buildNotionTicketDescription', () => {
+    it('builds a description with metadata', () => {
+      const envelope = normalizeNotionPageToEnvelope({
+        id: 'page-desc',
+        url: 'https://notion.so/page-desc',
+        properties: {
+          Name: { type: 'title', title: [{ plain_text: 'Desc Test' }] },
+          Description: { type: 'rich_text', rich_text: [{ plain_text: 'Body text' }] },
+          Status: { type: 'status', status: { id: 's1', name: 'Open', color: 'gray' } },
+        },
+      })
+
+      const description = buildNotionTicketDescription(envelope)
+      expect(description).to.include('Body text')
+      expect(description).to.include('External Issue Context')
+      expect(description).to.include('Source: notion')
+    })
+  })
+
+  describe('buildNotionMetadata', () => {
+    it('builds metadata with external source info', () => {
+      const envelope = normalizeNotionPageToEnvelope({
+        id: 'page-meta',
+        url: 'https://notion.so/page-meta',
+        properties: {
+          Name: { type: 'title', title: [{ plain_text: 'Meta Test' }] },
+        },
+      })
+
+      const metadata = buildNotionMetadata(envelope)
+      expect(metadata.external_source).to.equal('notion')
+      expect(metadata.external_id).to.equal('page-meta')
+      expect(metadata.external_url).to.equal('https://notion.so/page-meta')
+    })
+  })
+
+  describe('isNotionConfiguredFromEnv', () => {
+    it('returns true when API key is set', () => {
+      expect(isNotionConfiguredFromEnv({ apiKey: 'test-key' })).to.be.true
+    })
+
+    it('returns false when no API key', () => {
+      const origKey = process.env.PRLT_NOTION_API_KEY
+      const origKey2 = process.env.NOTION_API_KEY
+      delete process.env.PRLT_NOTION_API_KEY
+      delete process.env.NOTION_API_KEY
+
+      try {
+        expect(isNotionConfiguredFromEnv({})).to.be.false
+      } finally {
+        if (origKey) process.env.PRLT_NOTION_API_KEY = origKey
+        if (origKey2) process.env.NOTION_API_KEY = origKey2
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Resolves PRLT-1191: Implement Notion ticket provider — use Notion databases as kanban boards

## Description

Notion databases can act as kanban boards with status properties. Need NotionTicketProvider implementing TicketProvider interface. Use Notion API. Map database status property values to prlt intents. Auth via Notion integration token. Add notion to TicketProviderName type.

## External Issue Context

- Source: linear
- External key: PRLT-1191
- External id: d1ee26b3-a919-4bb9-8035-995d92d6790f
- URL: https://linear.app/proletariat/issue/PRLT-1191/implement-notion-ticket-provider-use-notion-databases-as-kanban-boards
- Status: Backlog
- Priority: P2
- Labels: None

## Changes

- b5ba65c0 feat(PRLT-1191): fix external-issues test to account for Notion as 7th issue source
- c114dafc feat(PRLT-1191): add tests and fix type registrations for Notion provider
- e24279ae feat(PRLT-1191): implement Notion ticket provider

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
