### PR TITLE
chore: bump version to 0.3.112

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.111",
+  "version": "0.3.112",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Version bump to publish PRLT-1279 (work ship fix), PRLT-1280 (reconciler), PRLT-1255 (Telegram bot MVP).