### PR TITLE
TKT-033: FlagResolver JSON prompt commands don't chain — flags not accumulated, internal names not registered

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -183,6 +183,43 @@ function isIssueSource(value: string | undefined): value is IssueSource {
   return value === 'linear' || value === 'jira' || value === 'asana' || value === 'shortcut' || value === 'trello'
 }
 
+/**
+ * Extract explicitly-set flags for JSON mode command chaining.
+ * Filters out defaults (false/undefined) and the json flag itself.
+ * Used as accumulatedFlags so buildCommand includes prior resolver results.
+ */
+function getAccumulatedFlags(flags: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, val] of Object.entries(flags)) {
+    if (key === 'json' || val === undefined || val === false) continue
+    result[key] = val
+  }
+  return result
+}
+
+/**
+ * Build a base command string with all explicitly-set flags for JSON mode chaining.
+ * Used by getCommand callbacks to include accumulated flags from prior prompts.
+ */
+function buildJsonBase(ticketId: string, flags: Record<string, unknown>): string {
+  let cmd = `prlt work start ${ticketId}`
+  for (const [key, val] of Object.entries(flags)) {
+    if (key === 'json' || val === undefined || val === false) continue
+    if (typeof val === 'boolean') {
+      cmd += ` --${key}`
+    } else if (typeof val === 'string') {
+      cmd += ` --${key} "${val}"`
+    } else if (Array.isArray(val)) {
+      for (const item of val) {
+        cmd += ` --${key} "${item}"`
+      }
+    } else {
+      cmd += ` --${key} ${val}`
+    }
+  }
+  return cmd
+}
+
 function buildExternalMetadata(envelope: NormalizedIssueEnvelope): Record<string, string> {
   switch (envelope.source.name) {
     case 'jira': return buildJiraMetadata(envelope)
@@ -410,6 +447,10 @@ export default class WorkStart extends PMOCommand {
       description: 'Validate environment and prerequisites without actually spawning an agent',
       default: false,
     }),
+    environment: Flags.string({
+      description: 'Execution environment (devcontainer or host). Use to bypass the environment selection prompt.',
+      options: ['devcontainer', 'host'],
+    }),
   }
 
   private async findLinkedTicketByEnvelope(_projectId: string, envelope: NormalizedIssueEnvelope): Promise<Ticket | undefined> {
@@ -579,6 +620,11 @@ export default class WorkStart extends PMOCommand {
     // Apply --skip-permissions as --permission-mode danger
     if (flags['skip-permissions']) {
       flags['permission-mode'] = 'danger'
+    }
+
+    // Handle --environment flag: normalize to --run-on-host for host mode
+    if (flags.environment === 'host') {
+      flags['run-on-host'] = true
     }
 
     // Check if JSON output mode is active
@@ -989,8 +1035,10 @@ export default class WorkStart extends PMOCommand {
           baseCommand: `prlt work start ${ticketId}`,
           jsonMode,
           flags: {},
+          accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
         })
 
+        const jsonBaseBlocked = buildJsonBase(ticketId!, flags as Record<string, unknown>)
         blockedResolver.addPrompt({
           flagName: 'startAnyway',
           type: 'list',
@@ -1000,6 +1048,10 @@ export default class WorkStart extends PMOCommand {
             { name: 'No, cancel', value: 'no' },
             { name: 'Yes, start despite blockers', value: 'yes' },
           ],
+          getCommand: (value) => {
+            if (value === 'yes') return `${jsonBaseBlocked} --force --json`
+            return ''
+          },
         })
 
         const blockedResult = await blockedResolver.resolve()
@@ -1019,15 +1071,16 @@ export default class WorkStart extends PMOCommand {
         }
 
         // Use FlagResolver for session action
-        const sessionResolver = new FlagResolver<{ sessionAction?: string }>({
+        const sessionResolver = new FlagResolver<{ 'session-action'?: string }>({
           commandName: 'work start',
           baseCommand: `prlt work start ${ticketId}`,
           jsonMode,
-          flags: flags['session-action'] ? { sessionAction: flags['session-action'] } : {},
+          flags: flags['session-action'] ? { 'session-action': flags['session-action'] } : {},
+          accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
         })
 
         sessionResolver.addPrompt({
-          flagName: 'sessionAction',
+          flagName: 'session-action',
           type: 'list',
           message: 'What would you like to do?',
           choices: () => [
@@ -1039,7 +1092,7 @@ export default class WorkStart extends PMOCommand {
         })
 
         const sessionResult = await sessionResolver.resolve()
-        const sessionAction = sessionResult.sessionAction
+        const sessionAction = sessionResult['session-action']
 
         if (sessionAction === 'cancel') {
           db.close()
@@ -1198,11 +1251,13 @@ export default class WorkStart extends PMOCommand {
           }
 
           // Use FlagResolver for agent selection
+          const jsonBaseAgent = buildJsonBase(ticketId!, flags as Record<string, unknown>)
           const agentResolver = new FlagResolver<{ selectedAgent?: string }>({
             commandName: 'work start',
             baseCommand: `prlt work start ${ticketId}`,
             jsonMode,
             flags: {},
+            accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
           })
 
           agentResolver.addPrompt({
@@ -1211,6 +1266,10 @@ export default class WorkStart extends PMOCommand {
             message: `Select agent for ${ticketId}:`,
             default: '__ephemeral__',
             choices: () => agentChoiceList,
+            getCommand: (value) => {
+              if (value === '__ephemeral__') return `${jsonBaseAgent} --ephemeral --json`
+              return `${jsonBaseAgent} --agent "${value}" --json`
+            },
           })
 
           const agentResult = await agentResolver.resolve()
@@ -1325,11 +1384,13 @@ export default class WorkStart extends PMOCommand {
           }
 
           // Use FlagResolver for unsaved work action
+          const jsonBaseUnsaved = buildJsonBase(ticketId!, flags as Record<string, unknown>)
           const unsavedResolver = new FlagResolver<{ unsavedAction?: string }>({
             commandName: 'work start',
             baseCommand: `prlt work start ${ticketId}`,
             jsonMode,
             flags: {},
+            accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
           })
 
           unsavedResolver.addPrompt({
@@ -1341,6 +1402,11 @@ export default class WorkStart extends PMOCommand {
               { name: 'Continue anyway (existing work may conflict)', value: 'continue' },
               { name: 'Cancel', value: 'cancel' },
             ],
+            getCommand: (value) => {
+              if (value === 'cancel') return ''
+              // Both 'push' and 'continue' advance; use --force to skip re-prompt
+              return `${jsonBaseUnsaved} --force --json`
+            },
           })
 
           const unsavedResult = await unsavedResolver.resolve()
@@ -1453,14 +1519,15 @@ export default class WorkStart extends PMOCommand {
       const hasDevcontainer = hasDevcontainerConfig(agentDir)
 
       // Use devcontainer by default if available, unless --run-on-host is set
-      const useDevcontainer = hasDevcontainer && !flags['run-on-host']
+      // --environment devcontainer explicitly requests devcontainer mode
+      const useDevcontainer = (hasDevcontainer && !flags['run-on-host']) || flags.environment === 'devcontainer'
 
       // Determine execution environment and display mode
       let environment: ExecutionEnvironment = 'host'
       let displayMode: DisplayMode = 'terminal'
       let permissionMode: PermissionMode = 'danger'
 
-      if (hasDevcontainer && !flags.display && !flags['run-on-host']) {
+      if (hasDevcontainer && !flags.display && !flags['run-on-host'] && !flags.environment) {
         // Agent has devcontainer - prompt for environment choice
         const devcontainerLabel = '🐳 devcontainer (isolated, recommended)'
 
@@ -1472,11 +1539,13 @@ export default class WorkStart extends PMOCommand {
 
         // In JSON mode, use FlagResolver (outputs prompt and exits)
         if (jsonMode) {
+          const jsonBaseEnv = buildJsonBase(ticketId!, flags as Record<string, unknown>)
           const envResolver = new FlagResolver<{ environment?: string }>({
             commandName: 'work start',
             baseCommand: `prlt work start ${ticketId}`,
             jsonMode,
             flags: {},
+            accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
           })
 
           envResolver.addPrompt({
@@ -1486,11 +1555,10 @@ export default class WorkStart extends PMOCommand {
             default: 'devcontainer',
             choices: () => envChoices,
             getCommand: (value) => {
-              const base = `prlt work start ${ticketId}`
-              if (value === 'host') return `${base} --run-on-host --json`
+              if (value === 'host') return `${jsonBaseEnv} --run-on-host --json`
               if (value === 'cancel') return ''
-              // devcontainer is the default when available
-              return `${base} --json`
+              // Explicit --environment devcontainer so the command advances past this prompt
+              return `${jsonBaseEnv} --environment devcontainer --json`
             },
           })
 
@@ -1546,11 +1614,13 @@ export default class WorkStart extends PMOCommand {
               const tokenMessage = 'GitHub token not found. Git push may fail. Continue without token?'
 
               // Use FlagResolver for token action prompt
+              const jsonBaseToken = buildJsonBase(ticketId!, flags as Record<string, unknown>)
               const tokenResolver = new FlagResolver<{ tokenAction?: string }>({
                 commandName: 'work start',
                 baseCommand: `prlt work start ${ticketId}`,
                 jsonMode,
                 flags: {},
+                accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
               })
 
               tokenResolver.addPrompt({
@@ -1563,6 +1633,12 @@ export default class WorkStart extends PMOCommand {
                   { name: 'No, let me run gh auth login first', value: 'cancel' },
                   { name: 'Switch to host mode instead', value: 'host' },
                 ],
+                getCommand: (value) => {
+                  if (value === 'cancel') return ''
+                  if (value === 'host') return `${jsonBaseToken} --run-on-host --json`
+                  // 'continue' — re-run with environment devcontainer explicit
+                  return `${jsonBaseToken} --environment devcontainer --json`
+                },
               })
 
               // In JSON mode, this will output prompt and exit
@@ -1671,15 +1747,16 @@ export default class WorkStart extends PMOCommand {
             : 'Select display mode (no devcontainer - running on host):'
 
           // Use FlagResolver for display mode selection
-          const displayResolver = new FlagResolver<{ selectedMode?: string }>({
+          const displayResolver = new FlagResolver<{ display?: string }>({
             commandName: 'work start',
             baseCommand: `prlt work start ${ticketId}`,
             jsonMode,
             flags: {},
+            accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
           })
 
           displayResolver.addPrompt({
-            flagName: 'selectedMode',
+            flagName: 'display',
             type: 'list',
             message: warningMsg,
             default: 'terminal',
@@ -1691,7 +1768,7 @@ export default class WorkStart extends PMOCommand {
           })
 
           const displayResult = await displayResolver.resolve()
-          displayMode = displayResult.selectedMode as DisplayMode
+          displayMode = displayResult.display as DisplayMode
         }
       }
 
@@ -1729,11 +1806,13 @@ export default class WorkStart extends PMOCommand {
             ]
             const dockerMessage = 'Docker is not running. What would you like to do?'
 
+            const jsonBaseDocker = buildJsonBase(ticketId!, flags as Record<string, unknown>)
             const dockerResolver = new FlagResolver<{ dockerAction?: string }>({
               commandName: 'work start',
               baseCommand: `prlt work start ${ticketId}`,
               jsonMode,
               flags: {},
+              accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
             })
 
             dockerResolver.addPrompt({
@@ -1741,6 +1820,10 @@ export default class WorkStart extends PMOCommand {
               type: 'list',
               message: dockerMessage,
               choices: () => dockerChoices,
+              getCommand: (value) => {
+                if (value === 'host') return `${jsonBaseDocker} --run-on-host --json`
+                return ''
+              },
             })
 
             const dockerResult = await dockerResolver.resolve()
@@ -1828,11 +1911,13 @@ export default class WorkStart extends PMOCommand {
               )
 
               // Use FlagResolver for auth method selection
+              const jsonBaseAuth = buildJsonBase(ticketId!, flags as Record<string, unknown>)
               const authResolver = new FlagResolver<{ authAction?: string }>({
                 commandName: 'work start',
                 baseCommand: `prlt work start ${ticketId}`,
                 jsonMode,
                 flags: {},
+                accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
               })
 
               authResolver.addPrompt({
@@ -1840,6 +1925,13 @@ export default class WorkStart extends PMOCommand {
                 type: 'list',
                 message: 'How should the agent authenticate with Claude?',
                 choices: () => authChoices,
+                getCommand: (value) => {
+                  if (value === 'apikey') return `${jsonBaseAuth} --use-api-key --json`
+                  if (value === 'host') return `${jsonBaseAuth} --run-on-host --json`
+                  if (value === 'cancel') return ''
+                  // oauth — re-run with environment devcontainer (requires interactive auth flow)
+                  return `${jsonBaseAuth} --environment devcontainer --json`
+                },
               })
 
               const authResult = await authResolver.resolve()
@@ -1928,6 +2020,7 @@ export default class WorkStart extends PMOCommand {
                   baseCommand: `prlt work start ${ticketId}`,
                   jsonMode,
                   flags: {},
+                  accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
                 })
 
                 saveResolver.addPrompt({
@@ -1980,6 +2073,7 @@ export default class WorkStart extends PMOCommand {
           baseCommand: `prlt work start ${ticketId}`,
           jsonMode,
           flags: { 'permission-mode': flags['permission-mode'] },
+          accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
         })
 
         const executorName = getExecutorDisplayName(executor)
@@ -2027,11 +2121,13 @@ export default class WorkStart extends PMOCommand {
           prModeSource = 'default (--json --yes)'
         } else {
           // Use FlagResolver for PR choice
+          const jsonBasePr = buildJsonBase(ticketId!, flags as Record<string, unknown>)
           const prResolver = new FlagResolver<{ prChoice?: string }>({
             commandName: 'work start',
             baseCommand: `prlt work start ${ticketId}`,
             jsonMode,
             flags: {},
+            accumulatedFlags: getAccumulatedFlags(flags as Record<string, unknown>),
           })
 
           prResolver.addPrompt({
@@ -2043,6 +2139,10 @@ export default class WorkStart extends PMOCommand {
               { name: '✓ Yes - Create PR when running `prlt work ready`', value: 'yes' },
               { name: '✗ No  - Just move ticket to review (can create PR later)', value: 'no' },
             ],
+            getCommand: (value) => {
+              if (value === 'yes') return `${jsonBasePr} --create-pr --json`
+              return `${jsonBasePr} --json`
+            },
           })
 
           const prResult = await prResolver.resolve()
@@ -2174,8 +2274,9 @@ export default class WorkStart extends PMOCommand {
         if (isExistingBranch) {
           // Ticket already has a branch linked - just use it
           this.log(styles.muted(`Using existing branch: ${branch}`))
-        } else if (flags.action || flags.force) {
-          // Non-interactive mode (spawned from batch command) - auto-create branch
+        } else if (flags.action || flags.force || jsonMode) {
+          // Non-interactive / JSON mode - auto-create branch
+          // JSON mode agents can't interactively enter branch names
           finalBranch = branch
           this.log(styles.muted(`Branch: ${finalBranch}`))
         } else {

--- a/apps/cli/src/lib/flags/resolver.ts
+++ b/apps/cli/src/lib/flags/resolver.ts
@@ -164,6 +164,13 @@ export interface FlagResolverOptions<TFlags extends Record<string, unknown>> {
 
   /** Additional custom context */
   context?: Record<string, unknown>;
+
+  /**
+   * Flags resolved by prior steps to include in generated commands.
+   * These are included in buildCommand output for JSON mode chaining
+   * but don't participate in prompt resolution.
+   */
+  accumulatedFlags?: Record<string, unknown>;
 }
 
 /**
@@ -448,12 +455,13 @@ export class FlagResolver<TFlags extends Record<string, unknown> = Record<string
   }
 
   /**
-   * Build a command string for a flag value
+   * Build a command string for a flag value.
+   * Includes accumulated flags from prior resolver steps for JSON mode chaining.
    */
   private buildCommand(flagName: string, value: unknown): string {
     const { baseCommand } = this.options;
 
-    // Build flags part from currently resolved flags
+    // Build flags part from accumulated + resolved flags
     let cmd = baseCommand;
 
     // Add any project flag from context
@@ -462,9 +470,31 @@ export class FlagResolver<TFlags extends Record<string, unknown> = Record<string
       cmd += ` -P ${projectId}`;
     }
 
+    // Track which keys we've already added to avoid duplicates
+    const addedKeys = new Set<string>();
+
+    // Add accumulated flags from prior resolver steps
+    if (this.options.accumulatedFlags) {
+      for (const [key, val] of Object.entries(this.options.accumulatedFlags)) {
+        if (key === flagName || val === undefined || key === 'json') continue;
+        // Skip if this flag is in resolvedFlags (it will be added below)
+        if (key in this.resolvedFlags && this.resolvedFlags[key as keyof TFlags] !== undefined) continue;
+        if (typeof val === 'boolean') {
+          if (val) { cmd += ` --${key}`; addedKeys.add(key); }
+        } else if (typeof val === 'string') {
+          cmd += ` --${key} "${val}"`; addedKeys.add(key);
+        } else if (Array.isArray(val)) {
+          cmd += ` --${key} "${val.join(',')}"`; addedKeys.add(key);
+        } else {
+          cmd += ` --${key} ${val}`; addedKeys.add(key);
+        }
+      }
+    }
+
     // Add resolved flags (except the one we're prompting for)
     for (const [key, val] of Object.entries(this.resolvedFlags)) {
       if (key === flagName || val === undefined || key === 'json') continue;
+      if (addedKeys.has(key)) continue;
       if (typeof val === 'boolean') {
         if (val) cmd += ` --${key}`;
       } else if (typeof val === 'string') {

--- a/apps/cli/test/unit/flag-resolver.test.ts
+++ b/apps/cli/test/unit/flag-resolver.test.ts
@@ -283,6 +283,340 @@ describe('@smoke FlagResolver', () => {
       });
     });
   });
+
+  describe('PRLT-1238: JSON mode command chaining', () => {
+    let capturedOutput: string;
+    let originalLog: typeof console.log;
+
+    beforeEach(() => {
+      capturedOutput = '';
+      originalLog = console.log;
+      console.log = (msg: string) => { capturedOutput = msg; };
+    });
+
+    afterEach(() => {
+      console.log = originalLog;
+    });
+
+    /**
+     * Resolve in JSON mode, capture JSON output. outputPromptAsJson throws ExitError.
+     */
+    async function resolveAndCapture(resolver: FlagResolver<Record<string, unknown>>): Promise<{
+      prompt: { name: string; choices?: Array<{ name: string; value: string; command?: string }> };
+    }> {
+      try {
+        await resolver.resolve();
+        throw new Error('Expected ExitError to be thrown');
+      } catch (error: unknown) {
+        if (error instanceof Error && error.message === 'Expected ExitError to be thrown') throw error;
+        return JSON.parse(capturedOutput);
+      }
+    }
+
+    describe('Bug 1: buildCommand accumulates previously resolved flags', () => {
+      it('should include accumulatedFlags in auto-generated commands', async () => {
+        const resolver = new FlagResolver<{ display?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+          accumulatedFlags: { 'run-on-host': true, 'permission-mode': 'danger' },
+        });
+
+        resolver.addPrompt({
+          flagName: 'display',
+          type: 'list',
+          message: 'Select display mode:',
+          choices: () => [
+            { name: 'Terminal', value: 'terminal' },
+            { name: 'Foreground', value: 'foreground' },
+          ],
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const terminalChoice = output.prompt.choices?.find(c => c.value === 'terminal');
+
+        expect(terminalChoice).to.exist;
+        expect(terminalChoice!.command).to.include('--run-on-host');
+        expect(terminalChoice!.command).to.include('--permission-mode "danger"');
+        expect(terminalChoice!.command).to.include('--display "terminal"');
+        expect(terminalChoice!.command).to.include('--json');
+      });
+
+      it('should not duplicate flags already in resolvedFlags', async () => {
+        const resolver = new FlagResolver<{ 'permission-mode'?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: { 'permission-mode': 'safe' },
+          accumulatedFlags: { 'permission-mode': 'safe', 'run-on-host': true },
+        });
+
+        resolver.addPrompt({
+          flagName: 'permission-mode',
+          type: 'list',
+          message: 'Permission mode:',
+          when: (ctx) => !ctx.flags['permission-mode'],
+        });
+
+        // permission-mode is already set, so no prompt should fire
+        const result = await resolver.resolve();
+        expect(result['permission-mode']).to.equal('safe');
+        expect(capturedOutput).to.equal('');
+      });
+
+      it('regression: commands without accumulatedFlags lose prior flags', async () => {
+        // Without accumulatedFlags — reproduces Bug 1
+        const resolverWithout = new FlagResolver<{ display?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+        });
+
+        resolverWithout.addPrompt({
+          flagName: 'display',
+          type: 'list',
+          message: 'Select display mode:',
+          choices: () => [{ name: 'Terminal', value: 'terminal' }],
+        });
+
+        const outputWithout = await resolveAndCapture(resolverWithout);
+        const choiceWithout = outputWithout.prompt.choices?.[0];
+        // Without accumulatedFlags, --run-on-host is NOT included
+        expect(choiceWithout!.command).to.not.include('--run-on-host');
+
+        // With accumulatedFlags — verifies fix
+        capturedOutput = '';
+        const resolverWith = new FlagResolver<{ display?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+          accumulatedFlags: { 'run-on-host': true },
+        });
+
+        resolverWith.addPrompt({
+          flagName: 'display',
+          type: 'list',
+          message: 'Select display mode:',
+          choices: () => [{ name: 'Terminal', value: 'terminal' }],
+        });
+
+        const outputWith = await resolveAndCapture(resolverWith);
+        const choiceWith = outputWith.prompt.choices?.[0];
+        expect(choiceWith!.command).to.include('--run-on-host');
+      });
+    });
+
+    describe('Bug 2: flag names must match registered oclif flags', () => {
+      it('should use kebab-case --session-action not camelCase --sessionAction', async () => {
+        const resolver = new FlagResolver<{ 'session-action'?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+        });
+
+        resolver.addPrompt({
+          flagName: 'session-action',
+          type: 'list',
+          message: 'What would you like to do?',
+          choices: () => [
+            { name: 'Attach', value: 'attach' },
+            { name: 'Spawn', value: 'spawn' },
+          ],
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const attachChoice = output.prompt.choices?.find(c => c.value === 'attach');
+
+        expect(attachChoice!.command).to.include('--session-action "attach"');
+        expect(attachChoice!.command).to.not.include('--sessionAction');
+      });
+
+      it('should use --display not --selectedMode in display resolver', async () => {
+        const resolver = new FlagResolver<{ display?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+        });
+
+        resolver.addPrompt({
+          flagName: 'display',
+          type: 'list',
+          message: 'Select display mode:',
+          choices: () => [
+            { name: 'Terminal', value: 'terminal' },
+            { name: 'Foreground', value: 'foreground' },
+          ],
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const terminalChoice = output.prompt.choices?.find(c => c.value === 'terminal');
+
+        expect(terminalChoice!.command).to.include('--display "terminal"');
+        expect(terminalChoice!.command).to.not.include('--selectedMode');
+      });
+
+      it('should use --create-pr not --prChoice via getCommand', async () => {
+        const jsonBase = 'prlt work start TKT-100';
+        const resolver = new FlagResolver<{ prChoice?: string }>({
+          commandName: 'work start',
+          baseCommand: jsonBase,
+          jsonMode: true,
+          flags: {},
+        });
+
+        resolver.addPrompt({
+          flagName: 'prChoice',
+          type: 'list',
+          message: 'Create a pull request?',
+          choices: () => [
+            { name: 'Yes', value: 'yes' },
+            { name: 'No', value: 'no' },
+          ],
+          getCommand: (value) => {
+            if (value === 'yes') return `${jsonBase} --create-pr --json`;
+            return `${jsonBase} --json`;
+          },
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const yesChoice = output.prompt.choices?.find(c => c.value === 'yes');
+        const noChoice = output.prompt.choices?.find(c => c.value === 'no');
+
+        expect(yesChoice!.command).to.include('--create-pr');
+        expect(yesChoice!.command).to.not.include('--prChoice');
+        expect(noChoice!.command).to.not.include('--prChoice');
+      });
+
+      it('regression: camelCase flag names produce invalid oclif commands', async () => {
+        // Old camelCase naming produces --sessionAction which oclif rejects
+        const resolver = new FlagResolver<{ sessionAction?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+        });
+
+        resolver.addPrompt({
+          flagName: 'sessionAction',
+          type: 'list',
+          message: 'What would you like to do?',
+          choices: () => [{ name: 'Attach', value: 'attach' }],
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const choice = output.prompt.choices?.[0];
+        // Proves the old naming produces --sessionAction (invalid for oclif)
+        expect(choice!.command).to.include('--sessionAction');
+      });
+    });
+
+    describe('Bug 3: devcontainer choice must add explicit flag', () => {
+      it('should add --environment devcontainer for devcontainer choice', async () => {
+        const jsonBase = 'prlt work start TKT-100';
+        const resolver = new FlagResolver<{ environment?: string }>({
+          commandName: 'work start',
+          baseCommand: jsonBase,
+          jsonMode: true,
+          flags: {},
+        });
+
+        resolver.addPrompt({
+          flagName: 'environment',
+          type: 'list',
+          message: 'Where should the agent run?',
+          default: 'devcontainer',
+          choices: () => [
+            { name: 'devcontainer', value: 'devcontainer' },
+            { name: 'host', value: 'host' },
+            { name: 'cancel', value: 'cancel' },
+          ],
+          getCommand: (value) => {
+            if (value === 'host') return `${jsonBase} --run-on-host --json`;
+            if (value === 'cancel') return '';
+            return `${jsonBase} --environment devcontainer --json`;
+          },
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const devChoice = output.prompt.choices?.find(c => c.value === 'devcontainer');
+
+        expect(devChoice!.command).to.include('--environment devcontainer');
+        expect(devChoice!.command).to.include('--json');
+        // Must NOT be identical to the base invocation (would loop forever)
+        expect(devChoice!.command).to.not.equal(`${jsonBase} --json`);
+      });
+
+      it('regression: devcontainer command without --environment loops forever', () => {
+        const jsonBase = 'prlt work start TKT-100';
+
+        // OLD behavior: devcontainer choice returns base command without any new flag
+        const oldGetCommand = (value: unknown) => {
+          if (value === 'host') return `${jsonBase} --run-on-host --json`;
+          if (value === 'cancel') return '';
+          return `${jsonBase} --json`; // BUG: identical to original invocation
+        };
+
+        expect(oldGetCommand('devcontainer')).to.equal(`${jsonBase} --json`);
+
+        // NEW behavior: adds explicit --environment devcontainer
+        const newGetCommand = (value: unknown) => {
+          if (value === 'host') return `${jsonBase} --run-on-host --json`;
+          if (value === 'cancel') return '';
+          return `${jsonBase} --environment devcontainer --json`;
+        };
+
+        const newDevCmd = newGetCommand('devcontainer');
+        expect(newDevCmd).to.include('--environment devcontainer');
+        expect(newDevCmd).to.not.equal(`${jsonBase} --json`);
+      });
+    });
+
+    describe('accumulated flags with getCommand callbacks', () => {
+      it('getCommand callbacks should include accumulated flags in commands', async () => {
+        const accumulated = { 'run-on-host': true, 'permission-mode': 'danger' };
+        let jsonBase = 'prlt work start TKT-100';
+        for (const [key, val] of Object.entries(accumulated)) {
+          if (typeof val === 'boolean' && val) jsonBase += ` --${key}`;
+          else if (typeof val === 'string') jsonBase += ` --${key} "${val}"`;
+        }
+
+        const resolver = new FlagResolver<{ prChoice?: string }>({
+          commandName: 'work start',
+          baseCommand: 'prlt work start TKT-100',
+          jsonMode: true,
+          flags: {},
+          accumulatedFlags: accumulated,
+        });
+
+        resolver.addPrompt({
+          flagName: 'prChoice',
+          type: 'list',
+          message: 'Create PR?',
+          choices: () => [
+            { name: 'Yes', value: 'yes' },
+            { name: 'No', value: 'no' },
+          ],
+          getCommand: (value) => {
+            if (value === 'yes') return `${jsonBase} --create-pr --json`;
+            return `${jsonBase} --json`;
+          },
+        });
+
+        const output = await resolveAndCapture(resolver);
+        const yesChoice = output.prompt.choices?.find(c => c.value === 'yes');
+
+        expect(yesChoice!.command).to.include('--run-on-host');
+        expect(yesChoice!.command).to.include('--permission-mode "danger"');
+        expect(yesChoice!.command).to.include('--create-pr');
+        expect(yesChoice!.command).to.include('--json');
+      });
+    });
+  });
 });
 
 describe('@smoke shouldOutputJson', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-033: FlagResolver JSON prompt commands don't chain — flags not accumulated, internal names not registered

## Description

## Problem

The FlagResolver JSON prompt `command` fields in `work start` are broken for agent-driven CLI chaining:

### Bug 1: Commands don't accumulate previously resolved flags

Each prompt's `command` field only includes the current choice's flag, dropping everything resolved in prior prompts:

```
Prompt 1 (environment): command = "prlt work start PRLT-1237 --run-on-host --json"  ← OK
Prompt 2 (display mode): command = "prlt work start PRLT-1237 --selectedMode "terminal" --json"  ← LOST --run-on-host
Prompt 3 (permission):   command = "prlt work start PRLT-1237 --permission-mode "danger" --json"  ← LOST everything
```

Agent has to manually track and re-add all previous flags to chain through prompts.

### Bug 2: Commands reference internal FlagResolver names, not registered CLI flags

Several prompt choices generate `command` fields with flag names that aren't registered oclif flags:

* `--branchChoice` → not a flag (causes `Nonexistent flag` error)
* `--selectedMode` → not a flag (should map to `-d`/`--display`)
* `--prChoice` → not a flag (should map to `--create-pr`)

These work in interactive mode (inquirer handles them internally) but break in JSON mode because agents try to run the command directly.

### Bug 3: Devcontainer choice command is a no-op loop

The devcontainer choice's command is identical to the original invocation:

```
"command": "prlt work start PRLT-1237 --json"  ← same command, loops forever
```

No flag is added because devcontainer is the default-when-no-flag-present path. Needs an explicit `--environment devcontainer` or similar.

## Expected Behavior

1. `buildCommand()` in FlagResolver should accumulate ALL previously resolved flags
2. Command field flag names must map to registered oclif flags (or internal flags need to be registered)
3. Default choices should add an explicit flag so the command advances past the prompt

## Impact

Agents cannot drive `prlt work start` in JSON mode — the prompt chain breaks, requiring human interactive mode. This defeats the purpose of the JSON mode agent pattern.

## Affected Commands

* `prlt work start` (confirmed broken)
* Likely any command using FlagResolver with multiple sequential prompts

---
_Imported from Linear: [PRLT-1238](https://linear.app/proletariat/issue/PRLT-1238/flagresolver-json-prompt-commands-dont-chain-flags-not-accumulated)_

## Changes

- 913d009c feat(PRLT-1238): fix(PRLT-1238): FlagResolver JSON prompt chaining — accumulate flags, fix names, add --environment

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
