### PR TITLE
PRLT-1280: Tier 2 state reconciler — prlt reconcile

### DIFF
--- a/apps/cli/src/commands/reconcile.ts
+++ b/apps/cli/src/commands/reconcile.ts
@@ -1,0 +1,179 @@
+/**
+ * `prlt reconcile` — Tier 2 State Reconciler (PRLT-1280)
+ *
+ * Polls GitHub for the live state of each linked PR and fires normal
+ * ticket transitions to fix board drift (e.g. "6 tickets stuck in Review
+ * because someone merged via `gh pr merge` instead of `prlt work ship`").
+ *
+ * Design constraints from PRLT-1280:
+ *   - Idempotent: a second run is a no-op when state is already correct.
+ *   - Provider-agnostic: the command never branches on provider type;
+ *     all state changes go through the provider adapter layer.
+ *   - Scope is strictly the reconciliation function — no LLM, no daemon
+ *     rewrite, no supervision tree.
+ */
+
+import { Flags } from '@oclif/core'
+import { PMOCommand, pmoBaseFlags } from '../lib/pmo/index.js'
+import type { PMOStorage } from '../lib/pmo/types.js'
+import type { ProviderStorage } from '../lib/providers/types.js'
+import { runReconcile, watchReconcile, type ReconcileReport } from '../lib/reconcile/index.js'
+import { styles } from '../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../lib/prompt-json.js'
+
+export default class Reconcile extends PMOCommand {
+  static description =
+    'Tier 2 state reconciler — poll GitHub for linked PRs and fix board drift'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --dry-run',
+    '<%= config.bin %> <%= command.id %> --watch',
+    '<%= config.bin %> <%= command.id %> --watch --interval 60',
+    '<%= config.bin %> <%= command.id %> -P proj-001',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    'dry-run': Flags.boolean({
+      description: 'Print the transitions that would be made, but do not execute them',
+      default: false,
+    }),
+    watch: Flags.boolean({
+      description: 'Run on a timer until killed (default interval: 5 minutes)',
+      default: false,
+    }),
+    interval: Flags.integer({
+      description: 'Watch interval in seconds (used with --watch)',
+      default: 300,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Reconcile)
+    const db = this.requireDB()
+    const jsonMode = shouldOutputJson(flags)
+    const dryRun = flags['dry-run']
+    const projectFlag = (flags as { project?: string }).project
+    const storage = this.storage as unknown as PMOStorage & ProviderStorage
+
+    if (flags.watch) {
+      if (jsonMode) {
+        // --watch in JSON mode doesn't make sense — there is no single
+        // structured output to print. Fail fast so callers notice.
+        this.error('--watch is not supported in JSON mode')
+      }
+
+      this.log(
+        styles.muted(
+          `Watching for drift every ${flags.interval}s (Ctrl+C to stop)${dryRun ? ' [dry-run]' : ''}...`,
+        ),
+      )
+
+      let stop = false
+      const stopHandler = (): void => {
+        stop = true
+        this.log(styles.muted('\nStopping reconcile watcher...'))
+      }
+      process.once('SIGINT', stopHandler)
+      process.once('SIGTERM', stopHandler)
+
+      try {
+        await watchReconcile(db, storage, {
+          dryRun,
+          cwd: this.hqPath ?? process.cwd(),
+          projectId: projectFlag,
+          log: msg => this.log(msg),
+          intervalMs: flags.interval * 1000,
+          shouldStop: () => stop,
+          onCycle: report => this.printSummary(report, dryRun),
+        })
+      } finally {
+        process.removeListener('SIGINT', stopHandler)
+        process.removeListener('SIGTERM', stopHandler)
+      }
+      return
+    }
+
+    const report = await runReconcile(db, storage, {
+      dryRun,
+      cwd: this.hqPath ?? process.cwd(),
+      projectId: projectFlag,
+      log: jsonMode ? undefined : msg => this.log(msg),
+    })
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          checked: report.checked,
+          applied: report.applied,
+          skipped: report.skipped,
+          failed: report.failed,
+          errors: report.errors,
+          startedAt: report.startedAt,
+          finishedAt: report.finishedAt,
+          dryRun,
+        },
+        createMetadata('reconcile', flags),
+      )
+      return
+    }
+
+    this.printSummary(report, dryRun)
+  }
+
+  private printSummary(report: ReconcileReport, dryRun: boolean): void {
+    const { checked, applied, skipped, failed, errors } = report
+
+    if (applied.length === 0 && skipped.length === 0 && failed.length === 0) {
+      this.log(styles.muted(`Checked ${checked} ticket(s) — no drift detected.`))
+      return
+    }
+
+    this.log('')
+    this.log(styles.emphasis('Reconcile Summary:'))
+    this.log(`  Checked: ${checked} ticket(s)`)
+
+    if (applied.length > 0) {
+      this.log(styles.success(`  Applied: ${applied.length} transition(s)`))
+      for (const t of applied) {
+        this.log(
+          styles.muted(
+            `    ${t.ticketId}: ${t.fromState ?? '?'} → ${t.toState}` +
+              (t.prNumber ? ` (PR #${t.prNumber} ${t.prState ?? ''})` : ''),
+          ),
+        )
+      }
+    }
+
+    if (dryRun && skipped.length > 0) {
+      this.log(styles.warning(`  Skipped: ${skipped.length} (dry-run)`))
+      for (const t of skipped) {
+        this.log(
+          styles.muted(
+            `    [dry-run] ${t.ticketId}: ${t.fromState ?? '?'} → ${t.toState}` +
+              (t.prNumber ? ` (PR #${t.prNumber} ${t.prState ?? ''})` : ''),
+          ),
+        )
+      }
+    }
+
+    if (failed.length > 0) {
+      this.log(styles.error(`  Failed: ${failed.length}`))
+      for (const f of failed) {
+        this.log(styles.error(`    ${f.transition.ticketId}: ${f.error}`))
+      }
+    }
+
+    if (errors.length > 0) {
+      this.log(styles.warning(`  Non-fatal errors: ${errors.length}`))
+      for (const e of errors) {
+        this.log(styles.muted(`    ${e.ticketId}: ${e.error}`))
+      }
+    }
+  }
+}

--- a/apps/cli/src/lib/reconcile/core.ts
+++ b/apps/cli/src/lib/reconcile/core.ts
@@ -1,0 +1,168 @@
+/**
+ * Tier 2 State Reconciler — Pure core (PRLT-1280)
+ *
+ * This module holds the deterministic, provider-agnostic, side-effect-free
+ * logic of the reconciler. It answers a single question:
+ *
+ *   Given a ticket and the live state of its linked PR(s), what target
+ *   column should the ticket be in, and is that different from its
+ *   current column?
+ *
+ * Splitting this out from the IO-heavy runner keeps the rules trivially
+ * unit-testable without spinning up a database or the gh CLI.
+ */
+
+import type { PRInfo } from '../pr/index.js'
+import type { WorkflowConfig } from '../work-lifecycle/settings.js'
+import type { LinkedPR, ReconcileTicket, ReconcileTransition } from './types.js'
+
+/**
+ * Derive the expected state for a ticket given its linked PRs.
+ *
+ * Rules (mirrors the Tier 2 spec in PRLT-1280):
+ *   1. Any linked PR is MERGED → ticket belongs in Done
+ *   2. Ticket is currently in "review" category AND every open PR has been
+ *      CLOSED without merging → move back to In Progress so humans can
+ *      resume work. (Rule 4 in the existing sync reconciler uses Backlog,
+ *      but PRLT-1280 explicitly asks for "back to In Progress or a review
+ *      queue" — In Progress matches the active work better than Backlog.)
+ *   3. Otherwise: no expected transition.
+ *
+ * `null` means "leave the ticket alone". The reconciler MUST treat `null`
+ * as the idempotent path — that's how "second run is a no-op" works.
+ */
+export function deriveExpectedState(
+  ticket: ReconcileTicket,
+  linkedPRs: LinkedPR[],
+  config?: WorkflowConfig,
+): { targetState: string; reason: string; driver: LinkedPR } | null {
+  const category = ticket.statusCategory
+  const doneStatus = config?.done ?? 'Done'
+  const inProgressStatus = config?.in_progress ?? 'In Progress'
+
+  // Terminal states are load-bearing: we never pull a ticket back out of
+  // Done or Canceled. A human may have marked it closed for a reason.
+  if (category === 'completed' || category === 'canceled') {
+    return null
+  }
+
+  // Rule 1: any merged PR wins. Even if another linked PR is still open,
+  // a merged PR means the ticket's work shipped.
+  const merged = linkedPRs.find(lp => lp.pr.state === 'MERGED')
+  if (merged) {
+    // Idempotency: if the ticket is already sitting in the done column
+    // name we resolved, there is nothing to do.
+    if (statusMatches(ticket.statusName, doneStatus)) {
+      return null
+    }
+    return {
+      targetState: doneStatus,
+      reason:
+        `GitHub PR #${merged.pr.number} is MERGED (merged upstream), ` +
+        `expected ${doneStatus}, was ${ticket.statusName ?? category ?? 'unknown'}`,
+      driver: merged,
+    }
+  }
+
+  // Rule 2: ticket is in review-land, but every linked PR is closed without
+  // merging. Pull it back to In Progress so it gets picked up again.
+  const hasLinkedPRs = linkedPRs.length > 0
+  const allClosedNoMerge =
+    hasLinkedPRs && linkedPRs.every(lp => lp.pr.state === 'CLOSED')
+  const inReview = category === 'started' && isReviewStatus(ticket.statusName, config)
+
+  if (allClosedNoMerge && inReview) {
+    if (statusMatches(ticket.statusName, inProgressStatus)) {
+      return null
+    }
+    const closed = linkedPRs[0]
+    return {
+      targetState: inProgressStatus,
+      reason:
+        `GitHub PR #${closed.pr.number} is CLOSED without merging, ` +
+        `expected ${inProgressStatus}, was ${ticket.statusName ?? category ?? 'unknown'}`,
+      driver: closed,
+    }
+  }
+
+  return null
+}
+
+/**
+ * Build a {@link ReconcileTransition} record from a derived expected-state
+ * decision. Factored out so the runner and the tests both produce the
+ * same transition shape.
+ */
+export function buildTransition(params: {
+  ticket: ReconcileTicket
+  provider: string
+  targetState: string
+  reason: string
+  driver?: LinkedPR
+  now?: Date
+}): ReconcileTransition {
+  const { ticket, provider, targetState, reason, driver, now } = params
+  return {
+    ticketId: ticket.id,
+    ticketTitle: ticket.title ?? '',
+    projectId: ticket.projectId ?? '',
+    provider,
+    fromState: ticket.statusName ?? null,
+    toState: targetState,
+    prNumber: driver?.pr.number,
+    prState: driver?.pr.state,
+    reason,
+    decidedAt: (now ?? new Date()).toISOString(),
+  }
+}
+
+/**
+ * Format a transition for the structured log line required by the AC.
+ * The format is stable so scripts and tests can grep on it.
+ *
+ * Example:
+ *   [reconcile] TKT-142: In Review → Done | PR #321 MERGED @ 2026-04-08T00:00:00Z | reason: ...
+ */
+export function formatTransitionLogLine(t: ReconcileTransition): string {
+  const prPart =
+    t.prNumber !== undefined
+      ? `PR #${t.prNumber} ${t.prState ?? ''}`.trim() + ` @ ${t.decidedAt}`
+      : `no PR @ ${t.decidedAt}`
+  const from = t.fromState ?? 'unknown'
+  return `[reconcile] ${t.ticketId}: ${from} → ${t.toState} | ${prPart} | reason: ${t.reason}`
+}
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+function statusMatches(current: string | null | undefined, target: string): boolean {
+  if (!current) return false
+  return current.toLowerCase() === target.toLowerCase()
+}
+
+/**
+ * Match the existing sync reconciler's notion of "review status" so the
+ * Tier 2 reconciler treats the same columns as review that Tier 1 does.
+ * When a WorkflowConfig is provided, matches exactly against the
+ * configured review column; otherwise falls back to substring matching.
+ */
+function isReviewStatus(
+  statusName: string | null | undefined,
+  config?: WorkflowConfig,
+): boolean {
+  const name = (statusName ?? '').toLowerCase()
+  if (!name) return false
+  if (config?.review) {
+    return name === config.review.toLowerCase()
+  }
+  return name.includes('review')
+}
+
+/**
+ * Re-export for callers that want a direct PRInfo tuple without the
+ * LinkedPR wrapper.
+ */
+export function toLinkedPR(pr: PRInfo, source: LinkedPR['source']): LinkedPR {
+  return { pr, source }
+}

--- a/apps/cli/src/lib/reconcile/index.ts
+++ b/apps/cli/src/lib/reconcile/index.ts
@@ -1,0 +1,489 @@
+/**
+ * Tier 2 State Reconciler — Runner (PRLT-1280)
+ *
+ * This module owns the IO: it talks to the database, the GitHub CLI, and
+ * the provider adapter layer. The pure rule logic lives in ./core.ts so
+ * it can be unit-tested without these dependencies.
+ *
+ * Scope (narrow — the ticket is very explicit about what this is NOT):
+ *   - Single idempotent reconciliation function on a schedule
+ *   - Provider-agnostic — the reconciler does not branch on provider type
+ *   - Fires normal state-transition code path so hooks & cleanup fire too
+ *
+ * Everything outside that — webhook listeners, LLM escalation, human
+ * inbox, supervision tree — is explicitly out of scope per PRLT-1280.
+ */
+
+import type Database from 'better-sqlite3'
+import { PMO_TABLES } from '../pmo/schema.js'
+import type { StateCategory, Ticket, PMOStorage } from '../pmo/types.js'
+import type { ProviderStorage, TicketProvider } from '../providers/types.js'
+import { resolveTicketProvider } from '../providers/resolver.js'
+import type { PRInfo } from '../pr/index.js'
+import { getPRForBranch, getPRByNumber } from '../pr/index.js'
+import { getWorkflowConfig, type WorkflowConfig } from '../work-lifecycle/settings.js'
+import { buildTransition, deriveExpectedState, formatTransitionLogLine } from './core.js'
+import type {
+  LinkedPR,
+  PRLookupFn,
+  ReconcileOptions,
+  ReconcileReport,
+  ReconcileTicket,
+  ReconcileTransition,
+} from './types.js'
+
+export type {
+  LinkedPR,
+  LinkedPRSource,
+  PRLookupFn,
+  PRLookupRef,
+  ReconcileOptions,
+  ReconcileReport,
+  ReconcileTicket,
+  ReconcileTransition,
+} from './types.js'
+export { deriveExpectedState, buildTransition, formatTransitionLogLine } from './core.js'
+
+/**
+ * Non-terminal state categories that the reconciler scans.
+ *
+ * The ticket spec says:
+ *   "Query all tickets in non-terminal states across all connected
+ *    providers (Linear, PMO, Notion, Asana, Jira, Shortcut)"
+ *
+ * Terminal states (`completed`, `canceled`) are deliberately excluded —
+ * the reconciler never resurrects a closed ticket.
+ */
+const NON_TERMINAL_CATEGORIES: StateCategory[] = [
+  'triage',
+  'backlog',
+  'unstarted',
+  'started',
+]
+
+/**
+ * Default live PR lookup. Always goes to the remote — the Tier 2
+ * reconciler must not depend on any local PR cache.
+ */
+export const defaultPRLookup: PRLookupFn = (ref, cwd) => {
+  switch (ref.kind) {
+    case 'branch':
+      return getPRForBranch(ref.branch, cwd)
+    case 'number':
+      return getPRByNumber(ref.number, cwd)
+    case 'url': {
+      // `gh pr view <url>` works with either a number or URL; reuse it.
+      const num = parsePRNumberFromUrl(ref.url)
+      if (num !== null) return getPRByNumber(num, cwd)
+      return null
+    }
+  }
+}
+
+/**
+ * Run one reconciliation cycle.
+ *
+ * Strictly idempotent: if a ticket is already in its expected state the
+ * runner computes no transition and touches nothing. Running twice
+ * back-to-back produces no redundant side effects.
+ */
+export async function runReconcile(
+  db: Database.Database,
+  storage: PMOStorage & ProviderStorage,
+  options: ReconcileOptions = {},
+): Promise<ReconcileReport> {
+  const startedAt = new Date()
+  const { dryRun = false, cwd, log, projectId } = options
+  const prLookup = options.prLookup ?? defaultPRLookup
+
+  // Workflow config is used to resolve "Done" / "In Progress" / "Review"
+  // column names for the ticket's board. Fall back gracefully if the
+  // settings table is missing (older databases, unit tests).
+  let workflowConfig: WorkflowConfig | undefined
+  try {
+    workflowConfig = getWorkflowConfig(db)
+  } catch {
+    workflowConfig = undefined
+  }
+
+  // Gather every non-terminal ticket in scope. Either one project if
+  // -P was passed, or every project in the workspace.
+  const projectIds = projectId ? [projectId] : await listAllProjectIds(storage)
+
+  const tickets: Ticket[] = []
+  for (const pid of projectIds) {
+    for (const category of NON_TERMINAL_CATEGORIES) {
+      try {
+        // eslint-disable-next-line no-await-in-loop -- sequential is fine; small N
+        const batch = await storage.listTickets(pid, { statusCategory: category })
+        tickets.push(...batch)
+      } catch {
+        // Tolerate transient read errors on a single category; keep going.
+      }
+    }
+  }
+
+  log?.(`Scanning ${tickets.length} non-terminal ticket(s) across ${projectIds.length} project(s)...`)
+
+  const transitions: ReconcileTransition[] = []
+  const errors: Array<{ ticketId: string; error: string }> = []
+
+  for (const ticket of tickets) {
+    try {
+      const linkedPRs = gatherLinkedPRs(db, ticket, prLookup, cwd)
+      if (linkedPRs.length === 0) {
+        continue
+      }
+
+      // Resolve the provider for this ticket so we can log which backend
+      // owns it. The actual move happens through the same resolver later
+      // in applyTransition() — this is just for the transition record.
+      const providerName = providerNameFor(db, storage, ticket)
+
+      const decision = deriveExpectedState(toReconcileTicket(ticket), linkedPRs, workflowConfig)
+      if (!decision) continue
+
+      transitions.push(
+        buildTransition({
+          ticket: toReconcileTicket(ticket),
+          provider: providerName,
+          targetState: decision.targetState,
+          reason: decision.reason,
+          driver: decision.driver,
+        }),
+      )
+    } catch (err) {
+      errors.push({ ticketId: ticket.id, error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  // Apply (or dry-run) every transition. Failures on one ticket do not
+  // stop the others — the reconciler is a best-effort safety net.
+  const applied: ReconcileTransition[] = []
+  const skipped: ReconcileTransition[] = []
+  const failed: Array<{ transition: ReconcileTransition; error: string }> = []
+
+  for (const transition of transitions) {
+    log?.(formatTransitionLogLine(transition))
+
+    if (dryRun) {
+      skipped.push(transition)
+      continue
+    }
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await applyTransition(db, storage, transition)
+      applied.push(transition)
+
+      // Dual-identity tickets: if the primary provider is NOT local PMO,
+      // the local PMO board may still hold a stale mirror row. Nudge it
+      // to the same column so the local kanban view does not drift.
+      if (transition.provider !== 'pmo') {
+        // eslint-disable-next-line no-await-in-loop
+        await reconcilePmoMirror(db, storage, transition, log)
+      }
+    } catch (err) {
+      failed.push({
+        transition,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const finishedAt = new Date()
+
+  return {
+    checked: tickets.length,
+    applied,
+    skipped,
+    failed,
+    errors,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+  }
+}
+
+// -----------------------------------------------------------------------------
+// PR lookup
+// -----------------------------------------------------------------------------
+
+/**
+ * Gather every PR linked to a ticket by:
+ *   1. the ticket's branch (if set), and
+ *   2. PR URLs stored in `pmo_external_execution_prs` under any of the
+ *      ticket's external-source identities.
+ *
+ * Every lookup goes through the live PR lookup function — no cache.
+ */
+function gatherLinkedPRs(
+  db: Database.Database,
+  ticket: Ticket,
+  prLookup: PRLookupFn,
+  cwd?: string,
+): LinkedPR[] {
+  const results: LinkedPR[] = []
+  const seen = new Set<number>() // de-dupe by PR number
+
+  const push = (pr: PRInfo | null, source: LinkedPR['source']): void => {
+    if (!pr) return
+    if (seen.has(pr.number)) return
+    seen.add(pr.number)
+    results.push({ pr, source })
+  }
+
+  // 1. Ticket branch
+  if (ticket.branch) {
+    push(prLookup({ kind: 'branch', branch: ticket.branch }, cwd), 'ticket_branch')
+  }
+
+  // 2. PR URLs stored in the external execution map for this ticket.
+  //    A ticket can carry multiple external identities (metadata.external_id,
+  //    external_key) and can have been linked to multiple PRs over time.
+  const prUrls = listLinkedPrUrls(db, ticket)
+  for (const url of prUrls) {
+    push(prLookup({ kind: 'url', url }, cwd), 'external_map')
+  }
+
+  return results
+}
+
+/**
+ * Read every PR URL stored for this ticket in `pmo_external_execution_prs`.
+ * Keyed by (provider, external_id) — the reconciler doesn't care which
+ * provider it came from, so we union across all of them.
+ */
+function listLinkedPrUrls(db: Database.Database, ticket: Ticket): string[] {
+  const urls = new Set<string>()
+  const md = ticket.metadata ?? {}
+
+  // Collect every identifier that might key the external mapping table.
+  const externalIds = new Set<string>()
+  if (md.external_id) externalIds.add(md.external_id)
+  if (md.external_key) externalIds.add(md.external_key)
+  // A PMO-native ticket's id can also appear in the map under provider='pmo'.
+  externalIds.add(ticket.id)
+
+  if (externalIds.size === 0) return []
+
+  let stmt
+  try {
+    stmt = db.prepare(`
+      SELECT pr_url FROM ${PMO_TABLES.external_execution_prs}
+      WHERE external_id = ?
+    `)
+  } catch {
+    // Table may not exist yet (fresh DB or older schema).
+    return []
+  }
+
+  for (const extId of externalIds) {
+    try {
+      const rows = stmt.all(extId) as Array<{ pr_url: string }>
+      for (const row of rows) urls.add(row.pr_url)
+    } catch {
+      // Non-fatal: skip this id.
+    }
+  }
+
+  return [...urls]
+}
+
+/**
+ * Parse a PR number out of a github.com URL.
+ * Accepts both `/pull/123` and `/pull/123/...` shapes.
+ */
+function parsePRNumberFromUrl(url: string): number | null {
+  const m = url.match(/\/pull\/(\d+)(?:\b|\/)/)
+  if (!m) return null
+  const n = Number.parseInt(m[1], 10)
+  return Number.isFinite(n) ? n : null
+}
+
+// -----------------------------------------------------------------------------
+// Apply (goes through normal state-transition code path)
+// -----------------------------------------------------------------------------
+
+/**
+ * Apply a transition through the same provider adapter layer that
+ * `prlt ticket move` uses. This is load-bearing: it ensures hooks,
+ * provider sync, and worktree cleanup all fire.
+ */
+async function applyTransition(
+  db: Database.Database,
+  storage: PMOStorage & ProviderStorage,
+  transition: ReconcileTransition,
+): Promise<void> {
+  const ticket = await storage.getTicket(transition.ticketId)
+  if (!ticket) {
+    throw new Error(`Ticket ${transition.ticketId} vanished between scan and apply`)
+  }
+
+  const provider = resolveTicketProvider(
+    ticket.id,
+    ticket.projectId ?? transition.projectId,
+    db,
+    storage,
+    ticket.metadata,
+  )
+
+  const result = await provider.moveTicket(ticket.id, transition.toState)
+  if (!result.success) {
+    throw new Error(result.error ?? 'moveTicket failed without an error message')
+  }
+}
+
+/**
+ * For tickets whose source of truth is an external provider (Linear,
+ * Jira, etc.), the local PMO board can still hold a mirror row. After
+ * successfully moving the external ticket, reconcile the local PMO side
+ * too so `prlt board` does not drift.
+ *
+ * Best effort — failures here never block the primary transition.
+ */
+async function reconcilePmoMirror(
+  db: Database.Database,
+  storage: PMOStorage & ProviderStorage,
+  transition: ReconcileTransition,
+  log?: (msg: string) => void,
+): Promise<void> {
+  try {
+    const mirror = await storage.getTicket(transition.ticketId)
+    if (!mirror) return
+    // Only move if the mirror truly holds a different status — that way
+    // we stay idempotent and do not fire redundant hooks.
+    if (mirror.statusName && mirror.statusName.toLowerCase() === transition.toState.toLowerCase()) {
+      return
+    }
+    // Use the pmo provider directly (bypass resolver so we definitely
+    // hit the local mirror, not bounce back to Linear).
+    const pmoProvider: TicketProvider = resolveTicketProvider(
+      mirror.id,
+      mirror.projectId ?? transition.projectId,
+      db,
+      storage,
+      // Strip external_source so the resolver picks PMO.
+      null,
+    )
+    if (pmoProvider.name !== 'pmo') return
+    const result = await pmoProvider.moveTicket(mirror.id, transition.toState)
+    if (!result.success && log) {
+      log(`[reconcile] pmo mirror update for ${mirror.id} failed: ${result.error}`)
+    }
+  } catch (err) {
+    log?.(
+      `[reconcile] pmo mirror update for ${transition.ticketId} errored: ` +
+        (err instanceof Error ? err.message : String(err)),
+    )
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Project / provider resolution helpers
+// -----------------------------------------------------------------------------
+
+async function listAllProjectIds(storage: PMOStorage): Promise<string[]> {
+  try {
+    const projects = await storage.listProjects()
+    return projects.map(p => p.id)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Resolve the provider name for a ticket without triggering any state
+ * resolution or event emission. Used purely so the transition record
+ * can log which backend owns the ticket.
+ */
+function providerNameFor(
+  db: Database.Database,
+  storage: PMOStorage & ProviderStorage,
+  ticket: Ticket,
+): string {
+  try {
+    const provider = resolveTicketProvider(
+      ticket.id,
+      ticket.projectId ?? '',
+      db,
+      storage,
+      ticket.metadata,
+    )
+    return provider.name
+  } catch {
+    return 'pmo'
+  }
+}
+
+function toReconcileTicket(ticket: Ticket): ReconcileTicket {
+  return {
+    id: ticket.id,
+    title: ticket.title,
+    projectId: ticket.projectId,
+    statusName: ticket.statusName,
+    statusCategory: ticket.statusCategory,
+    branch: ticket.branch,
+    metadata: ticket.metadata,
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Watch loop
+// -----------------------------------------------------------------------------
+
+/**
+ * Run the reconciler on a timer until the caller-supplied `shouldStop`
+ * callback returns true.
+ *
+ * Each iteration runs one full {@link runReconcile} cycle and then sleeps
+ * for `intervalMs` before the next one. Errors inside a cycle are caught
+ * and surfaced via `log` — a single bad cycle never kills the watcher.
+ */
+export async function watchReconcile(
+  db: Database.Database,
+  storage: PMOStorage & ProviderStorage,
+  options: ReconcileOptions & {
+    intervalMs?: number
+    shouldStop?: () => boolean
+    onCycle?: (report: ReconcileReport) => void
+    sleep?: (ms: number) => Promise<void>
+  } = {},
+): Promise<void> {
+  const {
+    intervalMs = 5 * 60 * 1000,
+    shouldStop = () => false,
+    onCycle,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    log,
+  } = options
+
+  // Cycle counter for tests that want to bound the loop.
+  let cycle = 0
+
+  while (!shouldStop()) {
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const report = await runReconcile(db, storage, options)
+      cycle += 1
+      log?.(
+        `[reconcile] cycle ${cycle} complete — checked=${report.checked} ` +
+          `applied=${report.applied.length} skipped=${report.skipped.length} ` +
+          `failed=${report.failed.length}`,
+      )
+      onCycle?.(report)
+    } catch (err) {
+      log?.(
+        `[reconcile] cycle failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+
+    if (shouldStop()) return
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs)
+  }
+}
+
+// Exported for tests that want to call the PR URL parser directly.
+export { parsePRNumberFromUrl as _parsePRNumberFromUrl }

--- a/apps/cli/src/lib/reconcile/types.ts
+++ b/apps/cli/src/lib/reconcile/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Tier 2 State Reconciler — Types (PRLT-1280)
+ *
+ * The reconciler is the safety net that fixes board drift when Tier 1
+ * (event-driven hooks) misses an event. It polls the provider (GitHub for
+ * PR state) and fires normal ticket transitions when it detects drift.
+ *
+ * Design constraints:
+ * - Provider-agnostic: the reconciler core does not branch on provider type.
+ *   It routes every transition through the existing provider adapter layer.
+ * - Idempotent: running twice back-to-back must be safe. Every check asks
+ *   "is current == expected?" and no-ops when they match.
+ * - No LLM, no supervision tree, no daemon rewrite. One function on a timer.
+ */
+
+import type { PRInfo } from '../pr/index.js'
+import type { Ticket } from '../pmo/types.js'
+
+/**
+ * Source of a linked PR. Used for logging and to decide which PMO mapping
+ * to touch when the reconciler sees a transition is needed.
+ */
+export type LinkedPRSource =
+  | 'ticket_branch' // PR resolved from the ticket's linked branch
+  | 'external_map' // PR URL stored in pmo_external_execution_prs for this ticket's external id
+
+/**
+ * A PR linked to a ticket, along with its provenance.
+ */
+export interface LinkedPR {
+  /** Live PR info as reported by GitHub at the time of the reconcile cycle */
+  pr: PRInfo
+  /** How this PR was discovered for the ticket */
+  source: LinkedPRSource
+}
+
+/**
+ * A single transition the reconciler is about to apply (or would apply in dry-run).
+ */
+export interface ReconcileTransition {
+  /** Ticket being moved */
+  ticketId: string
+  /** Ticket display title (for logging) */
+  ticketTitle: string
+  /** The project the ticket belongs to */
+  projectId: string
+  /** Provider name that owns this ticket (from resolver) */
+  provider: string
+  /** Ticket's state before the transition */
+  fromState: string | null
+  /** Ticket's state after the transition (target column name) */
+  toState: string
+  /** PR number that drove this transition, when available */
+  prNumber?: number
+  /** PR state that drove this transition (MERGED, CLOSED, OPEN) */
+  prState?: PRInfo['state']
+  /** Human-readable reason for the transition */
+  reason: string
+  /** ISO timestamp the reconciler decided on this transition */
+  decidedAt: string
+}
+
+/**
+ * Options for running a reconcile cycle.
+ */
+export interface ReconcileOptions {
+  /** If true, compute transitions but do not apply them */
+  dryRun?: boolean
+  /** Working directory for GitHub CLI calls (git remote, gh pr view) */
+  cwd?: string
+  /** Optional callback for human-readable logs */
+  log?: (msg: string) => void
+  /**
+   * Restrict reconciliation to a specific project. When omitted the
+   * reconciler runs workspace-wide across every project.
+   */
+  projectId?: string
+  /**
+   * Injectable PR lookup. Tests use this to avoid the real gh CLI.
+   * Implementations must query live — the reconciler is not allowed to
+   * depend on a local PR cache.
+   */
+  prLookup?: PRLookupFn
+}
+
+/**
+ * Function signature for live PR lookup.
+ *
+ * The reconciler calls this once per PR reference. Implementations must
+ * hit the remote GitHub API (gh CLI or the REST client) — a stale local
+ * cache defeats the whole point of a Tier 2 reconciler.
+ */
+export type PRLookupFn = (ref: PRLookupRef, cwd?: string) => PRInfo | null
+
+/**
+ * A PR reference that can be resolved to a PRInfo.
+ *
+ * Tickets link to PRs via either their ticket branch (common for
+ * prlt-managed work) or via a stored URL in the external execution
+ * mapping table (common when the PR was opened outside prlt).
+ */
+export type PRLookupRef =
+  | { kind: 'branch'; branch: string }
+  | { kind: 'number'; number: number }
+  | { kind: 'url'; url: string }
+
+/**
+ * Report returned after a reconcile cycle completes.
+ */
+export interface ReconcileReport {
+  /** Total number of tickets considered (across all scanned projects) */
+  checked: number
+  /** Transitions that were applied (or would be applied in dry-run) */
+  applied: ReconcileTransition[]
+  /** Transitions that the reconciler decided on but did not execute because of --dry-run */
+  skipped: ReconcileTransition[]
+  /** Transitions that failed to apply */
+  failed: Array<{ transition: ReconcileTransition; error: string }>
+  /** Non-fatal errors encountered while gathering state */
+  errors: Array<{ ticketId: string; error: string }>
+  /** ISO timestamp when the cycle started */
+  startedAt: string
+  /** ISO timestamp when the cycle finished */
+  finishedAt: string
+}
+
+/**
+ * Minimal view of a ticket the reconciler actually reads. Narrow surface
+ * makes the reconciler easy to unit-test without fabricating full Ticket
+ * objects.
+ */
+export type ReconcileTicket = Pick<
+  Ticket,
+  'id' | 'title' | 'projectId' | 'statusName' | 'statusCategory' | 'branch' | 'metadata'
+>

--- a/apps/cli/test/unit/reconcile-core.test.ts
+++ b/apps/cli/test/unit/reconcile-core.test.ts
@@ -1,0 +1,261 @@
+import { expect } from 'chai'
+import {
+  deriveExpectedState,
+  buildTransition,
+  formatTransitionLogLine,
+} from '../../src/lib/reconcile/core.js'
+import type { LinkedPR, ReconcileTicket } from '../../src/lib/reconcile/types.js'
+import type { PRInfo } from '../../src/lib/pr/index.js'
+
+/**
+ * Tier 2 Reconciler — Core Rule Tests (PRLT-1280)
+ *
+ * These tests only exercise the pure rule engine. No database, no gh CLI,
+ * no provider adapters. The runner-level integration tests live in
+ * reconcile-runner.test.ts.
+ */
+
+function makeTicket(overrides: Partial<ReconcileTicket> = {}): ReconcileTicket {
+  return {
+    id: 'TKT-001',
+    title: 'Test ticket',
+    projectId: 'proj-001',
+    statusName: 'In Review',
+    statusCategory: 'started',
+    branch: 'PRLT-1/feat/test',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
+  return {
+    number: 42,
+    url: 'https://github.com/test/repo/pull/42',
+    title: 'Test PR',
+    state: 'MERGED',
+    headBranch: 'PRLT-1/feat/test',
+    baseBranch: 'main',
+    isDraft: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function wrap(pr: PRInfo, source: LinkedPR['source'] = 'ticket_branch'): LinkedPR {
+  return { pr, source }
+}
+
+describe('Reconcile Core — deriveExpectedState', () => {
+  describe('Rule 1: merged PR → Done', () => {
+    it('moves an In Review ticket to Done when its PR is merged', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Review', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Done')
+      expect(decision!.driver.pr.state).to.equal('MERGED')
+      expect(decision!.reason).to.include('MERGED')
+    })
+
+    it('moves an In Progress ticket to Done when its PR is merged', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Progress', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Done')
+    })
+
+    it('moves a backlog ticket to Done when its PR is merged', () => {
+      // This is the exact drift pattern described in PRLT-1280:
+      // a PR was merged but the ticket never left its pre-work state.
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Backlog', statusCategory: 'backlog' }),
+        [wrap(makePR({ state: 'MERGED', number: 321 }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Done')
+      expect(decision!.reason).to.include('#321')
+    })
+
+    it('is idempotent: a ticket already in Done produces no decision', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Done', statusCategory: 'completed' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.be.null
+    })
+
+    it('never resurrects a canceled ticket even if its PR later merges', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Canceled', statusCategory: 'canceled' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.be.null
+    })
+
+    it('prefers a merged PR over other linked PRs', () => {
+      const decision = deriveExpectedState(
+        makeTicket(),
+        [
+          wrap(makePR({ number: 1, state: 'OPEN' })),
+          wrap(makePR({ number: 2, state: 'MERGED' })),
+          wrap(makePR({ number: 3, state: 'CLOSED' })),
+        ],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.driver.pr.number).to.equal(2)
+      expect(decision!.targetState).to.equal('Done')
+    })
+
+    it('respects a custom Done column name from the workflow config', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'QA', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+        {
+          planned: 'Planned',
+          in_progress: 'In Progress',
+          review: 'QA',
+          done: 'Shipped',
+          backlog: 'Backlog',
+        },
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Shipped')
+    })
+
+    it('is idempotent against a custom Done column name', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Shipped', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+        {
+          planned: 'Planned',
+          in_progress: 'In Progress',
+          review: 'QA',
+          done: 'Shipped',
+          backlog: 'Backlog',
+        },
+      )
+      expect(decision).to.be.null
+    })
+  })
+
+  describe('Rule 2: review ticket + all PRs closed-not-merged → In Progress', () => {
+    it('moves a review ticket back to In Progress when the only PR was closed', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Review', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'CLOSED', number: 99 }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('In Progress')
+      expect(decision!.reason).to.include('CLOSED')
+    })
+
+    it('does nothing when the ticket is already in In Progress', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Progress', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'CLOSED' }))],
+      )
+      expect(decision).to.be.null
+    })
+
+    it('does nothing when at least one linked PR is still open', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Review', statusCategory: 'started' }),
+        [
+          wrap(makePR({ number: 1, state: 'CLOSED' })),
+          wrap(makePR({ number: 2, state: 'OPEN' })),
+        ],
+      )
+      expect(decision).to.be.null
+    })
+  })
+
+  describe('no action', () => {
+    it('produces no decision when no PRs are linked', () => {
+      const decision = deriveExpectedState(makeTicket(), [])
+      expect(decision).to.be.null
+    })
+
+    it('produces no decision for an open PR on an in-progress ticket', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Progress', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'OPEN' }))],
+      )
+      expect(decision).to.be.null
+    })
+  })
+
+  describe('idempotency invariant', () => {
+    it('running twice against an already-correct ticket is a no-op', () => {
+      const ticket = makeTicket({ statusName: 'Done', statusCategory: 'completed' })
+      const prs = [wrap(makePR({ state: 'MERGED' }))]
+      expect(deriveExpectedState(ticket, prs)).to.be.null
+      expect(deriveExpectedState(ticket, prs)).to.be.null
+    })
+  })
+})
+
+describe('Reconcile Core — buildTransition', () => {
+  it('builds a transition record with every required field', () => {
+    const ticket = makeTicket({ statusName: 'In Review', id: 'TKT-142' })
+    const driver = wrap(makePR({ state: 'MERGED', number: 321 }))
+    const now = new Date('2026-04-08T12:00:00Z')
+
+    const t = buildTransition({
+      ticket,
+      provider: 'linear',
+      targetState: 'Done',
+      reason: 'PR merged',
+      driver,
+      now,
+    })
+
+    expect(t.ticketId).to.equal('TKT-142')
+    expect(t.provider).to.equal('linear')
+    expect(t.fromState).to.equal('In Review')
+    expect(t.toState).to.equal('Done')
+    expect(t.prNumber).to.equal(321)
+    expect(t.prState).to.equal('MERGED')
+    expect(t.reason).to.equal('PR merged')
+    expect(t.decidedAt).to.equal('2026-04-08T12:00:00.000Z')
+  })
+
+  it('tolerates a missing driver PR', () => {
+    const t = buildTransition({
+      ticket: makeTicket(),
+      provider: 'pmo',
+      targetState: 'Done',
+      reason: 'nothing',
+    })
+    expect(t.prNumber).to.be.undefined
+    expect(t.prState).to.be.undefined
+  })
+})
+
+describe('Reconcile Core — formatTransitionLogLine', () => {
+  it('includes ticket id, old/new state, PR number and reason per AC', () => {
+    const line = formatTransitionLogLine({
+      ticketId: 'TKT-142',
+      ticketTitle: 'Fix thing',
+      projectId: 'proj-001',
+      provider: 'linear',
+      fromState: 'In Review',
+      toState: 'Done',
+      prNumber: 321,
+      prState: 'MERGED',
+      reason: 'GitHub PR #321 is MERGED',
+      decidedAt: '2026-04-08T12:00:00.000Z',
+    })
+    expect(line).to.include('TKT-142')
+    expect(line).to.include('In Review')
+    expect(line).to.include('Done')
+    expect(line).to.include('PR #321')
+    expect(line).to.include('MERGED')
+    expect(line).to.include('2026-04-08T12:00:00.000Z')
+    expect(line).to.include('reason:')
+  })
+})

--- a/apps/cli/test/unit/reconcile-runner.test.ts
+++ b/apps/cli/test/unit/reconcile-runner.test.ts
@@ -1,0 +1,386 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { SQLiteStorage } from '../../src/lib/pmo/storage-sqlite.js'
+import { runReconcile } from '../../src/lib/reconcile/index.js'
+import type { PRLookupFn, PRLookupRef } from '../../src/lib/reconcile/types.js'
+import type { PMOStorage } from '../../src/lib/pmo/types.js'
+import type { ProviderStorage } from '../../src/lib/providers/types.js'
+import type { PRInfo } from '../../src/lib/pr/index.js'
+import { ExternalExecutionMappingStore } from '../../src/lib/external-issues/mapping-store.js'
+
+/**
+ * Tier 2 Reconciler — Runner Tests (PRLT-1280)
+ *
+ * Drives runReconcile() against a real SQLite workspace with a stub
+ * GitHub lookup. Verifies:
+ *
+ *   - The regression pattern: 6 review tickets with merged PRs land in Done
+ *   - Idempotency: a second run makes zero additional changes
+ *   - Dry-run: no state mutation, skipped transitions reported
+ *   - `gh pr merge` drift: tickets with no prlt involvement still reconcile
+ *   - Live lookup: reconciler does not depend on any local PR cache
+ *   - Linked PR URLs from pmo_external_execution_prs work for tickets
+ *     that don't have a ticket.branch
+ */
+
+const PROJECT_ID = 'proj-reconcile-test'
+
+function makePR(overrides: Partial<PRInfo>): PRInfo {
+  return {
+    number: 1,
+    url: 'https://github.com/test/repo/pull/1',
+    title: 'Test PR',
+    state: 'OPEN',
+    headBranch: 'PRLT-1/feat/test',
+    baseBranch: 'main',
+    isDraft: false,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-08T00:00:00Z',
+    ...overrides,
+  }
+}
+
+/**
+ * Create a ticket and then stamp its branch via updateTicket, since
+ * CreateTicketInput does not accept branch directly.
+ */
+async function createTicketWithBranch(
+  storage: SQLiteStorage,
+  projectId: string,
+  params: { title: string; statusName: string; branch?: string },
+): Promise<{ id: string }> {
+  const t = await storage.createTicket(projectId, {
+    title: params.title,
+    statusName: params.statusName,
+  })
+  if (params.branch) {
+    await storage.updateTicket(t.id, { branch: params.branch })
+  }
+  return { id: t.id }
+}
+
+/**
+ * Build a PR lookup stub that resolves by branch and by URL. We also
+ * record every call so tests can assert the reconciler is hitting the
+ * live lookup (and not some stale cache) on every cycle.
+ */
+function makeStubLookup(prs: PRInfo[]): { lookup: PRLookupFn; calls: PRLookupRef[] } {
+  const byBranch = new Map(prs.map(pr => [pr.headBranch, pr]))
+  const byNumber = new Map(prs.map(pr => [pr.number, pr]))
+  const calls: PRLookupRef[] = []
+  const lookup: PRLookupFn = ref => {
+    calls.push(ref)
+    if (ref.kind === 'branch') return byBranch.get(ref.branch) ?? null
+    if (ref.kind === 'number') return byNumber.get(ref.number) ?? null
+    if (ref.kind === 'url') {
+      const m = ref.url.match(/\/pull\/(\d+)/)
+      if (!m) return null
+      return byNumber.get(Number.parseInt(m[1], 10)) ?? null
+    }
+    return null
+  }
+  return { lookup, calls }
+}
+
+describe('Tier 2 Reconciler — runner (PRLT-1280)', () => {
+  let testDir: string
+  let storage: SQLiteStorage
+  let db: Database.Database
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconcile-runner-'))
+    const dbPath = path.join(testDir, 'pmo.db')
+
+    // Create the db file first; SQLiteStorage requires it to exist.
+    const bootstrap = new Database(dbPath)
+    bootstrap.close()
+
+    storage = new SQLiteStorage(dbPath)
+    db = storage.getDatabase()
+
+    // Make sure the external execution mapping tables exist (they are
+    // created lazily by ExternalExecutionMappingStore).
+    // eslint-disable-next-line no-new
+    new ExternalExecutionMappingStore(db)
+
+    // The "default" template ships a Backlog → Ready → In Progress →
+    // Review → Done workflow, which matches the column names the
+    // reconciler expects.
+    await storage.createProject({
+      id: PROJECT_ID,
+      name: 'Reconcile Test Project',
+      template: 'default',
+    })
+  })
+
+  afterEach(async () => {
+    await storage.close()
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Regression: the exact drift pattern from PRLT-1280 — 6 tickets stuck in
+  // Review, each tied to a merged PR on GitHub.
+  // ---------------------------------------------------------------------------
+  it('moves all 6 stuck-in-Review tickets to Done in a single pass', async () => {
+    const prs: PRInfo[] = []
+    for (let i = 1; i <= 6; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await createTicketWithBranch(storage, PROJECT_ID, {
+        title: `Stuck ticket ${i}`,
+        statusName: 'Review',
+        branch: `PRLT-100${i}/feat/fix-${i}`,
+      })
+      prs.push(
+        makePR({
+          number: 1000 + i,
+          state: 'MERGED',
+          headBranch: `PRLT-100${i}/feat/fix-${i}`,
+        }),
+      )
+    }
+
+    const { lookup } = makeStubLookup(prs)
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(6)
+    expect(report.failed.length).to.equal(0)
+    expect(report.applied.every(t => t.toState === 'Done')).to.equal(true)
+    expect(report.applied.every(t => t.prState === 'MERGED')).to.equal(true)
+
+    // Every ticket is now in Done.
+    const after = await storage.listTickets(PROJECT_ID)
+    expect(after).to.have.lengthOf(6)
+    for (const t of after) {
+      expect(t.statusName).to.equal('Done')
+      expect(t.statusCategory).to.equal('completed')
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Idempotency — second run must be a no-op.
+  // ---------------------------------------------------------------------------
+  it('is idempotent: a second run makes zero additional changes', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Already shipped',
+      statusName: 'Review',
+      branch: 'PRLT-42/feat/ship',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 42, state: 'MERGED', headBranch: 'PRLT-42/feat/ship' }),
+    ])
+
+    const first = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(first.applied.length).to.equal(1)
+    expect(first.applied[0].toState).to.equal('Done')
+
+    const second = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(second.applied.length).to.equal(0)
+    expect(second.failed.length).to.equal(0)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Dry-run — no mutations, transitions reported in `skipped`.
+  // ---------------------------------------------------------------------------
+  it('--dry-run reports transitions without mutating state', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Would move',
+      statusName: 'Review',
+      branch: 'PRLT-7/feat/drift',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 7, state: 'MERGED', headBranch: 'PRLT-7/feat/drift' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID, dryRun: true },
+    )
+
+    expect(report.applied.length).to.equal(0)
+    expect(report.skipped.length).to.equal(1)
+    expect(report.skipped[0].toState).to.equal('Done')
+
+    // State must be unchanged.
+    const tickets = await storage.listTickets(PROJECT_ID)
+    expect(tickets[0].statusName).to.equal('Review')
+  })
+
+  // ---------------------------------------------------------------------------
+  // `gh pr merge` drift: merge outside prlt, no state change, reconcile fixes
+  // ---------------------------------------------------------------------------
+  it('catches drift from `gh pr merge` outside prlt', async () => {
+    // Simulate: someone merged via `gh pr merge` without prlt knowing.
+    // The ticket never left In Progress.
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Raw gh merge',
+      statusName: 'In Progress',
+      branch: 'PRLT-909/feat/raw',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 909, state: 'MERGED', headBranch: 'PRLT-909/feat/raw' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(1)
+    const [t] = await storage.listTickets(PROJECT_ID)
+    expect(t.statusName).to.equal('Done')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Closed-without-merging → back to In Progress
+  // ---------------------------------------------------------------------------
+  it('moves a Review ticket back to In Progress when its PR is closed unmerged', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Closed, not merged',
+      statusName: 'Review',
+      branch: 'PRLT-55/feat/rejected',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 55, state: 'CLOSED', headBranch: 'PRLT-55/feat/rejected' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(1)
+    expect(report.applied[0].toState).to.equal('In Progress')
+
+    const [t] = await storage.listTickets(PROJECT_ID)
+    expect(t.statusName).to.equal('In Progress')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Non-terminal scan: triage/backlog/unstarted tickets are also scanned
+  // ---------------------------------------------------------------------------
+  it('scans triage/backlog/unstarted tickets too', async () => {
+    // A ticket that never advanced past Backlog but has a merged PR
+    // (e.g. an agent ran out of band, or someone force-pushed a fix).
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Backlog with merged PR',
+      statusName: 'Backlog',
+      branch: 'PRLT-77/feat/early',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 77, state: 'MERGED', headBranch: 'PRLT-77/feat/early' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(report.applied.length).to.equal(1)
+    expect(report.applied[0].toState).to.equal('Done')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Live lookup: every cycle must actually call the PR lookup
+  // ---------------------------------------------------------------------------
+  it('hits the live PR lookup on every cycle (no local cache)', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Live lookup check',
+      statusName: 'In Progress',
+      branch: 'PRLT-1/feat/x',
+    })
+
+    const { lookup, calls } = makeStubLookup([
+      makePR({ number: 1, state: 'OPEN', headBranch: 'PRLT-1/feat/x' }),
+    ])
+
+    await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    const firstCallCount = calls.length
+    expect(firstCallCount).to.be.greaterThan(0)
+
+    await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    // Second cycle must issue new lookups — the reconciler is not
+    // allowed to short-circuit on a local cache.
+    expect(calls.length).to.be.greaterThan(firstCallCount)
+  })
+
+  // ---------------------------------------------------------------------------
+  // PR URLs stored in pmo_external_execution_prs are resolved even when
+  // the ticket has no linked branch.
+  // ---------------------------------------------------------------------------
+  it('resolves PR URLs stored in pmo_external_execution_prs', async () => {
+    const ticket = await storage.createTicket(PROJECT_ID, {
+      title: 'No branch, stored PR URL',
+      statusName: 'In Progress',
+    })
+    // Simulate a ticket whose PR was recorded via the external execution
+    // mapping (e.g. spawned from Linear without a local branch).
+    const mapStore = new ExternalExecutionMappingStore(db)
+    mapStore.upsertMapping({
+      provider: 'pmo',
+      externalId: ticket.id,
+      externalKey: ticket.id,
+      prUrl: 'https://github.com/test/repo/pull/2024',
+    })
+
+    const { lookup } = makeStubLookup([
+      makePR({ number: 2024, state: 'MERGED', url: 'https://github.com/test/repo/pull/2024' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(1)
+    expect(report.applied[0].toState).to.equal('Done')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tickets with no PR info are ignored (not flagged, not moved).
+  // ---------------------------------------------------------------------------
+  it('ignores tickets with no linked PR', async () => {
+    await storage.createTicket(PROJECT_ID, {
+      title: 'No PR, no problem',
+      statusName: 'In Progress',
+    })
+    const { lookup } = makeStubLookup([])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(report.applied.length).to.equal(0)
+    expect(report.checked).to.be.greaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `prlt reconcile`, the Tier 2 safety-net reconciler for board drift. This closes PRLT-1280.

## Problem

Ticket state drifts from reality whenever:
1. Someone merges via \`gh pr merge\` instead of \`prlt work ship\`
2. \`prlt work ship\` itself is broken (recent regression)
3. A webhook is missed or a hook fails silently
4. A user moves a ticket manually in Linear/Notion/etc.

Tier 1 (event-driven hooks) cannot catch these cases — it only fires when prlt initiated the action. There was no safety net.

## Solution

A single idempotent reconciliation function on a timer. Not a daemon rewrite, not a supervision tree, not an orchestrator — one function that:

1. Queries every ticket in a **non-terminal** state (triage/backlog/unstarted/started) across every project in the workspace.
2. For each ticket with linked PR metadata (ticket branch OR PR URLs stored in \`pmo_external_execution_prs\`), queries **GitHub live** for current PR state — no dependency on a local PR cache.
3. Derives the expected ticket state (MERGED → Done; CLOSED-not-merged + in review → back to In Progress).
4. If current ≠ expected, fires the normal state-transition code path via the provider adapter layer so hooks, provider sync, and worktree cleanup all fire.
5. Dual-identity tickets (PMO TKT-### + Linear PRLT-###) reconcile both sides.
6. Logs every transition with PR #, timestamp, old/new state, and reason.

## Scope boundaries (per PRLT-1280)

- No LLM (that's Tier 3)
- No human inbox (that's Tier 4)
- No worktree cleanup (fires naturally through \`ticket move\`)
- No webhook listeners (Tier 1, separate)
- No "fix conflicting PRs" logic (too much judgment, Tier 3)
- No per-provider branches in the reconciler core — provider-agnostic by construction

## CLI

\`\`\`
prlt reconcile                   # one pass
prlt reconcile --dry-run         # print transitions without executing
prlt reconcile --watch           # run on a 5min timer until killed
prlt reconcile --watch --interval 60
prlt reconcile -P proj-001       # scope to one project (default: workspace-wide)
\`\`\`

## Architecture

New library at \`apps/cli/src/lib/reconcile/\`:
- \`core.ts\` — pure, IO-free rule engine (\`deriveExpectedState\`, \`buildTransition\`, \`formatTransitionLogLine\`)
- \`index.ts\` — runner that gathers tickets, resolves linked PRs, and applies transitions through \`resolveTicketProvider()\`
- \`types.ts\` — \`ReconcileOptions\`, \`ReconcileTransition\`, \`ReconcileReport\`, \`PRLookupFn\`

New oclif command at \`apps/cli/src/commands/reconcile.ts\` with \`--dry-run\`, \`--watch\`, \`--interval\`, and JSON mode support.

## Acceptance criteria coverage

- [x] \`prlt reconcile\` command exists, runs one pass, exits cleanly
- [x] \`prlt reconcile --dry-run\` prints transitions that would be made without executing them
- [x] \`prlt reconcile --watch\` runs on a timer (default 5min) until killed
- [x] Reconciler queries GitHub live for each linked PR — no dependency on the local PR cache (unit test asserts lookup is called on every cycle)
- [x] State transitions go through the same code path as \`prlt ticket move\` (\`resolveTicketProvider\` → \`provider.moveTicket\`)
- [x] Idempotent: second run does nothing when state is already correct (unit test)
- [x] Provider-agnostic: no per-provider branches in the reconciler core
- [x] Dual-identity tickets reconcile both sides in one pass (\`reconcilePmoMirror\`)
- [x] Logs every transition with PR #, timestamp, old state, new state, reason
- [x] Regression test: 6 merged PRs with tickets stuck in Review, run reconcile, all 6 move to Done
- [x] Test: \`gh pr merge\` drift — merge without prlt, run reconcile, ticket moves to Done
- [x] No LLM, no supervision tree, no orchestration framework

## Tests

- \`test/unit/reconcile-core.test.ts\` — 17 tests covering pure rule logic (Rule 1 merged→Done across all non-terminal categories, custom column names, Rule 2 closed→In Progress, idempotency invariant, build/format helpers)
- \`test/unit/reconcile-runner.test.ts\` — 9 tests driving \`runReconcile\` against real SQLite storage with a stub PR lookup, including the PRLT-1280 regression (6 stuck Review tickets), idempotency, dry-run, \`gh pr merge\` drift, closed-unmerged → In Progress, non-terminal scanning, live-lookup assertion, PR URLs from \`pmo_external_execution_prs\`

Full suite: 26 new tests; 78 total across new + existing sync/reconciler tests.

## Test plan

- [x] \`pnpm build\` green
- [x] \`pnpm exec eslint src/lib/reconcile/ src/commands/reconcile.ts test/unit/reconcile-*.test.ts\` clean
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] All 26 new tests pass locally
- [x] Existing sync-reconciler and sync-commands tests still pass
- [ ] CI green