### PR TITLE
TKT-062: Add computing pioneers to cracked-engineers theme — Hopper, Turing, Lovelace, Hidden Figures, etc.

### DIFF
--- a/apps/cli/src/lib/themes.ts
+++ b/apps/cli/src/lib/themes.ts
@@ -130,10 +130,17 @@ export const BUILTIN_THEMES: BuiltinThemeDefinition[] = [
     id: 'cracked-engineers',
     name: 'cracked-engineers',
     displayName: 'Cracked Engineers',
-    description: 'AI researchers, engineers, and tech legends',
+    description: 'Computing pioneers, AI researchers, engineers, and tech legends',
     persistentDir: 'staff',
     ephemeralDir: 'temp',
     names: [
+      // Computing pioneers
+      'babbage', 'berners-lee', 'dijkstra', 'hamilton', 'hopper',
+      'jackson', 'johnson', 'knuth', 'lovelace', 'ritchie',
+      'thompson', 'turing', 'vaughan',
+      // Computing pioneers (nice-to-have)
+      'cerf', 'kay', 'kernighan', 'lamport', 'liskov', 'mccarthy',
+      'stallman', 'wozniak',
       // AI researchers
       'karpathy', 'lecun', 'sutskever',
       // Engineers & creators

--- a/apps/cli/test/unit/theme-validation.test.ts
+++ b/apps/cli/test/unit/theme-validation.test.ts
@@ -112,6 +112,61 @@ describe('Theme Validation & Utilities', () => {
       expect(theme!.names).to.include('musk');
     });
 
+    it('includes cracked-engineers theme', () => {
+      const theme = BUILTIN_THEMES.find(t => t.id === 'cracked-engineers');
+      expect(theme).to.exist;
+      expect(theme!.description).to.include('Computing pioneers');
+    });
+
+    it('cracked-engineers theme includes computing pioneers (must-haves)', () => {
+      const theme = BUILTIN_THEMES.find(t => t.id === 'cracked-engineers')!;
+      const mustHaves = [
+        'hopper', 'turing', 'lovelace', 'babbage', 'hamilton',
+        'johnson', 'vaughan', 'jackson', 'ritchie', 'thompson',
+        'knuth', 'dijkstra', 'berners-lee',
+      ];
+      for (const name of mustHaves) {
+        expect(theme.names, `missing pioneer: ${name}`).to.include(name);
+      }
+    });
+
+    it('cracked-engineers theme includes computing pioneers (nice-to-haves)', () => {
+      const theme = BUILTIN_THEMES.find(t => t.id === 'cracked-engineers')!;
+      const niceToHaves = [
+        'mccarthy', 'kay', 'cerf', 'liskov', 'lamport',
+        'stallman', 'wozniak', 'kernighan',
+      ];
+      for (const name of niceToHaves) {
+        expect(theme.names, `missing pioneer: ${name}`).to.include(name);
+      }
+    });
+
+    it('cracked-engineers theme retains existing names', () => {
+      const theme = BUILTIN_THEMES.find(t => t.id === 'cracked-engineers')!;
+      const existingNames = [
+        'karpathy', 'lecun', 'sutskever', 'torvalds', 'fridman',
+      ];
+      for (const name of existingNames) {
+        expect(theme.names, `missing existing name: ${name}`).to.include(name);
+      }
+    });
+
+    it('cracked-engineers theme has no duplicate names', () => {
+      const theme = BUILTIN_THEMES.find(t => t.id === 'cracked-engineers')!;
+      const seen = new Set<string>();
+      for (const name of theme.names) {
+        expect(seen.has(name), `duplicate name: ${name}`).to.be.false;
+        seen.add(name);
+      }
+    });
+
+    it('cracked-engineers theme names are all valid agent names', () => {
+      const theme = BUILTIN_THEMES.find(t => t.id === 'cracked-engineers')!;
+      for (const name of theme.names) {
+        expect(isValidAgentName(name), `invalid agent name: ${name}`).to.be.true;
+      }
+    });
+
     it('includes toyotas theme', () => {
       const theme = BUILTIN_THEMES.find(t => t.id === 'toyotas');
       expect(theme).to.exist;


### PR DESCRIPTION
## Summary

Resolves TKT-062: Add computing pioneers to cracked-engineers theme — Hopper, Turing, Lovelace, Hidden Figures, etc.

## Description

The cracked-engineers agent naming theme is missing the actual pioneers of computing. Currently heavy on modern tech figures (Karpathy, Torvalds, Fridman) but has zero historical legends.

Add to the cracked-engineers names array in apps/cli/src/lib/themes.ts:

## Must-haves

* hopper (Grace Hopper — invented the compiler, coined "debugging")
* turing (Alan Turing — father of computer science)
* lovelace (Ada Lovelace — first programmer)
* babbage (Charles Babbage — designed the first mechanical computer)
* hamilton (Margaret Hamilton — Apollo flight software, coined "software engineering")
* johnson (Katherine Johnson — NASA orbital mechanics, Hidden Figures)
* vaughan (Dorothy Vaughan — NASA first Black supervisor, taught FORTRAN)
* jackson (Mary Jackson — NASA first Black female engineer)
* ritchie (Dennis Ritchie — created C and Unix)
* thompson (Ken Thompson — created Unix, Go)
* knuth (Donald Knuth — Art of Computer Programming)
* dijkstra (Edsger Dijkstra — structured programming, shortest path)
* berners-lee (Tim Berners-Lee — invented the web)

## Nice-to-haves

* mccarthy (John McCarthy — invented Lisp, coined "AI")
* kay (Alan Kay — invented OOP, Smalltalk)
* cerf (Vint Cerf — father of the internet)
* liskov (Barbara Liskov — Liskov substitution principle)
* lamport (Leslie Lamport — distributed systems, LaTeX)
* stallman (Richard Stallman — GNU, free software)
* wozniak (Steve Wozniak — built Apple I/II)
* kernighan (Brian Kernighan — K&R C, Unix)

One-file change: apps/cli/src/lib/themes.ts

---
_Imported from Linear: [PRLT-1241](https://linear.app/proletariat/issue/PRLT-1241/add-computing-pioneers-to-cracked-engineers-theme-hopper-turing)_

## Changes

- cea6126e feat(PRLT-1241): add computing pioneers to cracked-engineers theme

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
