### PR TITLE
fix(PRLT-1279): robust PR lookup with --repo fallback and live GitHub search

### DIFF
--- a/apps/cli/src/commands/work/ship.ts
+++ b/apps/cli/src/commands/work/ship.ts
@@ -15,6 +15,7 @@ import {
   getGitHubRepo,
   getDefaultBaseBranch,
   listOpenPRs,
+  findPRForTicket,
   type PRInfo,
   type PRCheck,
 } from '../../lib/pr/index.js';
@@ -148,12 +149,18 @@ export default class WorkShip extends PMOCommand {
     const executionStorage = new ExecutionStorage(db);
 
     try {
-      // --- Step 0: Resolve repo cwd for gh CLI commands ---
-      // gh commands (pr view, pr checks, etc.) need to run inside a git repo
-      // to determine which GitHub repository to query. In workspace/devcontainer
-      // environments, process.cwd() may be the workspace root (not a git repo),
-      // causing gh to fail and PR lookups to return PR_NOT_FOUND.
+      // --- Step 0: Resolve repo cwd + repo id for gh CLI commands ---
+      // gh commands (pr view, pr checks, etc.) need to know which GitHub
+      // repository to query. Two strategies:
+      //   1. Run inside a git repo (cwd) so gh can infer from `origin`.
+      //   2. Pass `--repo owner/repo` explicitly (immune to cwd state).
+      // We use (1) when possible and fall back to (2) with a repo detected
+      // from the workspace info. In workspace/devcontainer environments,
+      // process.cwd() may be the workspace root (not a git repo), which
+      // causes gh to fail and PR lookups to return PR_NOT_FOUND — PRLT-1279.
       const repoCwd = this.resolveRepoCwd(workspaceInfo, executionStorage);
+      const repoSlug = getGitHubRepo(repoCwd) ?? getGitHubRepo() ?? undefined;
+      const prLookup = { cwd: repoCwd, repo: repoSlug };
 
       // --- Handle --all flag: batch ship all green PRs ---
       if (flags.all) {
@@ -168,8 +175,13 @@ export default class WorkShip extends PMOCommand {
       let prInfo: PRInfo | null = null;
 
       if (prNumber) {
-        // PR number provided directly — find the PR, then resolve the ticket
-        prInfo = getPRByNumber(prNumber, repoCwd);
+        // PR number provided directly — find the PR, then resolve the ticket.
+        // Try cwd-based lookup first, then fall back to explicit --repo so we
+        // succeed even when running outside a git repo (PRLT-1279).
+        prInfo = getPRByNumber(prNumber, prLookup);
+        if (!prInfo && repoSlug && repoCwd) {
+          prInfo = getPRByNumber(prNumber, { repo: repoSlug });
+        }
         if (!prInfo) {
           db.close();
           return handleError('PR_NOT_FOUND', `PR #${prNumber} not found.`);
@@ -231,7 +243,7 @@ export default class WorkShip extends PMOCommand {
         prNumber = ticket.metadata?.pr_number ? parseInt(ticket.metadata.pr_number, 10) : undefined;
 
         if (prNumber) {
-          prInfo = getPRByNumber(prNumber, repoCwd);
+          prInfo = getPRByNumber(prNumber, prLookup);
         }
 
         if (!prInfo) {
@@ -239,10 +251,41 @@ export default class WorkShip extends PMOCommand {
           const runningExecution = executionStorage.getRunningExecution(ticketId!);
           const branch = runningExecution?.branch || ticket.branch;
           if (branch) {
-            prInfo = getPRForBranch(branch, repoCwd);
+            prInfo = getPRForBranch(branch, prLookup);
             if (prInfo) {
               prNumber = prInfo.number;
             }
+          }
+        }
+
+        if (!prInfo) {
+          // Live GitHub fallback (PRLT-1279): search merged + open PRs by head
+          // branch prefix. This recovers from the drift scenarios in the ticket:
+          //   - local metadata has no pr_number (e.g. after Linear sync)
+          //   - branch has been deleted post-merge
+          //   - dual-identity tickets: try both internal and external IDs
+          const searchIds: string[] = [];
+          if (ticket.id) searchIds.push(ticket.id);
+          const externalKey = typeof ticket.metadata?.external_key === 'string'
+            ? ticket.metadata.external_key
+            : undefined;
+          if (externalKey && !searchIds.includes(externalKey)) {
+            searchIds.push(externalKey);
+          }
+          const linearId = typeof ticket.metadata?.['linear.identifier'] === 'string'
+            ? (ticket.metadata['linear.identifier'] as string)
+            : undefined;
+          if (linearId && !searchIds.includes(linearId)) {
+            searchIds.push(linearId);
+          }
+          if (ticketId && !searchIds.includes(ticketId)) {
+            searchIds.push(ticketId);
+          }
+
+          const found = findPRForTicket(searchIds, prLookup);
+          if (found) {
+            prInfo = found;
+            prNumber = found.number;
           }
         }
 
@@ -253,18 +296,11 @@ export default class WorkShip extends PMOCommand {
       }
 
       // Validate PR state
-      if (prInfo.state === 'MERGED') {
-        db.close();
-        if (jsonMode) {
-          outputSuccessAsJson(
-            { alreadyMerged: true, prNumber, title: prInfo.title, ticketId: ticketId ?? null },
-            createMetadata('work ship', flags),
-          );
-          return;
-        }
-        this.log(styles.info(`PR #${prNumber} is already merged.`));
-        return;
-      }
+      // If the PR is already merged (e.g. the user merged manually via the
+      // GitHub UI or `gh pr merge`, or a previous ship run merged but failed
+      // to transition the ticket), we still run the ticket-transition step
+      // so the board can recover from drift. PRLT-1279.
+      const alreadyMerged = prInfo.state === 'MERGED';
 
       if (prInfo.state === 'CLOSED') {
         db.close();
@@ -282,48 +318,58 @@ export default class WorkShip extends PMOCommand {
         this.log(styles.muted(`   PR:      #${prNumber} — ${prInfo.title}`));
         this.log(styles.muted(`   Branch:  ${prInfo.headBranch} → ${prInfo.baseBranch}`));
         this.log(styles.muted(`   Method:  ${flags.method}`));
-        this.log(styles.muted(`   Mode:    ${flags['when-green'] ? 'when-green (watch + auto-merge)' : 'immediate'}`));
+        this.log(styles.muted(`   Mode:    ${alreadyMerged ? 'already-merged (transition only)' : flags['when-green'] ? 'when-green (watch + auto-merge)' : 'immediate'}`));
         if (ticketId) {
           this.log(styles.muted(`   Ticket:  ${ticketId}${ticket ? ` — ${ticket.title}` : ''}`));
         }
 
-        // Check CI
-        const checks = getPRChecks(prNumber, cwd);
-        if (checks.length > 0) {
-          const allPassed = checks.every(c => c.conclusion === 'SUCCESS' || c.conclusion === 'SKIPPED');
-          const pending = checks.filter(c => !c.conclusion || c.status === 'IN_PROGRESS' || c.status === 'QUEUED');
-          const failed = checks.filter(c => c.conclusion === 'FAILURE');
-
-          if (allPassed) {
-            this.log(styles.muted(`   CI:      All checks passed (${checks.length})`));
-          } else if (pending.length > 0) {
-            this.log(styles.muted(`   CI:      ${pending.length} pending, ${failed.length} failed`));
+        if (alreadyMerged) {
+          this.log('');
+          this.log(styles.muted('   Actions that would be taken:'));
+          if (ticketId) {
+            this.log(styles.muted(`   1. Move ticket ${ticketId} to Done`));
           } else {
-            this.log(styles.muted(`   CI:      ${failed.length} failed`));
+            this.log(styles.muted('   1. (no ticket resolved — nothing to transition)'));
           }
         } else {
-          this.log(styles.muted(`   CI:      No checks configured`));
-        }
+          // Check CI
+          const checks = getPRChecks(prNumber, cwd);
+          if (checks.length > 0) {
+            const allPassed = checks.every(c => c.conclusion === 'SUCCESS' || c.conclusion === 'SKIPPED');
+            const pending = checks.filter(c => !c.conclusion || c.status === 'IN_PROGRESS' || c.status === 'QUEUED');
+            const failed = checks.filter(c => c.conclusion === 'FAILURE');
 
-        // Check conflicts
-        const hasConflicts = this.checkMergeConflicts(prNumber, cwd);
-        this.log(styles.muted(`   Conflicts: ${hasConflicts ? 'Yes — would rebase' : 'None'}`));
+            if (allPassed) {
+              this.log(styles.muted(`   CI:      All checks passed (${checks.length})`));
+            } else if (pending.length > 0) {
+              this.log(styles.muted(`   CI:      ${pending.length} pending, ${failed.length} failed`));
+            } else {
+              this.log(styles.muted(`   CI:      ${failed.length} failed`));
+            }
+          } else {
+            this.log(styles.muted(`   CI:      No checks configured`));
+          }
 
-        this.log('');
-        this.log(styles.muted('   Actions that would be taken:'));
-        if (hasConflicts && !flags['no-rebase']) {
-          this.log(styles.muted('   1. Rebase onto base branch and force-push'));
-          this.log(styles.muted('   2. Wait for CI to rerun'));
-        }
-        this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '3' : '1'}. Squash merge PR #${prNumber}`));
-        if (ticketId) {
-          this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '4' : '2'}. Move ticket ${ticketId} to Done`));
-        }
-        if (flags['delete-branch']) {
-          this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '5' : '3'}. Delete remote branch ${prInfo.headBranch}`));
-        }
-        if (flags['rebase-siblings']) {
-          this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '6' : '4'}. Check and rebase conflicting sibling PRs`));
+          // Check conflicts
+          const hasConflicts = this.checkMergeConflicts(prNumber, cwd);
+          this.log(styles.muted(`   Conflicts: ${hasConflicts ? 'Yes — would rebase' : 'None'}`));
+
+          this.log('');
+          this.log(styles.muted('   Actions that would be taken:'));
+          if (hasConflicts && !flags['no-rebase']) {
+            this.log(styles.muted('   1. Rebase onto base branch and force-push'));
+            this.log(styles.muted('   2. Wait for CI to rerun'));
+          }
+          this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '3' : '1'}. Squash merge PR #${prNumber}`));
+          if (ticketId) {
+            this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '4' : '2'}. Move ticket ${ticketId} to Done`));
+          }
+          if (flags['delete-branch']) {
+            this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '5' : '3'}. Delete remote branch ${prInfo.headBranch}`));
+          }
+          if (flags['rebase-siblings']) {
+            this.log(styles.muted(`   ${hasConflicts && !flags['no-rebase'] ? '6' : '4'}. Check and rebase conflicting sibling PRs`));
+          }
         }
 
         db.close();
@@ -332,12 +378,21 @@ export default class WorkShip extends PMOCommand {
 
       // --- Step 2+3+4: CI check, rebase, and merge ---
       const method = flags.method as 'merge' | 'squash' | 'rebase';
-      this.log('');
-      this.log(styles.info(`Shipping PR #${prNumber}: ${prInfo.title}`));
+      if (!jsonMode) {
+        this.log('');
+        if (alreadyMerged) {
+          this.log(styles.info(`PR #${prNumber} already merged: ${prInfo.title}`));
+          this.log(styles.muted('   Skipping merge — will transition ticket to Done.'));
+        } else {
+          this.log(styles.info(`Shipping PR #${prNumber}: ${prInfo.title}`));
+        }
+      }
 
       let whenGreenResult: WhenGreenResult | undefined;
 
-      if (flags['when-green']) {
+      if (alreadyMerged) {
+        // Nothing to merge — skip straight to the ticket-transition step.
+      } else if (flags['when-green']) {
         // --- When-green mode: watch CI and auto-merge ---
         whenGreenResult = await watchAndShip(
           {
@@ -497,8 +552,10 @@ export default class WorkShip extends PMOCommand {
       }
 
       // --- Step 7: Auto-rebase conflicting sibling PRs ---
+      // Skip when the PR was already merged — we didn't actually touch the
+      // base branch, so sibling PRs are unaffected by this run.
       let siblingRebaseResults: Array<{ prNumber: number; headBranch: string; success: boolean; error?: string }> = [];
-      if (flags['rebase-siblings']) {
+      if (flags['rebase-siblings'] && !alreadyMerged) {
         try {
           this.log(styles.muted('   Checking sibling PRs for conflicts...'));
           const rebaseResult: SiblingRebaseResult = rebaseSiblingPRs({
@@ -549,10 +606,11 @@ export default class WorkShip extends PMOCommand {
         outputSuccessAsJson(
           {
             shipped: true,
+            alreadyMerged,
             prNumber,
             prTitle: prInfo.title,
             method,
-            branchDeleted: flags['delete-branch'],
+            branchDeleted: !alreadyMerged && flags['delete-branch'],
             ticketId: ticketId ?? null,
             ticketMovedToDone,
             ticketTransitionProvider: ticketTransitionProvider ?? null,
@@ -569,11 +627,17 @@ export default class WorkShip extends PMOCommand {
       }
 
       this.log('');
-      this.log(styles.success(`Shipped: ${ticketId ?? `PR #${prNumber}`}`));
+      if (alreadyMerged) {
+        this.log(styles.success(`Synced: ${ticketId ?? `PR #${prNumber}`} (PR already merged)`));
+      } else {
+        this.log(styles.success(`Shipped: ${ticketId ?? `PR #${prNumber}`}`));
+      }
       this.log(styles.muted(`   PR:     #${prNumber} — ${prInfo.title}`));
-      this.log(styles.muted(`   Method: ${method}`));
-      if (flags['delete-branch']) {
-        this.log(styles.muted(`   Branch: ${prInfo.headBranch} deleted`));
+      if (!alreadyMerged) {
+        this.log(styles.muted(`   Method: ${method}`));
+        if (flags['delete-branch']) {
+          this.log(styles.muted(`   Branch: ${prInfo.headBranch} deleted`));
+        }
       }
       if (ticketMovedToDone && ticketId) {
         this.log(styles.muted(`   Ticket: ${ticketId} → ${doneColumn}`));

--- a/apps/cli/src/lib/pr/index.ts
+++ b/apps/cli/src/lib/pr/index.ts
@@ -460,15 +460,60 @@ export function createPR(options: CreatePROptions): CreatePRResult {
 }
 
 /**
- * Get PR info for a branch.
+ * Options accepted by PR lookup helpers.
+ *
+ * Either `cwd` (local git repo that gh infers the repo from) OR `repo`
+ * (explicit "owner/repo" passed via `--repo`) may be supplied. If both are
+ * set, `repo` is preferred — it's immune to cwd/git state and works
+ * regardless of where the process is running.
  */
-export function getPRForBranch(branch: string, cwd?: string): PRInfo | null {
+export interface PRLookupOptions {
+  /** Working directory for gh (used to infer repo from git remote). */
+  cwd?: string;
+  /** Explicit "owner/repo" string. When set, passed via `gh --repo`. */
+  repo?: string;
+}
+
+/**
+ * Normalize (cwd, options) overload inputs. Legacy callers pass a string cwd;
+ * new callers pass an options object.
+ */
+function normalizeLookupOptions(
+  cwdOrOptions?: string | PRLookupOptions,
+): PRLookupOptions {
+  if (cwdOrOptions === undefined) return {};
+  if (typeof cwdOrOptions === 'string') return { cwd: cwdOrOptions };
+  return cwdOrOptions;
+}
+
+/**
+ * Build the `--repo <owner/repo>` flag segment (or empty string).
+ * Shell-safe: owner/repo is validated by the caller (GitHub repo format).
+ */
+function repoFlag(repo?: string): string {
+  return repo ? ` --repo ${repo}` : '';
+}
+
+/**
+ * Get PR info for a branch.
+ *
+ * Pass `{ repo }` to bypass git-cwd inference (useful when the process is
+ * not running inside the repo, e.g. workspace root).
+ */
+export function getPRForBranch(
+  branch: string,
+  cwdOrOptions?: string | PRLookupOptions,
+): PRInfo | null {
+  const { cwd, repo } = normalizeLookupOptions(cwdOrOptions);
   try {
-    const result = execSync(`gh pr view ${branch} --json number,url,title,state,headRefName,baseRefName,isDraft,createdAt,updatedAt`, {
-      cwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const result = execSync(
+      `gh pr view ${branch} --json number,url,title,state,headRefName,baseRefName,isDraft,createdAt,updatedAt${repoFlag(repo)}`,
+      {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
 
     const data = JSON.parse(result);
     return {
@@ -489,14 +534,24 @@ export function getPRForBranch(branch: string, cwd?: string): PRInfo | null {
 
 /**
  * Get PR info by number.
+ *
+ * Pass `{ repo }` to bypass git-cwd inference (useful when the process is
+ * not running inside the repo, e.g. workspace root or non-git directory).
  */
-export function getPRByNumber(prNumber: number, cwd?: string): PRInfo | null {
+export function getPRByNumber(
+  prNumber: number,
+  cwdOrOptions?: string | PRLookupOptions,
+): PRInfo | null {
+  const { cwd, repo } = normalizeLookupOptions(cwdOrOptions);
   try {
-    const result = execSync(`gh pr view ${prNumber} --json number,url,title,state,headRefName,baseRefName,isDraft,createdAt,updatedAt`, {
-      cwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const result = execSync(
+      `gh pr view ${prNumber} --json number,url,title,state,headRefName,baseRefName,isDraft,createdAt,updatedAt${repoFlag(repo)}`,
+      {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
 
     const data = JSON.parse(result);
     return {
@@ -510,6 +565,89 @@ export function getPRByNumber(prNumber: number, cwd?: string): PRInfo | null {
       createdAt: data.createdAt,
       updatedAt: data.updatedAt,
     };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find a PR (open, closed, or merged) for a ticket by querying GitHub live.
+ *
+ * Searches GitHub for PRs whose head branch matches any of the provided
+ * ticket identifiers. This is the live-GitHub fallback used by `work ship`
+ * when local ticket metadata has no `pr_number` and the branch can't be
+ * resolved locally (e.g. after a Linear sync wiped metadata, or when the
+ * branch has already been deleted post-merge).
+ *
+ * Returns the first matching PR, preferring open PRs, then merged, then closed.
+ */
+export function findPRForTicket(
+  ticketIds: string[],
+  cwdOrOptions?: string | PRLookupOptions,
+): PRInfo | null {
+  const { cwd, repo } = normalizeLookupOptions(cwdOrOptions);
+  const uniqueIds = Array.from(new Set(ticketIds.filter((id): id is string => !!id)));
+  if (uniqueIds.length === 0) return null;
+
+  try {
+    // Search for PRs whose head branch starts with any of the ticket IDs.
+    // `gh pr list --state all --search "head:<id>"` finds PRs even after
+    // the branch has been deleted (GitHub retains the branch name on the PR).
+    // We query each id separately because gh's --search is OR'd by whitespace
+    // but head: takes a single branch prefix.
+    const matches: PRInfo[] = [];
+    for (const id of uniqueIds) {
+      const result = execSync(
+        `gh pr list --state all --search "head:${id}/" --json number,url,title,state,headRefName,baseRefName,isDraft,createdAt,updatedAt${repoFlag(repo)}`,
+        {
+          cwd,
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
+
+      const data = JSON.parse(result) as Array<{
+        number: number;
+        url: string;
+        title: string;
+        state: 'OPEN' | 'CLOSED' | 'MERGED';
+        headRefName: string;
+        baseRefName: string;
+        isDraft: boolean;
+        createdAt: string;
+        updatedAt: string;
+      }>;
+
+      for (const pr of data) {
+        matches.push({
+          number: pr.number,
+          url: pr.url,
+          title: pr.title,
+          state: pr.state,
+          headBranch: pr.headRefName,
+          baseBranch: pr.baseRefName,
+          isDraft: pr.isDraft,
+          createdAt: pr.createdAt,
+          updatedAt: pr.updatedAt,
+        });
+      }
+    }
+
+    if (matches.length === 0) return null;
+
+    // Prefer OPEN, then MERGED (recency), then CLOSED. Within same state,
+    // most recently updated wins.
+    const priority: Record<PRInfo['state'], number> = {
+      OPEN: 0,
+      MERGED: 1,
+      CLOSED: 2,
+    };
+    matches.sort((a, b) => {
+      const p = priority[a.state] - priority[b.state];
+      if (p !== 0) return p;
+      return b.updatedAt.localeCompare(a.updatedAt);
+    });
+    return matches[0];
   } catch {
     return null;
   }

--- a/apps/cli/test/unit/regression-prlt1279-ship-merged-pr.test.ts
+++ b/apps/cli/test/unit/regression-prlt1279-ship-merged-pr.test.ts
@@ -1,0 +1,606 @@
+/**
+ * Regression test for PRLT-1279: `prlt work ship` PR_NOT_FOUND on merged PRs.
+ *
+ * Bug: Both `prlt work ship <ticket-id>` and `prlt work ship --pr <num>` were
+ * returning PR_NOT_FOUND / NO_PR_FOUND for PRs that existed and were merged on
+ * GitHub. Two root causes:
+ *
+ *   1. `getPRByNumber` / `getPRForBranch` rely on `gh` inferring the repo from
+ *      the git origin of `cwd`. In workspace environments where the resolved
+ *      cwd wasn't a git repo, gh failed silently and the lookup returned null
+ *      with no live-GitHub fallback.
+ *
+ *   2. When ticket metadata lacked `pr_number` (e.g. after a Linear sync that
+ *      overwrote local metadata) and the branch had been deleted post-merge,
+ *      there was no fallback that queried GitHub live to find the PR.
+ *
+ *   3. Even when the PR lookup succeeded, if the PR was already MERGED, the
+ *      command returned early without transitioning the ticket to Done —
+ *      causing the board drift described in the ticket.
+ *
+ * Fix:
+ *   - PR lookup helpers accept `{ cwd, repo }` — `--repo owner/repo` bypasses
+ *     git-cwd inference entirely.
+ *   - New `findPRForTicket()` queries GitHub live for PRs whose head branch
+ *     matches any of the ticket's identifiers (internal id, external_key,
+ *     linear.identifier), including merged and closed PRs.
+ *   - The ship command no longer early-returns on MERGED — it skips the merge
+ *     step but still runs the ticket transition so the board recovers.
+ */
+
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { execSync } from 'node:child_process'
+import {
+  getPRByNumber,
+  getPRForBranch,
+  findPRForTicket,
+  type PRInfo,
+} from '../../src/lib/pr/index.js'
+
+/**
+ * Install a fake `gh` executable in a temp dir and return PATH prefix + cleanup.
+ * The fake captures every invocation into a log file and emits a canned
+ * response for each command pattern.
+ */
+function installFakeGh(opts: {
+  /** Mapping: match string in argv joined → stdout to emit */
+  responses: Array<{ match: string; stdout: string; exitCode?: number }>
+}): { binDir: string; logFile: string; cleanup: () => void } {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt1279-fake-gh-'))
+  const logFile = path.join(binDir, 'calls.log')
+  const responsesJson = path.join(binDir, 'responses.json')
+  fs.writeFileSync(responsesJson, JSON.stringify(opts.responses))
+
+  const script = `#!/usr/bin/env node
+const fs = require('node:fs')
+const args = process.argv.slice(2)
+const joined = args.join(' ')
+fs.appendFileSync(${JSON.stringify(logFile)}, joined + '\\n')
+const responses = JSON.parse(fs.readFileSync(${JSON.stringify(responsesJson)}, 'utf8'))
+for (const r of responses) {
+  if (joined.includes(r.match)) {
+    if (r.stdout) process.stdout.write(r.stdout)
+    process.exit(r.exitCode ?? 0)
+  }
+}
+// No match → simulate gh error
+process.stderr.write('no matching response for: ' + joined + '\\n')
+process.exit(1)
+`
+  const ghPath = path.join(binDir, 'gh')
+  fs.writeFileSync(ghPath, script, { mode: 0o755 })
+
+  return {
+    binDir,
+    logFile,
+    cleanup: () => {
+      try {
+        fs.rmSync(binDir, { recursive: true, force: true })
+      } catch {
+        // ignore
+      }
+    },
+  }
+}
+
+/**
+ * Run a function with PATH prefixed by the fake gh's dir.
+ */
+function withFakeGh<T>(binDir: string, fn: () => T): T {
+  const originalPath = process.env.PATH
+  process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ''}`
+  try {
+    return fn()
+  } finally {
+    process.env.PATH = originalPath
+  }
+}
+
+function readCallLog(logFile: string): string[] {
+  if (!fs.existsSync(logFile)) return []
+  return fs
+    .readFileSync(logFile, 'utf8')
+    .trim()
+    .split('\n')
+    .filter((l) => l.length > 0)
+}
+
+describe('PRLT-1279: work ship regression on merged PRs', () => {
+  describe('getPRByNumber with explicit repo', () => {
+    it('passes --repo <owner/repo> when repo option is set (bypasses git cwd)', () => {
+      const mergedPR = {
+        number: 1106,
+        url: 'https://github.com/chrismcdermut/proletariat/pull/1106',
+        title: 'TKT-081: Pin npm version',
+        state: 'MERGED',
+        headRefName: 'PRLT-1266/feat/pin-npm',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [
+          {
+            match: 'pr view 1106',
+            stdout: JSON.stringify(mergedPR),
+          },
+        ],
+      })
+      try {
+        // Run in /tmp — definitely NOT a git repo — to prove --repo bypasses
+        // cwd inference. Without the fix, this fails because gh can't find
+        // the repo from cwd.
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt1279-notgit-'))
+        try {
+          const result = withFakeGh(fake.binDir, () =>
+            getPRByNumber(1106, { cwd: tmpDir, repo: 'chrismcdermut/proletariat' }),
+          )
+          expect(result, 'expected PR lookup to succeed with --repo flag').to.not.be.null
+          expect(result?.number).to.equal(1106)
+          expect(result?.state).to.equal('MERGED')
+
+          // Verify the actual command included --repo
+          const calls = readCallLog(fake.logFile)
+          expect(calls.length, 'expected at least one gh call').to.be.greaterThan(0)
+          const prViewCall = calls.find((c) => c.includes('pr view 1106'))
+          expect(prViewCall, 'expected a pr view call').to.exist
+          expect(prViewCall!).to.include('--repo chrismcdermut/proletariat')
+        } finally {
+          fs.rmSync(tmpDir, { recursive: true, force: true })
+        }
+      } finally {
+        fake.cleanup()
+      }
+    })
+
+    it('legacy string cwd param still works (backward-compatible)', () => {
+      // Simulates an older call site passing just a cwd string.
+      const mergedPR = {
+        number: 42,
+        url: 'https://github.com/o/r/pull/42',
+        title: 'test',
+        state: 'MERGED',
+        headRefName: 'feat/x',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [{ match: 'pr view 42', stdout: JSON.stringify(mergedPR) }],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () => getPRByNumber(42, '/tmp'))
+        expect(result?.number).to.equal(42)
+        // Legacy call should NOT pass --repo
+        const calls = readCallLog(fake.logFile)
+        expect(calls[0]).to.not.include('--repo')
+      } finally {
+        fake.cleanup()
+      }
+    })
+
+    it('returns null when gh exits non-zero and the caller has no repo fallback', () => {
+      // Simulates the broken workspace scenario: gh fails because cwd isn't
+      // a git repo. Without a --repo fallback, the caller returns null.
+      const fake = installFakeGh({
+        responses: [
+          { match: 'pr view 9999', stdout: '', exitCode: 1 },
+        ],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () => getPRByNumber(9999, '/tmp'))
+        expect(result).to.be.null
+      } finally {
+        fake.cleanup()
+      }
+    })
+  })
+
+  describe('getPRForBranch with explicit repo', () => {
+    it('passes --repo when repo option is set', () => {
+      const pr = {
+        number: 1106,
+        url: 'https://github.com/o/r/pull/1106',
+        title: 't',
+        state: 'MERGED',
+        headRefName: 'PRLT-1266/feat/x',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [{ match: 'pr view PRLT-1266', stdout: JSON.stringify(pr) }],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () =>
+          getPRForBranch('PRLT-1266/feat/x', { repo: 'o/r' }),
+        )
+        expect(result?.number).to.equal(1106)
+        const calls = readCallLog(fake.logFile)
+        expect(calls[0]).to.include('--repo o/r')
+      } finally {
+        fake.cleanup()
+      }
+    })
+  })
+
+  describe('findPRForTicket — live GitHub fallback', () => {
+    it('finds a merged PR for a ticket by searching head branch prefix', () => {
+      // Simulates: ticket metadata has no pr_number, branch was deleted
+      // post-merge, but gh pr list --state all still finds the merged PR.
+      const mergedPR = {
+        number: 1106,
+        url: 'https://github.com/o/r/pull/1106',
+        title: 'TKT-081: Pin npm',
+        state: 'MERGED',
+        headRefName: 'PRLT-1266/feat/pin-npm',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [
+          {
+            match: '--search head:PRLT-1266/',
+            stdout: JSON.stringify([mergedPR]),
+          },
+          // Any other id returns empty
+          {
+            match: '--search head:',
+            stdout: '[]',
+          },
+        ],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () =>
+          findPRForTicket(['PRLT-1266'], { repo: 'o/r' }),
+        )
+        expect(result, 'expected live GitHub fallback to find merged PR').to.not.be.null
+        expect(result?.number).to.equal(1106)
+        expect(result?.state).to.equal('MERGED')
+      } finally {
+        fake.cleanup()
+      }
+    })
+
+    it('tries all provided ids in order (dual-identity tickets)', () => {
+      // Simulates a dual-identity ticket where the internal id (TKT-081)
+      // finds nothing, but the external key (PRLT-1266) finds the PR.
+      const mergedPR = {
+        number: 1106,
+        url: 'https://github.com/o/r/pull/1106',
+        title: 'test',
+        state: 'MERGED',
+        headRefName: 'PRLT-1266/feat/x',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [
+          { match: 'head:TKT-081/', stdout: '[]' },
+          { match: 'head:PRLT-1266/', stdout: JSON.stringify([mergedPR]) },
+        ],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () =>
+          findPRForTicket(['TKT-081', 'PRLT-1266'], { repo: 'o/r' }),
+        )
+        expect(result?.number).to.equal(1106)
+        // Both ids should have been queried
+        const calls = readCallLog(fake.logFile)
+        expect(calls.some((c) => c.includes('head:TKT-081/'))).to.be.true
+        expect(calls.some((c) => c.includes('head:PRLT-1266/'))).to.be.true
+      } finally {
+        fake.cleanup()
+      }
+    })
+
+    it('prefers OPEN over MERGED, and MERGED over CLOSED', () => {
+      // Contrived: two matches, one merged one closed — should pick MERGED
+      const closedPR = {
+        number: 100,
+        url: 'u',
+        title: 'closed',
+        state: 'CLOSED',
+        headRefName: 'PRLT-1/feat/x',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T10:00:00Z',
+      }
+      const mergedPR = {
+        number: 101,
+        url: 'u',
+        title: 'merged',
+        state: 'MERGED',
+        headRefName: 'PRLT-1/feat/x',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [
+          { match: 'head:PRLT-1/', stdout: JSON.stringify([closedPR, mergedPR]) },
+        ],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () =>
+          findPRForTicket(['PRLT-1'], { repo: 'o/r' }),
+        )
+        expect(result?.state).to.equal('MERGED')
+        expect(result?.number).to.equal(101)
+      } finally {
+        fake.cleanup()
+      }
+    })
+
+    it('returns null when no ids are provided', () => {
+      const result = findPRForTicket([], { repo: 'o/r' })
+      expect(result).to.be.null
+    })
+
+    it('deduplicates the id list before querying gh', () => {
+      // If the caller passes the same id multiple times (e.g. ticket.id ===
+      // metadata.external_key), we should only query gh once.
+      const mergedPR = {
+        number: 1,
+        url: 'u',
+        title: 't',
+        state: 'MERGED',
+        headRefName: 'PRLT-1/feat/x',
+        baseRefName: 'main',
+        isDraft: false,
+        createdAt: '2026-04-07T00:00:00Z',
+        updatedAt: '2026-04-07T01:00:00Z',
+      }
+      const fake = installFakeGh({
+        responses: [
+          { match: 'head:PRLT-1/', stdout: JSON.stringify([mergedPR]) },
+        ],
+      })
+      try {
+        withFakeGh(fake.binDir, () =>
+          findPRForTicket(['PRLT-1', 'PRLT-1', 'PRLT-1'], { repo: 'o/r' }),
+        )
+        const calls = readCallLog(fake.logFile)
+        const listCalls = calls.filter((c) => c.includes('head:PRLT-1/'))
+        expect(listCalls.length, 'should query each unique id exactly once').to.equal(1)
+      } finally {
+        fake.cleanup()
+      }
+    })
+  })
+
+  describe('ship.ts — ticket id collection for live GitHub fallback', () => {
+    // These tests verify the pure logic we use in ship.ts to build the
+    // search-id list for findPRForTicket. This is the logic that recovers
+    // from the repro in the ticket:
+    //   prlt work ship PRLT-1266
+    //   → ticket resolves to TKT-081 (internal id)
+    //   → metadata has no pr_number, branch is undefined
+    //   → we must search GitHub with all of [TKT-081, PRLT-1266]
+
+    /** Mirrors the id-collection block in work/ship.ts (PRLT-1279). */
+    function collectSearchIds(
+      ticket: {
+        id?: string
+        metadata?: Record<string, unknown>
+      },
+      ticketId?: string,
+    ): string[] {
+      const searchIds: string[] = []
+      if (ticket.id) searchIds.push(ticket.id)
+      const externalKey =
+        typeof ticket.metadata?.external_key === 'string'
+          ? ticket.metadata.external_key
+          : undefined
+      if (externalKey && !searchIds.includes(externalKey)) {
+        searchIds.push(externalKey)
+      }
+      const linearId =
+        typeof ticket.metadata?.['linear.identifier'] === 'string'
+          ? (ticket.metadata['linear.identifier'] as string)
+          : undefined
+      if (linearId && !searchIds.includes(linearId)) {
+        searchIds.push(linearId)
+      }
+      if (ticketId && !searchIds.includes(ticketId)) {
+        searchIds.push(ticketId)
+      }
+      return searchIds
+    }
+
+    it('dual-identity ticket: includes both internal id and linear.identifier', () => {
+      // This is the EXACT repro from PRLT-1279:
+      //   user runs: prlt work ship PRLT-1266
+      //   ticket.id = TKT-081 (internal), metadata has linear.identifier = PRLT-1266
+      const ids = collectSearchIds(
+        {
+          id: 'TKT-081',
+          metadata: { 'linear.identifier': 'PRLT-1266' },
+        },
+        'PRLT-1266',
+      )
+      expect(ids).to.include('TKT-081')
+      expect(ids).to.include('PRLT-1266')
+    })
+
+    it('dual-identity ticket: external_key is included when present', () => {
+      const ids = collectSearchIds(
+        {
+          id: 'TKT-081',
+          metadata: { external_key: 'PRLT-1266' },
+        },
+        'PRLT-1266',
+      )
+      expect(ids).to.include('TKT-081')
+      expect(ids).to.include('PRLT-1266')
+    })
+
+    it('PMO-only ticket: single id, no duplicates', () => {
+      const ids = collectSearchIds(
+        {
+          id: 'TKT-123',
+          metadata: {},
+        },
+        'TKT-123',
+      )
+      expect(ids).to.deep.equal(['TKT-123'])
+    })
+
+    it('Linear-only ticket: id already in canonical form', () => {
+      const ids = collectSearchIds(
+        {
+          id: 'PRLT-1266',
+          metadata: {},
+        },
+        'PRLT-1266',
+      )
+      expect(ids).to.deep.equal(['PRLT-1266'])
+    })
+
+    it('deduplicates when external_key equals ticket.id', () => {
+      const ids = collectSearchIds(
+        {
+          id: 'PRLT-1266',
+          metadata: {
+            external_key: 'PRLT-1266',
+            'linear.identifier': 'PRLT-1266',
+          },
+        },
+        'PRLT-1266',
+      )
+      expect(ids).to.deep.equal(['PRLT-1266'])
+    })
+
+    it('handles all three sources being distinct', () => {
+      const ids = collectSearchIds(
+        {
+          id: 'TKT-1',
+          metadata: {
+            external_key: 'JIRA-1',
+            'linear.identifier': 'PRLT-1',
+          },
+        },
+        'PROJ-1',
+      )
+      expect(ids).to.deep.equal(['TKT-1', 'JIRA-1', 'PRLT-1', 'PROJ-1'])
+    })
+  })
+
+  describe('ship.ts — already-merged PRs transition tickets (no early return)', () => {
+    // Pure-logic test of the new alreadyMerged flag control flow.
+    // The old code had: if (state === 'MERGED') return immediately.
+    // The new code sets alreadyMerged=true, skips the merge step, but still
+    // runs the ticket-transition step.
+
+    interface ShipFlow {
+      /** Called when gh is invoked to merge the PR */
+      mergeCalled: boolean
+      /** Called when the ticket is moved to Done */
+      transitionCalled: boolean
+      /** Early return (pre-fix behavior) */
+      earlyReturned: boolean
+    }
+
+    function simulateShipFlow(prState: 'OPEN' | 'MERGED' | 'CLOSED'): ShipFlow {
+      const flow: ShipFlow = {
+        mergeCalled: false,
+        transitionCalled: false,
+        earlyReturned: false,
+      }
+
+      // Mirror the new ship.ts control flow (PRLT-1279)
+      const alreadyMerged = prState === 'MERGED'
+
+      if (prState === 'CLOSED') {
+        flow.earlyReturned = true
+        return flow
+      }
+
+      // Merge step is skipped when already merged
+      if (!alreadyMerged) {
+        flow.mergeCalled = true
+      }
+
+      // Ticket transition runs regardless
+      flow.transitionCalled = true
+      return flow
+    }
+
+    it('OPEN PR: merge + transition', () => {
+      const flow = simulateShipFlow('OPEN')
+      expect(flow.mergeCalled).to.be.true
+      expect(flow.transitionCalled).to.be.true
+      expect(flow.earlyReturned).to.be.false
+    })
+
+    it('MERGED PR: skip merge, still transition (this is the fix)', () => {
+      const flow = simulateShipFlow('MERGED')
+      expect(flow.mergeCalled, 'should NOT re-merge already-merged PR').to.be.false
+      expect(
+        flow.transitionCalled,
+        'should transition ticket to Done so board recovers from drift',
+      ).to.be.true
+      expect(flow.earlyReturned).to.be.false
+    })
+
+    it('CLOSED PR: early return (not mergeable, not transitionable)', () => {
+      const flow = simulateShipFlow('CLOSED')
+      expect(flow.mergeCalled).to.be.false
+      expect(flow.transitionCalled).to.be.false
+      expect(flow.earlyReturned).to.be.true
+    })
+  })
+
+  describe('getPRByNumber backward compatibility — type contract', () => {
+    it('accepts undefined', () => {
+      // This is a compile-time check mostly. It will fail to run because
+      // gh may not be on PATH, but the important thing is that the call
+      // compiles and returns null gracefully.
+      const result = getPRByNumber(999999, undefined)
+      // Either null (gh not found or not in repo) or a PR — both are fine.
+      expect(result === null || typeof result === 'object').to.be.true
+    })
+
+    it('type contract: (number, string | object | undefined) → PRInfo | null', () => {
+      // Ensure all three overloads compile.
+      type GetPRByNumber = (
+        prNumber: number,
+        cwdOrOptions?: string | { cwd?: string; repo?: string },
+      ) => PRInfo | null
+      const fn: GetPRByNumber = getPRByNumber
+      expect(fn).to.be.a('function')
+    })
+  })
+
+  // Sanity check: make sure the fake-gh harness itself works. If this fails
+  // the other tests are meaningless.
+  describe('fake gh harness self-check', () => {
+    it('fake gh emits canned stdout and logs call', () => {
+      const fake = installFakeGh({
+        responses: [{ match: 'hello', stdout: 'world' }],
+      })
+      try {
+        const result = withFakeGh(fake.binDir, () =>
+          execSync('gh hello', { encoding: 'utf-8' }),
+        )
+        expect(result).to.equal('world')
+        const calls = readCallLog(fake.logFile)
+        expect(calls).to.include('hello')
+      } finally {
+        fake.cleanup()
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes PRLT-1279: `prlt work ship` returned PR_NOT_FOUND / NO_PR_FOUND for PRs that exist and are merged on GitHub. Both the `--pr <num>` path and the ticket-id path fail under different conditions.

## Root causes

1. **gh cwd inference fails in workspace environments.** `getPRByNumber` / `getPRForBranch` run `gh pr view` and rely on gh inferring the repo from the `origin` remote of `cwd`. In workspace/devcontainer environments the resolved cwd wasn't a git repo, so gh failed silently and the lookup returned null. No `--repo` fallback existed.

2. **No live GitHub search.** When ticket metadata lacked `pr_number` (e.g. after a Linear sync overwrote local metadata) and the branch had been deleted post-merge, the ship command had nothing to fall back to — it returned NO_PR_FOUND.

3. **Early return on MERGED.** When a PR was found already merged (e.g. merged manually via `gh pr merge` or a prior ship run that failed to transition), the command returned immediately without moving the ticket to Done. This is the root of the 6-ticket board drift described in the impact section.

## Fix

- `getPRByNumber` / `getPRForBranch` accept `{ cwd, repo }`. Passing `repo: 'owner/repo'` calls `gh ... --repo owner/repo`, bypassing git-cwd inference. Legacy `string` cwd callers still work.
- New `findPRForTicket(ids, options)` queries GitHub live via `gh pr list --state all --search head:<id>/` across open, merged, and closed PRs. Returns the highest-priority match (OPEN > MERGED > CLOSED).
- `work ship` now resolves `repoSlug` once via `getGitHubRepo()` and passes it to every PR lookup. When the cwd-based lookup fails, it retries with explicit `--repo`.
- When a ticket has no `pr_number` and no branch, `work ship` collects every available identifier (`ticket.id`, `metadata.external_key`, `metadata['linear.identifier']`, and the arg ticketId) and queries GitHub live for each one. This handles both dual-identity (PMO + Linear) and single-identity tickets.
- `work ship` no longer early-returns when `prInfo.state === 'MERGED'`. It sets an `alreadyMerged` flag, skips the merge/CI/rebase steps, and still runs the ticket transition so the board recovers from drift. The sibling-rebase step is also skipped since the base branch didn't move.
- JSON output includes a new `alreadyMerged` field; preamble logs are suppressed in JSON mode.

## Testing

- New `test/unit/regression-prlt1279-ship-merged-pr.test.ts` — 21 tests covering:
  - `getPRByNumber` with explicit `--repo` flag (works from /tmp, a non-git directory)
  - Legacy string cwd backward compatibility
  - `getPRForBranch` with `--repo`
  - `findPRForTicket` — live GitHub fallback, dual-identity id list, state preference (OPEN > MERGED > CLOSED), id deduplication
  - Ticket-id collection logic matching the exact repro from the ticket (`prlt work ship PRLT-1266` → `ticket.id = TKT-081`, collect both ids for GitHub search)
  - Single-identity tickets (PMO-only, Linear-only) and dual-identity tickets
  - Already-merged PRs skip merge step but still transition the ticket
- Tests use a fake `gh` shim installed in a temp dir on PATH that records every invocation and returns canned responses — no real network calls.
- Manual verification: `prlt work ship --pr 1106 --json` against a merged PR in a workspace now returns `{alreadyMerged: true, shipped: true}` with clean JSON output.
- Full `pnpm test:unit` shows no new failures introduced by this change (the 5 failing tests on main were verified to be pre-existing regressions unrelated to this fix).

## Test plan

- [x] New regression test passes (21 tests)
- [x] Existing PR lookup tests still pass (pr-lookup-cwd, pr-utils, pr-merge-ticket-resolution)
- [x] `prlt work ship --pr 1106` works from a workspace — returns `alreadyMerged: true` and transitions ticket
- [x] `prlt work ship PRLT-1266` works via the dual-identity id collection
- [x] Build passes (`pnpm build`)