### PR TITLE
fix(PRLT-1240): add claude-launcher.sh wrapper to prevent container onboarding clobber

### DIFF
--- a/apps/cli/src/lib/execution/cc-version.ts
+++ b/apps/cli/src/lib/execution/cc-version.ts
@@ -2,9 +2,9 @@
  * Claude Code Version Management (PRLT-1240)
  *
  * Utilities for detecting Claude Code versions in containers and generating
- * version-appropriate permission settings. Prevents container agents from
- * getting stuck at the bypass permissions prompt when Claude Code updates
- * change the expected settings format.
+ * version-appropriate permission settings. Also provides a launcher wrapper
+ * script that ensures onboarding settings persist through Claude Code's
+ * startup config write.
  */
 
 import { execSync } from 'node:child_process'
@@ -14,23 +14,16 @@ import { execSync } from 'node:child_process'
 // =============================================================================
 
 /**
- * Default Claude Code version for container builds.
- *
- * Pinned to last known-good version where permission bypass settings work
- * correctly. Without this pin, containers install "latest" which may introduce
- * breaking changes to the permission prompt flow.
- *
- * PRLT-1240: Claude Code 2.1.86 changed settings handling so that
- * skipDangerousModePermissionPrompt and bypassPermissionsModeAccepted
- * are no longer sufficient to skip the permissions prompt.
- */
-export const CC_DEFAULT_VERSION = '2.1.81'
-
-/**
  * Version where Claude Code changed the permissions prompt settings format.
  * Versions >= this require additional settings to suppress the prompt.
  */
 export const CC_BREAKING_VERSION = '2.1.86'
+
+/**
+ * Command name for the Claude launcher wrapper script.
+ * Installed at /usr/local/bin/ so it's in PATH inside containers.
+ */
+export const CLAUDE_LAUNCHER_CMD = 'claude-launcher.sh'
 
 // =============================================================================
 // Version Detection
@@ -147,4 +140,93 @@ export function getCCAppPermissionSettings(version?: string): CCAppSettings {
   }
 
   return settings
+}
+
+// =============================================================================
+// Claude Launcher Wrapper (PRLT-1240)
+// =============================================================================
+
+/**
+ * Build the claude-launcher.sh wrapper script content.
+ *
+ * Claude Code >=2.1.86 overwrites ~/.claude.json on startup with its own
+ * runtime cache (OAuth state, feature flags), clobbering hasCompletedOnboarding=true
+ * that prlt writes during container setup. Without that flag, Claude starts the
+ * first-run onboarding flow (theme picker → permissions → workspace trust) and
+ * agents get stuck.
+ *
+ * This wrapper:
+ * 1. Merges onboarding settings into ~/.claude.json before launch
+ * 2. Starts a background guardian that re-applies settings if Claude clobbers them
+ * 3. Execs into claude with all original arguments
+ *
+ * The guardian checks every 500ms for 15 seconds. Once settings survive 3
+ * consecutive checks (1.5s stable), it exits. This covers the startup window
+ * where Claude may overwrite the config.
+ */
+export function buildClaudeLauncherScript(): string {
+  // The node one-liner that merges onboarding settings into ~/.claude.json.
+  // Uses Node.js (always available in containers) instead of jq for reliability.
+  const applySettingsScript = `
+      const fs = require("fs");
+      const f = require("os").homedir() + "/.claude.json";
+      let s = {};
+      try { s = JSON.parse(fs.readFileSync(f, "utf8")); } catch {}
+      if (s.hasCompletedOnboarding === true) process.exit(0);
+      s.hasCompletedOnboarding = true;
+      s.numStartups = Math.max(s.numStartups || 0, 1);
+      s.theme = s.theme || "dark";
+      s.effortCalloutDismissed = true;
+      s.tipsHistory = Object.assign(s.tipsHistory || {}, {"new-user-warmup": 1});
+      s.projects = s.projects || {};
+      ["/workspace", "/hq", "/"].forEach(function(p) {
+        s.projects[p] = Object.assign(s.projects[p] || {}, {
+          hasTrustDialogAccepted: true,
+          hasCompletedProjectOnboarding: true
+        });
+      });
+      fs.writeFileSync(f, JSON.stringify(s));
+      process.exit(1);
+  `.trim()
+
+  return `#!/bin/bash
+# claude-launcher.sh — PRLT-1240: Ensure onboarding settings survive Claude startup
+# Claude Code >=2.1.86 overwrites ~/.claude.json on startup with runtime cache,
+# clobbering hasCompletedOnboarding=true. This wrapper applies settings before
+# launch and runs a background guardian that re-applies if clobbered.
+
+# Pre-launch: ensure onboarding settings exist in .claude.json
+node -e '${applySettingsScript}' 2>/dev/null || true
+
+# Background guardian: re-apply settings if Claude clobbers them during startup.
+# Checks every 500ms for up to 15s. Exits early once settings are stable (3 consecutive OKs).
+(
+  settled=0
+  for i in $(seq 1 30); do
+    sleep 0.5
+    node -e '${applySettingsScript}' 2>/dev/null
+    if [ $? -eq 0 ]; then
+      settled=$((settled + 1))
+      [ $settled -ge 6 ] && break
+    else
+      settled=0
+    fi
+  done
+) &
+
+# Launch Claude Code with all original arguments
+exec claude "$@"
+`
+}
+
+/**
+ * Install the claude-launcher.sh wrapper script into a running container.
+ * Writes to /usr/local/bin/ (requires --user root for docker exec).
+ */
+export function installClaudeLauncherInContainer(containerId: string): void {
+  const script = buildClaudeLauncherScript()
+  execSync(
+    `docker exec --user root -i ${containerId} bash -c 'cat > /usr/local/bin/${CLAUDE_LAUNCHER_CMD} && chmod +x /usr/local/bin/${CLAUDE_LAUNCHER_CMD}'`,
+    { input: script, stdio: ['pipe', 'pipe', 'pipe'] }
+  )
 }

--- a/apps/cli/src/lib/execution/devcontainer.ts
+++ b/apps/cli/src/lib/execution/devcontainer.ts
@@ -9,7 +9,8 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { ExecutionConfig, DEFAULT_EXECUTION_CONFIG, ExecutorType } from './types.js'
 import { parseChannel } from '../workspace-config.js'
-import { CC_DEFAULT_VERSION } from './cc-version.js'
+// CC_DEFAULT_VERSION removed in PRLT-1240 — no longer pinning Claude Code version.
+// The claude-launcher.sh wrapper handles onboarding settings persistence.
 
 export type MountMode = 'worktree' | 'clone'
 
@@ -86,12 +87,12 @@ export function generateDevcontainerJson(options: DevcontainerOptions, config?: 
     buildArgs.PRLT_VERSION = channel.version || 'latest'
   }
 
-  // PRLT-1240: Always pin Claude Code version to prevent upstream breakage.
-  // Uses explicit version if provided, otherwise falls back to CC_DEFAULT_VERSION.
-  // Without pinning, containers install "latest" which may change the settings
-  // format and cause agents to get stuck at the permissions prompt.
-  const ccVersion = options.claudeCodeVersion || CC_DEFAULT_VERSION
-  buildArgs.CC_VERSION = ccVersion
+  // PRLT-1240: Only pin Claude Code version if explicitly specified.
+  // The claude-launcher.sh wrapper handles onboarding settings persistence,
+  // so version pinning is no longer needed as a workaround.
+  if (options.claudeCodeVersion) {
+    buildArgs.CC_VERSION = options.claudeCodeVersion
+  }
 
   // For GitHub Packages, pass GITHUB_TOKEN as build arg
   if (channel.registry === 'gh') {

--- a/apps/cli/src/lib/execution/runners/devcontainer.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer.ts
@@ -40,6 +40,7 @@ import { runDevcontainerInTmux } from './devcontainer-tmux.js'
 import { runDevcontainerInTerminal } from './devcontainer-terminal.js'
 import { writeWorkspaceManifest } from '../context.js'
 import type { WorkspaceManifest } from '../types.js'
+import { CLAUDE_LAUNCHER_CMD } from '../cc-version.js'
 
 // =============================================================================
 // Prompt File Management
@@ -149,7 +150,9 @@ export function buildDevcontainerCommand(
     // Tool registry (TKT-083): pass MCP config to Claude Code via --mcp-config flag
     const mcpConfigFlag = mcpConfigFile ? `--mcp-config ${mcpConfigFile} ` : ''
     // PRLT-950: Use -- to separate flags from positional prompt argument.
-    executorCmd = `claude ${bypassTrustFlag}${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}${mcpConfigFlag}-- "$(cat ${promptFile})"`
+    // PRLT-1240: Use claude-launcher.sh wrapper in containers to ensure onboarding
+    // settings survive Claude Code's startup config write.
+    executorCmd = `${CLAUDE_LAUNCHER_CMD} ${bypassTrustFlag}${permissionsFlag}${effortFlag}${printFlag}${disallowPlanFlag}${mcpConfigFlag}-- "$(cat ${promptFile})"`
   } else if (executor === 'codex') {
     const codexPermission: PermissionMode = permissionMode
     const codexContext = resolveCodexExecutionContext(displayMode, outputMode)

--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -22,6 +22,7 @@ import {
   detectCCVersionInContainer,
   getCCUserPermissionSettings,
   getCCAppPermissionSettings,
+  installClaudeLauncherInContainer,
 } from '../cc-version.js'
 
 /** Docker volume name for the shared pnpm store cache (PRLT-1130) */
@@ -543,6 +544,13 @@ export function runContainerSetup(containerId: string, permissionMode: Permissio
         { input: enforceTestsScript, stdio: ['pipe', 'pipe', 'pipe'] }
       )
       console.debug(`[runners:docker] Wrote enforce-tests hook script to container`)
+
+      // PRLT-1240: Install claude-launcher.sh wrapper that ensures onboarding
+      // settings survive Claude Code's startup config write. Claude >=2.1.86
+      // overwrites ~/.claude.json on startup, clobbering hasCompletedOnboarding.
+      // The launcher re-applies settings before and during Claude's startup.
+      installClaudeLauncherInContainer(containerId)
+      console.debug(`[runners:docker] Installed claude-launcher.sh in container`)
     } catch (error) {
       console.debug('[runners:docker] Failed to copy Claude settings to container:', error)
     }

--- a/apps/cli/src/lib/execution/runners/orchestrator.ts
+++ b/apps/cli/src/lib/execution/runners/orchestrator.ts
@@ -35,6 +35,8 @@ import {
   detectCCVersionInContainer,
   getCCUserPermissionSettings,
   getCCAppPermissionSettings,
+  installClaudeLauncherInContainer,
+  CLAUDE_LAUNCHER_CMD,
 } from '../cc-version.js'
 
 /**
@@ -245,6 +247,11 @@ export async function runOrchestratorInDocker(
           `docker exec -i ${containerId} bash -c 'mkdir -p /home/node/.claude && cat > /home/node/.claude/settings.json'`,
           { input: claudeSettings, stdio: ['pipe', 'pipe', 'pipe'] }
         )
+
+        // PRLT-1240: Install claude-launcher.sh wrapper that ensures onboarding
+        // settings survive Claude Code's startup config write.
+        installClaudeLauncherInContainer(containerId)
+        console.debug(`[runners:orchestrator-docker] Installed claude-launcher.sh in container`)
       } catch (error) {
         console.debug('[runners:orchestrator-docker] Failed to copy Claude settings:', error)
       }
@@ -273,9 +280,11 @@ export async function runOrchestratorInDocker(
     const disallowPlanFlag = displayMode === 'background' ? '--disallowedTools EnterPlanMode ' : ''
     // PRLT-950: Use -- to separate flags from positional prompt argument.
     // --disallowedTools is variadic and will consume the prompt as its second arg without --.
+    // PRLT-1240: Use claude-launcher.sh wrapper in containers to ensure onboarding
+    // settings survive Claude Code's startup config write.
     const executorCmd = executor === 'claude-code'
-      ? `claude ${permissionsFlag}${effortFlag}${disallowPlanFlag}-- "$(cat ${promptPath})"`
-      : `claude ${permissionsFlag}${effortFlag}-- "$(cat ${promptPath})"`
+      ? `${CLAUDE_LAUNCHER_CMD} ${permissionsFlag}${effortFlag}${disallowPlanFlag}-- "$(cat ${promptPath})"`
+      : `${CLAUDE_LAUNCHER_CMD} ${permissionsFlag}${effortFlag}-- "$(cat ${promptPath})"`
 
     // Build tmux session name (reuses the same name as host tmux for consistency)
     const tmuxSessionName = options?.sessionName || containerName
@@ -296,7 +305,7 @@ export async function runOrchestratorInDocker(
         const scriptContent = `#!/bin/bash
 cd /hq
 unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT
-${executor === 'claude-code' ? `claude ${permissionsFlag}${effortFlag}${disallowPlanFlag}"$(cat ${promptPath})"` : `claude "$(cat ${promptPath})"`}
+${executor === 'claude-code' ? `${CLAUDE_LAUNCHER_CMD} ${permissionsFlag}${effortFlag}${disallowPlanFlag}"$(cat ${promptPath})"` : `${CLAUDE_LAUNCHER_CMD} "$(cat ${promptPath})"`}
 echo ""
 echo "Orchestrator complete. Press Enter to close."
 exec bash

--- a/apps/cli/test/unit/cc-version.test.ts
+++ b/apps/cli/test/unit/cc-version.test.ts
@@ -1,34 +1,31 @@
 import { expect } from 'chai'
 
 import {
-  CC_DEFAULT_VERSION,
   CC_BREAKING_VERSION,
+  CLAUDE_LAUNCHER_CMD,
   parseCCVersionOutput,
   compareCCVersion,
   isPostBreakingVersion,
   getCCUserPermissionSettings,
   getCCAppPermissionSettings,
+  buildClaudeLauncherScript,
 } from '../../src/lib/execution/cc-version.js'
 
 /**
  * Unit tests for Claude Code version management (PRLT-1240)
  *
- * Verifies version detection, comparison, and version-aware permission settings
- * that prevent container agents from getting stuck at the bypass permissions prompt.
+ * Verifies version detection, comparison, version-aware permission settings,
+ * and the claude-launcher.sh wrapper that ensures onboarding settings persist
+ * through Claude Code's startup config write.
  */
 describe('Claude Code Version Management (PRLT-1240)', () => {
   // ===========================================================================
   // Constants
   // ===========================================================================
 
-  describe('CC_DEFAULT_VERSION', () => {
-    it('should be a valid semver string', () => {
-      expect(CC_DEFAULT_VERSION).to.match(/^\d+\.\d+\.\d+$/)
-    })
-
-    it('should be pinned to a pre-breaking version', () => {
-      // The default version should be before the breaking change
-      expect(compareCCVersion(CC_DEFAULT_VERSION, CC_BREAKING_VERSION)).to.equal(-1)
+  describe('CLAUDE_LAUNCHER_CMD', () => {
+    it('should be claude-launcher.sh', () => {
+      expect(CLAUDE_LAUNCHER_CMD).to.equal('claude-launcher.sh')
     })
   })
 
@@ -234,6 +231,87 @@ describe('Claude Code Version Management (PRLT-1240)', () => {
       const parsed = JSON.parse(json)
       expect(parsed.skipDangerousModePermissionPrompt).to.be.true
       expect(parsed.dangerouslySkipPermissions).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // Claude Launcher Wrapper (PRLT-1240)
+  // ===========================================================================
+
+  describe('buildClaudeLauncherScript', () => {
+    let script: string
+
+    before(() => {
+      script = buildClaudeLauncherScript()
+    })
+
+    it('should return a non-empty bash script', () => {
+      expect(script).to.be.a('string')
+      expect(script.length).to.be.greaterThan(0)
+      expect(script).to.match(/^#!/)
+    })
+
+    it('should start with a bash shebang', () => {
+      expect(script.startsWith('#!/bin/bash')).to.be.true
+    })
+
+    it('should exec into claude with all arguments', () => {
+      expect(script).to.include('exec claude "$@"')
+    })
+
+    it('should set hasCompletedOnboarding to true', () => {
+      expect(script).to.include('hasCompletedOnboarding')
+    })
+
+    it('should set theme to dark as default', () => {
+      expect(script).to.include('s.theme = s.theme || "dark"')
+    })
+
+    it('should set hasTrustDialogAccepted for project paths', () => {
+      expect(script).to.include('hasTrustDialogAccepted')
+      expect(script).to.include('/workspace')
+      expect(script).to.include('/hq')
+    })
+
+    it('should include a background guardian loop', () => {
+      // Guardian runs in background subshell
+      expect(script).to.include(') &')
+      // Guardian checks periodically
+      expect(script).to.include('sleep 0.5')
+    })
+
+    it('should include pre-launch settings application', () => {
+      // The script applies settings BEFORE the background guardian starts
+      const prelaunchIndex = script.indexOf('Pre-launch')
+      const guardianIndex = script.indexOf('Background guardian')
+      const execIndex = script.indexOf('exec claude')
+      expect(prelaunchIndex).to.be.lessThan(guardianIndex)
+      expect(guardianIndex).to.be.lessThan(execIndex)
+    })
+
+    it('should set effortCalloutDismissed', () => {
+      expect(script).to.include('effortCalloutDismissed')
+    })
+
+    it('should set tipsHistory for new-user-warmup', () => {
+      expect(script).to.include('new-user-warmup')
+    })
+
+    it('should use node for settings manipulation (not jq)', () => {
+      // Node.js is always available in containers; jq may not be
+      expect(script).to.include('node -e')
+      expect(script).to.not.include('jq ')
+    })
+
+    // Regression: launcher must exit cleanly if .claude.json already has onboarding
+    it('should exit 0 from node script when hasCompletedOnboarding is already true', () => {
+      expect(script).to.include('if (s.hasCompletedOnboarding === true) process.exit(0)')
+    })
+
+    // Regression: guardian must self-terminate
+    it('should have a bounded guardian loop that exits after settling', () => {
+      expect(script).to.include('settled')
+      expect(script).to.include('break')
     })
   })
 })

--- a/apps/cli/test/unit/devcontainer.test.ts
+++ b/apps/cli/test/unit/devcontainer.test.ts
@@ -22,9 +22,7 @@ import {
   getGitIdentity,
 } from '../../src/lib/pr/index.js'
 
-import {
-  CC_DEFAULT_VERSION,
-} from '../../src/lib/execution/cc-version.js'
+// CC_DEFAULT_VERSION removed in PRLT-1240 — no longer pinning Claude Code version
 
 /**
  * Unit tests for devcontainer generation
@@ -986,24 +984,21 @@ describe('Devcontainer', () => {
         expect(result.build.args).to.have.property('CC_VERSION', '2.1.80')
       })
 
-      // PRLT-1240: CC_VERSION now always set — defaults to CC_DEFAULT_VERSION
-      it('should use CC_DEFAULT_VERSION when claudeCodeVersion is not specified', () => {
+      // PRLT-1240: CC_VERSION no longer pinned by default — launcher handles onboarding
+      it('should NOT set CC_VERSION when claudeCodeVersion is not specified', () => {
         const options = makeOptions()
         const result = generateDevcontainerJson(options)
 
-        // CC_VERSION should always be set to prevent installing latest
-        expect(result.build.args).to.have.property('CC_VERSION')
-        // Should use the default pinned version
-        // CC_DEFAULT_VERSION imported at top of file
-        expect(result.build.args!.CC_VERSION).to.equal(CC_DEFAULT_VERSION)
+        // CC_VERSION should not be set — installs latest Claude Code
+        expect(result.build.args).to.not.have.property('CC_VERSION')
       })
 
-      it('should use CC_DEFAULT_VERSION when claudeCodeVersion is undefined', () => {
+      it('should NOT set CC_VERSION when claudeCodeVersion is undefined', () => {
         const options = makeOptions({ claudeCodeVersion: undefined })
         const result = generateDevcontainerJson(options)
 
-        // CC_DEFAULT_VERSION imported at top of file
-        expect(result.build.args).to.have.property('CC_VERSION', CC_DEFAULT_VERSION)
+        // CC_VERSION should not be set — installs latest Claude Code
+        expect(result.build.args).to.not.have.property('CC_VERSION')
       })
     })
 
@@ -1064,8 +1059,8 @@ describe('Devcontainer', () => {
         expect(config.build.args.CC_VERSION).to.equal('2.1.80')
       })
 
-      // PRLT-1240: CC_VERSION now always set — defaults to CC_DEFAULT_VERSION
-      it('should use CC_DEFAULT_VERSION in devcontainer.json when version is not pinned', () => {
+      // PRLT-1240: CC_VERSION no longer pinned by default — launcher handles onboarding
+      it('should NOT include CC_VERSION in devcontainer.json when version is not pinned', () => {
         const options: DevcontainerOptions = {
           agentName: 'unpinned-agent',
           agentDir: testDir,
@@ -1078,8 +1073,8 @@ describe('Devcontainer', () => {
           'utf-8'
         )
         const config = JSON.parse(jsonContent)
-        // CC_DEFAULT_VERSION imported at top of file
-        expect(config.build.args).to.have.property('CC_VERSION', CC_DEFAULT_VERSION)
+        // CC_VERSION should not be set — installs latest Claude Code
+        expect(config.build.args).to.not.have.property('CC_VERSION')
       })
 
       it('should include CC_VERSION ARG in generated Dockerfile', () => {


### PR DESCRIPTION
## Summary

- **Root cause**: Claude Code ≥2.1.86 overwrites `~/.claude.json` on startup with runtime cache, clobbering `hasCompletedOnboarding=true` that prlt writes during container setup. Agents get stuck on the theme picker screen.
- **Fix**: Add a `claude-launcher.sh` wrapper script that ensures onboarding settings persist through Claude's startup config write. The launcher applies settings pre-launch and runs a self-terminating background guardian (15s) that re-applies settings if Claude clobbers them.
- **Version pin removed**: `CC_DEFAULT_VERSION` pin to 2.1.81 is no longer needed — containers now install the latest Claude Code version.

## Changes

- `cc-version.ts`: Remove `CC_DEFAULT_VERSION`, add `buildClaudeLauncherScript()` and `installClaudeLauncherInContainer()`
- `docker-management.ts`: Install launcher during `runContainerSetup()`
- `orchestrator.ts`: Install launcher during orchestrator container setup
- `devcontainer.ts` (runner): Use `claude-launcher.sh` instead of `claude` in container commands
- `orchestrator.ts` (runner): Use `claude-launcher.sh` instead of `claude` in container commands
- `devcontainer.ts` (generator): Only set `CC_VERSION` build arg when explicitly specified

## Test plan

- [x] cc-version unit tests updated (version pin tests removed, launcher script tests added)
- [x] devcontainer unit tests updated (version pin default tests changed to expect no pin)
- [x] All 185 tests pass (`pnpm test:unit`)
- [x] Build passes (`pnpm build`)
- [ ] Manual verification: spin up agent container with CC ≥2.1.86, verify no theme picker prompt

Closes PRLT-1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)