### PR TITLE
fix(PRLT-1240): pin Claude Code version and add version-aware permission settings

### DIFF
--- a/apps/cli/src/lib/execution/cc-version.ts
+++ b/apps/cli/src/lib/execution/cc-version.ts
@@ -1,0 +1,150 @@
+/**
+ * Claude Code Version Management (PRLT-1240)
+ *
+ * Utilities for detecting Claude Code versions in containers and generating
+ * version-appropriate permission settings. Prevents container agents from
+ * getting stuck at the bypass permissions prompt when Claude Code updates
+ * change the expected settings format.
+ */
+
+import { execSync } from 'node:child_process'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Default Claude Code version for container builds.
+ *
+ * Pinned to last known-good version where permission bypass settings work
+ * correctly. Without this pin, containers install "latest" which may introduce
+ * breaking changes to the permission prompt flow.
+ *
+ * PRLT-1240: Claude Code 2.1.86 changed settings handling so that
+ * skipDangerousModePermissionPrompt and bypassPermissionsModeAccepted
+ * are no longer sufficient to skip the permissions prompt.
+ */
+export const CC_DEFAULT_VERSION = '2.1.81'
+
+/**
+ * Version where Claude Code changed the permissions prompt settings format.
+ * Versions >= this require additional settings to suppress the prompt.
+ */
+export const CC_BREAKING_VERSION = '2.1.86'
+
+// =============================================================================
+// Version Detection
+// =============================================================================
+
+/**
+ * Detect the installed Claude Code version inside a container.
+ * Returns the version string (e.g., "2.1.86") or undefined if detection fails.
+ */
+export function detectCCVersionInContainer(containerId: string): string | undefined {
+  try {
+    const output = execSync(
+      `docker exec ${containerId} claude --version 2>/dev/null`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10_000 }
+    ).trim()
+    return parseCCVersionOutput(output)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Parse Claude Code version from `claude --version` output.
+ * The output format is typically "claude <version>" or just "<version>".
+ * Returns the version string or undefined if parsing fails.
+ */
+export function parseCCVersionOutput(output: string): string | undefined {
+  if (!output) return undefined
+  // Match version pattern: digits.digits.digits (with optional pre-release suffix)
+  const match = output.match(/(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)/)
+  return match ? match[1] : undefined
+}
+
+// =============================================================================
+// Version Comparison
+// =============================================================================
+
+/**
+ * Compare two semver version strings.
+ * Returns: -1 if a < b, 0 if a === b, 1 if a > b.
+ * Only compares major.minor.patch — ignores pre-release suffixes.
+ */
+export function compareCCVersion(a: string, b: string): -1 | 0 | 1 {
+  const partsA = a.split('.').map(Number)
+  const partsB = b.split('.').map(Number)
+
+  for (let i = 0; i < 3; i++) {
+    const va = partsA[i] || 0
+    const vb = partsB[i] || 0
+    if (va < vb) return -1
+    if (va > vb) return 1
+  }
+  return 0
+}
+
+/**
+ * Check if a version is >= the breaking version where settings format changed.
+ */
+export function isPostBreakingVersion(version: string): boolean {
+  return compareCCVersion(version, CC_BREAKING_VERSION) >= 0
+}
+
+// =============================================================================
+// Version-Aware Permission Settings
+// =============================================================================
+
+/**
+ * Settings to write to ~/.claude.json for permission bypass.
+ */
+export interface CCUserSettings {
+  bypassPermissionsModeAccepted: boolean
+  /** Added in 2.1.86+ — records explicit acceptance of dangerous mode */
+  dangerouslySkipPermissionsAccepted?: boolean
+}
+
+/**
+ * Settings to write to ~/.claude/settings.json for permission bypass.
+ */
+export interface CCAppSettings {
+  skipDangerousModePermissionPrompt: boolean
+  /** Added in 2.1.86+ — explicit bypass of the permissions confirmation */
+  dangerouslySkipPermissions?: boolean
+}
+
+/**
+ * Get the permission-related user settings (.claude.json) for a given CC version.
+ * Writes both old and new format keys for forward compatibility.
+ */
+export function getCCUserPermissionSettings(version?: string): CCUserSettings {
+  const settings: CCUserSettings = {
+    bypassPermissionsModeAccepted: true,
+  }
+
+  // For 2.1.86+ or unknown versions, also write the new format
+  if (!version || isPostBreakingVersion(version)) {
+    settings.dangerouslySkipPermissionsAccepted = true
+  }
+
+  return settings
+}
+
+/**
+ * Get the permission-related app settings (settings.json) for a given CC version.
+ * Writes both old and new format keys for forward compatibility.
+ */
+export function getCCAppPermissionSettings(version?: string): CCAppSettings {
+  const settings: CCAppSettings = {
+    skipDangerousModePermissionPrompt: true,
+  }
+
+  // For 2.1.86+ or unknown versions, also write the new format
+  if (!version || isPostBreakingVersion(version)) {
+    settings.dangerouslySkipPermissions = true
+  }
+
+  return settings
+}

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { ExecutionConfig, DEFAULT_EXECUTION_CONFIG, ExecutorType } from './types.js'
 import { parseChannel } from '../workspace-config.js'
+import { CC_DEFAULT_VERSION } from './cc-version.js'
 
 export type MountMode = 'worktree' | 'clone'
 
@@ -85,10 +86,12 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
     buildArgs.PRLT_VERSION = channel.version || 'latest'
   }
 
-  // Pass Claude Code version as build arg if pinned
-  if (options.claudeCodeVersion) {
-    buildArgs.CC_VERSION = options.claudeCodeVersion
-  }
+  // PRLT-1240: Always pin Claude Code version to prevent upstream breakage.
+  // Uses explicit version if provided, otherwise falls back to CC_DEFAULT_VERSION.
+  // Without pinning, containers install "latest" which may change the settings
+  // format and cause agents to get stuck at the permissions prompt.
+  const ccVersion = options.claudeCodeVersion || CC_DEFAULT_VERSION
+  buildArgs.CC_VERSION = ccVersion
 
   // For GitHub Packages, pass GITHUB_TOKEN as build arg
   if (channel.registry === 'gh') {

--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -18,6 +18,11 @@ import {
 import { readDevcontainerJson } from '../devcontainer.js'
 import { isClaudeExecutor } from './executor.js'
 import { getMachineId } from '../../telemetry/analytics.js'
+import {
+  detectCCVersionInContainer,
+  getCCUserPermissionSettings,
+  getCCAppPermissionSettings,
+} from '../cc-version.js'
 
 /** Docker volume name for the shared pnpm store cache (PRLT-1130) */
 export const PNPM_STORE_CACHE_VOLUME = 'pnpm-store-cache'
@@ -461,6 +466,10 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
 
   if (isClaudeExecutor(executor)) {
     try {
+      // PRLT-1240: Detect CC version in container for version-aware settings
+      const ccVersion = detectCCVersionInContainer(containerId)
+      console.debug(`[runners:docker] Detected Claude Code version: ${ccVersion || 'unknown'}`)
+
       const hostClaudeJson = path.join(os.homedir(), '.claude.json')
       let settings: Record<string, unknown> = {}
       if (fs.existsSync(hostClaudeJson)) {
@@ -471,7 +480,9 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
         }
       }
       if (permissionMode === 'danger') {
-        settings.bypassPermissionsModeAccepted = true
+        // PRLT-1240: Write version-aware permission settings to .claude.json
+        const permSettings = getCCUserPermissionSettings(ccVersion)
+        Object.assign(settings, permSettings)
       }
       settings.numStartups = settings.numStartups || 1
       settings.hasCompletedOnboarding = true
@@ -499,9 +510,11 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
         `docker exec -i ${containerId} bash -c 'cat > /home/node/.claude.json'`,
         { input: settingsJson, stdio: ['pipe', 'pipe', 'pipe'] }
       )
-      console.debug(`[runners:docker] Copied .claude.json settings to container (bypassPermissionsModeAccepted=${permissionMode === 'danger'})`)
+      console.debug(`[runners:docker] Copied .claude.json settings to container (permissionMode=${permissionMode})`)
 
-      const claudeSettings = JSON.stringify({ skipDangerousModePermissionPrompt: true })
+      // PRLT-1240: Write version-aware app settings to settings.json
+      const appPermSettings = getCCAppPermissionSettings(ccVersion)
+      const claudeSettings = JSON.stringify(appPermSettings)
       execSync(
         `docker exec -i ${containerId} bash -c 'mkdir -p /home/node/.claude && cat > /home/node/.claude/settings.json'`,
         { input: claudeSettings, stdio: ['pipe', 'pipe', 'pipe'] }

--- a/apps/cli/src/lib/execution/runners/orchestrator.ts
+++ b/apps/cli/src/lib/execution/runners/orchestrator.ts
@@ -31,6 +31,12 @@ import {
   getHostPrltVersion,
 } from './shared.js'
 
+import {
+  detectCCVersionInContainer,
+  getCCUserPermissionSettings,
+  getCCAppPermissionSettings,
+} from '../cc-version.js'
+
 /**
  * Run orchestrator in a Docker container using the sibling container pattern.
  *
@@ -187,6 +193,10 @@ export async function runOrchestratorInDocker(
     // Copy Claude Code settings to container (for bypassing prompts)
     if (executor === 'claude-code') {
       try {
+        // PRLT-1240: Detect CC version in container for version-aware settings
+        const ccVersion = detectCCVersionInContainer(containerId)
+        console.debug(`[runners:orchestrator-docker] Detected Claude Code version: ${ccVersion || 'unknown'}`)
+
         const hostClaudeJson = path.join(os.homedir(), '.claude.json')
         let settings: Record<string, unknown> = {}
 
@@ -199,7 +209,9 @@ export async function runOrchestratorInDocker(
         }
 
         if (config.permissionMode === 'danger') {
-          settings.bypassPermissionsModeAccepted = true
+          // PRLT-1240: Write version-aware permission settings to .claude.json
+          const permSettings = getCCUserPermissionSettings(ccVersion)
+          Object.assign(settings, permSettings)
         }
         settings.numStartups = settings.numStartups || 1
         settings.hasCompletedOnboarding = true
@@ -226,7 +238,9 @@ export async function runOrchestratorInDocker(
           { input: JSON.stringify(settings), stdio: ['pipe', 'pipe', 'pipe'] }
         )
 
-        const claudeSettings = JSON.stringify({ skipDangerousModePermissionPrompt: true })
+        // PRLT-1240: Write version-aware app settings to settings.json
+        const appPermSettings = getCCAppPermissionSettings(ccVersion)
+        const claudeSettings = JSON.stringify(appPermSettings)
         execSync(
           `docker exec -i ${containerId} bash -c 'mkdir -p /home/node/.claude && cat > /home/node/.claude/settings.json'`,
           { input: claudeSettings, stdio: ['pipe', 'pipe', 'pipe'] }

--- a/apps/cli/test/unit/cc-version.test.ts
+++ b/apps/cli/test/unit/cc-version.test.ts
@@ -1,0 +1,239 @@
+import { expect } from 'chai'
+
+import {
+  CC_DEFAULT_VERSION,
+  CC_BREAKING_VERSION,
+  parseCCVersionOutput,
+  compareCCVersion,
+  isPostBreakingVersion,
+  getCCUserPermissionSettings,
+  getCCAppPermissionSettings,
+} from '../../src/lib/execution/cc-version.js'
+
+/**
+ * Unit tests for Claude Code version management (PRLT-1240)
+ *
+ * Verifies version detection, comparison, and version-aware permission settings
+ * that prevent container agents from getting stuck at the bypass permissions prompt.
+ */
+describe('Claude Code Version Management (PRLT-1240)', () => {
+  // ===========================================================================
+  // Constants
+  // ===========================================================================
+
+  describe('CC_DEFAULT_VERSION', () => {
+    it('should be a valid semver string', () => {
+      expect(CC_DEFAULT_VERSION).to.match(/^\d+\.\d+\.\d+$/)
+    })
+
+    it('should be pinned to a pre-breaking version', () => {
+      // The default version should be before the breaking change
+      expect(compareCCVersion(CC_DEFAULT_VERSION, CC_BREAKING_VERSION)).to.equal(-1)
+    })
+  })
+
+  describe('CC_BREAKING_VERSION', () => {
+    it('should be a valid semver string', () => {
+      expect(CC_BREAKING_VERSION).to.match(/^\d+\.\d+\.\d+$/)
+    })
+
+    it('should be 2.1.86', () => {
+      expect(CC_BREAKING_VERSION).to.equal('2.1.86')
+    })
+  })
+
+  // ===========================================================================
+  // Version Parsing
+  // ===========================================================================
+
+  describe('parseCCVersionOutput', () => {
+    it('should parse plain version string', () => {
+      expect(parseCCVersionOutput('2.1.81')).to.equal('2.1.81')
+    })
+
+    it('should parse "claude X.Y.Z" format', () => {
+      expect(parseCCVersionOutput('claude 2.1.86')).to.equal('2.1.86')
+    })
+
+    it('should parse version with pre-release suffix', () => {
+      expect(parseCCVersionOutput('2.1.86-beta.1')).to.equal('2.1.86-beta.1')
+    })
+
+    it('should parse version from multi-line output', () => {
+      expect(parseCCVersionOutput('Claude Code v2.1.90\nSome other info')).to.equal('2.1.90')
+    })
+
+    it('should return undefined for empty string', () => {
+      expect(parseCCVersionOutput('')).to.be.undefined
+    })
+
+    it('should return undefined for non-version string', () => {
+      expect(parseCCVersionOutput('no version here')).to.be.undefined
+    })
+
+    it('should return undefined for undefined-like input', () => {
+      expect(parseCCVersionOutput('')).to.be.undefined
+    })
+  })
+
+  // ===========================================================================
+  // Version Comparison
+  // ===========================================================================
+
+  describe('compareCCVersion', () => {
+    it('should return 0 for equal versions', () => {
+      expect(compareCCVersion('2.1.81', '2.1.81')).to.equal(0)
+    })
+
+    it('should return -1 when a < b (patch)', () => {
+      expect(compareCCVersion('2.1.81', '2.1.86')).to.equal(-1)
+    })
+
+    it('should return 1 when a > b (patch)', () => {
+      expect(compareCCVersion('2.1.86', '2.1.81')).to.equal(1)
+    })
+
+    it('should return -1 when a < b (minor)', () => {
+      expect(compareCCVersion('2.1.86', '2.2.0')).to.equal(-1)
+    })
+
+    it('should return 1 when a > b (minor)', () => {
+      expect(compareCCVersion('2.2.0', '2.1.86')).to.equal(1)
+    })
+
+    it('should return -1 when a < b (major)', () => {
+      expect(compareCCVersion('2.1.86', '3.0.0')).to.equal(-1)
+    })
+
+    it('should return 1 when a > b (major)', () => {
+      expect(compareCCVersion('3.0.0', '2.1.86')).to.equal(1)
+    })
+
+    it('should handle versions with different segment counts', () => {
+      // parseCCVersionOutput always returns X.Y.Z, but compareCCVersion handles missing parts
+      expect(compareCCVersion('2.1', '2.1.0')).to.equal(0)
+    })
+  })
+
+  // ===========================================================================
+  // isPostBreakingVersion
+  // ===========================================================================
+
+  describe('isPostBreakingVersion', () => {
+    it('should return false for pre-breaking versions', () => {
+      expect(isPostBreakingVersion('2.1.81')).to.be.false
+      expect(isPostBreakingVersion('2.1.85')).to.be.false
+    })
+
+    it('should return true for the breaking version itself', () => {
+      expect(isPostBreakingVersion('2.1.86')).to.be.true
+    })
+
+    it('should return true for post-breaking versions', () => {
+      expect(isPostBreakingVersion('2.1.87')).to.be.true
+      expect(isPostBreakingVersion('2.2.0')).to.be.true
+      expect(isPostBreakingVersion('3.0.0')).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Version-Aware Permission Settings
+  // ===========================================================================
+
+  describe('getCCUserPermissionSettings', () => {
+    it('should always include bypassPermissionsModeAccepted', () => {
+      const settings = getCCUserPermissionSettings('2.1.81')
+      expect(settings.bypassPermissionsModeAccepted).to.be.true
+    })
+
+    it('should NOT include new format for pre-breaking versions', () => {
+      const settings = getCCUserPermissionSettings('2.1.81')
+      expect(settings.dangerouslySkipPermissionsAccepted).to.be.undefined
+    })
+
+    it('should include new format for post-breaking versions', () => {
+      const settings = getCCUserPermissionSettings('2.1.86')
+      expect(settings.bypassPermissionsModeAccepted).to.be.true
+      expect(settings.dangerouslySkipPermissionsAccepted).to.be.true
+    })
+
+    it('should include new format for future versions', () => {
+      const settings = getCCUserPermissionSettings('3.0.0')
+      expect(settings.dangerouslySkipPermissionsAccepted).to.be.true
+    })
+
+    it('should include new format when version is undefined (forward compat)', () => {
+      const settings = getCCUserPermissionSettings(undefined)
+      expect(settings.bypassPermissionsModeAccepted).to.be.true
+      expect(settings.dangerouslySkipPermissionsAccepted).to.be.true
+    })
+  })
+
+  describe('getCCAppPermissionSettings', () => {
+    it('should always include skipDangerousModePermissionPrompt', () => {
+      const settings = getCCAppPermissionSettings('2.1.81')
+      expect(settings.skipDangerousModePermissionPrompt).to.be.true
+    })
+
+    it('should NOT include new format for pre-breaking versions', () => {
+      const settings = getCCAppPermissionSettings('2.1.81')
+      expect(settings.dangerouslySkipPermissions).to.be.undefined
+    })
+
+    it('should include new format for post-breaking versions', () => {
+      const settings = getCCAppPermissionSettings('2.1.86')
+      expect(settings.skipDangerousModePermissionPrompt).to.be.true
+      expect(settings.dangerouslySkipPermissions).to.be.true
+    })
+
+    it('should include new format for future versions', () => {
+      const settings = getCCAppPermissionSettings('3.0.0')
+      expect(settings.dangerouslySkipPermissions).to.be.true
+    })
+
+    it('should include new format when version is undefined (forward compat)', () => {
+      const settings = getCCAppPermissionSettings(undefined)
+      expect(settings.skipDangerousModePermissionPrompt).to.be.true
+      expect(settings.dangerouslySkipPermissions).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Regression: settings written to container must include bypass keys
+  // ===========================================================================
+
+  describe('Regression: permission settings completeness', () => {
+    it('pre-breaking version user settings should be spreadable into .claude.json', () => {
+      const settings = getCCUserPermissionSettings('2.1.81')
+      const claudeJson: Record<string, unknown> = { numStartups: 1 }
+      Object.assign(claudeJson, settings)
+      expect(claudeJson.bypassPermissionsModeAccepted).to.be.true
+      expect(claudeJson.numStartups).to.equal(1)
+    })
+
+    it('post-breaking version user settings should be spreadable into .claude.json', () => {
+      const settings = getCCUserPermissionSettings('2.1.86')
+      const claudeJson: Record<string, unknown> = { numStartups: 1 }
+      Object.assign(claudeJson, settings)
+      expect(claudeJson.bypassPermissionsModeAccepted).to.be.true
+      expect(claudeJson.dangerouslySkipPermissionsAccepted).to.be.true
+      expect(claudeJson.numStartups).to.equal(1)
+    })
+
+    it('pre-breaking version app settings should be JSON-serializable', () => {
+      const settings = getCCAppPermissionSettings('2.1.81')
+      const json = JSON.stringify(settings)
+      const parsed = JSON.parse(json)
+      expect(parsed.skipDangerousModePermissionPrompt).to.be.true
+      expect(parsed).to.not.have.property('dangerouslySkipPermissions')
+    })
+
+    it('post-breaking version app settings should be JSON-serializable', () => {
+      const settings = getCCAppPermissionSettings('2.1.86')
+      const json = JSON.stringify(settings)
+      const parsed = JSON.parse(json)
+      expect(parsed.skipDangerousModePermissionPrompt).to.be.true
+      expect(parsed.dangerouslySkipPermissions).to.be.true
+    })
+  })
+})

--- a/apps/cli/test/unit/devcontainer.test.ts
+++ b/apps/cli/test/unit/devcontainer.test.ts
@@ -22,6 +22,10 @@ import {
   getGitIdentity,
 } from '../../src/lib/pr/index.js'
 
+import {
+  CC_DEFAULT_VERSION,
+} from '../../src/lib/execution/cc-version.js'
+
 /**
  * Unit tests for devcontainer generation
  */
@@ -982,18 +986,24 @@ describe('Devcontainer', () => {
         expect(result.build.args).to.have.property('CC_VERSION', '2.1.80')
       })
 
-      it('should not include CC_VERSION build arg when claudeCodeVersion is not specified', () => {
+      // PRLT-1240: CC_VERSION now always set — defaults to CC_DEFAULT_VERSION
+      it('should use CC_DEFAULT_VERSION when claudeCodeVersion is not specified', () => {
         const options = makeOptions()
         const result = generateDevcontainerJson(options)
 
-        expect(result.build.args).to.not.have.property('CC_VERSION')
+        // CC_VERSION should always be set to prevent installing latest
+        expect(result.build.args).to.have.property('CC_VERSION')
+        // Should use the default pinned version
+        // CC_DEFAULT_VERSION imported at top of file
+        expect(result.build.args!.CC_VERSION).to.equal(CC_DEFAULT_VERSION)
       })
 
-      it('should not include CC_VERSION build arg when claudeCodeVersion is undefined', () => {
+      it('should use CC_DEFAULT_VERSION when claudeCodeVersion is undefined', () => {
         const options = makeOptions({ claudeCodeVersion: undefined })
         const result = generateDevcontainerJson(options)
 
-        expect(result.build.args).to.not.have.property('CC_VERSION')
+        // CC_DEFAULT_VERSION imported at top of file
+        expect(result.build.args).to.have.property('CC_VERSION', CC_DEFAULT_VERSION)
       })
     })
 
@@ -1054,7 +1064,8 @@ describe('Devcontainer', () => {
         expect(config.build.args.CC_VERSION).to.equal('2.1.80')
       })
 
-      it('should not include CC_VERSION in devcontainer.json when version is not pinned', () => {
+      // PRLT-1240: CC_VERSION now always set — defaults to CC_DEFAULT_VERSION
+      it('should use CC_DEFAULT_VERSION in devcontainer.json when version is not pinned', () => {
         const options: DevcontainerOptions = {
           agentName: 'unpinned-agent',
           agentDir: testDir,
@@ -1067,7 +1078,8 @@ describe('Devcontainer', () => {
           'utf-8'
         )
         const config = JSON.parse(jsonContent)
-        expect(config.build.args).to.not.have.property('CC_VERSION')
+        // CC_DEFAULT_VERSION imported at top of file
+        expect(config.build.args).to.have.property('CC_VERSION', CC_DEFAULT_VERSION)
       })
 
       it('should include CC_VERSION ARG in generated Dockerfile', () => {


### PR DESCRIPTION
## Summary

- **Pin Claude Code to known-good version (2.1.81)** by default in container builds, preventing upstream changes from breaking the permission bypass flow
- **Add version-aware permission settings** that detect the installed Claude Code version and write both old and new format settings for forward compatibility  
- **Version detection utility** (`cc-version.ts`) with semver comparison, output parsing, and version-specific settings generation

## Problem

Container agents running Claude Code 2.1.86 get stuck at the bypass permissions prompt even though all settings are correct (`skipDangerousModePermissionPrompt`, `bypassPermissionsModeAccepted`, `--dangerously-skip-permissions`). This worked in 2.1.81 but broke in 2.1.86 due to a settings format change.

## Changes

- `apps/cli/src/lib/execution/cc-version.ts` — New module with `CC_DEFAULT_VERSION` constant, version detection, comparison, and version-aware settings generators
- `apps/cli/src/lib/execution/devcontainer.ts` — Always set `CC_VERSION` build arg (defaults to `CC_DEFAULT_VERSION` instead of installing latest)
- `apps/cli/src/lib/execution/runners/docker-management.ts` — Detect CC version in container, write version-appropriate `.claude.json` and `settings.json` 
- `apps/cli/src/lib/execution/runners/orchestrator.ts` — Same version-aware settings for orchestrator containers
- `apps/cli/test/unit/cc-version.test.ts` — 36 tests covering version parsing, comparison, and settings generation
- `apps/cli/test/unit/devcontainer.test.ts` — Updated existing tests for new default version pin behavior

## Test plan

- [x] All 36 cc-version unit tests pass (version parsing, comparison, settings generation)
- [x] Updated devcontainer tests pass with new default version pin behavior
- [x] Build passes (`pnpm build`)
- [ ] Deploy container agent and verify it no longer gets stuck at permissions prompt

Closes PRLT-1240