### PR TITLE
feat(PRLT-1296): pin Claude Code version to host + auto-refresh credentials

### DIFF
--- a/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
@@ -137,6 +137,21 @@ ${containerPostExec}
       } catch {
         return { success: false, error: `Failed to verify tmux session "${sessionName}" inside container.` }
       }
+
+      // PRLT-1296: Early-exit detection — if Claude dies immediately (e.g., auth failure),
+      // the tmux session disappears within seconds. Wait briefly and re-check so we can
+      // report failure instead of falsely reporting 'running'.
+      await new Promise(resolve => setTimeout(resolve, 5000))
+      try {
+        execSync(`docker exec ${actualContainerId} tmux has-session -t "${sessionName}" 2>&1`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+      } catch {
+        // Session died within 5 seconds of creation — likely auth failure or immediate crash
+        return {
+          success: false,
+          error: `Agent session "${sessionName}" exited immediately after spawn. This usually indicates an authentication failure (expired/invalid credentials) or a Claude Code startup error. Check container logs: docker logs ${actualContainerId}`,
+        }
+      }
+
       return { success: true, containerId: actualContainerId, sessionId: sessionName }
     }
 

--- a/apps/cli/src/lib/execution/runners/devcontainer.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer.ts
@@ -33,6 +33,7 @@ import {
   checkDockerDaemon,
   ensureDockerContainer,
   copyClaudeCredentials,
+  refreshCredentialVolume,
   ensureWorkflowScope,
 } from './shared.js'
 
@@ -235,6 +236,11 @@ export async function runDevcontainer(
     // Copy Claude credentials into agent directory so container can access them
     if (isClaudeExecutor(executor)) {
       copyClaudeCredentials(context.agentDir)
+
+      // PRLT-1296: Refresh credential volume with fresh host credentials before each spawn.
+      // OAuth tokens expire every ~24h; the volume is a snapshot that goes stale.
+      // This ensures containers always get the host's current (auto-refreshed) tokens.
+      refreshCredentialVolume()
     }
 
     // Start or reuse container using raw Docker commands

--- a/apps/cli/src/lib/execution/runners/docker-credentials.ts
+++ b/apps/cli/src/lib/execution/runners/docker-credentials.ts
@@ -94,6 +94,64 @@ export function getDockerCredentialInfo(): { expiresAt: Date; subscriptionType?:
 }
 
 /**
+ * PRLT-1296: Refresh the claude-credentials Docker volume with fresh credentials from the host.
+ *
+ * OAuth tokens expire every ~24h. The host's Claude Code auto-refreshes its tokens,
+ * but the Docker volume is a snapshot that goes stale. This copies the host's current
+ * credentials into the volume before each container spawn, ensuring fresh tokens.
+ *
+ * Creates the volume if it doesn't exist.
+ * Sets file ownership to UID 1000 (node user) so the container can read them.
+ *
+ * @returns true if credentials were refreshed successfully, false otherwise
+ */
+export function refreshCredentialVolume(): boolean {
+  const homeDir = process.env.HOME || os.homedir()
+  const hostCredPath = path.join(homeDir, '.claude', '.credentials.json')
+
+  // Check if host has credentials to copy
+  if (!fs.existsSync(hostCredPath)) {
+    console.debug('[runners:credentials] No host credentials at ~/.claude/.credentials.json, skipping refresh')
+    return false
+  }
+
+  try {
+    // Use a temporary container to copy host credentials into the named volume.
+    // -v ~/.claude:/src:ro  → mount host credentials read-only
+    // -v claude-credentials:/dest  → mount the target volume
+    // cp + chown ensures node user (UID 1000) owns the file inside the container.
+    // --pull never avoids Docker Hub auth issues on locked keychains / headless environments.
+    const refreshCmd = [
+      'docker run --rm --pull never',
+      `-v "${path.join(homeDir, '.claude')}:/src:ro"`,
+      `-v "${CLAUDE_CREDENTIALS_VOLUME}:/dest"`,
+      `alpine sh -c 'cp /src/.credentials.json /dest/.credentials.json && chown 1000:1000 /dest/.credentials.json'`,
+    ].join(' ')
+
+    execSync(refreshCmd, { stdio: 'pipe', timeout: 15000 })
+    console.debug('[runners:credentials] Refreshed credential volume with host credentials')
+    return true
+  } catch (error) {
+    // alpine image may not be cached — try with node:22 which is already pulled for agent builds
+    try {
+      const fallbackCmd = [
+        'docker run --rm --pull never',
+        `-v "${path.join(homeDir, '.claude')}:/src:ro"`,
+        `-v "${CLAUDE_CREDENTIALS_VOLUME}:/dest"`,
+        `node:22 bash -c 'cp /src/.credentials.json /dest/.credentials.json && chown 1000:1000 /dest/.credentials.json'`,
+      ].join(' ')
+
+      execSync(fallbackCmd, { stdio: 'pipe', timeout: 15000 })
+      console.debug('[runners:credentials] Refreshed credential volume with host credentials (node:22 fallback)')
+      return true
+    } catch {
+      console.debug('[runners:credentials] Failed to refresh credential volume:', error)
+      return false
+    }
+  }
+}
+
+/**
  * Check if Claude Code authentication is available on the host system.
  * Returns true if any of:
  * 1. ANTHROPIC_API_KEY environment variable is set

--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -157,6 +157,27 @@ export function getHostPrltVersion(): string | null {
 }
 
 /**
+ * PRLT-1296: Get the host's installed Claude Code version.
+ * Returns the semver version string (e.g., "2.1.89") or null if not available.
+ * Used to pin the container's Claude Code version to match the host,
+ * preventing credential format/handling mismatches between versions.
+ */
+export function getHostClaudeCodeVersion(): string | null {
+  try {
+    const output = execSync('claude --version', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10_000,
+    }).trim()
+    // claude --version output: "claude <version>" or just "<version>"
+    const match = output.match(/(\d+\.\d+\.\d+)/)
+    return match ? match[1] : null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Get the container name for an agent.
  * Format: prlt-agent-{agentName}
  */
@@ -630,10 +651,21 @@ export function ensureDockerContainer(
     PRLT_REGISTRY: devcontainerJson?.build?.args?.PRLT_REGISTRY || 'npm',
   }
 
-  // Pass Claude Code version if pinned in devcontainer config
-  const ccVersion = devcontainerJson?.build?.args?.CC_VERSION
-  if (ccVersion) {
-    buildArgs.CC_VERSION = ccVersion
+  // PRLT-1296: Pin Claude Code version to match host.
+  // Priority: devcontainer config pin > host version detection > latest (fallback).
+  // This prevents credential format/handling mismatches between container and host.
+  const ccVersionFromConfig = devcontainerJson?.build?.args?.CC_VERSION
+  if (ccVersionFromConfig) {
+    buildArgs.CC_VERSION = ccVersionFromConfig
+    console.debug(`[runners:docker] Using CC version from devcontainer config: ${ccVersionFromConfig}`)
+  } else {
+    const hostCCVersion = getHostClaudeCodeVersion()
+    if (hostCCVersion) {
+      buildArgs.CC_VERSION = hostCCVersion
+      console.debug(`[runners:docker] Pinning CC version to host: ${hostCCVersion}`)
+    } else {
+      console.debug(`[runners:docker] Could not detect host CC version, container will use latest`)
+    }
   }
 
   const configuredVersion = devcontainerJson?.build?.args?.PRLT_VERSION || 'latest'

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -328,6 +328,7 @@ export {
   hostCredentialsExist,
   ensureTmuxServerHasKeychainAccess,
   copyClaudeCredentials,
+  refreshCredentialVolume,
 } from './docker-credentials.js'
 
 export {
@@ -343,6 +344,7 @@ export {
 
 export {
   getHostPrltVersion,
+  getHostClaudeCodeVersion,
   getAgentContainerName,
   getContainerName,
   getImageName,

--- a/apps/cli/test/unit/docker-version-pin-credentials.test.ts
+++ b/apps/cli/test/unit/docker-version-pin-credentials.test.ts
@@ -1,0 +1,425 @@
+/**
+ * PRLT-1296: Docker agents version pinning and credential refresh tests
+ *
+ * Ensures:
+ * 1. getHostClaudeCodeVersion() correctly parses `claude --version` output
+ * 2. ensureDockerContainer() passes host CC version as CC_VERSION build arg
+ * 3. refreshCredentialVolume() copies host credentials into Docker volume with correct ownership
+ * 4. refreshCredentialVolume() uses --pull never to avoid Docker Hub auth issues
+ * 5. Credential refresh is called before container spawn in runDevcontainer()
+ * 6. Early-exit detection catches agents that die immediately after spawn
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseCCVersionOutput } from '../../src/lib/execution/cc-version.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+describe('Docker Version Pinning & Credential Refresh (PRLT-1296)', () => {
+  // =========================================================================
+  // 1. Host Claude Code version detection
+  // =========================================================================
+  describe('getHostClaudeCodeVersion()', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should exist as an exported function', () => {
+      expect(content).to.include('export function getHostClaudeCodeVersion()')
+    })
+
+    it('should call claude --version to detect host version', () => {
+      const fnMatch = content.match(
+        /export function getHostClaudeCodeVersion\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'getHostClaudeCodeVersion function not found').to.exist
+      expect(fnMatch![0]).to.include('claude --version')
+    })
+
+    it('should parse semver version from output', () => {
+      const fnMatch = content.match(
+        /export function getHostClaudeCodeVersion\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'getHostClaudeCodeVersion function not found').to.exist
+      // Should extract version pattern like getHostPrltVersion does
+      expect(fnMatch![0]).to.match(/match.*\\d/)
+    })
+
+    it('should return null on failure (not throw)', () => {
+      const fnMatch = content.match(
+        /export function getHostClaudeCodeVersion\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'getHostClaudeCodeVersion function not found').to.exist
+      expect(fnMatch![0]).to.include('return null')
+      expect(fnMatch![0]).to.include('catch')
+    })
+
+    it('should set a timeout to avoid hanging', () => {
+      const fnMatch = content.match(
+        /export function getHostClaudeCodeVersion\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'getHostClaudeCodeVersion function not found').to.exist
+      expect(fnMatch![0]).to.include('timeout')
+    })
+  })
+
+  // =========================================================================
+  // 2. CC version output parsing (unit tests using shared parseCCVersionOutput)
+  // =========================================================================
+  describe('parseCCVersionOutput()', () => {
+    it('should parse "2.1.89" from "claude 2.1.89"', () => {
+      expect(parseCCVersionOutput('claude 2.1.89')).to.equal('2.1.89')
+    })
+
+    it('should parse bare version string "2.1.100"', () => {
+      expect(parseCCVersionOutput('2.1.100')).to.equal('2.1.100')
+    })
+
+    it('should parse version with pre-release suffix', () => {
+      expect(parseCCVersionOutput('claude 2.1.89-beta.1')).to.equal('2.1.89-beta.1')
+    })
+
+    it('should return undefined for empty string', () => {
+      expect(parseCCVersionOutput('')).to.be.undefined
+    })
+
+    it('should return undefined for non-version output', () => {
+      expect(parseCCVersionOutput('Not logged in')).to.be.undefined
+    })
+  })
+
+  // =========================================================================
+  // 3. ensureDockerContainer() pins CC version to host
+  // =========================================================================
+  describe('ensureDockerContainer() — CC version pinning', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should detect host CC version when no config pin exists', () => {
+      const fnMatch = content.match(
+        /export function ensureDockerContainer\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'ensureDockerContainer function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should call getHostClaudeCodeVersion() when no config pin
+      expect(fnBody).to.include('getHostClaudeCodeVersion()')
+    })
+
+    it('should pass CC_VERSION as build arg', () => {
+      const fnMatch = content.match(
+        /export function ensureDockerContainer\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'ensureDockerContainer function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should set buildArgs.CC_VERSION from host version
+      expect(fnBody).to.include("buildArgs.CC_VERSION")
+    })
+
+    it('should prefer devcontainer config pin over host detection', () => {
+      const fnMatch = content.match(
+        /export function ensureDockerContainer\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'ensureDockerContainer function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // The config-based pin should be checked first
+      expect(fnBody).to.include('ccVersionFromConfig')
+      // Config should be read from devcontainerJson
+      expect(fnBody).to.include('CC_VERSION')
+    })
+  })
+
+  // =========================================================================
+  // 4. refreshCredentialVolume()
+  // =========================================================================
+  describe('refreshCredentialVolume()', () => {
+    const credentialsFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-credentials.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(credentialsFile, 'utf-8')
+    })
+
+    it('should exist as an exported function', () => {
+      expect(content).to.include('export function refreshCredentialVolume()')
+    })
+
+    it('should check for host credentials before attempting copy', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should check if host credentials exist
+      expect(fnBody).to.include('.credentials.json')
+      expect(fnBody).to.include('existsSync')
+    })
+
+    it('should use --pull never to avoid Docker Hub auth issues', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // All docker run commands must use --pull never
+      const dockerRunCommands = fnBody.match(/docker run[^`'"]*(?=['"`])/g) || []
+      for (const cmd of dockerRunCommands) {
+        expect(cmd).to.include(
+          '--pull never',
+          `refreshCredentialVolume() has docker run without --pull never: "${cmd}"`
+        )
+      }
+    })
+
+    it('should mount host ~/.claude as read-only source', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Host .claude dir should be mounted read-only
+      expect(fnBody).to.include('/src:ro')
+    })
+
+    it('should mount claude-credentials volume as destination', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should mount the credential volume
+      expect(fnBody).to.include('CLAUDE_CREDENTIALS_VOLUME')
+    })
+
+    it('should set file ownership to UID 1000 (node user)', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Must chown to 1000:1000 (node user in container)
+      expect(fnBody).to.include('1000:1000')
+    })
+
+    it('should return boolean indicating success/failure', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('return true')
+      expect(fnBody).to.include('return false')
+    })
+
+    it('should have a fallback when alpine image is not cached', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should have a fallback using node:22 which is already pulled for agent builds
+      expect(fnBody).to.include('node:22')
+    })
+  })
+
+  // =========================================================================
+  // 5. Credential refresh wired into runDevcontainer()
+  // =========================================================================
+  describe('runDevcontainer() — credential refresh integration', () => {
+    const devcontainerFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/devcontainer.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(devcontainerFile, 'utf-8')
+    })
+
+    it('should import refreshCredentialVolume', () => {
+      expect(content).to.include('refreshCredentialVolume')
+    })
+
+    it('should call refreshCredentialVolume() before ensureDockerContainer()', () => {
+      const fnMatch = content.match(
+        /export async function runDevcontainer\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runDevcontainer function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // refreshCredentialVolume should appear before ensureDockerContainer
+      const refreshIndex = fnBody.indexOf('refreshCredentialVolume()')
+      const ensureIndex = fnBody.indexOf('ensureDockerContainer(')
+      expect(refreshIndex, 'refreshCredentialVolume() not found in runDevcontainer').to.be.greaterThan(-1)
+      expect(ensureIndex, 'ensureDockerContainer() not found in runDevcontainer').to.be.greaterThan(-1)
+      expect(refreshIndex).to.be.lessThan(
+        ensureIndex,
+        'refreshCredentialVolume() must be called BEFORE ensureDockerContainer() to ensure fresh tokens'
+      )
+    })
+
+    it('should only refresh credentials for Claude Code executors', () => {
+      const fnMatch = content.match(
+        /export async function runDevcontainer\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runDevcontainer function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Find the block containing refreshCredentialVolume
+      // It should be inside an isClaudeExecutor check
+      const lines = fnBody.split('\n')
+      const refreshLine = lines.findIndex(l => l.includes('refreshCredentialVolume()'))
+      expect(refreshLine).to.be.greaterThan(-1)
+
+      // Look backward for the isClaudeExecutor guard
+      const contextBefore = lines.slice(Math.max(0, refreshLine - 10), refreshLine).join('\n')
+      expect(contextBefore).to.include(
+        'isClaudeExecutor',
+        'refreshCredentialVolume() should be guarded by isClaudeExecutor() check'
+      )
+    })
+  })
+
+  // =========================================================================
+  // 6. Early-exit detection for dead Docker agents
+  // =========================================================================
+  describe('runDevcontainerInTmux() — early-exit detection', () => {
+    const tmuxFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/devcontainer-tmux.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(tmuxFile, 'utf-8')
+    })
+
+    it('should re-check tmux session after initial verification in background mode', () => {
+      const fnMatch = content.match(
+        /export async function runDevcontainerInTmux\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runDevcontainerInTmux function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Extract the background mode block
+      const bgStartIdx = fnBody.indexOf("displayMode === 'background'")
+      expect(bgStartIdx).to.be.greaterThan(-1, 'Background mode block not found')
+
+      const bgBlock = fnBody.substring(bgStartIdx, bgStartIdx + 2000)
+
+      // Should have TWO has-session checks in background mode (initial + re-check)
+      const hasSessionMatches = bgBlock.match(/has-session/g) || []
+      expect(hasSessionMatches.length).to.be.at.least(
+        2,
+        'Background mode should have at least 2 has-session checks: initial verification + early-exit detection'
+      )
+    })
+
+    it('should return failure with descriptive error when session dies immediately', () => {
+      const fnMatch = content.match(
+        /export async function runDevcontainerInTmux\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runDevcontainerInTmux function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // The early-exit error should mention authentication/credentials
+      expect(fnBody).to.include('authentication failure')
+      // Should suggest checking container logs
+      expect(fnBody).to.include('docker logs')
+    })
+
+    it('should wait before re-checking to allow Claude to start', () => {
+      const fnMatch = content.match(
+        /export async function runDevcontainerInTmux\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runDevcontainerInTmux function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Extract background mode block
+      const bgStartIdx = fnBody.indexOf("displayMode === 'background'")
+      const bgBlock = fnBody.substring(bgStartIdx, bgStartIdx + 2000)
+
+      // Should have a delay (setTimeout) between the two checks
+      const setTimeoutMatches = bgBlock.match(/setTimeout/g) || []
+      expect(setTimeoutMatches.length).to.be.at.least(
+        2,
+        'Background mode should have at least 2 setTimeout calls: initial wait + early-exit wait'
+      )
+    })
+  })
+
+  // =========================================================================
+  // 7. Re-exports from shared.ts
+  // =========================================================================
+  describe('shared.ts re-exports', () => {
+    const sharedFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/shared.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(sharedFile, 'utf-8')
+    })
+
+    it('should re-export refreshCredentialVolume from docker-credentials', () => {
+      expect(content).to.include('refreshCredentialVolume')
+    })
+
+    it('should re-export getHostClaudeCodeVersion from docker-management', () => {
+      expect(content).to.include('getHostClaudeCodeVersion')
+    })
+  })
+
+  // =========================================================================
+  // 8. Dockerfile supports CC_VERSION build arg
+  // =========================================================================
+  describe('Dockerfile template — CC_VERSION arg', () => {
+    const devcontainerFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/devcontainer.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(devcontainerFile, 'utf-8')
+    })
+
+    it('should declare CC_VERSION as a build arg', () => {
+      expect(content).to.include('ARG CC_VERSION=')
+    })
+
+    it('should conditionally pin version when CC_VERSION is set', () => {
+      // The Dockerfile should use ${CC_VERSION:+@${CC_VERSION}} syntax
+      // which expands to @<version> when CC_VERSION is set, nothing otherwise
+      expect(content).to.include('CC_VERSION:+@')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes Docker agents being completely broken due to two compounding issues:

- **Version pinning**: `ensureDockerContainer()` now detects the host's Claude Code version via `claude --version` and passes it as the `CC_VERSION` build arg, ensuring containers install the exact same version as the host. Prevents credential format/handling mismatches between versions.

- **Credential refresh**: New `refreshCredentialVolume()` copies fresh `~/.claude/.credentials.json` from the host into the `claude-credentials` Docker volume before every container spawn. OAuth tokens expire every ~24h; this ensures containers always get the host's auto-refreshed tokens. Uses `--pull never` with alpine/node:22 fallback to avoid Docker Hub auth issues.

- **Early-exit detection**: Background tmux sessions now re-check after 5 seconds. If Claude dies immediately (e.g., auth failure), the spawn returns failure with a descriptive error instead of falsely reporting 'running'.

### Files changed
- `docker-management.ts` — `getHostClaudeCodeVersion()` + version pinning in `ensureDockerContainer()`
- `docker-credentials.ts` — `refreshCredentialVolume()`
- `devcontainer.ts` — wires credential refresh before container creation
- `devcontainer-tmux.ts` — early-exit detection in background mode
- `shared.ts` — re-exports new functions

## Test plan

- [x] 31 new unit tests in `docker-version-pin-credentials.test.ts`
- [x] Version detection: `getHostClaudeCodeVersion()` parses `claude --version` output
- [x] Version pinning: `ensureDockerContainer()` passes host CC version as build arg
- [x] Config pin takes priority over host detection
- [x] Credential refresh: checks host creds exist, mounts read-only, chowns to UID 1000
- [x] Refresh uses `--pull never`, has node:22 fallback
- [x] Refresh called before `ensureDockerContainer()`, only for Claude executors
- [x] Early-exit detection: re-checks tmux session, returns descriptive failure
- [x] Full test suite passes (pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes PRLT-1296