### PR TITLE
fix(PRLT-1244): mock tmux in sendTmuxMessage tests, fix run-mocha.sh for macOS

### DIFF
--- a/apps/cli/src/lib/execution/session-utils.ts
+++ b/apps/cli/src/lib/execution/session-utils.ts
@@ -270,6 +270,49 @@ export function findSessionForExecution(
 }
 
 /**
+ * Describes the three tmux commands needed to deliver a message:
+ * escape (clear buffered input), text (send literal message), enter (submit).
+ */
+export interface TmuxMessageCommands {
+  escape: { cmd: string; args: string[] }
+  text: { cmd: string; args: string[] }
+  enter: { cmd: string; args: string[] }
+}
+
+/**
+ * Build the tmux command arrays for sending a message to a session.
+ * Returns the commands without executing them — useful for testing
+ * that the shell escaping logic builds correct arguments.
+ *
+ * Uses execFileSync-style argument arrays (no shell) so the message
+ * is passed directly as an argv argument, avoiding all shell escaping
+ * issues with parentheses, quotes, newlines, dollar signs, backticks, etc.
+ */
+export function buildTmuxMessageCommands(
+  sessionId: string,
+  message: string,
+  containerId?: string,
+): TmuxMessageCommands {
+  const escapeArgs = ['send-keys', '-t', sessionId, 'Escape']
+  const textArgs = ['send-keys', '-l', '-t', sessionId, message]
+  const enterArgs = ['send-keys', '-t', sessionId, 'Enter']
+
+  if (containerId) {
+    return {
+      escape: { cmd: 'docker', args: ['exec', containerId, 'tmux', ...escapeArgs] },
+      text: { cmd: 'docker', args: ['exec', containerId, 'tmux', ...textArgs] },
+      enter: { cmd: 'docker', args: ['exec', containerId, 'tmux', ...enterArgs] },
+    }
+  }
+
+  return {
+    escape: { cmd: 'tmux', args: escapeArgs },
+    text: { cmd: 'tmux', args: textArgs },
+    enter: { cmd: 'tmux', args: enterArgs },
+  }
+}
+
+/**
  * Send a text message to a tmux session via send-keys.
  * Sends the text first, then Enter separately with a small delay
  * to avoid race conditions where Enter arrives before text is rendered.
@@ -279,51 +322,20 @@ export function findSessionForExecution(
  * parentheses, quotes, newlines, dollar signs, backticks, etc.
  */
 export function sendTmuxMessage(sessionId: string, message: string, containerId?: string): void {
-  // Argument arrays for each tmux command — passed directly via execFileSync
-  // to bypass shell interpretation entirely.
-  const escapeArgs = ['send-keys', '-t', sessionId, 'Escape']
-  const textArgs = ['send-keys', '-l', '-t', sessionId, message]
-  const enterArgs = ['send-keys', '-t', sessionId, 'Enter']
+  const cmds = buildTmuxMessageCommands(sessionId, message, containerId)
+  const timeout = containerId ? 10000 : 5000
+  const stdio: ['pipe', 'pipe', 'pipe'] = ['pipe', 'pipe', 'pipe']
 
-  if (containerId) {
-    // Clear any buffered input first
-    execFileSync('docker', ['exec', containerId, 'tmux', ...escapeArgs], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    })
-    // Wait for Escape to take effect before sending new text
-    execSync('sleep 0.2', { stdio: ['pipe', 'pipe', 'pipe'] })
-    // Send the text literally — execFileSync bypasses shell, so the message
-    // reaches tmux verbatim regardless of content (parens, quotes, newlines, etc.)
-    execFileSync('docker', ['exec', containerId, 'tmux', ...textArgs], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    })
-    // Small delay before sending Enter to avoid race conditions
-    execSync('sleep 0.1', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execFileSync('docker', ['exec', containerId, 'tmux', ...enterArgs], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    })
-  } else {
-    // Clear any buffered input first
-    execFileSync('tmux', escapeArgs, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000,
-    })
-    // Wait for Escape to take effect before sending new text
-    execSync('sleep 0.2', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execFileSync('tmux', textArgs, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000,
-    })
-    // Small delay before sending Enter
-    execSync('sleep 0.1', { stdio: ['pipe', 'pipe', 'pipe'] })
-    execFileSync('tmux', enterArgs, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000,
-    })
-  }
+  // Clear any buffered input first
+  execFileSync(cmds.escape.cmd, cmds.escape.args, { stdio, timeout })
+  // Wait for Escape to take effect before sending new text
+  execSync('sleep 0.2', { stdio })
+  // Send the text literally — execFileSync bypasses shell, so the message
+  // reaches tmux verbatim regardless of content (parens, quotes, newlines, etc.)
+  execFileSync(cmds.text.cmd, cmds.text.args, { stdio, timeout })
+  // Small delay before sending Enter to avoid race conditions
+  execSync('sleep 0.1', { stdio })
+  execFileSync(cmds.enter.cmd, cmds.enter.args, { stdio, timeout })
 }
 
 // =============================================================================

--- a/apps/cli/test/run-mocha.sh
+++ b/apps/cli/test/run-mocha.sh
@@ -17,7 +17,8 @@ echo "$OUTPUT"
 
 if [ "$EXIT_CODE" -ne 0 ]; then
   # Check if the only failure is the workerpool teardown error
-  FAILING_COUNT=$(echo "$OUTPUT" | grep -oP '(\d+) failing' | head -1 | grep -oP '\d+' || echo "0")
+  # Use POSIX-compatible grep (no -P flag, which is unavailable on macOS)
+  FAILING_COUNT=$(echo "$OUTPUT" | grep -o '[0-9]* failing' | head -1 | grep -o '[0-9]*' || echo "0")
   if [ "$FAILING_COUNT" = "1" ] && echo "$OUTPUT" | grep -q "Uncaught error outside test suite" && echo "$OUTPUT" | grep -q "workerpool/src/WorkerHandler"; then
     echo ""
     echo "⚠ Suppressed known workerpool teardown error (all real tests passed)"

--- a/apps/cli/test/unit/send-tmux-message.test.ts
+++ b/apps/cli/test/unit/send-tmux-message.test.ts
@@ -1,168 +1,119 @@
 import { expect } from 'chai'
-import { execSync, execFileSync } from 'node:child_process'
-import {
-  sendTmuxMessage,
-  captureTmuxPane,
-} from '../../src/lib/execution/session-utils.js'
-
-/**
- * Check if tmux is available in the current environment.
- * These tests require a real tmux server and are skipped in CI where tmux may not be available.
- */
-function isTmuxAvailable(): boolean {
-  try {
-    execSync('tmux -V', { stdio: 'pipe' })
-    // Also check if we can actually create a session (some CI runners have tmux binary but no server)
-    execSync('tmux new-session -d -s prlt-tmux-check -x 80 -y 24', { stdio: 'pipe' })
-    execSync('tmux kill-session -t prlt-tmux-check', { stdio: 'pipe' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-const tmuxAvailable = isTmuxAvailable()
+import { buildTmuxMessageCommands } from '../../src/lib/execution/session-utils.js'
 
 /**
  * Regression tests for PRLT-1134: session poke breaks on parentheses and newlines.
  *
- * These tests create real tmux sessions and verify that messages containing
- * shell metacharacters are delivered verbatim, without shell interpretation.
+ * These tests verify that buildTmuxMessageCommands produces correct argument
+ * arrays for execFileSync, ensuring shell metacharacters in messages are passed
+ * verbatim to tmux send-keys -l (literal mode) without shell interpretation.
  *
- * Skipped when tmux is not available (e.g., GitHub Actions CI).
+ * Previously these tests required a real tmux server (failing in CI — PRLT-1244).
+ * Now they test the command-building logic directly as pure unit tests.
  */
 describe('sendTmuxMessage — shell escaping (PRLT-1134)', function () {
-  if (!tmuxAvailable) {
-    before(function () { this.skip() })
-  }
-  const TEST_SESSION = 'prlt-test-send-tmux-msg'
-
-  beforeEach(() => {
-    // Create a tmux session running cat, which echoes stdin to the pane
-    try {
-      execSync(`tmux kill-session -t ${TEST_SESSION} 2>/dev/null`, { stdio: 'pipe' })
-    } catch {
-      // Session may not exist
-    }
-    execFileSync('tmux', [
-      'new-session', '-d', '-s', TEST_SESSION, '-x', '200', '-y', '50',
-    ])
-    // Brief pause for session to initialize
-    execSync('sleep 0.3', { stdio: 'pipe' })
-  })
-
-  afterEach(() => {
-    try {
-      execSync(`tmux kill-session -t ${TEST_SESSION} 2>/dev/null`, { stdio: 'pipe' })
-    } catch {
-      // Best-effort cleanup
-    }
-  })
+  const SESSION = 'test-session'
 
   /**
-   * Capture the pane content and return just the text lines (trimmed, non-empty).
+   * Helper: verify the text command passes the message verbatim via send-keys -l.
    */
-  function getPaneContent(): string {
-    const raw = captureTmuxPane(TEST_SESSION, 200)
-    return raw ?? ''
+  function expectLiteralMessage(message: string, containerId?: string): void {
+    const cmds = buildTmuxMessageCommands(SESSION, message, containerId)
+
+    // Must use -l flag (literal mode) to prevent tmux key interpretation
+    expect(cmds.text.args).to.include('-l')
+
+    // Message must be the last argument, passed as-is (no escaping/transformation)
+    expect(cmds.text.args[cmds.text.args.length - 1]).to.equal(message)
+
+    // Without container: command is tmux directly
+    if (!containerId) {
+      expect(cmds.text.cmd).to.equal('tmux')
+      expect(cmds.text.args).to.deep.equal(['send-keys', '-l', '-t', SESSION, message])
+    }
   }
 
   it('should handle parentheses in message', () => {
-    const msg = 'Install foo (option 1) or bar'
-    sendTmuxMessage(TEST_SESSION, msg)
-    // Allow tmux to render
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('Install foo (option 1) or bar')
+    expectLiteralMessage('Install foo (option 1) or bar')
   })
 
   it('should handle single quotes in message', () => {
-    const msg = "it's a test with 'quotes'"
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include("it's a test with 'quotes'")
+    expectLiteralMessage("it's a test with 'quotes'")
   })
 
   it('should handle double quotes in message', () => {
-    const msg = 'say "hello world"'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('say "hello world"')
+    expectLiteralMessage('say "hello world"')
   })
 
   it('should handle dollar signs and backticks without expansion', () => {
-    const msg = 'cost is $100 and `command` here'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('cost is $100')
-    expect(pane).to.include('`command`')
+    expectLiteralMessage('cost is $100 and `command` here')
   })
 
   it('should handle semicolons and pipes', () => {
-    const msg = 'run this; then that | grep foo'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('run this; then that | grep foo')
+    expectLiteralMessage('run this; then that | grep foo')
   })
 
   it('should handle ampersands and redirects', () => {
-    const msg = 'cmd1 && cmd2 || cmd3 > /dev/null 2>&1'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('cmd1 && cmd2 || cmd3 > /dev/null 2>&1')
+    expectLiteralMessage('cmd1 && cmd2 || cmd3 > /dev/null 2>&1')
   })
 
   it('should handle exclamation marks and hash', () => {
-    const msg = 'hello! # this is not a comment'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('hello!')
-    expect(pane).to.include('# this is not a comment')
+    expectLiteralMessage('hello! # this is not a comment')
   })
 
   it('should handle curly braces and square brackets', () => {
-    const msg = 'data: {key: [1, 2, 3]}'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('data: {key: [1, 2, 3]}')
+    expectLiteralMessage('data: {key: [1, 2, 3]}')
   })
 
   it('should handle backslashes', () => {
-    const msg = 'path\\to\\file and \\n literal'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('path\\to\\file')
+    expectLiteralMessage('path\\to\\file and \\n literal')
   })
 
   it('should handle multi-line messages (newlines)', () => {
-    // Multi-line messages should be delivered to the pane.
-    // With send-keys -l, newlines become Enter keystrokes,
-    // which is the expected behavior for poke.
-    const msg = 'line one\nline two\nline three'
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    // All lines should appear in the pane
-    expect(pane).to.include('line one')
-    expect(pane).to.include('line two')
-    expect(pane).to.include('line three')
+    expectLiteralMessage('line one\nline two\nline three')
   })
 
   it('should handle mixed special characters', () => {
-    const msg = "Fix bug (issue #42): use `printf '%s'` instead of $var"
-    sendTmuxMessage(TEST_SESSION, msg)
-    execSync('sleep 0.5', { stdio: 'pipe' })
-    const pane = getPaneContent()
-    expect(pane).to.include('Fix bug (issue #42)')
-    expect(pane).to.include("printf '%s'")
-    expect(pane).to.include('$var')
+    expectLiteralMessage("Fix bug (issue #42): use `printf '%s'` instead of $var")
+  })
+
+  // Verify the full command structure (escape, text, enter sequence)
+  describe('command structure', function () {
+    it('should produce escape, text, and enter commands for host tmux', () => {
+      const msg = 'hello world'
+      const cmds = buildTmuxMessageCommands(SESSION, msg)
+
+      expect(cmds.escape).to.deep.equal({
+        cmd: 'tmux',
+        args: ['send-keys', '-t', SESSION, 'Escape'],
+      })
+      expect(cmds.text).to.deep.equal({
+        cmd: 'tmux',
+        args: ['send-keys', '-l', '-t', SESSION, msg],
+      })
+      expect(cmds.enter).to.deep.equal({
+        cmd: 'tmux',
+        args: ['send-keys', '-t', SESSION, 'Enter'],
+      })
+    })
+
+    it('should wrap commands with docker exec for container sessions', () => {
+      const msg = 'hello (world) $var'
+      const containerId = 'abc123'
+      const cmds = buildTmuxMessageCommands(SESSION, msg, containerId)
+
+      // All commands should go through docker exec
+      expect(cmds.escape.cmd).to.equal('docker')
+      expect(cmds.text.cmd).to.equal('docker')
+      expect(cmds.enter.cmd).to.equal('docker')
+
+      // Docker args should wrap tmux args
+      expect(cmds.text.args).to.deep.equal([
+        'exec', containerId, 'tmux', 'send-keys', '-l', '-t', SESSION, msg,
+      ])
+
+      // Message is still passed verbatim as the last arg
+      expect(cmds.text.args[cmds.text.args.length - 1]).to.equal(msg)
+    })
   })
 })


### PR DESCRIPTION
## Summary

- **Extract `buildTmuxMessageCommands` pure function** from `sendTmuxMessage` — returns the tmux command arrays without executing them, making the shell escaping logic directly testable without a real tmux server
- **Rewrite shell escaping tests as pure unit tests** — verify command construction (message passed verbatim via `send-keys -l`) instead of requiring real tmux sessions that fail in CI
- **Fix `run-mocha.sh` workerpool suppression on macOS** — replace `grep -oP` (GNU Perl regex) with POSIX-compatible `grep -o` so the known workerpool teardown error is properly suppressed cross-platform

## Test plan

- [x] All 13 shell escaping tests pass (4ms, no tmux dependency)
- [x] 2 new tests verify full command structure (host + container modes)
- [x] `run-mocha.sh` workerpool suppression works on macOS
- [x] Full unit test suite passes (3540 passing, pre-existing failures unchanged)
- [x] Build passes cleanly

Closes PRLT-1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)