### PR TITLE
chore: bump version to 0.3.111

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.110",
+  "version": "0.3.111",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Publish machine.db migration (PRLT-1275) + prlt install preservation (PRLT-1276) + session grouping (PRLT-1272) + defaults fix (PRLT-1274).