### PR TITLE
TKT-069: Telegram bot MVP — text your agents from your phone

### DIFF
--- a/apps/cli/src/commands/gateway/connect.ts
+++ b/apps/cli/src/commands/gateway/connect.ts
@@ -1,0 +1,163 @@
+/**
+ * prlt gateway connect — Register a messaging channel (PRLT-1255)
+ *
+ * MVP: only the telegram channel type is implemented. The command stores
+ * the bot token + allowlist in machine.db so `prlt gateway start` can
+ * bring the adapter up later.
+ *
+ * Examples:
+ *   prlt gateway connect telegram --token 123:abc --allow 111 --allow 222
+ *   prlt gateway connect telegram --token 123:abc --allow 111,222
+ */
+
+import { Args, Flags } from '@oclif/core'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB } from '../../lib/machine-db.js'
+import type { TelegramChannelConfig } from '../../lib/gateway/types.js'
+
+const SUPPORTED_CHANNEL_TYPES = ['telegram'] as const
+type SupportedChannelType = typeof SUPPORTED_CHANNEL_TYPES[number]
+
+export default class GatewayConnect extends PromptCommand {
+  static description = 'Register a messaging channel (Telegram) with the gateway'
+
+  static examples = [
+    '<%= config.bin %> gateway connect telegram --token 123:abc --allow 111 --allow 222',
+    '<%= config.bin %> gateway connect telegram --token 123:abc --allow 111,222 --name my-bot',
+  ]
+
+  static args = {
+    type: Args.string({
+      description: 'Channel type',
+      required: true,
+      options: [...SUPPORTED_CHANNEL_TYPES],
+    }),
+  }
+
+  static flags = {
+    ...machineOutputFlags,
+    name: Flags.string({
+      description: 'Channel name (primary key). Defaults to the channel type.',
+    }),
+    token: Flags.string({
+      description: 'Telegram bot token from @BotFather',
+    }),
+    allow: Flags.string({
+      description: 'Telegram user id(s) allowed to message agents (repeatable, or comma-separated)',
+      multiple: true,
+    }),
+    'poll-interval-ms': Flags.integer({
+      description: 'Delay between getUpdates polls (0 uses Telegram long-poll)',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(GatewayConnect)
+    const jsonMode = shouldOutputJson(flags)
+    const channelType = args.type as SupportedChannelType
+    const channelName = flags.name || channelType
+
+    if (channelType === 'telegram') {
+      if (!flags.token) {
+        if (jsonMode) {
+          outputErrorAsJson(
+            'MISSING_TOKEN',
+            'Telegram requires --token',
+            createMetadata('gateway connect', flags),
+          )
+          return
+        }
+        this.log(styles.error('Telegram requires --token'))
+        return
+      }
+
+      const allowlist = parseAllowlist(flags.allow)
+      if (allowlist.length === 0) {
+        if (jsonMode) {
+          outputErrorAsJson(
+            'MISSING_ALLOWLIST',
+            'Telegram requires --allow <user-id> (at least one)',
+            createMetadata('gateway connect', flags),
+          )
+          return
+        }
+        this.log(styles.error('Telegram requires --allow <user-id> (at least one)'))
+        return
+      }
+
+      const config: TelegramChannelConfig = {
+        token: flags.token,
+        allowlist,
+        ...(flags['poll-interval-ms'] !== undefined ? { pollIntervalMs: flags['poll-interval-ms'] } : {}),
+      }
+
+      const db = new MachineDB()
+      try {
+        db.upsertMessagingChannel({
+          name: channelName,
+          type: 'telegram',
+          configJson: JSON.stringify(config),
+          active: true,
+        })
+      } finally {
+        db.close()
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            channel: {
+              name: channelName,
+              type: 'telegram',
+              allowlist,
+              active: true,
+            },
+          },
+          createMetadata('gateway connect', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Connected telegram channel "${channelName}"`))
+      this.log(styles.muted(`  Allowlist: ${allowlist.join(', ')}`))
+      this.log(styles.muted(`  Start the gateway with: prlt gateway start`))
+      return
+    }
+
+    // Unreachable under current oclif `options` constraint, but we keep
+    // it so future channel types slot in cleanly.
+    if (jsonMode) {
+      outputErrorAsJson(
+        'UNSUPPORTED_CHANNEL',
+        `Channel type "${channelType}" is not implemented yet`,
+        createMetadata('gateway connect', flags),
+      )
+      return
+    }
+    this.log(styles.error(`Channel type "${channelType}" is not implemented yet`))
+  }
+}
+
+/**
+ * Accept `--allow 111 --allow 222` and `--allow 111,222` equally. Blank
+ * entries are stripped so users can't accidentally register an empty id.
+ */
+export function parseAllowlist(raw: string[] | undefined): string[] {
+  if (!raw) return []
+  const out: string[] = []
+  for (const entry of raw) {
+    for (const piece of entry.split(',')) {
+      const trimmed = piece.trim()
+      if (trimmed) out.push(trimmed)
+    }
+  }
+  return out
+}

--- a/apps/cli/src/commands/gateway/disconnect.ts
+++ b/apps/cli/src/commands/gateway/disconnect.ts
@@ -1,0 +1,92 @@
+/**
+ * prlt gateway disconnect — Remove or deactivate a messaging channel.
+ *
+ * By default, this deletes the channel registration outright. Pass
+ * --deactivate to keep the row around (and its stored credentials) but
+ * mark it inactive so `prlt gateway start` skips it.
+ */
+
+import { Args, Flags } from '@oclif/core'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB } from '../../lib/machine-db.js'
+
+export default class GatewayDisconnect extends PromptCommand {
+  static description = 'Disconnect a registered messaging channel'
+
+  static examples = [
+    '<%= config.bin %> gateway disconnect telegram',
+    '<%= config.bin %> gateway disconnect telegram --deactivate',
+  ]
+
+  static args = {
+    name: Args.string({
+      description: 'Channel name (as registered with `gateway connect`)',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    ...machineOutputFlags,
+    deactivate: Flags.boolean({
+      description: 'Mark the channel inactive instead of deleting it',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(GatewayDisconnect)
+    const jsonMode = shouldOutputJson(flags)
+
+    const db = new MachineDB()
+    try {
+      const existing = db.getMessagingChannel(args.name)
+      if (!existing) {
+        if (jsonMode) {
+          outputErrorAsJson(
+            'CHANNEL_NOT_FOUND',
+            `No channel registered with name "${args.name}"`,
+            createMetadata('gateway disconnect', flags),
+          )
+          return
+        }
+        this.log(styles.error(`No channel registered with name "${args.name}"`))
+        return
+      }
+
+      if (flags.deactivate) {
+        db.setMessagingChannelActive(args.name, false)
+      } else {
+        db.deleteMessagingChannel(args.name)
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            channel: args.name,
+            action: flags.deactivate ? 'deactivated' : 'deleted',
+          },
+          createMetadata('gateway disconnect', flags),
+        )
+        return
+      }
+
+      this.log(
+        styles.success(
+          flags.deactivate
+            ? `Deactivated channel "${args.name}"`
+            : `Removed channel "${args.name}"`,
+        ),
+      )
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/gateway/start.ts
+++ b/apps/cli/src/commands/gateway/start.ts
@@ -1,0 +1,160 @@
+/**
+ * prlt gateway start — Start the messaging gateway daemon.
+ *
+ * Loads every active channel from machine.db, wires it up to the
+ * MessagingGateway router, and blocks until SIGINT/SIGTERM. Each inbound
+ * message is forwarded to its bound agent via `prlt session poke`.
+ *
+ * MVP note: this runs in the foreground. `--background` is documented on
+ * the ticket but intentionally deferred — it will land alongside the
+ * generic daemon lifecycle work in a follow-up ticket.
+ */
+
+import { Flags } from '@oclif/core'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB } from '../../lib/machine-db.js'
+import { MessagingGateway } from '../../lib/gateway/router.js'
+import { ShellSessionPoker } from '../../lib/gateway/session-poker.js'
+import { buildChannelFromRecord } from '../../lib/gateway/channel-factory.js'
+import type { Message } from '../../lib/gateway/types.js'
+
+export default class GatewayStart extends PromptCommand {
+  static description = 'Start the messaging gateway daemon (foreground)'
+
+  static examples = [
+    '<%= config.bin %> gateway start',
+    '<%= config.bin %> gateway start --default-agent altman',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    'default-agent': Flags.string({
+      description: 'Agent session id to bind newly-seen users to (required unless a static resolver is configured)',
+    }),
+    'wait-timeout': Flags.integer({
+      description: 'Max seconds to wait for an agent response before giving up',
+      default: 90,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(GatewayStart)
+    const jsonMode = shouldOutputJson(flags)
+
+    const db = new MachineDB()
+
+    // Load active channels at startup. A future revision can hot-reload
+    // this by watching the table for changes, but the MVP only reads at
+    // start time.
+    const records = db.listMessagingChannels({ onlyActive: true })
+    if (records.length === 0) {
+      db.close()
+      if (jsonMode) {
+        outputErrorAsJson(
+          'NO_CHANNELS',
+          'No active messaging channels registered. Connect one first with `prlt gateway connect`.',
+          createMetadata('gateway start', flags),
+        )
+        return
+      }
+      this.log(styles.error('No active messaging channels registered.'))
+      this.log(styles.muted('Connect one with: prlt gateway connect telegram --token ... --allow ...'))
+      return
+    }
+
+    const gateway = new MessagingGateway({
+      db,
+      sessionPoker: new ShellSessionPoker(),
+      waitTimeoutSec: flags['wait-timeout'],
+      resolveAgentForNewUser: (_msg: Message) => flags['default-agent'] ?? null,
+      logger: {
+        info: msg => this.log(styles.muted(msg)),
+        error: (msg, err) => {
+          const errMsg = err instanceof Error ? err.message : err !== undefined ? String(err) : ''
+          this.log(styles.error(errMsg ? `${msg}: ${errMsg}` : msg))
+        },
+      },
+    })
+
+    for (const record of records) {
+      try {
+        const channel = buildChannelFromRecord(record)
+        gateway.registerChannel(channel)
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err)
+        this.log(styles.error(`Failed to build channel "${record.name}": ${errMsg}`))
+      }
+    }
+
+    if (gateway.listChannelNames().length === 0) {
+      db.close()
+      if (jsonMode) {
+        outputErrorAsJson(
+          'NO_VALID_CHANNELS',
+          'No valid messaging channels could be built from storage.',
+          createMetadata('gateway start', flags),
+        )
+        return
+      }
+      this.log(styles.error('No valid messaging channels could be built from storage.'))
+      return
+    }
+
+    await gateway.start()
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          started: true,
+          channels: gateway.listChannelNames(),
+          defaultAgent: flags['default-agent'] ?? null,
+        },
+        createMetadata('gateway start', flags),
+      )
+    } else {
+      this.log(styles.success('Messaging gateway started'))
+      this.log(styles.muted(`  channels: ${gateway.listChannelNames().join(', ')}`))
+      if (flags['default-agent']) {
+        this.log(styles.muted(`  default agent: ${flags['default-agent']}`))
+      } else {
+        this.log(styles.warning('  no --default-agent: new users will be rejected'))
+      }
+      this.log(styles.muted('  press Ctrl-C to stop'))
+    }
+
+    // Block until we're asked to shut down. We install handlers for both
+    // SIGINT and SIGTERM so `docker stop` and Ctrl-C both unwind cleanly.
+    await waitForShutdownSignal()
+
+    this.log(styles.muted('Shutting down gateway...'))
+    try {
+      await gateway.stop()
+    } finally {
+      db.close()
+    }
+  }
+}
+
+/**
+ * Resolve when we receive SIGINT or SIGTERM. Exported-less so tests don't
+ * have to shim it — the test suite exercises `MessagingGateway` directly.
+ */
+function waitForShutdownSignal(): Promise<void> {
+  return new Promise(resolve => {
+    const onSignal = () => {
+      process.off('SIGINT', onSignal)
+      process.off('SIGTERM', onSignal)
+      resolve()
+    }
+    process.on('SIGINT', onSignal)
+    process.on('SIGTERM', onSignal)
+  })
+}

--- a/apps/cli/src/commands/gateway/status.ts
+++ b/apps/cli/src/commands/gateway/status.ts
@@ -1,0 +1,93 @@
+/**
+ * prlt gateway status — Show registered messaging channels and routes.
+ *
+ * Reports one line per channel with its type, active flag, last
+ * activity timestamp, and the number of user→agent routes it owns.
+ */
+
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB, type MessagingChannelRecord } from '../../lib/machine-db.js'
+
+interface ChannelStatus {
+  name: string
+  type: string
+  active: boolean
+  lastMessageAt: string | null
+  routeCount: number
+}
+
+export default class GatewayStatus extends PromptCommand {
+  static description = 'Show registered messaging channels and their activity'
+
+  static examples = ['<%= config.bin %> gateway status']
+
+  static flags = {
+    ...machineOutputFlags,
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(GatewayStatus)
+    const jsonMode = shouldOutputJson(flags)
+
+    const db = new MachineDB()
+    let statuses: ChannelStatus[] = []
+    try {
+      const channels = db.listMessagingChannels({ onlyActive: false })
+      statuses = channels.map(ch => buildStatus(db, ch))
+    } finally {
+      db.close()
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({ channels: statuses }, createMetadata('gateway status', flags))
+      return
+    }
+
+    if (statuses.length === 0) {
+      this.log(styles.muted('No messaging channels registered.'))
+      this.log(styles.muted('Connect one with: prlt gateway connect telegram --token ... --allow ...'))
+      return
+    }
+
+    this.log(styles.header('Messaging Gateway Channels'))
+    this.log('')
+    for (const s of statuses) {
+      const active = s.active ? styles.success('active') : styles.muted('inactive')
+      const last = s.lastMessageAt ? formatRelative(new Date(s.lastMessageAt)) : 'never'
+      this.log(`  ${styles.emphasis(s.name)} [${s.type}] — ${active}`)
+      this.log(`    last activity: ${last}`)
+      this.log(`    routes: ${s.routeCount}`)
+      this.log('')
+    }
+  }
+}
+
+function buildStatus(db: MachineDB, ch: MessagingChannelRecord): ChannelStatus {
+  return {
+    name: ch.name,
+    type: ch.type,
+    active: ch.active,
+    lastMessageAt: ch.lastMessageAt ? ch.lastMessageAt.toISOString() : null,
+    routeCount: db.countMessagingRoutesForChannel(ch.name),
+  }
+}
+
+function formatRelative(d: Date): string {
+  const deltaMs = Date.now() - d.getTime()
+  if (deltaMs < 0) return d.toISOString()
+  const seconds = Math.floor(deltaMs / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 48) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}

--- a/apps/cli/src/commands/gateway/test.ts
+++ b/apps/cli/src/commands/gateway/test.ts
@@ -1,0 +1,115 @@
+/**
+ * prlt gateway test — Send a test message through a registered channel.
+ *
+ * Loads a channel's config from machine.db, instantiates the adapter,
+ * and calls `sendMessage` directly. This doesn't start the polling loop,
+ * so it's safe to run alongside a live `gateway start`.
+ */
+
+import { Args, Flags } from '@oclif/core'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB } from '../../lib/machine-db.js'
+import { buildChannelFromRecord } from '../../lib/gateway/channel-factory.js'
+
+export default class GatewayTest extends PromptCommand {
+  static description = 'Send a test message through a registered messaging channel'
+
+  static examples = [
+    '<%= config.bin %> gateway test telegram --to 123456789 --message "hello from prlt"',
+  ]
+
+  static args = {
+    name: Args.string({
+      description: 'Channel name (as registered with `gateway connect`)',
+      required: true,
+    }),
+  }
+
+  static flags = {
+    ...machineOutputFlags,
+    to: Flags.string({
+      description: 'Recipient id on the channel (e.g. Telegram chat id)',
+      required: true,
+    }),
+    message: Flags.string({
+      description: 'Text to send',
+      default: 'hello from prlt',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(GatewayTest)
+    const jsonMode = shouldOutputJson(flags)
+
+    const db = new MachineDB()
+    const record = db.getMessagingChannel(args.name)
+    db.close()
+
+    if (!record) {
+      if (jsonMode) {
+        outputErrorAsJson(
+          'CHANNEL_NOT_FOUND',
+          `No channel registered with name "${args.name}"`,
+          createMetadata('gateway test', flags),
+        )
+        return
+      }
+      this.log(styles.error(`No channel registered with name "${args.name}"`))
+      return
+    }
+
+    let channel
+    try {
+      channel = buildChannelFromRecord(record)
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      if (jsonMode) {
+        outputErrorAsJson(
+          'CHANNEL_BUILD_FAILED',
+          errMsg,
+          createMetadata('gateway test', flags),
+        )
+        return
+      }
+      this.log(styles.error(errMsg))
+      return
+    }
+
+    try {
+      await channel.sendMessage(
+        { channel: channel.name, id: flags.to },
+        flags.message,
+      )
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      if (jsonMode) {
+        outputErrorAsJson(
+          'SEND_FAILED',
+          errMsg,
+          createMetadata('gateway test', flags),
+        )
+        return
+      }
+      this.log(styles.error(`Failed to send: ${errMsg}`))
+      return
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        { channel: args.name, to: flags.to, message: flags.message },
+        createMetadata('gateway test', flags),
+      )
+      return
+    }
+
+    this.log(styles.success(`Sent test message via "${args.name}" to ${flags.to}`))
+  }
+}

--- a/apps/cli/src/lib/gateway/channel-factory.ts
+++ b/apps/cli/src/lib/gateway/channel-factory.ts
@@ -1,0 +1,40 @@
+/**
+ * Channel factory (PRLT-1255)
+ *
+ * Single place that knows how to decode a persisted MessagingChannelRecord
+ * into a live MessagingChannel instance. Commands and the gateway daemon
+ * call this so they never import individual adapters directly.
+ *
+ * To add Slack/Discord/WhatsApp later: import the new adapter and add a
+ * case to `buildChannelFromRecord`. No other file needs to change.
+ */
+
+import type { MessagingChannelRecord } from '../machine-db.js'
+import type { MessagingChannel, TelegramChannelConfig } from './types.js'
+import { TelegramChannel } from './channels/telegram.js'
+
+export function buildChannelFromRecord(record: MessagingChannelRecord): MessagingChannel {
+  switch (record.type) {
+    case 'telegram': {
+      const config = parseConfig<TelegramChannelConfig>(record.configJson, record.name)
+      if (!config.token) {
+        throw new Error(`Channel "${record.name}" has no Telegram token configured`)
+      }
+      if (!Array.isArray(config.allowlist)) {
+        throw new TypeError(`Channel "${record.name}" has a malformed allowlist`)
+      }
+      return new TelegramChannel({ config })
+    }
+    default:
+      throw new Error(`Unknown channel type "${record.type}" for "${record.name}"`)
+  }
+}
+
+function parseConfig<T>(json: string, channelName: string): T {
+  try {
+    return JSON.parse(json) as T
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Channel "${channelName}" has invalid config JSON: ${msg}`)
+  }
+}

--- a/apps/cli/src/lib/gateway/channels/telegram.ts
+++ b/apps/cli/src/lib/gateway/channels/telegram.ts
@@ -1,0 +1,310 @@
+/**
+ * Telegram Channel Adapter (PRLT-1255)
+ *
+ * Polling-mode Telegram bot that implements MessagingChannel.
+ *
+ * Uses Telegram's `getUpdates` long-polling API — no webhook, no server
+ * required. Messages arrive over an outgoing HTTPS request, so the bot
+ * works fine from behind NAT, on a laptop, or in a container.
+ *
+ * This adapter is the ONLY Telegram-aware code in the gateway. To add
+ * Slack/Discord/WhatsApp later: write a new adapter next to this file,
+ * implementing the same interface. The router and commands do not need
+ * to change.
+ *
+ * @see PRLT-1251 (Messaging Gateway epic)
+ */
+
+import type {
+  ChannelAddress,
+  Message,
+  MessageHandler,
+  MessagingChannel,
+  TelegramChannelConfig,
+} from '../types.js'
+
+// =============================================================================
+// Telegram Bot API shapes (subset we use)
+// =============================================================================
+
+interface TelegramUser {
+  id: number
+  is_bot?: boolean
+  first_name?: string
+  last_name?: string
+  username?: string
+}
+
+interface TelegramChat {
+  id: number
+  type: 'private' | 'group' | 'supergroup' | 'channel'
+  title?: string
+  username?: string
+  first_name?: string
+}
+
+interface TelegramMessage {
+  message_id: number
+  from?: TelegramUser
+  chat: TelegramChat
+  date: number
+  text?: string
+}
+
+export interface TelegramUpdate {
+  update_id: number
+  message?: TelegramMessage
+  edited_message?: TelegramMessage
+}
+
+interface TelegramResponse<T> {
+  ok: boolean
+  result?: T
+  description?: string
+  error_code?: number
+}
+
+// =============================================================================
+// Telegram HTTP client
+// =============================================================================
+
+/**
+ * Minimal Telegram Bot API client. Broken out so tests can substitute a
+ * fake client without touching the network.
+ */
+export interface TelegramClient {
+  getUpdates(options: { offset?: number; timeoutSec?: number }): Promise<TelegramUpdate[]>
+  sendMessage(chatId: string | number, text: string): Promise<void>
+}
+
+class HttpTelegramClient implements TelegramClient {
+  constructor(private token: string) {}
+
+  private url(method: string): string {
+    return `https://api.telegram.org/bot${this.token}/${method}`
+  }
+
+  async getUpdates(options: { offset?: number; timeoutSec?: number }): Promise<TelegramUpdate[]> {
+    const params = new URLSearchParams()
+    if (options.offset !== undefined) params.set('offset', String(options.offset))
+    params.set('timeout', String(options.timeoutSec ?? 25))
+    // Only request message updates — we don't need callback queries, polls, etc.
+    params.set('allowed_updates', JSON.stringify(['message']))
+
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins -- global fetch is stable in Node 20+
+    const res = await fetch(`${this.url('getUpdates')}?${params.toString()}`)
+    if (!res.ok) {
+      throw new Error(`Telegram getUpdates failed: HTTP ${res.status}`)
+    }
+    const body = (await res.json()) as TelegramResponse<TelegramUpdate[]>
+    if (!body.ok) {
+      throw new Error(`Telegram getUpdates failed: ${body.description ?? 'unknown'}`)
+    }
+    return body.result ?? []
+  }
+
+  async sendMessage(chatId: string | number, text: string): Promise<void> {
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins -- global fetch is stable in Node 20+
+    const res = await fetch(this.url('sendMessage'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text }),
+    })
+    if (!res.ok) {
+      throw new Error(`Telegram sendMessage failed: HTTP ${res.status}`)
+    }
+    const body = (await res.json()) as TelegramResponse<TelegramMessage>
+    if (!body.ok) {
+      throw new Error(`Telegram sendMessage failed: ${body.description ?? 'unknown'}`)
+    }
+  }
+}
+
+// =============================================================================
+// TelegramChannel
+// =============================================================================
+
+/**
+ * Options for constructing a TelegramChannel.
+ *
+ * - `config`: TelegramChannelConfig loaded from machine.db.
+ * - `client`: optional injectable Telegram client (tests use this).
+ * - `logger`: optional error/info sink. Defaults to console.
+ */
+export interface TelegramChannelOptions {
+  config: TelegramChannelConfig
+  client?: TelegramClient
+  logger?: {
+    info?: (msg: string) => void
+    error?: (msg: string, err?: unknown) => void
+  }
+  /**
+   * How long to back off after a failed poll. Defaults to 5000ms.
+   * Tests shorten this so they don't have to sit on a 5s sleep.
+   */
+  errorBackoffMs?: number
+}
+
+/**
+ * Polling-mode Telegram adapter.
+ *
+ * The read loop is a vanilla `while (running) await getUpdates()`. We
+ * acknowledge updates by advancing the `offset` cursor to the id after
+ * the highest update seen in the batch — this is Telegram's documented
+ * delete semantics for getUpdates.
+ */
+export class TelegramChannel implements MessagingChannel {
+  readonly name = 'telegram'
+
+  private handler: MessageHandler | null = null
+  private running = false
+  private loopPromise: Promise<void> | null = null
+  private offset: number | undefined
+  private readonly client: TelegramClient
+  private readonly config: TelegramChannelConfig
+  private readonly logger: NonNullable<TelegramChannelOptions['logger']>
+  private readonly errorBackoffMs: number
+
+  constructor(options: TelegramChannelOptions) {
+    this.config = options.config
+    this.client = options.client ?? new HttpTelegramClient(options.config.token)
+    this.logger = options.logger ?? {}
+    this.errorBackoffMs = options.errorBackoffMs ?? 5000
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.handler = handler
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return
+    if (!this.handler) {
+      throw new Error('TelegramChannel.start() called before onMessage() — no handler registered')
+    }
+    this.running = true
+    this.loopPromise = this.runLoop()
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return
+    this.running = false
+    if (this.loopPromise) {
+      try {
+        await this.loopPromise
+      } catch {
+        // Loop errors are already logged; ignore here so stop() is always clean.
+      }
+      this.loopPromise = null
+    }
+  }
+
+  async sendMessage(to: ChannelAddress, text: string): Promise<void> {
+    if (to.channel !== this.name) {
+      throw new Error(`TelegramChannel cannot send to channel=${to.channel}`)
+    }
+    await this.client.sendMessage(to.id, text)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Main polling loop. Runs until `stop()` flips `running` false.
+   *
+   * Errors are caught, logged, and followed by a small backoff so a
+   * transient network blip doesn't hot-spin the bot against Telegram.
+   *
+   * The awaits are deliberately sequential: Telegram long-poll demands
+   * one outstanding getUpdates at a time per bot, and we must drain
+   * each batch before advancing the cursor.
+   */
+  /* eslint-disable no-await-in-loop -- polling loop is intentionally sequential */
+  private async runLoop(): Promise<void> {
+    const pollInterval = this.config.pollIntervalMs ?? 0
+
+    while (this.running) {
+      try {
+        const updates = await this.client.getUpdates({
+          offset: this.offset,
+          timeoutSec: 25,
+        })
+
+        for (const update of updates) {
+          await this.handleUpdate(update)
+          // Advance cursor past the highest update id we've seen.
+          this.offset = update.update_id + 1
+        }
+
+        if (pollInterval > 0) await sleep(pollInterval)
+      } catch (err) {
+        this.logger.error?.('telegram: poll loop error', err)
+        // Backoff on errors so we don't hammer the API when the network
+        // is flaky or the token got revoked.
+        await sleep(this.errorBackoffMs)
+      }
+    }
+  }
+  /* eslint-enable no-await-in-loop */
+
+  /**
+   * Normalize a Telegram update into a generic `Message` and hand it to
+   * the router. Drops non-text messages silently (MVP is text-only).
+   */
+  private async handleUpdate(update: TelegramUpdate): Promise<void> {
+    const msg = update.message ?? update.edited_message
+    if (!msg) return
+    if (!msg.text) return // MVP: text-only
+    if (!this.handler) return
+
+    // Reject messages from users not on the allowlist. We match on the
+    // sender's user id (falling back to chat id for groups where there
+    // is no `from`). Allowlist is explicit — empty list means "nobody".
+    const senderId = String(msg.from?.id ?? msg.chat.id)
+    if (!this.config.allowlist.includes(senderId)) {
+      this.logger.info?.(`telegram: dropping message from non-allowlisted user ${senderId}`)
+      return
+    }
+
+    const address: ChannelAddress = {
+      channel: this.name,
+      // We always send replies to the chat, not the user — that way
+      // group chats work correctly in a future multi-user mode.
+      id: String(msg.chat.id),
+      displayName: resolveDisplayName(msg),
+    }
+
+    const normalized: Message = {
+      id: `telegram:${msg.message_id}`,
+      channel: this.name,
+      from: address,
+      text: msg.text,
+      timestamp: new Date(msg.date * 1000),
+    }
+
+    try {
+      await this.handler(normalized)
+    } catch (err) {
+      this.logger.error?.('telegram: handler failed', err)
+    }
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function resolveDisplayName(msg: TelegramMessage): string | undefined {
+  const from = msg.from
+  if (from?.username) return `@${from.username}`
+  if (from?.first_name) {
+    return from.last_name ? `${from.first_name} ${from.last_name}` : from.first_name
+  }
+  if (msg.chat.title) return msg.chat.title
+  if (msg.chat.username) return `@${msg.chat.username}`
+  return undefined
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/apps/cli/src/lib/gateway/router.ts
+++ b/apps/cli/src/lib/gateway/router.ts
@@ -1,0 +1,200 @@
+/**
+ * Messaging Gateway Router (PRLT-1255)
+ *
+ * Sits between N `MessagingChannel` adapters and the `prlt session poke`
+ * path. The router is intentionally small — it does four things:
+ *
+ *   1. Look up (or create) the agent mapping for `(channel, user)`.
+ *   2. Forward the user's text to that agent via a `SessionPoker`.
+ *   3. Ship the agent's response back via the channel's `sendMessage`.
+ *   4. Stamp channel + route usage timestamps in machine.db.
+ *
+ * Everything Telegram-specific lives in `channels/telegram.ts`. Everything
+ * storage-specific lives in `MachineDB`. This file owns the glue.
+ */
+
+import type { MachineDB, MessagingRouteRecord } from '../machine-db.js'
+import type { MessagingChannel, Message } from './types.js'
+
+// =============================================================================
+// Session poker abstraction
+// =============================================================================
+
+/**
+ * Indirection over `prlt session poke`. The default implementation shells
+ * out to the globally-installed `prlt` binary, but tests and embedders can
+ * inject a custom poker.
+ *
+ * Returning `null` means "message delivered, no response captured".
+ * Throwing means "failed to reach the agent at all".
+ */
+export interface SessionPoker {
+  poke(agent: string, message: string, options?: { waitTimeoutSec?: number }): Promise<string | null>
+}
+
+// =============================================================================
+// Gateway options
+// =============================================================================
+
+export interface MessagingGatewayOptions {
+  /** Machine DB handle used for channel/route persistence. */
+  db: MachineDB
+  /** How to forward messages to an agent. Defaults to the shell poker. */
+  sessionPoker: SessionPoker
+  /**
+   * Called when there is no existing route for a user. Must return the
+   * agent session id (typically an agent name) that should own this
+   * conversation going forward. Returning `null` rejects the message —
+   * useful for "deny if no mapping" policies.
+   */
+  resolveAgentForNewUser: (msg: Message) => Promise<string | null> | string | null
+  /** Optional logger sink. Defaults to console. */
+  logger?: {
+    info?: (msg: string) => void
+    error?: (msg: string, err?: unknown) => void
+  }
+  /**
+   * How long to wait for an agent response before giving up and sending
+   * a "still working on it" message back. Defaults to 90 seconds.
+   */
+  waitTimeoutSec?: number
+}
+
+// =============================================================================
+// MessagingGateway
+// =============================================================================
+
+export class MessagingGateway {
+  private channels = new Map<string, MessagingChannel>()
+  private readonly db: MachineDB
+  private readonly poker: SessionPoker
+  private readonly resolveAgentForNewUser: MessagingGatewayOptions['resolveAgentForNewUser']
+  private readonly logger: NonNullable<MessagingGatewayOptions['logger']>
+  private readonly waitTimeoutSec: number
+  private started = false
+
+  constructor(options: MessagingGatewayOptions) {
+    this.db = options.db
+    this.poker = options.sessionPoker
+    this.resolveAgentForNewUser = options.resolveAgentForNewUser
+    this.logger = options.logger ?? {}
+    this.waitTimeoutSec = options.waitTimeoutSec ?? 90
+  }
+
+  /**
+   * Register a channel adapter. Wires the inbound handler but does NOT
+   * start the channel — the caller decides when to start() everything.
+   */
+  registerChannel(channel: MessagingChannel): void {
+    if (this.channels.has(channel.name)) {
+      throw new Error(`Channel already registered: ${channel.name}`)
+    }
+    channel.onMessage(msg => this.routeInbound(msg))
+    this.channels.set(channel.name, channel)
+  }
+
+  /** Get a previously-registered channel by name. */
+  getChannel(name: string): MessagingChannel | undefined {
+    return this.channels.get(name)
+  }
+
+  /** List names of all registered channels. */
+  listChannelNames(): string[] {
+    return [...this.channels.keys()]
+  }
+
+  /** Start every registered channel in parallel. */
+  async start(): Promise<void> {
+    if (this.started) return
+    this.started = true
+    await Promise.all([...this.channels.values()].map(ch => ch.start()))
+  }
+
+  /** Stop every registered channel in parallel. Safe to call multiple times. */
+  async stop(): Promise<void> {
+    if (!this.started) return
+    this.started = false
+    await Promise.all([...this.channels.values()].map(ch => ch.stop()))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Core routing
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Route a single inbound message.
+   *
+   * This is exposed (not `private`) so tests can drive it directly
+   * without standing up a real channel adapter.
+   */
+  async routeInbound(msg: Message): Promise<void> {
+    const channel = this.channels.get(msg.channel)
+    if (!channel) {
+      this.logger.error?.(`router: no channel registered for ${msg.channel}`)
+      return
+    }
+
+    if (!msg.text || msg.text.trim().length === 0) {
+      // MVP: text-only. Voice notes land in PRLT-1234.
+      this.logger.info?.(`router: dropping empty message ${msg.id}`)
+      return
+    }
+
+    // 1. Find or create the route.
+    let route = this.db.getMessagingRoute(msg.channel, msg.from.id)
+    if (!route) {
+      route = await this.createRouteForNewUser(msg)
+      if (!route) {
+        // Denied by policy — silently drop, do not leak whether the user
+        // exists to a possibly-hostile sender.
+        return
+      }
+    }
+
+    // 2. Forward to the agent session.
+    let response: string | null = null
+    try {
+      response = await this.poker.poke(route.agentSessionId, msg.text, {
+        waitTimeoutSec: this.waitTimeoutSec,
+      })
+    } catch (err) {
+      this.logger.error?.(`router: poke failed for ${route.agentSessionId}`, err)
+      await this.safeReply(channel, msg, `Sorry, I couldn't reach ${route.agentSessionId}. Try again in a moment.`)
+      return
+    }
+
+    // 3. Stamp usage.
+    this.db.touchMessagingRoute(msg.channel, msg.from.id)
+    this.db.touchMessagingChannel(msg.channel)
+
+    // 4. Reply (if we captured anything).
+    if (response && response.trim().length > 0) {
+      await this.safeReply(channel, msg, response)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private async createRouteForNewUser(msg: Message): Promise<MessagingRouteRecord | null> {
+    const agentSessionId = await this.resolveAgentForNewUser(msg)
+    if (!agentSessionId) {
+      this.logger.info?.(`router: no agent resolved for ${msg.channel}:${msg.from.id}`)
+      return null
+    }
+    return this.db.upsertMessagingRoute({
+      channel: msg.channel,
+      userId: msg.from.id,
+      agentSessionId,
+    })
+  }
+
+  private async safeReply(channel: MessagingChannel, msg: Message, text: string): Promise<void> {
+    try {
+      await channel.sendMessage(msg.from, text)
+    } catch (err) {
+      this.logger.error?.(`router: sendMessage failed for ${channel.name}`, err)
+    }
+  }
+}

--- a/apps/cli/src/lib/gateway/session-poker.ts
+++ b/apps/cli/src/lib/gateway/session-poker.ts
@@ -1,0 +1,101 @@
+/**
+ * Default SessionPoker implementation (PRLT-1255)
+ *
+ * Shells out to `prlt session poke <agent> <message> --wait --timeout N --json`
+ * and extracts the captured response from the JSON output.
+ *
+ * The router code itself is agnostic to this — tests inject a fake
+ * SessionPoker. This file exists so production code can pick up the real
+ * poker with zero wiring.
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { SessionPoker } from './router.js'
+
+const execFileAsync = promisify(execFile)
+
+export interface ShellSessionPokerOptions {
+  /**
+   * Name of the binary to exec. Defaults to `prlt` on PATH. Tests can
+   * point this at a shim script.
+   */
+  binary?: string
+  /**
+   * Working directory for the exec call. Defaults to the current process
+   * cwd — `prlt session poke` resolves workspace context from there.
+   */
+  cwd?: string
+}
+
+/**
+ * Shell-based SessionPoker. Uses `execFile` (no shell) so nothing in the
+ * message body can trigger shell expansion or injection.
+ */
+export class ShellSessionPoker implements SessionPoker {
+  private readonly binary: string
+  private readonly cwd: string | undefined
+
+  constructor(options: ShellSessionPokerOptions = {}) {
+    this.binary = options.binary ?? 'prlt'
+    this.cwd = options.cwd
+  }
+
+  async poke(agent: string, message: string, options?: { waitTimeoutSec?: number }): Promise<string | null> {
+    const timeoutSec = options?.waitTimeoutSec ?? 90
+    const args = [
+      'session',
+      'poke',
+      agent,
+      message,
+      '--wait',
+      '--timeout',
+      String(timeoutSec),
+      '--json',
+    ]
+
+    const { stdout } = await execFileAsync(this.binary, args, {
+      cwd: this.cwd,
+      // Give the child a little longer than the internal wait so we
+      // don't race the --timeout.
+      timeout: (timeoutSec + 15) * 1000,
+      maxBuffer: 8 * 1024 * 1024,
+    })
+
+    // `prlt session poke --json` emits a single JSON object on success.
+    const parsed = parseFirstJsonObject(stdout)
+    if (!parsed) return null
+    if (typeof parsed.response === 'string') return parsed.response
+    return null
+  }
+}
+
+/**
+ * Pull the first JSON object out of a mixed stdout stream. Needed because
+ * some oclif commands still emit human banners alongside `--json` output
+ * depending on terminal state.
+ */
+function parseFirstJsonObject(stdout: string): Record<string, unknown> | null {
+  const trimmed = stdout.trim()
+  if (!trimmed) return null
+
+  // Fast path: whole payload is JSON.
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>
+  } catch {
+    // Fall through to scan.
+  }
+
+  const start = trimmed.indexOf('{')
+  const end = trimmed.lastIndexOf('}')
+  if (start === -1 || end === -1 || end < start) return null
+
+  try {
+    const parsed = JSON.parse(trimmed.slice(start, end + 1))
+    if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>
+  } catch {
+    return null
+  }
+  return null
+}

--- a/apps/cli/src/lib/gateway/types.ts
+++ b/apps/cli/src/lib/gateway/types.ts
@@ -1,0 +1,156 @@
+/**
+ * Messaging Gateway Types
+ *
+ * Defines the channel-agnostic abstraction that sits between external
+ * messaging platforms (Telegram, Slack, Discord, WhatsApp, ...) and the
+ * internal `prlt session poke` path that forwards user input to agent
+ * sessions.
+ *
+ * The gateway is designed so adding a new platform is a new adapter that
+ * implements `MessagingChannel` — zero changes to the router, storage,
+ * or commands.
+ *
+ * Epic: PRLT-1251 (Messaging Gateway)
+ * Ticket: PRLT-1255 (Telegram bot MVP)
+ */
+
+// =============================================================================
+// Addressing
+// =============================================================================
+
+/**
+ * A platform-specific identifier for a user or conversation on a channel.
+ *
+ * `channel` is the channel name (e.g. "telegram", "slack"), and `id` is the
+ * platform's own identifier. For Telegram, `id` is the numeric chat id
+ * encoded as a string (e.g. `"123456789"`).
+ *
+ * `displayName` is a best-effort human-readable label for logs/UI. It must
+ * never be used for routing.
+ */
+export interface ChannelAddress {
+  channel: string
+  id: string
+  displayName?: string
+}
+
+// =============================================================================
+// Messages
+// =============================================================================
+
+/**
+ * A normalized inbound message from any channel.
+ *
+ * Adapters convert platform payloads into this shape before handing them
+ * to the router. Adapters are responsible for idempotency via `id` — the
+ * router uses it to de-duplicate re-delivered messages.
+ */
+export interface Message {
+  /** Stable per-channel message id (platform's id, stringified). */
+  id: string
+  /** Channel name (matches MessagingChannel.name). */
+  channel: string
+  /** Who sent the message. */
+  from: ChannelAddress
+  /** Optional text body. Either `text` or `audio` should be set. */
+  text?: string
+  /** Optional raw audio payload (voice note / audio message). */
+  audio?: Buffer
+  /** Server-side timestamp of the message. */
+  timestamp: Date
+}
+
+/**
+ * Handler signature used by channels to deliver inbound messages to the
+ * router. Channels call this from their read loop.
+ */
+export type MessageHandler = (msg: Message) => Promise<void>
+
+// =============================================================================
+// Channel interface
+// =============================================================================
+
+/**
+ * A bidirectional adapter to an external messaging platform.
+ *
+ * Implementations MUST:
+ * - Normalize their inbound payloads into `Message` objects.
+ * - Deliver inbound messages by invoking the handler registered via
+ *   `onMessage`.
+ * - Honor `start()` / `stop()` lifecycle cleanly so the gateway can shut
+ *   down without leaking sockets, timers, or worker threads.
+ *
+ * Adapters MUST NOT touch the database, the session system, or the
+ * router directly. Their only public entry points are the methods
+ * defined here.
+ */
+export interface MessagingChannel {
+  /** Stable channel name (e.g. "telegram"). Used as a primary key. */
+  readonly name: string
+
+  /** Begin reading messages (e.g. open socket, start polling loop). */
+  start(): Promise<void>
+
+  /** Stop reading and release all resources. Must be idempotent. */
+  stop(): Promise<void>
+
+  /** Register the inbound-message handler. Called before `start()`. */
+  onMessage(handler: MessageHandler): void
+
+  /** Send an outbound text message to a ChannelAddress. */
+  sendMessage(to: ChannelAddress, text: string): Promise<void>
+
+  /** Optional: send an outbound voice note (PRLT-1234 territory). */
+  sendVoiceNote?(to: ChannelAddress, audio: Buffer): Promise<void>
+}
+
+// =============================================================================
+// Stored channel configuration
+// =============================================================================
+
+/**
+ * Persisted configuration for a registered channel.
+ *
+ * Stored in `machine.db` → `messaging_channels`. `configJson` is an
+ * adapter-specific blob — for Telegram it contains the bot token and
+ * allowlist of permitted user ids.
+ */
+export interface MessagingChannelRecord {
+  name: string
+  type: string
+  configJson: string
+  active: boolean
+  lastMessageAt: Date | undefined
+}
+
+/**
+ * A user → agent routing binding. The router creates one on first
+ * contact and reuses it for all subsequent messages.
+ */
+export interface MessagingRouteRecord {
+  channel: string
+  userId: string
+  agentSessionId: string
+  createdAt: Date
+  lastUsedAt: Date | undefined
+}
+
+// =============================================================================
+// Telegram-specific config shape
+// =============================================================================
+
+/**
+ * Shape of `messaging_channels.config_json` when `type === "telegram"`.
+ *
+ * - `token`: Telegram Bot API token from @BotFather.
+ * - `allowlist`: numeric Telegram user ids (stringified) that are allowed
+ *   to poke agents. Messages from non-allowlisted users are rejected at
+ *   the router boundary.
+ * - `pollIntervalMs`: how often to long-poll getUpdates. Defaults to 0
+ *   (use Telegram's long-poll timeout of 25 seconds).
+ */
+export interface TelegramChannelConfig {
+  token: string
+  allowlist: string[]
+  pollIntervalMs?: number
+}

--- a/apps/cli/src/lib/machine-db.ts
+++ b/apps/cli/src/lib/machine-db.ts
@@ -28,6 +28,51 @@ export type MachineExecutionStatus = 'starting' | 'running' | 'completed' | 'fai
 export type MachineLifecycleState = 'healthy' | 'idle' | 'died' | 'completed'
 export type MachineCleanupPolicy = 'on-exit' | 'persistent' | 'on-error-keep'
 
+// =============================================================================
+// Messaging gateway types (PRLT-1255)
+// =============================================================================
+
+/**
+ * A registered messaging channel (Telegram, Slack, Discord, ...).
+ * `configJson` is an adapter-specific blob stored as text.
+ */
+export interface MessagingChannelRow {
+  name: string
+  type: string
+  config_json: string
+  active: number
+  last_message_at: number | null
+}
+
+export interface MessagingChannelRecord {
+  name: string
+  type: string
+  configJson: string
+  active: boolean
+  lastMessageAt: Date | undefined
+}
+
+/**
+ * A persistent binding of `(channel, userId)` to an agent session.
+ * The router looks this up on every inbound message so a given user
+ * always lands on the same agent.
+ */
+export interface MessagingRouteRow {
+  channel: string
+  user_id: string
+  agent_session_id: string
+  created_at: number
+  last_used_at: number | null
+}
+
+export interface MessagingRouteRecord {
+  channel: string
+  userId: string
+  agentSessionId: string
+  createdAt: Date
+  lastUsedAt: Date | undefined
+}
+
 export interface MachineExecution {
   id: string
   prompt: string
@@ -175,6 +220,28 @@ export class MachineDB {
         lifecycle_state TEXT NOT NULL DEFAULT 'healthy',
         retries INTEGER NOT NULL DEFAULT 0
       );
+
+      -- Messaging gateway (PRLT-1255) — bridges external messaging platforms
+      -- (Telegram, Slack, ...) to agent sessions via prlt session poke.
+      CREATE TABLE IF NOT EXISTS messaging_channels (
+        name TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1,
+        last_message_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS messaging_routes (
+        channel TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        agent_session_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_used_at INTEGER,
+        PRIMARY KEY (channel, user_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_messaging_routes_agent
+        ON messaging_routes(agent_session_id);
     `)
 
     // Migrate existing databases that don't have the persistent columns
@@ -506,7 +573,165 @@ export class MachineDB {
     return rows.map(rowToExecution)
   }
 
+  // ===========================================================================
+  // Messaging gateway (PRLT-1255)
+  // ===========================================================================
+
+  /**
+   * Insert or replace a registered messaging channel.
+   *
+   * Channels are keyed by `name` (e.g. "telegram"). Re-registering the
+   * same channel updates its config and marks it active — this is what
+   * `prlt gateway connect` does on repeat calls.
+   */
+  upsertMessagingChannel(params: {
+    name: string
+    type: string
+    configJson: string
+    active?: boolean
+  }): void {
+    const active = params.active === false ? 0 : 1
+    this.db.prepare(`
+      INSERT INTO messaging_channels (name, type, config_json, active, last_message_at)
+      VALUES (?, ?, ?, ?, NULL)
+      ON CONFLICT(name) DO UPDATE SET
+        type = excluded.type,
+        config_json = excluded.config_json,
+        active = excluded.active
+    `).run(params.name, params.type, params.configJson, active)
+  }
+
+  /** Look up a single channel by name. */
+  getMessagingChannel(name: string): MessagingChannelRecord | null {
+    const row = this.db.prepare<MessagingChannelRow>(
+      'SELECT * FROM messaging_channels WHERE name = ?'
+    ).get(name)
+    return row ? messagingChannelRowToRecord(row) : null
+  }
+
+  /**
+   * List channels. When `onlyActive` is true (the default), only channels
+   * with `active = 1` are returned — this is what the gateway daemon
+   * uses at startup.
+   */
+  listMessagingChannels(options?: { onlyActive?: boolean }): MessagingChannelRecord[] {
+    const onlyActive = options?.onlyActive !== false
+    const rows = onlyActive
+      ? (this.db.prepare(
+          'SELECT * FROM messaging_channels WHERE active = 1 ORDER BY name ASC'
+        ).all() as unknown as MessagingChannelRow[])
+      : (this.db.prepare(
+          'SELECT * FROM messaging_channels ORDER BY name ASC'
+        ).all() as unknown as MessagingChannelRow[])
+    return rows.map(messagingChannelRowToRecord)
+  }
+
+  /** Mark a channel inactive (keeps config around for re-enable). */
+  setMessagingChannelActive(name: string, active: boolean): void {
+    this.db.prepare(
+      'UPDATE messaging_channels SET active = ? WHERE name = ?'
+    ).run(active ? 1 : 0, name)
+  }
+
+  /** Remove a channel's registration entirely. */
+  deleteMessagingChannel(name: string): void {
+    this.db.prepare('DELETE FROM messaging_channels WHERE name = ?').run(name)
+  }
+
+  /**
+   * Stamp a channel's `last_message_at` to now — called each time the
+   * router successfully routes an inbound message. Used by
+   * `prlt gateway status` to show channel activity.
+   */
+  touchMessagingChannel(name: string, timestamp: number = Date.now()): void {
+    this.db.prepare(
+      'UPDATE messaging_channels SET last_message_at = ? WHERE name = ?'
+    ).run(timestamp, name)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Routes — (channel, user) → agent session
+  // ---------------------------------------------------------------------------
+
+  /** Look up an existing route, or null if this user has never been seen. */
+  getMessagingRoute(channel: string, userId: string): MessagingRouteRecord | null {
+    const row = this.db.prepare<MessagingRouteRow>(
+      'SELECT * FROM messaging_routes WHERE channel = ? AND user_id = ?'
+    ).get(channel, userId)
+    return row ? messagingRouteRowToRecord(row) : null
+  }
+
+  /**
+   * Bind a `(channel, user)` pair to an agent session. Idempotent — if a
+   * binding already exists it is updated to point at the new agent.
+   */
+  upsertMessagingRoute(params: {
+    channel: string
+    userId: string
+    agentSessionId: string
+  }): MessagingRouteRecord {
+    const now = Date.now()
+    this.db.prepare(`
+      INSERT INTO messaging_routes (channel, user_id, agent_session_id, created_at, last_used_at)
+      VALUES (?, ?, ?, ?, NULL)
+      ON CONFLICT(channel, user_id) DO UPDATE SET
+        agent_session_id = excluded.agent_session_id
+    `).run(params.channel, params.userId, params.agentSessionId, now)
+    return this.getMessagingRoute(params.channel, params.userId)!
+  }
+
+  /** Stamp `last_used_at` to now — called every time a route is used. */
+  touchMessagingRoute(channel: string, userId: string, timestamp: number = Date.now()): void {
+    this.db.prepare(
+      'UPDATE messaging_routes SET last_used_at = ? WHERE channel = ? AND user_id = ?'
+    ).run(timestamp, channel, userId)
+  }
+
+  /** List routes for a channel (or all channels when `channel` omitted). */
+  listMessagingRoutes(channel?: string): MessagingRouteRecord[] {
+    const rows = channel
+      ? (this.db.prepare(
+          'SELECT * FROM messaging_routes WHERE channel = ? ORDER BY created_at DESC'
+        ).all(channel) as unknown as MessagingRouteRow[])
+      : (this.db.prepare(
+          'SELECT * FROM messaging_routes ORDER BY created_at DESC'
+        ).all() as unknown as MessagingRouteRow[])
+    return rows.map(messagingRouteRowToRecord)
+  }
+
+  /** Count messages handled by a channel since `since` (for status output). */
+  countMessagingRoutesForChannel(channel: string): number {
+    const row = this.db.prepare<{ n: number }>(
+      'SELECT COUNT(*) AS n FROM messaging_routes WHERE channel = ?'
+    ).get(channel)
+    return row?.n ?? 0
+  }
+
   close(): void {
     this.db.close()
+  }
+}
+
+// =============================================================================
+// Row → record converters for messaging tables
+// =============================================================================
+
+function messagingChannelRowToRecord(row: MessagingChannelRow): MessagingChannelRecord {
+  return {
+    name: row.name,
+    type: row.type,
+    configJson: row.config_json,
+    active: row.active === 1,
+    lastMessageAt: row.last_message_at ? new Date(row.last_message_at) : undefined,
+  }
+}
+
+function messagingRouteRowToRecord(row: MessagingRouteRow): MessagingRouteRecord {
+  return {
+    channel: row.channel,
+    userId: row.user_id,
+    agentSessionId: row.agent_session_id,
+    createdAt: new Date(row.created_at),
+    lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : undefined,
   }
 }

--- a/apps/cli/test/unit/gateway-channel-factory.test.ts
+++ b/apps/cli/test/unit/gateway-channel-factory.test.ts
@@ -1,0 +1,75 @@
+import { expect } from 'chai'
+import { buildChannelFromRecord } from '../../src/lib/gateway/channel-factory.js'
+import { parseAllowlist } from '../../src/commands/gateway/connect.js'
+import type { MessagingChannelRecord } from '../../src/lib/machine-db.js'
+
+/**
+ * PRLT-1255 — Factory + helpers. The factory is the only place that
+ * knows how to turn a DB row into a live adapter, so it's worth
+ * pinning down its error messages precisely.
+ */
+
+function record(partial: Partial<MessagingChannelRecord>): MessagingChannelRecord {
+  return {
+    name: 'telegram',
+    type: 'telegram',
+    configJson: JSON.stringify({ token: 'T', allowlist: ['1'] }),
+    active: true,
+    lastMessageAt: undefined,
+    ...partial,
+  }
+}
+
+describe('gateway channel factory (PRLT-1255)', () => {
+  it('builds a TelegramChannel for a valid telegram record', () => {
+    const ch = buildChannelFromRecord(record({}))
+    expect(ch.name).to.equal('telegram')
+  })
+
+  it('rejects telegram records with no token', () => {
+    expect(() =>
+      buildChannelFromRecord(record({ configJson: JSON.stringify({ token: '', allowlist: ['1'] }) })),
+    ).to.throw(/token/i)
+  })
+
+  it('rejects telegram records with a malformed allowlist', () => {
+    expect(() =>
+      buildChannelFromRecord(record({ configJson: JSON.stringify({ token: 'T', allowlist: 'nope' }) })),
+    ).to.throw(/allowlist/i)
+  })
+
+  it('rejects telegram records with invalid JSON', () => {
+    expect(() =>
+      buildChannelFromRecord(record({ configJson: '{not-json' })),
+    ).to.throw(/invalid config json/i)
+  })
+
+  it('rejects unknown channel types with a helpful message', () => {
+    expect(() =>
+      buildChannelFromRecord(record({ type: 'imagined' })),
+    ).to.throw(/unknown channel type/i)
+  })
+})
+
+describe('parseAllowlist (PRLT-1255)', () => {
+  it('returns an empty array when no flags were passed', () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- explicit undefined documents the no-flag case
+    expect(parseAllowlist(undefined)).to.deep.equal([])
+  })
+
+  it('accepts repeated --allow flags', () => {
+    expect(parseAllowlist(['111', '222', '333'])).to.deep.equal(['111', '222', '333'])
+  })
+
+  it('splits comma-separated entries', () => {
+    expect(parseAllowlist(['111,222,333'])).to.deep.equal(['111', '222', '333'])
+  })
+
+  it('trims whitespace and drops empty entries', () => {
+    expect(parseAllowlist(['111 ,, 222 , '])).to.deep.equal(['111', '222'])
+  })
+
+  it('handles a mix of repeated and comma-separated entries', () => {
+    expect(parseAllowlist(['111,222', '333'])).to.deep.equal(['111', '222', '333'])
+  })
+})

--- a/apps/cli/test/unit/gateway-messaging-storage.test.ts
+++ b/apps/cli/test/unit/gateway-messaging-storage.test.ts
@@ -1,0 +1,212 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { MachineDB } from '../../src/lib/machine-db.js'
+
+/**
+ * PRLT-1255 — Coverage for the messaging_channels and messaging_routes
+ * tables added to machine.db. The gateway daemon's persistence layer
+ * must survive process restarts, so every CRUD path is exercised against
+ * a real sqlite file.
+ */
+describe('MachineDB — messaging gateway storage (PRLT-1255)', () => {
+  let db: MachineDB
+  let dbPath: string
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-gateway-storage-test-')))
+    dbPath = path.join(tmpDir, 'machine.db')
+    db = new MachineDB(dbPath)
+  })
+
+  afterEach(() => {
+    db.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('messaging_channels', () => {
+    it('upserts a new channel and reads it back', () => {
+      db.upsertMessagingChannel({
+        name: 'telegram',
+        type: 'telegram',
+        configJson: JSON.stringify({ token: 'T', allowlist: ['1'] }),
+      })
+
+      const got = db.getMessagingChannel('telegram')
+      expect(got).to.not.be.null
+      expect(got!.name).to.equal('telegram')
+      expect(got!.type).to.equal('telegram')
+      expect(got!.active).to.equal(true)
+      expect(got!.lastMessageAt).to.be.undefined
+      expect(JSON.parse(got!.configJson)).to.deep.equal({ token: 'T', allowlist: ['1'] })
+    })
+
+    it('upserts an existing channel in place (idempotent connect)', () => {
+      db.upsertMessagingChannel({
+        name: 'telegram',
+        type: 'telegram',
+        configJson: JSON.stringify({ token: 'old', allowlist: ['1'] }),
+      })
+      db.upsertMessagingChannel({
+        name: 'telegram',
+        type: 'telegram',
+        configJson: JSON.stringify({ token: 'new', allowlist: ['1', '2'] }),
+      })
+
+      const got = db.getMessagingChannel('telegram')
+      expect(JSON.parse(got!.configJson)).to.deep.equal({ token: 'new', allowlist: ['1', '2'] })
+
+      // Still exactly one row — not a duplicate.
+      const all = db.listMessagingChannels({ onlyActive: false })
+      expect(all).to.have.lengthOf(1)
+    })
+
+    it('respects the onlyActive filter in listMessagingChannels', () => {
+      db.upsertMessagingChannel({ name: 'a', type: 'telegram', configJson: '{}', active: true })
+      db.upsertMessagingChannel({ name: 'b', type: 'telegram', configJson: '{}', active: false })
+
+      const active = db.listMessagingChannels({ onlyActive: true })
+      expect(active.map(c => c.name)).to.deep.equal(['a'])
+
+      const everything = db.listMessagingChannels({ onlyActive: false })
+      expect(everything.map(c => c.name)).to.deep.equal(['a', 'b'])
+    })
+
+    it('defaults to onlyActive = true when options omitted', () => {
+      db.upsertMessagingChannel({ name: 'on', type: 'telegram', configJson: '{}', active: true })
+      db.upsertMessagingChannel({ name: 'off', type: 'telegram', configJson: '{}', active: false })
+
+      const channels = db.listMessagingChannels()
+      expect(channels.map(c => c.name)).to.deep.equal(['on'])
+    })
+
+    it('setMessagingChannelActive toggles the flag without deleting config', () => {
+      db.upsertMessagingChannel({
+        name: 'telegram',
+        type: 'telegram',
+        configJson: JSON.stringify({ token: 'T', allowlist: ['1'] }),
+      })
+
+      db.setMessagingChannelActive('telegram', false)
+      const inactive = db.getMessagingChannel('telegram')
+      expect(inactive!.active).to.equal(false)
+      expect(JSON.parse(inactive!.configJson)).to.deep.equal({ token: 'T', allowlist: ['1'] })
+
+      db.setMessagingChannelActive('telegram', true)
+      expect(db.getMessagingChannel('telegram')!.active).to.equal(true)
+    })
+
+    it('deleteMessagingChannel removes the row', () => {
+      db.upsertMessagingChannel({ name: 'telegram', type: 'telegram', configJson: '{}' })
+      db.deleteMessagingChannel('telegram')
+      expect(db.getMessagingChannel('telegram')).to.be.null
+    })
+
+    it('touchMessagingChannel stamps last_message_at', () => {
+      db.upsertMessagingChannel({ name: 'telegram', type: 'telegram', configJson: '{}' })
+      const t = 1_700_000_000_000
+      db.touchMessagingChannel('telegram', t)
+
+      const got = db.getMessagingChannel('telegram')
+      expect(got!.lastMessageAt).to.be.instanceOf(Date)
+      expect(got!.lastMessageAt!.getTime()).to.equal(t)
+    })
+  })
+
+  describe('messaging_routes', () => {
+    it('returns null for an unknown (channel, user) pair', () => {
+      expect(db.getMessagingRoute('telegram', 'ghost')).to.be.null
+    })
+
+    it('upsertMessagingRoute creates a new route with a created_at stamp', () => {
+      const before = Date.now()
+      const route = db.upsertMessagingRoute({
+        channel: 'telegram',
+        userId: '111',
+        agentSessionId: 'altman',
+      })
+      const after = Date.now()
+
+      expect(route.channel).to.equal('telegram')
+      expect(route.userId).to.equal('111')
+      expect(route.agentSessionId).to.equal('altman')
+      expect(route.createdAt).to.be.instanceOf(Date)
+      expect(route.createdAt.getTime()).to.be.at.least(before)
+      expect(route.createdAt.getTime()).to.be.at.most(after)
+      expect(route.lastUsedAt).to.be.undefined
+    })
+
+    it('upsertMessagingRoute rebinds an existing user to a new agent', () => {
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '111', agentSessionId: 'alice' })
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '111', agentSessionId: 'bob' })
+
+      const route = db.getMessagingRoute('telegram', '111')
+      expect(route!.agentSessionId).to.equal('bob')
+
+      // Exactly one route exists for this user.
+      expect(db.listMessagingRoutes('telegram')).to.have.lengthOf(1)
+    })
+
+    it('primary key scopes uniqueness to (channel, user) pairs', () => {
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '111', agentSessionId: 'alice' })
+      db.upsertMessagingRoute({ channel: 'slack', userId: '111', agentSessionId: 'bob' })
+
+      expect(db.getMessagingRoute('telegram', '111')!.agentSessionId).to.equal('alice')
+      expect(db.getMessagingRoute('slack', '111')!.agentSessionId).to.equal('bob')
+    })
+
+    it('touchMessagingRoute stamps last_used_at to the provided timestamp', () => {
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '111', agentSessionId: 'alice' })
+      db.touchMessagingRoute('telegram', '111', 1_700_000_000_000)
+
+      const route = db.getMessagingRoute('telegram', '111')
+      expect(route!.lastUsedAt).to.be.instanceOf(Date)
+      expect(route!.lastUsedAt!.getTime()).to.equal(1_700_000_000_000)
+    })
+
+    it('listMessagingRoutes optionally filters by channel', () => {
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '1', agentSessionId: 'a' })
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '2', agentSessionId: 'b' })
+      db.upsertMessagingRoute({ channel: 'slack', userId: '3', agentSessionId: 'c' })
+
+      expect(db.listMessagingRoutes('telegram')).to.have.lengthOf(2)
+      expect(db.listMessagingRoutes('slack')).to.have.lengthOf(1)
+      expect(db.listMessagingRoutes()).to.have.lengthOf(3)
+    })
+
+    it('countMessagingRoutesForChannel counts per-channel routes', () => {
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '1', agentSessionId: 'a' })
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '2', agentSessionId: 'b' })
+      db.upsertMessagingRoute({ channel: 'slack', userId: '3', agentSessionId: 'c' })
+
+      expect(db.countMessagingRoutesForChannel('telegram')).to.equal(2)
+      expect(db.countMessagingRoutesForChannel('slack')).to.equal(1)
+      expect(db.countMessagingRoutesForChannel('discord')).to.equal(0)
+    })
+  })
+
+  describe('persistence', () => {
+    it('survives process restarts (re-opening the same file)', () => {
+      db.upsertMessagingChannel({
+        name: 'telegram',
+        type: 'telegram',
+        configJson: JSON.stringify({ token: 'T', allowlist: ['1'] }),
+      })
+      db.upsertMessagingRoute({ channel: 'telegram', userId: '1', agentSessionId: 'altman' })
+      db.close()
+
+      const reopened = new MachineDB(dbPath)
+      try {
+        expect(reopened.getMessagingChannel('telegram')).to.not.be.null
+        expect(reopened.getMessagingRoute('telegram', '1')).to.not.be.null
+      } finally {
+        reopened.close()
+      }
+
+      // Reassign for afterEach teardown.
+      db = new MachineDB(dbPath)
+    })
+  })
+})

--- a/apps/cli/test/unit/gateway-router.test.ts
+++ b/apps/cli/test/unit/gateway-router.test.ts
@@ -1,0 +1,344 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { MachineDB } from '../../src/lib/machine-db.js'
+import { MessagingGateway, type SessionPoker } from '../../src/lib/gateway/router.js'
+import type {
+  ChannelAddress,
+  Message,
+  MessageHandler,
+  MessagingChannel,
+} from '../../src/lib/gateway/types.js'
+
+/**
+ * PRLT-1255 — Router-level tests for the MessagingGateway. These exercise
+ * routing without a real Telegram connection: we feed messages into the
+ * router through a FakeChannel and assert on the resulting DB state,
+ * poke calls, and replies.
+ */
+
+// =============================================================================
+// Test doubles
+// =============================================================================
+
+class FakeChannel implements MessagingChannel {
+  readonly name: string
+  started = false
+  stopped = false
+  sent: Array<{ to: ChannelAddress; text: string }> = []
+  private handler: MessageHandler | null = null
+  private sendImpl: ((to: ChannelAddress, text: string) => Promise<void>) | null = null
+
+  constructor(name: string = 'fake') {
+    this.name = name
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.handler = handler
+  }
+
+  async start(): Promise<void> {
+    this.started = true
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true
+  }
+
+  async sendMessage(to: ChannelAddress, text: string): Promise<void> {
+    if (this.sendImpl) {
+      await this.sendImpl(to, text)
+    }
+    this.sent.push({ to, text })
+  }
+
+  /** Simulate a user sending a message to the bot. */
+  async inject(msg: Message): Promise<void> {
+    if (!this.handler) throw new Error('FakeChannel has no handler — router not registered?')
+    await this.handler(msg)
+  }
+
+  /** Force sendMessage to throw on the next call. */
+  failNextSendWith(err: Error): void {
+    let thrown = false
+    this.sendImpl = async () => {
+      if (!thrown) {
+        thrown = true
+        throw err
+      }
+    }
+  }
+}
+
+class FakePoker implements SessionPoker {
+  calls: Array<{ agent: string; message: string; waitTimeoutSec?: number }> = []
+  private responder: (agent: string, message: string) => Promise<string | null> =
+    async () => 'ack'
+
+  async poke(
+    agent: string,
+    message: string,
+    options?: { waitTimeoutSec?: number },
+  ): Promise<string | null> {
+    this.calls.push({ agent, message, waitTimeoutSec: options?.waitTimeoutSec })
+    return this.responder(agent, message)
+  }
+
+  respondWith(fn: (agent: string, message: string) => Promise<string | null>): void {
+    this.responder = fn
+  }
+}
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function sampleMessage(partial: Partial<Message> = {}): Message {
+  return {
+    id: 'telegram:1',
+    channel: 'fake',
+    from: { channel: 'fake', id: '42', displayName: 'tester' },
+    text: 'hello agent',
+    timestamp: new Date('2026-01-01T00:00:00Z'),
+    ...partial,
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('MessagingGateway (PRLT-1255)', () => {
+  let db: MachineDB
+  let dbPath: string
+  let tmpDir: string
+  let channel: FakeChannel
+  let poker: FakePoker
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-gateway-router-test-')))
+    dbPath = path.join(tmpDir, 'machine.db')
+    db = new MachineDB(dbPath)
+    channel = new FakeChannel('fake')
+    poker = new FakePoker()
+  })
+
+  afterEach(() => {
+    db.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function makeGateway(
+    resolveAgentForNewUser: (msg: Message) => string | null = () => 'altman',
+  ): MessagingGateway {
+    return new MessagingGateway({
+      db,
+      sessionPoker: poker,
+      resolveAgentForNewUser,
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Registration + lifecycle
+  // ---------------------------------------------------------------------------
+
+  describe('lifecycle', () => {
+    it('registerChannel wires the onMessage handler', () => {
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+      expect(gw.listChannelNames()).to.deep.equal(['fake'])
+    })
+
+    it('rejects duplicate channel registration', () => {
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+      expect(() => gw.registerChannel(new FakeChannel('fake'))).to.throw(
+        /already registered/,
+      )
+    })
+
+    it('start() and stop() fan out to every channel', async () => {
+      const gw = makeGateway()
+      const a = new FakeChannel('a')
+      const b = new FakeChannel('b')
+      gw.registerChannel(a)
+      gw.registerChannel(b)
+
+      await gw.start()
+      expect(a.started).to.equal(true)
+      expect(b.started).to.equal(true)
+
+      await gw.stop()
+      expect(a.stopped).to.equal(true)
+      expect(b.stopped).to.equal(true)
+    })
+
+    it('start() is idempotent', async () => {
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+      await gw.start()
+      channel.started = false
+      await gw.start() // no-op
+      expect(channel.started).to.equal(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Routing a new user
+  // ---------------------------------------------------------------------------
+
+  describe('new user routing', () => {
+    it('creates a route on first message and pokes the agent', async () => {
+      const gw = makeGateway(() => 'altman')
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+
+      expect(poker.calls).to.have.lengthOf(1)
+      expect(poker.calls[0].agent).to.equal('altman')
+      expect(poker.calls[0].message).to.equal('hello agent')
+
+      const route = db.getMessagingRoute('fake', '42')
+      expect(route).to.not.be.null
+      expect(route!.agentSessionId).to.equal('altman')
+    })
+
+    it('forwards the captured response back through the channel', async () => {
+      poker.respondWith(async () => 'here is your tests output')
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+
+      expect(channel.sent).to.have.lengthOf(1)
+      expect(channel.sent[0].to.id).to.equal('42')
+      expect(channel.sent[0].text).to.equal('here is your tests output')
+    })
+
+    it('does not send an outbound message when the agent returns null', async () => {
+      poker.respondWith(async () => null)
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+      expect(channel.sent).to.have.lengthOf(0)
+    })
+
+    it('drops messages for unresolved users without calling the poker', async () => {
+      const gw = makeGateway(() => null)
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+
+      expect(poker.calls).to.have.lengthOf(0)
+      expect(channel.sent).to.have.lengthOf(0)
+      expect(db.getMessagingRoute('fake', '42')).to.be.null
+    })
+
+    it('drops empty text messages before consulting the poker', async () => {
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage({ text: '   ' }))
+      expect(poker.calls).to.have.lengthOf(0)
+
+      await channel.inject(sampleMessage({ text: undefined }))
+      expect(poker.calls).to.have.lengthOf(0)
+    })
+
+    it('logs and ignores messages from unknown channels', async () => {
+      const errors: string[] = []
+      const gw = new MessagingGateway({
+        db,
+        sessionPoker: poker,
+        resolveAgentForNewUser: () => 'altman',
+        logger: { error: msg => errors.push(msg) },
+      })
+      // Do NOT register the channel — routeInbound should log and return.
+      await gw.routeInbound(sampleMessage({ channel: 'ghost' }))
+
+      expect(poker.calls).to.have.lengthOf(0)
+      expect(errors.some(e => e.includes('no channel registered'))).to.equal(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Routing an existing user
+  // ---------------------------------------------------------------------------
+
+  describe('existing user routing', () => {
+    it('reuses an existing route and bypasses resolveAgentForNewUser', async () => {
+      db.upsertMessagingRoute({ channel: 'fake', userId: '42', agentSessionId: 'preset' })
+
+      let resolverCalls = 0
+      const gw = makeGateway(() => {
+        resolverCalls++
+        return 'should-not-be-used'
+      })
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+
+      expect(resolverCalls).to.equal(0)
+      expect(poker.calls[0].agent).to.equal('preset')
+    })
+
+    it('updates last_used_at on the route and last_message_at on the channel', async () => {
+      db.upsertMessagingChannel({ name: 'fake', type: 'telegram', configJson: '{}' })
+      db.upsertMessagingRoute({ channel: 'fake', userId: '42', agentSessionId: 'preset' })
+
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+
+      expect(db.getMessagingRoute('fake', '42')!.lastUsedAt).to.be.instanceOf(Date)
+      expect(db.getMessagingChannel('fake')!.lastMessageAt).to.be.instanceOf(Date)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('sends a friendly error reply when the poker throws', async () => {
+      poker.respondWith(async () => {
+        throw new Error('session dead')
+      })
+
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+
+      expect(channel.sent).to.have.lengthOf(1)
+      expect(channel.sent[0].text).to.match(/couldn't reach/i)
+    })
+
+    it('swallows channel.sendMessage errors so they do not escape routeInbound', async () => {
+      poker.respondWith(async () => 'ok')
+      const gw = makeGateway()
+      gw.registerChannel(channel)
+
+      channel.failNextSendWith(new Error('telegram 500'))
+
+      // Must not throw.
+      await channel.inject(sampleMessage())
+    })
+
+    it('passes the waitTimeoutSec through to the poker', async () => {
+      const gw = new MessagingGateway({
+        db,
+        sessionPoker: poker,
+        resolveAgentForNewUser: () => 'altman',
+        waitTimeoutSec: 33,
+      })
+      gw.registerChannel(channel)
+
+      await channel.inject(sampleMessage())
+      expect(poker.calls[0].waitTimeoutSec).to.equal(33)
+    })
+  })
+})

--- a/apps/cli/test/unit/gateway-telegram.test.ts
+++ b/apps/cli/test/unit/gateway-telegram.test.ts
@@ -1,0 +1,268 @@
+import { expect } from 'chai'
+import {
+  TelegramChannel,
+  type TelegramClient,
+  type TelegramUpdate,
+} from '../../src/lib/gateway/channels/telegram.js'
+import type { Message } from '../../src/lib/gateway/types.js'
+
+/**
+ * PRLT-1255 — Telegram adapter tests. We don't touch the network: a
+ * FakeTelegramClient sits in for the HTTP client so we can drive the
+ * poll loop deterministically and assert on inbound normalization,
+ * allowlist enforcement, and cursor advancement.
+ */
+
+// =============================================================================
+// Test double
+// =============================================================================
+
+class FakeTelegramClient implements TelegramClient {
+  getUpdatesCalls: Array<{ offset?: number; timeoutSec?: number }> = []
+  sentMessages: Array<{ chatId: string | number; text: string }> = []
+
+  /** Pending batches of updates. Each call to getUpdates returns the next batch. */
+  private batches: TelegramUpdate[][] = []
+  /** Whether to throw on the next getUpdates call. */
+  private throwNext = false
+  /** Resolves immediately after each batch is drained. */
+  private drainSignals: Array<() => void> = []
+
+  queueBatch(batch: TelegramUpdate[]): Promise<void> {
+    this.batches.push(batch)
+    return new Promise(resolve => {
+      this.drainSignals.push(resolve)
+    })
+  }
+
+  throwOnNext(): void {
+    this.throwNext = true
+  }
+
+  async getUpdates(options: { offset?: number; timeoutSec?: number }): Promise<TelegramUpdate[]> {
+    this.getUpdatesCalls.push(options)
+    if (this.throwNext) {
+      this.throwNext = false
+      throw new Error('simulated network error')
+    }
+    const batch = this.batches.shift()
+    if (!batch) {
+      // Simulate Telegram long-poll timeout with an empty response.
+      await new Promise(resolve => setTimeout(resolve, 10))
+      return []
+    }
+    // Signal that this batch is being returned.
+    const signal = this.drainSignals.shift()
+    if (signal) signal()
+    return batch
+  }
+
+  async sendMessage(chatId: string | number, text: string): Promise<void> {
+    this.sentMessages.push({ chatId, text })
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('TelegramChannel (PRLT-1255)', () => {
+  let client: FakeTelegramClient
+  let channel: TelegramChannel
+  let received: Message[]
+
+  beforeEach(() => {
+    client = new FakeTelegramClient()
+    received = []
+  })
+
+  afterEach(async () => {
+    if (channel) await channel.stop()
+  })
+
+  function build(allowlist: string[] = ['111']): TelegramChannel {
+    channel = new TelegramChannel({
+      config: { token: 'fake-token', allowlist, pollIntervalMs: 1 },
+      client,
+    })
+    channel.onMessage(async msg => {
+      received.push(msg)
+    })
+    return channel
+  }
+
+  it('refuses start() without a handler registered', async () => {
+    const ch = new TelegramChannel({
+      config: { token: 'fake-token', allowlist: [] },
+      client,
+    })
+    let err: unknown = null
+    try {
+      await ch.start()
+    } catch (e) {
+      err = e
+    }
+    expect(err).to.be.instanceOf(Error)
+    expect((err as Error).message).to.match(/onMessage/)
+  })
+
+  it('normalizes a text message into the gateway Message shape', async () => {
+    const ch = build(['111'])
+    const drained = client.queueBatch([
+      {
+        update_id: 10,
+        message: {
+          message_id: 5,
+          from: { id: 111, username: 'alice' },
+          chat: { id: 999, type: 'private' },
+          date: 1_700_000_000,
+          text: 'hello bot',
+        },
+      },
+    ])
+
+    await ch.start()
+    await drained
+    // Give the loop a beat to invoke the handler.
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await ch.stop()
+
+    expect(received).to.have.lengthOf(1)
+    const msg = received[0]
+    expect(msg.channel).to.equal('telegram')
+    expect(msg.id).to.equal('telegram:5')
+    expect(msg.text).to.equal('hello bot')
+    expect(msg.from.id).to.equal('999')
+    expect(msg.from.displayName).to.equal('@alice')
+    expect(msg.timestamp).to.be.instanceOf(Date)
+    expect(msg.timestamp.getTime()).to.equal(1_700_000_000 * 1000)
+  })
+
+  it('advances the offset cursor past the highest update id', async () => {
+    const ch = build()
+    const drained = client.queueBatch([
+      {
+        update_id: 42,
+        message: {
+          message_id: 1,
+          from: { id: 111 },
+          chat: { id: 999, type: 'private' },
+          date: 1_700_000_000,
+          text: 'hi',
+        },
+      },
+    ])
+    await ch.start()
+    await drained
+    await new Promise(resolve => setTimeout(resolve, 30))
+    await ch.stop()
+
+    // First call had no offset, subsequent calls must use offset 43.
+    const calls = client.getUpdatesCalls
+    expect(calls[0].offset).to.be.undefined
+    const post = calls.slice(1)
+    expect(post.length).to.be.greaterThan(0)
+    for (const c of post) {
+      expect(c.offset).to.equal(43)
+    }
+  })
+
+  it('drops messages from users not on the allowlist', async () => {
+    const ch = build(['111']) // only 111 is allowed
+    const drained = client.queueBatch([
+      {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          from: { id: 222 },
+          chat: { id: 999, type: 'private' },
+          date: 1_700_000_000,
+          text: 'please ignore me',
+        },
+      },
+    ])
+    await ch.start()
+    await drained
+    await new Promise(resolve => setTimeout(resolve, 30))
+    await ch.stop()
+
+    expect(received).to.have.lengthOf(0)
+  })
+
+  it('drops updates without text (MVP is text-only)', async () => {
+    const ch = build()
+    const drained = client.queueBatch([
+      {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          from: { id: 111 },
+          chat: { id: 999, type: 'private' },
+          date: 1_700_000_000,
+          // no text
+        },
+      },
+    ])
+    await ch.start()
+    await drained
+    await new Promise(resolve => setTimeout(resolve, 30))
+    await ch.stop()
+
+    expect(received).to.have.lengthOf(0)
+  })
+
+  it('sendMessage forwards to the injected client', async () => {
+    const ch = build()
+    await ch.sendMessage({ channel: 'telegram', id: '999' }, 'pong')
+    expect(client.sentMessages).to.have.lengthOf(1)
+    expect(client.sentMessages[0]).to.deep.equal({ chatId: '999', text: 'pong' })
+  })
+
+  it('sendMessage refuses to send to a foreign channel address', async () => {
+    const ch = build()
+    let err: unknown = null
+    try {
+      await ch.sendMessage({ channel: 'slack', id: '999' }, 'nope')
+    } catch (e) {
+      err = e
+    }
+    expect(err).to.be.instanceOf(Error)
+    expect((err as Error).message).to.match(/cannot send/)
+  })
+
+  it('recovers from a getUpdates error via backoff + retry', async () => {
+    const errors: string[] = []
+    channel = new TelegramChannel({
+      config: { token: 'fake-token', allowlist: ['111'], pollIntervalMs: 1 },
+      client,
+      logger: { error: msg => errors.push(msg) },
+      errorBackoffMs: 50, // keep the test fast
+    })
+    channel.onMessage(async msg => {
+      received.push(msg)
+    })
+
+    client.throwOnNext()
+    const drained = client.queueBatch([
+      {
+        update_id: 7,
+        message: {
+          message_id: 1,
+          from: { id: 111 },
+          chat: { id: 999, type: 'private' },
+          date: 1_700_000_000,
+          text: 'after recovery',
+        },
+      },
+    ])
+
+    await channel.start()
+    await drained
+    // Give the 50ms backoff + poll a beat.
+    await new Promise(resolve => setTimeout(resolve, 300))
+    await channel.stop()
+
+    expect(errors.some(e => e.includes('poll loop error'))).to.equal(true)
+    expect(received.map(m => m.text)).to.include('after recovery')
+  })
+})


### PR DESCRIPTION
## Summary

Resolves TKT-069: Telegram bot MVP — text your agents from your phone

## Description

## Goal

Telegram bot MVP that bridges messages to prlt sessions. Text your agents from your phone.

## Package layout

Ships as part of @proletariat/cli. No separate package. Lives at apps/cli/src/lib/gateway/ and apps/cli/src/commands/gateway/. Single install, single binary, single identity.

## Architecture — channel-agnostic from day 1

Build a channel abstraction layer from the start — do NOT write Telegram-specific code outside of one adapter file.

```typescript
interface MessagingChannel {
  name: string
  start(): Promise<void>
  stop(): Promise<void>
  onMessage(handler: MessageHandler): void
  sendMessage(to: ChannelAddress, text: string): Promise<void>
  sendVoiceNote?(to: ChannelAddress, audio: Buffer): Promise<void>  // optional, voice later
}

interface Message {
  id: string
  channel: string
  from: ChannelAddress
  text?: string
  audio?: Buffer
  timestamp: Date
}
```

## File structure

```
apps/cli/src/
  lib/gateway/
    types.ts           — MessagingChannel, Message, ChannelAddress interfaces
    router.ts          — Routes inbound messages to agent sessions via prlt session poke
    channels/
      telegram.ts      — TelegramChannel implementation
      # future: slack.ts, discord.ts, whatsapp.ts, etc.
  commands/gateway/
    start.ts           — Starts the gateway daemon (loads active channels from machine.db)
    connect.ts         — Registers a new channel with credentials
    disconnect.ts      — Removes a channel
    test.ts            — Sends a test message
    status.ts          — Shows active channels + recent message counts
```

## Gateway router

```typescript
class MessagingGateway {
  registerChannel(channel: MessagingChannel): void
  routeInbound(msg: Message): Promise<void>
    // 1. Look up agent mapped to (channel, user) in machine.db
    // 2. If no mapping, create a persistent named agent for that user
    // 3. prlt session poke <agent> "<msg.text>"
    // 4. Capture agent response
    // 5. Route response back via channel.sendMessage()
}
```

## Storage (machine.db)

```sql
CREATE TABLE messaging_channels (
  name TEXT PRIMARY KEY,           -- "telegram", "slack", etc.
  type TEXT NOT NULL,              -- channel type
  config_json TEXT NOT NULL,       -- encrypted credentials
  active INTEGER NOT NULL DEFAULT 1,
  last_message_at INTEGER
);

CREATE TABLE messaging_routes (
  channel TEXT NOT NULL,
  user_id TEXT NOT NULL,
  agent_session_id TEXT NOT NULL,
  created_at INTEGER NOT NULL,
  last_used_at INTEGER,
  PRIMARY KEY (channel, user_id)
);
```

## Commands

```bash
# Connect a Telegram bot
prlt gateway connect telegram --token <bot-token>

# Start the gateway (blocking daemon)
prlt gateway start

# Start in background
prlt gateway start --background

# List connected channels
prlt gateway status

# Send a test message
prlt gateway test telegram --to <user-id> --message "hello from prlt"
```

## MVP scope

- MessagingChannel interface
- TelegramChannel implementation (polling mode via getUpdates, webhooks later)
- MessagingGateway router with machine.db storage
- prlt gateway connect/start/status/test commands
- Default routing: new (channel, user) → spawn persistent named agent tied to that user
- Auth allowlist: only specific Telegram user IDs can message agents (configurable)

## Out of scope for MVP

- Voice notes (PRLT-1234)
- Real-time voice calls
- Multiple channels (Slack, Discord, etc. — come after)
- Webhook mode for Telegram (use polling first)
- Multi-user per channel (just the operator for now)

## Why this shape matters

Adding Slack/Discord/WhatsApp later is a new adapter file implementing MessagingChannel. Zero changes to the router, gateway, commands, or storage. The first adapter validates the abstraction.

Epic: PRLT-1251 (Messaging Gateway)

## Changes

- e9675185 feat(PRLT-1255): add telegram bot MVP gateway with channel-agnostic router

## Test Plan

- [ ] Tests pass locally
- [ ] Manual testing completed
