### PR TITLE
TKT-061: Fix main CI: notification layer action not registered in presets and action count test outdated

### DIFF
--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -48,6 +48,8 @@ const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Re
   // CI lifecycle
   { event: 'on_ci_failed', action: 'notify' },
   { event: 'on_ci_failed', action: 'spawn-fix-agent' },
+  // Periodic cleanup
+  { event: 'on_agent_completed', action: 'gc-sweep' },
 ]
 
 /**
@@ -67,6 +69,7 @@ const SAFE_ACTIONS = new Set([
   'health-check',
   'rebase-conflicting-prs',
   'spawn-review-agent',
+  'gc-sweep',
 ])
 
 export const PRESETS: Record<PresetName, PresetDefinition> = {

--- a/apps/cli/test/unit/orchestrate-actions.test.ts
+++ b/apps/cli/test/unit/orchestrate-actions.test.ts
@@ -30,6 +30,7 @@ describe('Orchestrate Built-in Actions', () => {
       'spawn-review-agent',
       'health-check',
       'resolve-conflict',
+      'gc-sweep',
     ]
 
     it('should have all expected actions registered', () => {

--- a/apps/cli/test/unit/orchestrate-daemon-supervised.test.ts
+++ b/apps/cli/test/unit/orchestrate-daemon-supervised.test.ts
@@ -85,6 +85,7 @@ function insertSupervisedHooks(db: Database.Database): void {
     { name: 'sup:on_agent_idle:health-check', event: 'on_agent_idle', action: 'health-check', mode: 'auto' },
     { name: 'sup:on_ci_failed:notify', event: 'on_ci_failed', action: 'notify', mode: 'auto' },
     { name: 'sup:on_ci_failed:spawn-fix', event: 'on_ci_failed', action: 'spawn-fix-agent', mode: 'confirm' },
+    { name: 'sup:on_agent_completed:gc-sweep', event: 'on_agent_completed', action: 'gc-sweep', mode: 'auto' },
   ]
 
   for (const hook of hooks) {

--- a/apps/cli/test/unit/orchestrate-presets.test.ts
+++ b/apps/cli/test/unit/orchestrate-presets.test.ts
@@ -22,6 +22,7 @@ const SAFE_ACTIONS = new Set([
   'health-check',
   'rebase-conflicting-prs',
   'spawn-review-agent',
+  'gc-sweep',
 ])
 
 describe('Orchestrate Presets', () => {


### PR DESCRIPTION
## Summary

Resolves TKT-061: Fix main CI: notification layer action not registered in presets and action count test outdated

## Description

PRLT-1157 (notification layer) added a new built-in action but:

1. orchestrate-actions.test.ts expects exactly 11 actions, now there are 12
2. The new action is not in any preset (orchestrate-presets.test.ts invariant fails)
3. orchestrate-daemon-supervised.test.ts fails because supervised mode doesnt know about the new action

Fix: update action count in test, add new action to appropriate presets, verify supervised mode handles it.

Files:

* apps/cli/test/unit/orchestrate-actions.test.ts — update expected count from 11 to 12
* apps/cli/src/lib/orchestrate/presets.ts — add notification action to presets
* apps/cli/test/unit/orchestrate-daemon-supervised.test.ts — update for new action

The sendTmuxMessage failures (11 tests) are pre-existing CI flakes unrelated to our merges.

---
_Imported from Linear: [PRLT-1242](https://linear.app/proletariat/issue/PRLT-1242/fix-main-ci-notification-layer-action-not-registered-in-presets-and)_

## Changes

- 65be978a feat(PRLT-1242): fix: register gc-sweep action in presets and update test counts for PRLT-1157 notification layer

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
