### PR TITLE
TKT-064: Publish prlt ClawHub skill for OpenClaw integration

### DIFF
--- a/apps/cli/test/unit/clawhub-skill.test.ts
+++ b/apps/cli/test/unit/clawhub-skill.test.ts
@@ -1,0 +1,210 @@
+import { expect } from 'chai';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Unit tests for the ClawHub SKILL.md file.
+ * Validates frontmatter structure and markdown body content
+ * for the OpenClaw integration skill.
+ *
+ * PRLT-1243: Publish prlt ClawHub skill for OpenClaw integration
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Path from apps/cli/test/unit/ to repo root
+const SKILL_PATH = resolve(__dirname, '..', '..', '..', '..', 'skills', 'openclaw', 'SKILL.md');
+
+function parseSkillFile(content: string): { frontmatter: Record<string, unknown>; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) throw new Error('SKILL.md must have YAML frontmatter delimited by ---');
+  const rawYaml = match[1];
+  const body = match[2];
+
+  // Simple YAML parser for the flat/nested structure we expect
+  const frontmatter: Record<string, unknown> = {};
+  let currentKey: string | null = null;
+  let currentList: string[] | null = null;
+
+  for (const line of rawYaml.split('\n')) {
+    // Nested list item (e.g. "    - prlt")
+    const nestedListMatch = line.match(/^ {4}- (.+)$/);
+    if (nestedListMatch && currentKey) {
+      if (!currentList) currentList = [];
+      currentList.push(nestedListMatch[1].trim());
+      continue;
+    }
+
+    // Top-level list item (e.g. "  - orchestration")
+    const topListMatch = line.match(/^ {2}- (.+)$/);
+    if (topListMatch && currentKey) {
+      if (!currentList) currentList = [];
+      currentList.push(topListMatch[1].trim());
+      continue;
+    }
+
+    // Flush previous list
+    if (currentList && currentKey) {
+      // Assign list to the right path
+      frontmatter[currentKey] = currentList;
+      currentList = null;
+      currentKey = null;
+    }
+
+    // Top-level key: value (e.g. "name: proletariat")
+    const kvMatch = line.match(/^(\w+):\s*(.*)$/);
+    if (kvMatch) {
+      const key = kvMatch[1];
+      const value = kvMatch[2].trim();
+      if (value) {
+        frontmatter[key] = value;
+        currentKey = null;
+      } else {
+        currentKey = key;
+      }
+      continue;
+    }
+
+    // Nested key (e.g. "  bins:")
+    const nestedKeyMatch = line.match(/^\s+(\w+):\s*(.*)$/);
+    if (nestedKeyMatch) {
+      const nestedKey = nestedKeyMatch[1];
+      const nestedValue = nestedKeyMatch[2].trim();
+      if (nestedValue) {
+        frontmatter[`${currentKey}.${nestedKey}`] = nestedValue;
+      } else {
+        // bins: (with list below) — update currentKey to track nested path
+        currentKey = `${currentKey}.${nestedKey}`;
+      }
+    }
+  }
+
+  // Flush any trailing list
+  if (currentList && currentKey) {
+    frontmatter[currentKey] = currentList;
+  }
+
+  return { frontmatter, body };
+}
+
+describe('ClawHub SKILL.md', () => {
+  let content: string;
+  let frontmatter: Record<string, unknown>;
+  let body: string;
+
+  before(() => {
+    content = readFileSync(SKILL_PATH, 'utf-8');
+    const parsed = parseSkillFile(content);
+    frontmatter = parsed.frontmatter;
+    body = parsed.body;
+  });
+
+  describe('file structure', () => {
+    it('exists and is non-empty', () => {
+      expect(content.length).to.be.greaterThan(0);
+    });
+
+    it('has valid YAML frontmatter delimiters', () => {
+      expect(content).to.match(/^---\n[\s\S]*?\n---\n/);
+    });
+  });
+
+  describe('frontmatter', () => {
+    it('has name field set to proletariat', () => {
+      expect(frontmatter.name).to.equal('proletariat');
+    });
+
+    it('has a description', () => {
+      expect(frontmatter.description).to.be.a('string');
+      expect((frontmatter.description as string).length).to.be.greaterThan(10);
+    });
+
+    it('has a semver version', () => {
+      expect(frontmatter.version).to.match(/^\d+\.\d+\.\d+$/);
+    });
+
+    it('requires prlt binary', () => {
+      const bins = frontmatter['requires.bins'] as string[];
+      expect(bins).to.be.an('array');
+      expect(bins).to.include('prlt');
+    });
+
+    it('has tags array with required tags', () => {
+      const tags = frontmatter.tags as string[];
+      expect(tags).to.be.an('array');
+      const requiredTags = ['orchestration', 'agents', 'devops', 'git', 'docker'];
+      for (const tag of requiredTags) {
+        expect(tags, `missing tag: ${tag}`).to.include(tag);
+      }
+    });
+  });
+
+  describe('markdown body — command documentation', () => {
+    it('documents prlt work start', () => {
+      expect(body).to.include('prlt work start');
+    });
+
+    it('documents prlt work ship', () => {
+      expect(body).to.include('prlt work ship');
+    });
+
+    it('documents prlt session list', () => {
+      expect(body).to.include('prlt session list');
+    });
+
+    it('documents prlt session peek', () => {
+      expect(body).to.include('prlt session peek');
+    });
+
+    it('documents prlt session poke', () => {
+      expect(body).to.include('prlt session poke');
+    });
+
+    it('documents prlt ticket list', () => {
+      expect(body).to.include('prlt ticket list');
+    });
+
+    it('documents prlt ticket create', () => {
+      expect(body).to.include('prlt ticket create');
+    });
+
+    it('documents prlt ticket move', () => {
+      expect(body).to.include('prlt ticket move');
+    });
+
+    it('documents prlt pr checks', () => {
+      expect(body).to.include('prlt pr checks');
+    });
+  });
+
+  describe('markdown body — workflow examples', () => {
+    it('includes start work example with flags', () => {
+      expect(body).to.include('prlt work start PRLT-123 --skip-permissions --create-pr --yes');
+    });
+
+    it('includes peek example', () => {
+      expect(body).to.include('prlt session peek');
+    });
+
+    it('includes ship --when-green example', () => {
+      expect(body).to.include('prlt work ship');
+      expect(body).to.include('--when-green');
+    });
+  });
+
+  describe('markdown body — structure', () => {
+    it('has a top-level heading', () => {
+      expect(body).to.match(/^#\s+/m);
+    });
+
+    it('has command tables with pipe-separated columns', () => {
+      expect(body).to.include('| Command | Description |');
+    });
+
+    it('has code blocks with examples', () => {
+      expect(body).to.include('```bash');
+    });
+  });
+});

--- a/skills/openclaw/SKILL.md
+++ b/skills/openclaw/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: proletariat
+description: AI agent orchestration CLI — spawn, monitor, and manage coding agents in isolated git worktrees
+version: 0.3.105
+requires:
+  bins:
+    - prlt
+tags:
+  - orchestration
+  - agents
+  - devops
+  - git
+  - docker
+---
+
+# Proletariat (`prlt`)
+
+Proletariat is an AI agent orchestration CLI. Use it to spawn, monitor, and manage coding agents that work on tickets in isolated git worktrees or Docker containers.
+
+## Core Commands
+
+### Work — Agent Lifecycle
+
+| Command | Description |
+|---------|-------------|
+| `prlt work start <ticket>` | Spawn an agent on a ticket |
+| `prlt work ship <ticket>` | Merge PR and close ticket |
+| `prlt work propose <ticket>` | Create PR and move ticket to Review |
+| `prlt work complete <ticket>` | Mark ticket as complete |
+| `prlt work stop <ticket>` | Stop a running agent |
+| `prlt work status <ticket>` | Check agent status for a ticket |
+
+### Session — Monitor Agents
+
+| Command | Description |
+|---------|-------------|
+| `prlt session list` | List all active agent sessions |
+| `prlt session peek <agent>` | View agent output (read-only) |
+| `prlt session poke <agent> "<message>"` | Send a message to a running agent |
+| `prlt session attach <agent>` | Attach to an agent session interactively |
+| `prlt session health` | Check health of all sessions |
+
+### Ticket — Manage Board
+
+| Command | Description |
+|---------|-------------|
+| `prlt ticket list` | List tickets on the board |
+| `prlt ticket create` | Create a new ticket |
+| `prlt ticket show <id>` | View full ticket details |
+| `prlt ticket move <id> <status>` | Move ticket to a new status |
+| `prlt ticket edit <id> [flags]` | Update ticket fields |
+
+### PR — Pull Request Operations
+
+| Command | Description |
+|---------|-------------|
+| `prlt pr checks` | Check CI status of current PR |
+| `prlt pr create` | Create a PR with ticket context |
+| `prlt pr status` | View PR status |
+
+## Common Workflows
+
+### Start work on a ticket
+
+```bash
+prlt work start PRLT-123 --skip-permissions --create-pr --yes
+```
+
+This spawns an agent in an isolated environment, checks out a new branch, and begins implementation. The `--create-pr` flag auto-creates a draft PR when the agent pushes its first commit.
+
+### Check agent progress
+
+```bash
+prlt session peek <agent-name>
+```
+
+View the agent's recent output without interrupting it. Use `prlt session list` first to find the agent name.
+
+### Send instructions to a running agent
+
+```bash
+prlt session poke <agent-name> "focus on the unit tests next"
+```
+
+### Ship when CI passes
+
+```bash
+prlt work ship <ticket> --when-green
+```
+
+Waits for CI checks to pass, then merges the PR and moves the ticket to Done.
+
+### Monitor all agents
+
+```bash
+prlt session list
+prlt session health
+```
+
+### Create and assign a ticket
+
+```bash
+prlt ticket create --title "Fix login bug" --priority P1
+prlt ticket move TKT-456 "In Progress"
+```
+
+## Tips
+
+- Use `prlt work start` instead of manually cloning and branching — it handles worktree isolation automatically.
+- Agents run in Docker containers by default for full isolation.
+- Use `prlt work propose <ticket>` instead of `gh pr create` — it keeps ticket state in sync.
+- Use `prlt commit "message"` instead of `git commit` — it prefixes the ticket ID automatically.


### PR DESCRIPTION
## Summary

Resolves TKT-064: Publish prlt ClawHub skill for OpenClaw integration

## Description

## Goal

Publish a prlt skill to ClawHub so OpenClaw users (247K+) can discover and use Proletariat for agent orchestration.

## What is a ClawHub Skill

A [SKILL.md](<http://SKILL.md>) file with YAML frontmatter (metadata, dependencies, OS gates) and a markdown body (instructions the agent follows). Skills inject into the agents system prompt and are loaded contextually.

## Implementation

Create a [SKILL.md](<http://SKILL.md>) in the repo (e.g. skills/openclaw/SKILL.md) with:

### Frontmatter

* name: proletariat
* description: AI agent orchestration CLI — spawn, monitor, and manage coding agents in isolated git worktrees
* version: 0.3.105
* requires.bins: \["prlt"\]
* tags: \[orchestration, agents, devops, git, docker\]

### Markdown body

Teach OpenClaw how to use prlt commands:

* prlt work start <ticket> — spawn an agent on a ticket
* prlt work ship <ticket> — merge PR and close ticket
* prlt session list / peek / poke — monitor agents
* prlt ticket list / create / move — manage board
* prlt pr checks — check CI status

Include examples of common workflows:

* "Start work on a ticket": prlt work start PRLT-123 --skip-permissions --create-pr --yes
* "Check agent progress": prlt session peek <agent-name>
* "Ship when CI passes": prlt work ship <ticket> --when-green

### Publish

* Install clawhub CLI: pip install clawhub
* Publish: clawhub publish skills/openclaw --slug proletariat --version 0.3.105 --tags latest

## Future

* MCP server for deeper integration (expose prlt operations as MCP tools)
* ACPX harness adapter so OpenClaw can delegate coding tasks directly to prlt

## References

* ClawHub skill format: [https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md](<https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md>)
* ClawHub registry: [https://clawhub.ai](<https://clawhub.ai>)
* Existing ticket: PRLT-469 (submit to registries)

---
_Imported from Linear: [PRLT-1243](https://linear.app/proletariat/issue/PRLT-1243/publish-prlt-clawhub-skill-for-openclaw-integration)_

## Changes

- 446fe127 feat(PRLT-1243): add ClawHub SKILL.md for OpenClaw integration with validation tests

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
