### PR TITLE
feat(PRLT-1287): Reconciler as supervised daemon — register in machine.db, spawn from orchestrator, survive terminal close

### DIFF
--- a/apps/cli/src/commands/hook/export.ts
+++ b/apps/cli/src/commands/hook/export.ts
@@ -1,0 +1,69 @@
+/**
+ * prlt hook export — Export hook configuration to YAML.
+ *
+ * Dumps the current hook configuration from the database as YAML,
+ * suitable for saving to .proletariat/hooks.yml.
+ */
+
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { exportHooksToYaml } from '../../lib/orchestrate/index.js'
+
+export default class HookExport extends PMOCommand {
+  static description = 'Export hook configuration as YAML'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(HookExport)
+    const jsonMode = shouldOutputJson(flags)
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook export', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      const yamlContent = exportHooksToYaml(db)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { yaml: yamlContent },
+          createMetadata('hook export', flags),
+        )
+        return
+      }
+
+      this.log(styles.title('Hook Configuration (YAML)'))
+      this.log('')
+      this.log(yamlContent)
+      this.log(styles.muted('  Save to .proletariat/hooks.yml to version control'))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/fire.ts
+++ b/apps/cli/src/commands/hook/fire.ts
@@ -1,0 +1,172 @@
+/**
+ * prlt hook fire <event> — Manually fire an orchestrate event.
+ *
+ * This is the bridge between external event sources (GitHub Actions, polling, etc.)
+ * and the internal orchestrate engine. When an external system detects an event
+ * (e.g., CI passes), it runs `prlt hook fire on_ci_green --pr 123` to trigger
+ * the configured hooks.
+ */
+
+import { Args, Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import {
+  OrchestrateEngine,
+  ORCHESTRATE_EVENTS,
+} from '../../lib/orchestrate/index.js'
+import type { OrchestrateEventContext } from '../../lib/orchestrate/index.js'
+
+export default class HookFire extends PMOCommand {
+  static description = 'Fire an orchestrate event to trigger configured hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> on_ci_green --pr 123',
+    '<%= config.bin %> <%= command.id %> on_pr_merged --ticket TKT-100 --pr 456',
+    '<%= config.bin %> <%= command.id %> on_ticket_ready --ticket TKT-200',
+    '<%= config.bin %> <%= command.id %> on_agent_died --ticket TKT-100 --agent bold-turing',
+  ]
+
+  static args = {
+    event: Args.string({
+      description: 'Event name to fire',
+      required: true,
+      options: ORCHESTRATE_EVENTS,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+    ticket: Flags.string({
+      description: 'Ticket ID',
+      char: 't',
+    }),
+    pr: Flags.integer({
+      description: 'PR number',
+    }),
+    branch: Flags.string({
+      description: 'Branch name',
+    }),
+    agent: Flags.string({
+      description: 'Agent name',
+    }),
+    action: Flags.string({
+      description: 'Action to execute (for direct invocation)',
+    }),
+    'pr-url': Flags.string({
+      description: 'PR URL',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Show what would happen without executing',
+      default: false,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(HookFire)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook fire', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      const ctx: OrchestrateEventContext = {
+        event: args.event,
+        ticket: parsedFlags.ticket as string | undefined,
+        pr: parsedFlags.pr as number | undefined,
+        branch: parsedFlags.branch as string | undefined,
+        agent: parsedFlags.agent as string | undefined,
+        prUrl: parsedFlags['pr-url'] as string | undefined,
+      }
+
+      if (parsedFlags['dry-run']) {
+        // Show what hooks would fire
+        const hooks = db.prepare(
+          'SELECT name, event, action_type, action_value, mode FROM pmo_work_hooks WHERE event = ? AND enabled = 1 ORDER BY priority ASC'
+        ).all(args.event) as Array<{ name: string; event: string; action_type: string; action_value: string; mode?: string }>
+
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { event: args.event, hooks, context: ctx, dryRun: true },
+            createMetadata('hook fire', flags),
+          )
+          return
+        }
+
+        if (hooks.length === 0) {
+          this.log(styles.info(`No hooks configured for event: ${args.event}`))
+          return
+        }
+
+        this.log(styles.title(`Dry run: ${args.event}`))
+        this.log('')
+        for (const hook of hooks) {
+          const mode = hook.mode || 'auto'
+          this.log(`  ${styles.code(hook.name)} ${styles.muted('→')} ${hook.action_value} ${styles.muted(`(${mode})`)}`)
+        }
+        this.log('')
+        this.log(styles.muted(`${hooks.length} hook${hooks.length === 1 ? '' : 's'} would fire`))
+        return
+      }
+
+      // Create engine and fire event
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          if (!jsonMode) this.log(styles.muted(msg))
+        },
+      })
+
+      const results = await engine.fireEvent(args.event, ctx)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { event: args.event, results, context: ctx },
+          createMetadata('hook fire', flags),
+        )
+        return
+      }
+
+      if (results.length === 0) {
+        this.log(styles.info(`No hooks configured for event: ${args.event}`))
+        return
+      }
+
+      this.log(styles.title(`Fired: ${args.event}`))
+      this.log('')
+      for (const result of results) {
+        const status = result.skipped
+          ? styles.muted('skipped')
+          : result.awaitingConfirmation
+            ? styles.warning('awaiting confirmation')
+            : result.success
+              ? styles.success('success')
+              : styles.error(`failed: ${result.error}`)
+        this.log(`  ${styles.code(result.action)} ${styles.muted('→')} ${status} ${styles.muted(`(${result.durationMs}ms)`)}`)
+      }
+      this.log('')
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/index.ts
+++ b/apps/cli/src/commands/hook/index.ts
@@ -1,0 +1,60 @@
+/**
+ * prlt hook — Interactive menu for orchestrate hooks.
+ */
+
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+
+export default class Hook extends PMOCommand {
+  static description = 'Manage orchestrate hooks (event-driven pipeline automation)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> hook fire on_ci_green --pr 123',
+    '<%= config.bin %> hook list',
+    '<%= config.bin %> hook preset supervised',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Hook)
+    const jsonMode = shouldOutputJson(flags)
+
+    const menuChoices = [
+      { id: 'list', name: 'List configured hooks', command: 'prlt hook list --json' },
+      { id: 'fire', name: 'Fire an event', command: 'prlt hook fire --json' },
+      { id: 'preset', name: 'Apply a preset', command: 'prlt hook preset --json' },
+      { id: 'add', name: 'Add a new hook', command: 'prlt work hooks add --json' },
+      { id: 'cancel', name: 'Cancel', command: '' },
+    ]
+
+    const action = await this.selectFromList({
+      message: 'Orchestrate Hooks - What would you like to do?',
+      items: menuChoices,
+      getName: (c) => c.name,
+      getValue: (c) => c.id,
+      getCommand: (c) => c.command,
+      jsonMode: jsonMode ? { flags, commandName: 'hook' } : null,
+    })
+
+    if (action === 'cancel' || !action) return
+
+    switch (action) {
+      case 'list':
+        await this.config.runCommand('hook:list')
+        break
+      case 'fire':
+        await this.config.runCommand('hook:fire')
+        break
+      case 'preset':
+        await this.config.runCommand('hook:preset')
+        break
+      case 'add':
+        await this.config.runCommand('work:hooks:add')
+        break
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/list.ts
+++ b/apps/cli/src/commands/hook/list.ts
@@ -1,0 +1,177 @@
+/**
+ * prlt hook list — List all configured orchestrate hooks.
+ *
+ * Shows hooks with their mode, priority, and source.
+ */
+
+import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { ORCHESTRATE_EVENTS } from '../../lib/orchestrate/index.js'
+
+interface HookRow {
+  id: string
+  name: string
+  event: string
+  action_type: string
+  action_value: string
+  enabled: number
+  description: string | null
+  mode: string | null
+  priority: number | null
+  source: string | null
+  config: string | null
+  created_at: string
+}
+
+export default class HookList extends PMOCommand {
+  static description = 'List configured orchestrate hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --event on_ci_green',
+    '<%= config.bin %> <%= command.id %> --mode auto',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    event: Flags.string({
+      description: 'Filter by event name',
+    }),
+    mode: Flags.string({
+      description: 'Filter by mode (auto, confirm, notify, off)',
+      options: ['auto', 'confirm', 'notify', 'off'],
+    }),
+    source: Flags.string({
+      description: 'Filter by source (yaml, cli, preset)',
+      options: ['yaml', 'cli', 'preset'],
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(HookList)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook list', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      let sql = 'SELECT * FROM pmo_work_hooks WHERE 1=1'
+      const params: unknown[] = []
+
+      if (parsedFlags.event) {
+        sql += ' AND event = ?'
+        params.push(parsedFlags.event)
+      }
+
+      if (parsedFlags.mode) {
+        sql += ' AND mode = ?'
+        params.push(parsedFlags.mode)
+      }
+
+      if (parsedFlags.source) {
+        sql += ' AND source = ?'
+        params.push(parsedFlags.source)
+      }
+
+      sql += ' ORDER BY event ASC, priority ASC, created_at ASC'
+
+      let hooks: HookRow[]
+      try {
+        hooks = db.prepare(sql).all(...params) as HookRow[]
+      } catch {
+        // Fallback without new columns
+        hooks = db.prepare('SELECT * FROM pmo_work_hooks ORDER BY created_at ASC').all() as HookRow[]
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            hooks: hooks.map(h => ({
+              id: h.id,
+              name: h.name,
+              event: h.event,
+              actionType: h.action_type,
+              actionValue: h.action_value,
+              enabled: h.enabled === 1,
+              mode: h.mode || 'auto',
+              priority: h.priority ?? 0,
+              source: h.source || 'cli',
+              description: h.description,
+              config: h.config ? JSON.parse(h.config) : null,
+            })),
+            count: hooks.length,
+          },
+          createMetadata('hook list', flags),
+        )
+        return
+      }
+
+      if (hooks.length === 0) {
+        this.log(styles.info('No hooks configured.'))
+        this.log(styles.muted('  Add one with: prlt work hooks add'))
+        this.log(styles.muted('  Or apply a preset: prlt hook preset supervised'))
+        return
+      }
+
+      this.log(styles.title('Orchestrate Hooks'))
+      this.log('')
+
+      // Group by event
+      const grouped: Record<string, HookRow[]> = {}
+      for (const hook of hooks) {
+        if (!grouped[hook.event]) grouped[hook.event] = []
+        grouped[hook.event].push(hook)
+      }
+
+      for (const [event, eventHooks] of Object.entries(grouped)) {
+        this.log(`  ${styles.emphasis(event)}`)
+        for (const hook of eventHooks) {
+          const enabled = hook.enabled === 1
+          const mode = hook.mode || 'auto'
+          const source = hook.source || 'cli'
+          const status = !enabled
+            ? styles.muted('off')
+            : mode === 'auto'
+              ? styles.success('auto')
+              : mode === 'confirm'
+                ? styles.warning('confirm')
+                : mode === 'notify'
+                  ? styles.info('notify')
+                  : styles.muted('off')
+
+          this.log(`    ${status} ${styles.code(hook.action_value)} ${styles.muted(`[${source}]`)}`)
+          if (hook.description) {
+            this.log(`         ${styles.muted(hook.description)}`)
+          }
+        }
+        this.log('')
+      }
+
+      this.log(styles.muted(`  ${hooks.length} hook${hooks.length === 1 ? '' : 's'} configured`))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/preset.ts
+++ b/apps/cli/src/commands/hook/preset.ts
@@ -1,0 +1,96 @@
+/**
+ * prlt hook preset <name> — Apply a hook preset.
+ *
+ * Presets:
+ * - aggressive: auto everything
+ * - conservative: confirm everything
+ * - supervised: auto for safe ops, confirm for destructive
+ */
+
+import { Args } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { applyPreset, PRESET_NAMES, PRESETS } from '../../lib/orchestrate/index.js'
+import type { PresetName } from '../../lib/orchestrate/index.js'
+
+export default class HookPreset extends PMOCommand {
+  static description = 'Apply a hook preset (aggressive, conservative, supervised)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> aggressive',
+    '<%= config.bin %> <%= command.id %> conservative',
+    '<%= config.bin %> <%= command.id %> supervised',
+  ]
+
+  static args = {
+    preset: Args.string({
+      description: 'Preset name to apply',
+      required: true,
+      options: PRESET_NAMES,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(HookPreset)
+    const jsonMode = shouldOutputJson(flags)
+    const presetName = args.preset as PresetName
+
+    if (!PRESET_NAMES.includes(presetName)) {
+      if (jsonMode) {
+        outputErrorAsJson('INVALID_PRESET', `Unknown preset: ${presetName}. Valid: ${PRESET_NAMES.join(', ')}`, createMetadata('hook preset', flags))
+        return
+      }
+      this.error(`Unknown preset: ${presetName}. Valid: ${PRESET_NAMES.join(', ')}`)
+    }
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook preset', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      const count = applyPreset(db, presetName)
+      const preset = PRESETS[presetName]
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            preset: presetName,
+            description: preset.description,
+            hooksApplied: count,
+          },
+          createMetadata('hook preset', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Applied preset: ${presetName}`))
+      this.log(styles.muted(`  ${preset.description}`))
+      this.log(styles.muted(`  ${count} hooks configured`))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -1,0 +1,300 @@
+/**
+ * prlt orchestrate — Autonomous pipeline daemon with event-driven hooks.
+ *
+ * Starts the orchestrate engine which:
+ * 1. Loads hook configuration from DB (synced from YAML/presets/CLI)
+ * 2. Subscribes to EventBus events for internal triggers
+ * 3. Optionally polls external sources (Linear, GitHub) for events
+ * 4. Executes matching hooks with mode-aware behavior (auto/confirm/notify/off)
+ *
+ * External events can also be fired via `prlt hook fire <event>`.
+ */
+
+import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import {
+  OrchestrateEngine,
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  PRESET_NAMES,
+} from '../../lib/orchestrate/index.js'
+import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
+import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
+import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
+import { setupSignalHandler } from '../../lib/signal-handler.js'
+
+export default class Orchestrate extends PMOCommand {
+  static description = 'Start the autonomous pipeline daemon with event-driven hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --preset supervised',
+    '<%= config.bin %> <%= command.id %> --load-yaml',
+    '<%= config.bin %> <%= command.id %> --poll-interval 300',
+    '<%= config.bin %> <%= command.id %> --once on_ci_green --pr 123',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    preset: Flags.string({
+      description: 'Apply a preset before starting (aggressive, conservative, supervised)',
+      options: PRESET_NAMES,
+    }),
+    'load-yaml': Flags.boolean({
+      description: 'Load hooks from .proletariat/hooks.yml before starting',
+      default: false,
+    }),
+    'poll-interval': Flags.integer({
+      description: 'Poll interval in seconds for external event sources (0 to disable)',
+      default: 0,
+    }),
+    once: Flags.string({
+      description: 'Fire a single event and exit (useful for CI/GitHub Actions)',
+    }),
+    ticket: Flags.string({
+      description: 'Ticket ID (for --once)',
+      char: 't',
+    }),
+    pr: Flags.integer({
+      description: 'PR number (for --once)',
+    }),
+    branch: Flags.string({
+      description: 'Branch name (for --once)',
+    }),
+    agent: Flags.string({
+      description: 'Agent name (for --once)',
+    }),
+    verbose: Flags.boolean({
+      description: 'Show detailed output',
+      char: 'v',
+      default: false,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Orchestrate)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('orchestrate', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+    const verbose = parsedFlags.verbose as boolean
+
+    try {
+      // Load YAML config if requested
+      if (parsedFlags['load-yaml']) {
+        const hooksYaml = loadHooksYaml(workspaceInfo.path)
+        if (hooksYaml) {
+          const count = syncHooksFromYaml(db, hooksYaml)
+          this.log(styles.muted(`  Loaded ${count} hooks from hooks.yml`))
+        } else {
+          this.log(styles.muted('  No .proletariat/hooks.yml found'))
+        }
+
+        const workflowYaml = loadWorkflowYaml(workspaceInfo.path)
+        if (workflowYaml) {
+          this.log(styles.muted('  Loaded workflow.yml'))
+          // Store workflow config in settings for later use
+          if (workflowYaml.branches?.target) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.branches.target', ?)").run(workflowYaml.branches.target)
+            } catch { /* ignore */ }
+          }
+          if (workflowYaml.branches?.strategy) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.branches.strategy', ?)").run(workflowYaml.branches.strategy)
+            } catch { /* ignore */ }
+          }
+          if (workflowYaml.review?.auto_merge_on_green !== undefined) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.review.auto_merge_on_green', ?)").run(String(workflowYaml.review.auto_merge_on_green))
+            } catch { /* ignore */ }
+          }
+        }
+      }
+
+      // Apply preset if specified
+      if (parsedFlags.preset) {
+        const count = applyPreset(db, parsedFlags.preset as PresetName)
+        this.log(styles.muted(`  Applied preset "${parsedFlags.preset}" (${count} hooks)`))
+      }
+
+      // Create the orchestrate engine
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          if (verbose || jsonMode) {
+            this.log(msg)
+          }
+        },
+        onNotify: (hookName, event, action, result) => {
+          this.log(`${styles.info('[notify]')} ${hookName}: ${event} → ${action} (${result.success ? 'ok' : 'failed'})`)
+        },
+      })
+
+      // Initialize work-lifecycle systems
+      initWorkLifecycleAdapter()
+      initHookManager(db)
+
+      // One-shot mode: fire a single event and exit
+      if (parsedFlags.once) {
+        const eventName = parsedFlags.once as string
+        const results = await engine.fireEvent(eventName, {
+          event: eventName,
+          ticket: parsedFlags.ticket as string | undefined,
+          pr: parsedFlags.pr as number | undefined,
+          branch: parsedFlags.branch as string | undefined,
+          agent: parsedFlags.agent as string | undefined,
+        })
+
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { event: eventName, results, mode: 'once' },
+            createMetadata('orchestrate', flags),
+          )
+          return
+        }
+
+        this.logResults(eventName, results)
+        return
+      }
+
+      // Daemon mode: start the engine and run until stopped
+      engine.start()
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { status: 'running', mode: 'daemon' },
+          createMetadata('orchestrate', flags),
+        )
+      } else {
+        this.log('')
+        this.log(styles.title('Orchestrate daemon started'))
+        this.log(styles.muted('  Listening for events on the EventBus'))
+        this.log(styles.muted('  Press Ctrl+C to stop'))
+
+        // Show configured hooks summary
+        try {
+          const hookCount = (db.prepare('SELECT COUNT(*) as count FROM pmo_work_hooks WHERE enabled = 1').get() as { count: number })?.count ?? 0
+          this.log(styles.muted(`  ${hookCount} active hooks`))
+        } catch { /* ignore */ }
+
+        if (parsedFlags['poll-interval'] && (parsedFlags['poll-interval'] as number) > 0) {
+          this.log(styles.muted(`  Polling every ${parsedFlags['poll-interval']}s for external events`))
+        }
+        this.log('')
+      }
+
+      // Set up polling if configured
+      const pollInterval = parsedFlags['poll-interval'] as number
+      let pollTimer: ReturnType<typeof setInterval> | null = null
+
+      if (pollInterval > 0) {
+        pollTimer = setInterval(() => {
+          void this.pollExternalEvents(engine, db, verbose)
+        }, pollInterval * 1000)
+      }
+
+      // Keep the process alive until signal
+      await new Promise<void>((resolve) => {
+        const cleanup = () => {
+          engine.stop()
+          if (pollTimer) clearInterval(pollTimer)
+          this.log(styles.muted('\n  Orchestrate daemon stopped'))
+          resolve()
+        }
+
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Poll external event sources for new events.
+   * Currently a stub — real implementations would check Linear, GitHub, etc.
+   */
+  private async pollExternalEvents(
+    engine: OrchestrateEngine,
+    db: SqliteDatabase,
+    verbose: boolean,
+  ): Promise<void> {
+    if (verbose) {
+      this.log(styles.muted('[orchestrate] Polling external event sources...'))
+    }
+
+    // Check for tickets in "Ready" status → fire on_ticket_ready
+    try {
+      const readyTickets = db.prepare(`
+        SELECT t.id, t.title, ws.category
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
+        WHERE ws.category = 'todo'
+          AND t.assignee IS NULL
+          AND t.id NOT IN (
+            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
+          )
+        LIMIT 5
+      `).all() as Array<{ id: string; title: string }>
+
+      for (const ticket of readyTickets) {
+        await engine.fireEvent('on_ticket_ready', {
+          event: 'on_ticket_ready',
+          ticket: ticket.id,
+        })
+      }
+    } catch {
+      // Polling errors are non-fatal
+    }
+  }
+
+  /**
+   * Log the results of firing an event.
+   */
+  private logResults(event: string, results: OrchestrateActionResult[]): void {
+    if (results.length === 0) {
+      this.log(styles.info(`No hooks configured for event: ${event}`))
+      return
+    }
+
+    this.log(styles.title(`Event: ${event}`))
+    for (const result of results) {
+      const status = result.skipped
+        ? styles.muted('skipped')
+        : result.awaitingConfirmation
+          ? styles.warning('awaiting')
+          : result.success
+            ? styles.success('ok')
+            : styles.error('failed')
+      this.log(`  ${status} ${result.action} ${styles.muted(`${result.durationMs}ms`)}`)
+      if (result.error) {
+        this.log(`       ${styles.error(result.error)}`)
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -33,8 +33,6 @@ import {
 import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
 import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
 import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
-import { setupSignalHandler } from '../../lib/signal-handler.js'
-
 export default class Orchestrate extends PMOCommand {
   static description = 'Start the autonomous pipeline daemon with event-driven hooks'
 

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -33,6 +33,11 @@ import {
 import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
 import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
 import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
+import { ExecutionStorage } from '../../lib/execution/index.js'
+import {
+  ensureReconcilerRunning,
+  checkAndRestartReconciler,
+} from '../../lib/orchestrate/reconciler-supervisor.js'
 export default class Orchestrate extends PMOCommand {
   static description = 'Start the autonomous pipeline daemon with event-driven hooks'
 
@@ -183,6 +188,11 @@ export default class Orchestrate extends PMOCommand {
       // Daemon mode: start the engine and run until stopped
       engine.start()
 
+      // Auto-spawn the reconciler daemon if not already running (PRLT-1287)
+      const executionStorage = new ExecutionStorage(db)
+      const logFn = verbose ? (msg: string) => this.log(msg) : undefined
+      ensureReconcilerRunning(executionStorage, logFn)
+
       if (jsonMode) {
         outputSuccessAsJson(
           { status: 'running', mode: 'daemon' },
@@ -216,11 +226,19 @@ export default class Orchestrate extends PMOCommand {
         }, pollInterval * 1000)
       }
 
+      // Set up reconciler health check: every 60s, check if reconciler is alive
+      // and restart it if it died. This ensures the reconciler is always running
+      // as long as the orchestrator is alive. (PRLT-1287)
+      const reconcilerCheckTimer = setInterval(() => {
+        checkAndRestartReconciler(executionStorage, logFn)
+      }, 60_000)
+
       // Keep the process alive until signal
       await new Promise<void>((resolve) => {
         const cleanup = () => {
           engine.stop()
           if (pollTimer) clearInterval(pollTimer)
+          clearInterval(reconcilerCheckTimer)
           this.log(styles.muted('\n  Orchestrate daemon stopped'))
           resolve()
         }

--- a/apps/cli/src/commands/reconcile.ts
+++ b/apps/cli/src/commands/reconcile.ts
@@ -1,0 +1,179 @@
+/**
+ * `prlt reconcile` — Tier 2 State Reconciler (PRLT-1280)
+ *
+ * Polls GitHub for the live state of each linked PR and fires normal
+ * ticket transitions to fix board drift (e.g. "6 tickets stuck in Review
+ * because someone merged via `gh pr merge` instead of `prlt work ship`").
+ *
+ * Design constraints from PRLT-1280:
+ *   - Idempotent: a second run is a no-op when state is already correct.
+ *   - Provider-agnostic: the command never branches on provider type;
+ *     all state changes go through the provider adapter layer.
+ *   - Scope is strictly the reconciliation function — no LLM, no daemon
+ *     rewrite, no supervision tree.
+ */
+
+import { Flags } from '@oclif/core'
+import { PMOCommand, pmoBaseFlags } from '../lib/pmo/index.js'
+import type { PMOStorage } from '../lib/pmo/types.js'
+import type { ProviderStorage } from '../lib/providers/types.js'
+import { runReconcile, watchReconcile, type ReconcileReport } from '../lib/reconcile/index.js'
+import { styles } from '../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../lib/prompt-json.js'
+
+export default class Reconcile extends PMOCommand {
+  static description =
+    'Tier 2 state reconciler — poll GitHub for linked PRs and fix board drift'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --dry-run',
+    '<%= config.bin %> <%= command.id %> --watch',
+    '<%= config.bin %> <%= command.id %> --watch --interval 60',
+    '<%= config.bin %> <%= command.id %> -P proj-001',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    'dry-run': Flags.boolean({
+      description: 'Print the transitions that would be made, but do not execute them',
+      default: false,
+    }),
+    watch: Flags.boolean({
+      description: 'Run on a timer until killed (default interval: 5 minutes)',
+      default: false,
+    }),
+    interval: Flags.integer({
+      description: 'Watch interval in seconds (used with --watch)',
+      default: 300,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Reconcile)
+    const db = this.storage.getDatabase()
+    const jsonMode = shouldOutputJson(flags)
+    const dryRun = flags['dry-run']
+    const projectFlag = (flags as { project?: string }).project
+    const storage = this.storage as unknown as PMOStorage & ProviderStorage
+
+    if (flags.watch) {
+      if (jsonMode) {
+        // --watch in JSON mode doesn't make sense — there is no single
+        // structured output to print. Fail fast so callers notice.
+        this.error('--watch is not supported in JSON mode')
+      }
+
+      this.log(
+        styles.muted(
+          `Watching for drift every ${flags.interval}s (Ctrl+C to stop)${dryRun ? ' [dry-run]' : ''}...`,
+        ),
+      )
+
+      let stop = false
+      const stopHandler = (): void => {
+        stop = true
+        this.log(styles.muted('\nStopping reconcile watcher...'))
+      }
+      process.once('SIGINT', stopHandler)
+      process.once('SIGTERM', stopHandler)
+
+      try {
+        await watchReconcile(db, storage, {
+          dryRun,
+          cwd: process.cwd(),
+          projectId: projectFlag,
+          log: msg => this.log(msg),
+          intervalMs: flags.interval * 1000,
+          shouldStop: () => stop,
+          onCycle: report => this.printSummary(report, dryRun),
+        })
+      } finally {
+        process.removeListener('SIGINT', stopHandler)
+        process.removeListener('SIGTERM', stopHandler)
+      }
+      return
+    }
+
+    const report = await runReconcile(db, storage, {
+      dryRun,
+      cwd: process.cwd(),
+      projectId: projectFlag,
+      log: jsonMode ? undefined : msg => this.log(msg),
+    })
+
+    if (jsonMode) {
+      outputSuccessAsJson(
+        {
+          checked: report.checked,
+          applied: report.applied,
+          skipped: report.skipped,
+          failed: report.failed,
+          errors: report.errors,
+          startedAt: report.startedAt,
+          finishedAt: report.finishedAt,
+          dryRun,
+        },
+        createMetadata('reconcile', flags),
+      )
+      return
+    }
+
+    this.printSummary(report, dryRun)
+  }
+
+  private printSummary(report: ReconcileReport, dryRun: boolean): void {
+    const { checked, applied, skipped, failed, errors } = report
+
+    if (applied.length === 0 && skipped.length === 0 && failed.length === 0) {
+      this.log(styles.muted(`Checked ${checked} ticket(s) — no drift detected.`))
+      return
+    }
+
+    this.log('')
+    this.log(styles.emphasis('Reconcile Summary:'))
+    this.log(`  Checked: ${checked} ticket(s)`)
+
+    if (applied.length > 0) {
+      this.log(styles.success(`  Applied: ${applied.length} transition(s)`))
+      for (const t of applied) {
+        this.log(
+          styles.muted(
+            `    ${t.ticketId}: ${t.fromState ?? '?'} → ${t.toState}` +
+              (t.prNumber ? ` (PR #${t.prNumber} ${t.prState ?? ''})` : ''),
+          ),
+        )
+      }
+    }
+
+    if (dryRun && skipped.length > 0) {
+      this.log(styles.warning(`  Skipped: ${skipped.length} (dry-run)`))
+      for (const t of skipped) {
+        this.log(
+          styles.muted(
+            `    [dry-run] ${t.ticketId}: ${t.fromState ?? '?'} → ${t.toState}` +
+              (t.prNumber ? ` (PR #${t.prNumber} ${t.prState ?? ''})` : ''),
+          ),
+        )
+      }
+    }
+
+    if (failed.length > 0) {
+      this.log(styles.error(`  Failed: ${failed.length}`))
+      for (const f of failed) {
+        this.log(styles.error(`    ${f.transition.ticketId}: ${f.error}`))
+      }
+    }
+
+    if (errors.length > 0) {
+      this.log(styles.warning(`  Non-fatal errors: ${errors.length}`))
+      for (const e of errors) {
+        this.log(styles.muted(`    ${e.ticketId}: ${e.error}`))
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/reconcile.ts
+++ b/apps/cli/src/commands/reconcile.ts
@@ -1,19 +1,18 @@
 /**
- * `prlt reconcile` — Tier 2 State Reconciler (PRLT-1280)
+ * `prlt reconcile` — Tier 2 State Reconciler (PRLT-1280 + PRLT-1287)
  *
  * Polls GitHub for the live state of each linked PR and fires normal
- * ticket transitions to fix board drift (e.g. "6 tickets stuck in Review
- * because someone merged via `gh pr merge` instead of `prlt work ship`").
+ * ticket transitions to fix board drift.
  *
- * Design constraints from PRLT-1280:
- *   - Idempotent: a second run is a no-op when state is already correct.
- *   - Provider-agnostic: the command never branches on provider type;
- *     all state changes go through the provider adapter layer.
- *   - Scope is strictly the reconciliation function — no LLM, no daemon
- *     rewrite, no supervision tree.
+ * PRLT-1287: `--watch` now spawns a tmux session and registers in
+ * machine.db with `role: 'daemon'` so the reconciler survives terminal
+ * close and can be supervised by the orchestrator.
+ * Use `--foreground` to run in the current terminal for debugging.
  */
 
 import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { execSync } from 'node:child_process'
 import { PMOCommand, pmoBaseFlags } from '../lib/pmo/index.js'
 import type { PMOStorage } from '../lib/pmo/types.js'
 import type { ProviderStorage } from '../lib/providers/types.js'
@@ -24,6 +23,15 @@ import {
   outputSuccessAsJson,
   createMetadata,
 } from '../lib/prompt-json.js'
+import { getWorkspaceInfo } from '../lib/agents/commands.js'
+import { SqliteDatabase } from '../lib/database/sqlite.js'
+import { ExecutionStorage } from '../lib/execution/index.js'
+
+/** Well-known tmux session name for the reconciler daemon */
+export const RECONCILER_SESSION_NAME = 'reconciler'
+
+/** Sentinel ticket ID used for daemon sessions (no real ticket) */
+export const DAEMON_TICKET_ID = 'DAEMON'
 
 export default class Reconcile extends PMOCommand {
   static description =
@@ -33,6 +41,7 @@ export default class Reconcile extends PMOCommand {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --dry-run',
     '<%= config.bin %> <%= command.id %> --watch',
+    '<%= config.bin %> <%= command.id %> --watch --foreground',
     '<%= config.bin %> <%= command.id %> --watch --interval 60',
     '<%= config.bin %> <%= command.id %> -P proj-001',
   ]
@@ -44,7 +53,11 @@ export default class Reconcile extends PMOCommand {
       default: false,
     }),
     watch: Flags.boolean({
-      description: 'Run on a timer until killed (default interval: 5 minutes)',
+      description: 'Run as a daemon in a tmux session (survives terminal close)',
+      default: false,
+    }),
+    foreground: Flags.boolean({
+      description: 'Run --watch in the current terminal instead of spawning a tmux session (for debugging)',
       default: false,
     }),
     interval: Flags.integer({
@@ -63,39 +76,17 @@ export default class Reconcile extends PMOCommand {
 
     if (flags.watch) {
       if (jsonMode) {
-        // --watch in JSON mode doesn't make sense — there is no single
-        // structured output to print. Fail fast so callers notice.
         this.error('--watch is not supported in JSON mode')
       }
 
-      this.log(
-        styles.muted(
-          `Watching for drift every ${flags.interval}s (Ctrl+C to stop)${dryRun ? ' [dry-run]' : ''}...`,
-        ),
-      )
-
-      let stop = false
-      const stopHandler = (): void => {
-        stop = true
-        this.log(styles.muted('\nStopping reconcile watcher...'))
+      // --foreground: run in current terminal (same as old behavior)
+      if (flags.foreground) {
+        await this.runWatchForeground(db, storage, flags.interval, dryRun, projectFlag)
+        return
       }
-      process.once('SIGINT', stopHandler)
-      process.once('SIGTERM', stopHandler)
 
-      try {
-        await watchReconcile(db, storage, {
-          dryRun,
-          cwd: process.cwd(),
-          projectId: projectFlag,
-          log: msg => this.log(msg),
-          intervalMs: flags.interval * 1000,
-          shouldStop: () => stop,
-          onCycle: report => this.printSummary(report, dryRun),
-        })
-      } finally {
-        process.removeListener('SIGINT', stopHandler)
-        process.removeListener('SIGTERM', stopHandler)
-      }
+      // Default: spawn as a tmux daemon session
+      await this.spawnDaemon(flags.interval, dryRun, projectFlag)
       return
     }
 
@@ -124,6 +115,124 @@ export default class Reconcile extends PMOCommand {
     }
 
     this.printSummary(report, dryRun)
+  }
+
+  /**
+   * Spawn the reconciler as a detached tmux session and register it
+   * in machine.db with role='daemon'.
+   */
+  private async spawnDaemon(
+    interval: number,
+    dryRun: boolean,
+    projectId?: string,
+  ): Promise<void> {
+    // Check if tmux is available
+    try {
+      execSync('which tmux', { stdio: 'pipe' })
+    } catch {
+      this.error('tmux is not installed. Install tmux or use --foreground to run in the current terminal.')
+    }
+
+    // Check if a reconciler session is already running
+    const existingSessions = getReconcilerTmuxSessions()
+    if (existingSessions.length > 0) {
+      this.log(styles.warning('Reconciler daemon is already running.'))
+      this.log(styles.muted(`  Session: ${existingSessions[0]}`))
+      this.log(styles.muted('  Attach with: tmux attach -t reconciler'))
+      this.log(styles.muted('  Or stop with: prlt session stop reconciler'))
+      return
+    }
+
+    // Build the prlt command to run inside the tmux session
+    // Use --foreground so the inner invocation runs in the tmux pane
+    const args = ['reconcile', '--watch', '--foreground', `--interval`, String(interval)]
+    if (dryRun) args.push('--dry-run')
+    if (projectId) args.push('-P', projectId)
+
+    const prltCmd = `prlt ${args.join(' ')}`
+
+    // Spawn the tmux session
+    const tmuxCmd = `tmux new-session -d -s "${RECONCILER_SESSION_NAME}" -n "${RECONCILER_SESSION_NAME}" bash -c '${prltCmd}; echo "Reconciler exited. Press Enter to close."; exec bash'`
+
+    try {
+      execSync(tmuxCmd, { stdio: 'pipe' })
+    } catch (error) {
+      this.error(`Failed to create tmux session: ${error instanceof Error ? error.message : error}`)
+    }
+
+    // Register in workspace.db as a daemon execution
+    try {
+      const workspaceInfo = getWorkspaceInfo()
+      const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+      const wsDb = new SqliteDatabase(dbPath)
+      try {
+        const executionStorage = new ExecutionStorage(wsDb)
+        const execution = executionStorage.createExecution({
+          ticketId: DAEMON_TICKET_ID,
+          agentName: RECONCILER_SESSION_NAME,
+          executor: 'custom',
+          environment: 'host',
+          displayMode: 'background',
+          permissionMode: 'safe',
+          cleanupPolicy: 'persistent',
+          role: 'daemon',
+          sessionId: RECONCILER_SESSION_NAME,
+        })
+        executionStorage.updateStatus(execution.id, 'running')
+      } finally {
+        wsDb.close()
+      }
+    } catch {
+      // Non-fatal: the tmux session was created successfully even if
+      // DB registration fails. The session will be discoverable via tmux.
+    }
+
+    this.log(styles.success('Reconciler daemon started.'))
+    this.log(styles.muted(`  Session: ${RECONCILER_SESSION_NAME}`))
+    this.log(styles.muted(`  Interval: ${interval}s`))
+    this.log(styles.muted(`  Attach: tmux attach -t ${RECONCILER_SESSION_NAME}`))
+    this.log(styles.muted('  Stop: prlt session stop reconciler'))
+  }
+
+  /**
+   * Run --watch in the current terminal (foreground mode for debugging).
+   * This is the original --watch behavior before PRLT-1287.
+   */
+  private async runWatchForeground(
+    db: ReturnType<typeof this.storage.getDatabase>,
+    storage: PMOStorage & ProviderStorage,
+    interval: number,
+    dryRun: boolean,
+    projectId?: string,
+  ): Promise<void> {
+    this.log(
+      styles.muted(
+        `Watching for drift every ${interval}s (Ctrl+C to stop)${dryRun ? ' [dry-run]' : ''}...`,
+      ),
+    )
+
+    let stop = false
+    const stopHandler = (): void => {
+      stop = true
+      this.log(styles.muted('\nStopping reconcile watcher...'))
+    }
+    process.once('SIGINT', stopHandler)
+    process.once('SIGTERM', stopHandler)
+
+    try {
+      await watchReconcile(db, storage, {
+        dryRun,
+        cwd: process.cwd(),
+        projectId,
+        log: msg => this.log(msg),
+        intervalMs: interval * 1000,
+        shouldStop: () => stop,
+        onCycle: report => this.printSummary(report, dryRun),
+      })
+    } finally {
+      process.removeListener('SIGINT', stopHandler)
+      process.removeListener('SIGTERM', stopHandler)
+    }
   }
 
   private printSummary(report: ReconcileReport, dryRun: boolean): void {
@@ -176,4 +285,29 @@ export default class Reconcile extends PMOCommand {
       }
     }
   }
+}
+
+/**
+ * Check if a reconciler tmux session is currently running.
+ * Returns the list of matching session names.
+ */
+export function getReconcilerTmuxSessions(): string[] {
+  try {
+    const output = execSync(
+      'tmux list-sessions -F "#{session_name}"',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim()
+    if (!output) return []
+    return output.split('\n').filter(s => s === RECONCILER_SESSION_NAME)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Check if the reconciler daemon is registered and running in the workspace DB.
+ */
+export function isReconcilerRunning(executionStorage: ExecutionStorage): boolean {
+  const executions = executionStorage.listExecutions({ status: 'running' })
+  return executions.some(e => e.role === 'daemon' && e.agentName === RECONCILER_SESSION_NAME)
 }

--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -21,6 +21,7 @@ interface VerifiedSession {
   ticketId: string
   agentName: string
   status: string
+  role: string  // worker, orchestrator, daemon, headless
   environment: 'host' | 'container'
   containerId?: string
   exists: boolean  // Whether the tmux session actually exists
@@ -146,6 +147,7 @@ export default class SessionList extends PMOCommand {
             ticketId: exec.ticketId,
             agentName: exec.agentName,
             status: exists ? exec.status : 'stale',
+            role: exec.role || 'worker',
             environment: isContainer ? 'container' : 'host',
             containerId,
             exists,
@@ -190,6 +192,7 @@ export default class SessionList extends PMOCommand {
               ticketId: exec.ticketId,
               agentName: exec.agentName,
               status: 'running',
+              role: exec.role || 'worker',
               environment: isContainer ? 'container' : 'host',
               containerId,
               exists: true,
@@ -211,6 +214,7 @@ export default class SessionList extends PMOCommand {
             ticketId: parsed.ticketId,
             agentName: parsed.agentName,
             status: 'orphan',
+            role: 'worker',
             environment: 'host',
             exists: true,
             source: 'discovered',
@@ -229,6 +233,7 @@ export default class SessionList extends PMOCommand {
             ticketId: parsed.ticketId,
             agentName: parsed.agentName,
             status: 'orphan',
+            role: 'worker',
             environment: 'container',
             containerId,
             exists: true,
@@ -250,9 +255,9 @@ export default class SessionList extends PMOCommand {
         this.log(
           styles.muted(
             '  ' +
-            visualPadEnd('Session', 34) +
+            visualPadEnd('Session', 28) +
             visualPadEnd('Ticket', 12) +
-            visualPadEnd('Agent', 18) +
+            visualPadEnd('Role', 14) +
             visualPadEnd('Type', 15) +
             'Status'
           )
@@ -270,15 +275,18 @@ export default class SessionList extends PMOCommand {
           const statusText = session.source === 'discovered' ? `${session.status}*` : session.status
 
           // Truncate long session names to fit column
-          const displaySession = session.sessionId.length > 32
-            ? session.sessionId.substring(0, 29) + '...'
+          const displaySession = session.sessionId.length > 26
+            ? session.sessionId.substring(0, 23) + '...'
             : session.sessionId
+
+          // Display ticket ID: show '—' for daemon sentinel
+          const displayTicket = session.ticketId === 'DAEMON' ? '—' : session.ticketId
 
           this.log(
             '  ' +
-            visualPadEnd(displaySession, 34) +
-            visualPadEnd(session.ticketId, 12) +
-            visualPadEnd(session.agentName, 18) +
+            visualPadEnd(displaySession, 28) +
+            visualPadEnd(displayTicket, 12) +
+            visualPadEnd(session.role, 14) +
             visualPadEnd(typeIcon, 15) +
             statusColor(statusText)
           )

--- a/apps/cli/src/commands/session/prune.ts
+++ b/apps/cli/src/commands/session/prune.ts
@@ -25,6 +25,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { RECONCILER_SESSION_NAME } from '../reconcile.js'
 
 interface PruneResult {
   staleExecutionsCleaned: number
@@ -149,10 +150,23 @@ export default class SessionPrune extends PMOCommand {
         }
       }
 
+      // Collect daemon session names from DB so we never prune them.
+      // Daemons are supposed to run forever — pruning them defeats their purpose.
+      const daemonSessionNames = new Set<string>()
+      const allRunning = executionStorage.listExecutions({ status: 'running' })
+      for (const exec of allRunning) {
+        if (exec.role === 'daemon' && exec.sessionId) {
+          daemonSessionNames.add(exec.sessionId)
+        }
+      }
+      // Also protect the well-known reconciler session name
+      daemonSessionNames.add(RECONCILER_SESSION_NAME)
+
       // Find orphan host sessions (match prlt pattern but not tracked in DB)
       const orphanHostSessions: string[] = []
       for (const sessionName of hostTmuxSessions) {
         if (matchedHostSessions.has(sessionName)) continue
+        if (daemonSessionNames.has(sessionName)) continue  // Never prune daemons
         const parsed = parseSessionName(sessionName)
         if (parsed) {
           orphanHostSessions.push(sessionName)

--- a/apps/cli/src/lib/database/migrations/0013_agent_lifecycle_states.ts
+++ b/apps/cli/src/lib/database/migrations/0013_agent_lifecycle_states.ts
@@ -1,0 +1,41 @@
+/**
+ * Migration 0013 — Add agent lifecycle states
+ *
+ * Extends the agents.status column to support lifecycle states:
+ * 'active', 'running', 'completed', 'dead', 'cleaned'
+ */
+
+import type { SqliteDatabase } from '../sqlite.js'
+import type { Migration } from '../migrator.js'
+
+export const agentLifecycleStates: Migration = {
+  id: '0013',
+  name: 'agent_lifecycle_states',
+  up: (db: SqliteDatabase) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS agents_new (
+        name TEXT PRIMARY KEY,
+        type TEXT NOT NULL DEFAULT 'persistent' CHECK (type IN ('persistent', 'ephemeral')),
+        status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'running', 'completed', 'dead', 'cleaned')),
+        base_name TEXT,
+        theme_id TEXT,
+        worktree_path TEXT,
+        mount_mode TEXT NOT NULL DEFAULT 'worktree' CHECK (mount_mode IN ('worktree', 'clone')),
+        created_at TEXT NOT NULL,
+        cleaned_at TEXT,
+        FOREIGN KEY (theme_id) REFERENCES agent_themes(id) ON DELETE SET NULL
+      );
+
+      INSERT OR IGNORE INTO agents_new (name, type, status, base_name, theme_id, worktree_path, mount_mode, created_at, cleaned_at)
+        SELECT name, type, status, base_name, theme_id, worktree_path, mount_mode, created_at, cleaned_at
+        FROM agents;
+
+      DROP TABLE agents;
+
+      ALTER TABLE agents_new RENAME TO agents;
+
+      CREATE INDEX IF NOT EXISTS idx_agents_theme ON agents(theme_id);
+      CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+    `)
+  },
+}

--- a/apps/cli/src/lib/database/migrations/0014_orchestrate_hooks.ts
+++ b/apps/cli/src/lib/database/migrations/0014_orchestrate_hooks.ts
@@ -1,0 +1,58 @@
+/**
+ * Migration 0014 — Orchestrate Hooks
+ *
+ * Extends pmo_work_hooks with mode (auto/confirm/notify/off), priority,
+ * project_id, source, and config columns for the orchestrate daemon.
+ */
+
+import type { SqliteDatabase } from '../sqlite.js'
+import type { Migration } from '../migrator.js'
+
+export const orchestrateHooks: Migration = {
+  id: '0014',
+  name: 'orchestrate_hooks',
+  up: (db: SqliteDatabase) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(pmo_work_hooks)").all() as { name: string }[]
+    const existingCols = new Set(tableInfo.map(col => col.name))
+
+    if (!existingCols.has('mode')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'off'))"
+      )
+    }
+
+    if (!existingCols.has('priority')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0"
+      )
+    }
+
+    if (!existingCols.has('project_id')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT"
+      )
+    }
+
+    if (!existingCols.has('source')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))"
+      )
+    }
+
+    if (!existingCols.has('config')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT"
+      )
+    }
+
+    // Create index for priority-ordered lookup
+    db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)"
+    )
+  },
+}

--- a/apps/cli/src/lib/database/migrations/0015_add_session_role.ts
+++ b/apps/cli/src/lib/database/migrations/0015_add_session_role.ts
@@ -1,0 +1,32 @@
+/**
+ * Migration 0015 — Add session role to agent_work
+ *
+ * Adds a `role` column to the agent_work table to distinguish between
+ * workers, orchestrators, daemons, and headless sessions.
+ *
+ * Daemon-role sessions (like the reconciler) are long-running infrastructure
+ * that should not be pruned and should be supervised by the orchestrator.
+ */
+
+import type { SqliteDatabase } from '../sqlite.js'
+import type { Migration } from '../migrator.js'
+
+export const addSessionRole: Migration = {
+  id: '0015',
+  name: 'add_session_role',
+  up: (db: SqliteDatabase) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_work'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(agent_work)").all() as { name: string }[]
+    const existingCols = new Set(tableInfo.map(col => col.name))
+
+    if (!existingCols.has('role')) {
+      db.exec(
+        "ALTER TABLE agent_work ADD COLUMN role TEXT NOT NULL DEFAULT 'worker'"
+      )
+    }
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -18,6 +18,8 @@ import { createMediaItems } from './0009_create_media_items.js'
 import { addTicketPosition } from './0010_add_ticket_position.js'
 import { addReviewGate } from './0011_add_review_gate.js'
 import { addActionNetworkAllowlist } from './0012_add_action_network_allowlist.js'
+import { agentLifecycleStates } from './0013_agent_lifecycle_states.js'
+import { orchestrateHooks } from './0014_orchestrate_hooks.js'
 
 /**
  * Ordered list of all migrations.
@@ -36,4 +38,6 @@ export const ALL_MIGRATIONS: Migration[] = [
   addTicketPosition,
   addReviewGate,
   addActionNetworkAllowlist,
+  agentLifecycleStates,
+  orchestrateHooks,
 ]

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -20,6 +20,7 @@ import { addReviewGate } from './0011_add_review_gate.js'
 import { addActionNetworkAllowlist } from './0012_add_action_network_allowlist.js'
 import { agentLifecycleStates } from './0013_agent_lifecycle_states.js'
 import { orchestrateHooks } from './0014_orchestrate_hooks.js'
+import { addSessionRole } from './0015_add_session_role.js'
 
 /**
  * Ordered list of all migrations.
@@ -40,4 +41,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   addActionNetworkAllowlist,
   agentLifecycleStates,
   orchestrateHooks,
+  addSessionRole,
 ]

--- a/apps/cli/src/lib/events/events.ts
+++ b/apps/cli/src/lib/events/events.ts
@@ -116,6 +116,28 @@ export interface WorkflowRuleMatchedEvent {
 }
 
 // =============================================================================
+// Orchestrate Events
+// =============================================================================
+
+/**
+ * Generic event payload for orchestrate daemon events.
+ * These events are triggered externally (GitHub Actions, polling, prlt hook fire)
+ * and carry flexible context.
+ */
+export interface OrchestrateGenericEvent {
+  ticket?: string
+  pr?: number
+  branch?: string
+  agent?: string
+  container?: string
+  executionId?: string
+  prUrl?: string
+  projectId?: string
+  timestamp: Date
+  [key: string]: unknown
+}
+
+// =============================================================================
 // Event Map
 // =============================================================================
 
@@ -141,6 +163,19 @@ export interface RuntimeEventMap {
   'work:pr_merged': WorkPRMergedEvent
   'work:pr_closed': WorkPRClosedEvent
   'work:completed': WorkCompletedEvent
+
+  // Orchestrate events (external triggers + daemon events)
+  'on_ci_green': OrchestrateGenericEvent
+  'on_ci_failed': OrchestrateGenericEvent
+  'on_pr_opened': OrchestrateGenericEvent
+  'on_pr_merged': OrchestrateGenericEvent
+  'on_pr_conflicting': OrchestrateGenericEvent
+  'on_ticket_ready': OrchestrateGenericEvent
+  'on_agent_spawned': OrchestrateGenericEvent
+  'on_agent_died': OrchestrateGenericEvent
+  'on_agent_completed': OrchestrateGenericEvent
+  'on_agent_idle': OrchestrateGenericEvent
+  'on_version_published': OrchestrateGenericEvent
 }
 
 /** Union of all event names. */

--- a/apps/cli/src/lib/events/index.ts
+++ b/apps/cli/src/lib/events/index.ts
@@ -13,6 +13,7 @@ export type {
   AgentOutputEvent,
   TicketStatusChangedEvent,
   TicketPRLinkedEvent,
+  OrchestrateGenericEvent,
 } from './events.js'
 
 export {

--- a/apps/cli/src/lib/execution/storage.ts
+++ b/apps/cli/src/lib/execution/storage.ts
@@ -17,6 +17,7 @@ import {
   DisplayMode,
   PermissionMode,
   CleanupPolicy,
+  SessionRole,
 } from './types.js'
 
 // =============================================================================
@@ -52,6 +53,7 @@ interface AgentWorkRow {
   permission_mode: string
   cleanup_policy: string
   status: string
+  role: string | null
   branch: string | null
   pid: string | null
   container_id: string | null
@@ -83,6 +85,7 @@ function rowToAgentWork(row: AgentWorkRow): AgentWork {
     permissionMode: (row.permission_mode || 'safe') as PermissionMode,
     cleanupPolicy: (row.cleanup_policy || 'on-exit') as CleanupPolicy,
     status: row.status as ExecutionStatus,
+    role: (row.role || 'worker') as SessionRole,
     branch: row.branch || undefined,
     pid: row.pid || undefined,
     containerId: row.container_id || undefined,
@@ -130,6 +133,7 @@ export class ExecutionStorage {
     displayMode: DisplayMode
     permissionMode: PermissionMode
     cleanupPolicy?: CleanupPolicy
+    role?: SessionRole
     branch?: string
     pid?: string
     containerId?: string
@@ -150,9 +154,9 @@ export class ExecutionStorage {
     this.db.prepare(`
       INSERT INTO ${T.agent_work} (
         id, ticket_id, agent_name, executor, environment, display_mode, permission_mode,
-        cleanup_policy, status, branch, pid, container_id, session_id, host, log_path,
+        cleanup_policy, role, status, branch, pid, container_id, session_id, host, log_path,
         external_source, external_key, external_id, external_url, started_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       params.ticketId,
@@ -162,6 +166,7 @@ export class ExecutionStorage {
       params.displayMode,
       params.permissionMode,
       params.cleanupPolicy || 'on-exit',
+      params.role || 'worker',
       params.branch || null,
       params.pid || null,
       params.containerId || null,

--- a/apps/cli/src/lib/execution/storage.ts
+++ b/apps/cli/src/lib/execution/storage.ts
@@ -376,9 +376,12 @@ export class ExecutionStorage {
    * (e.g., commit validation and implement→Review transition).
    */
   cleanupStaleExecutionsDetailed(): CleanedExecution[] {
-    // Get all "running" or "starting" executions
+    // Get all "running" or "starting" executions, excluding daemons.
+    // Daemons (role='daemon') are long-running infrastructure that should
+    // not be reaped by stale cleanup — they are supposed to run forever.
     const activeExecutions = this.listExecutions({ status: 'running' })
       .concat(this.listExecutions({ status: 'starting' }))
+      .filter(exec => exec.role !== 'daemon')
 
     if (activeExecutions.length === 0) {
       return []

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -138,6 +138,23 @@ export type ExecutionStatus =
   | 'stopped'     // Manually terminated
 
 // =============================================================================
+// Session Role
+// =============================================================================
+
+/**
+ * SessionRole - What kind of process this execution represents.
+ * - worker: An agent working on a ticket (default)
+ * - orchestrator: The root supervisor daemon
+ * - daemon: A long-running infrastructure process (reconciler, rebase coordinator, etc.)
+ * - headless: A background task with no interactive session
+ */
+export type SessionRole =
+  | 'worker'       // Agent working on a ticket
+  | 'orchestrator' // Root supervisor
+  | 'daemon'       // Long-running infrastructure (reconciler, etc.)
+  | 'headless'     // Background task
+
+// =============================================================================
 // Agent Work Record
 // =============================================================================
 
@@ -152,6 +169,7 @@ export interface AgentWork {
   permissionMode: PermissionMode  // Permission mode used for this execution
   cleanupPolicy: CleanupPolicy   // Container cleanup policy for this execution
   status: ExecutionStatus
+  role: SessionRole              // What kind of process: worker, orchestrator, daemon, headless
   branch?: string
   pid?: string
   containerId?: string

--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -1,0 +1,208 @@
+/**
+ * Orchestrate Built-in Actions
+ *
+ * Implementations for the built-in hook actions that the orchestrate daemon
+ * can execute. Each action receives an event context and returns a result.
+ *
+ * Actions use prlt CLI commands where possible to keep behavior consistent
+ * with manual invocations.
+ */
+
+import { execSync } from 'node:child_process'
+import type { OrchestrateEventContext, OrchestrateActionResult } from './types.js'
+
+type ActionHandler = (ctx: OrchestrateEventContext, config?: Record<string, unknown>) => OrchestrateActionResult
+
+/**
+ * Merge a PR via `prlt work ship`.
+ */
+const mergePr: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket && !ctx.pr) {
+      return { action: 'merge-pr', success: false, error: 'No ticket or PR number in context', durationMs: Date.now() - start }
+    }
+
+    const args: string[] = ['prlt', 'work', 'ship']
+    if (ctx.ticket) args.push(ctx.ticket)
+    if (ctx.pr) args.push('--pr', String(ctx.pr))
+    args.push('--yes') // Skip confirmation
+
+    execSync(args.join(' '), { timeout: 120_000, stdio: 'pipe' })
+    return { action: 'merge-pr', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'merge-pr', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Move a ticket to a target status.
+ */
+const moveTicket: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    const target = (config?.target as string) || 'done'
+    if (!ctx.ticket) {
+      return { action: 'move-ticket', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt ticket move ${ctx.ticket} --to "${target}" --yes`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'move-ticket', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'move-ticket', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Rebase conflicting PRs after a merge.
+ */
+const rebaseConflictingPrs: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    execSync('prlt work rebase --all --yes 2>/dev/null || true', { timeout: 300_000, stdio: 'pipe' })
+    return { action: 'rebase-conflicting-prs', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'rebase-conflicting-prs', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Spawn an agent for a ticket.
+ */
+const spawnAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'spawn-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Respawn a failed/died agent.
+ */
+const respawn: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'respawn', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --yes --display background --force`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'respawn', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'respawn', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Send a notification about an event.
+ */
+const notify: ActionHandler = (ctx) => {
+  const start = Date.now()
+  const parts: string[] = []
+  if (ctx.event) parts.push(`[${ctx.event}]`)
+  if (ctx.ticket) parts.push(`ticket=${ctx.ticket}`)
+  if (ctx.pr) parts.push(`PR=#${ctx.pr}`)
+  if (ctx.agent) parts.push(`agent=${ctx.agent}`)
+
+  // eslint-disable-next-line no-console
+  console.log(`[orchestrate:notify] ${parts.join(' ')}`)
+  return { action: 'notify', success: true, durationMs: Date.now() - start }
+}
+
+/**
+ * Clean up a container after agent completion.
+ */
+const cleanupContainer: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.agent && !ctx.container) {
+      return { action: 'cleanup-container', success: false, error: 'No agent or container in context', durationMs: Date.now() - start }
+    }
+
+    const target = ctx.container || ctx.agent
+    execSync(`prlt docker rm ${target} --yes 2>/dev/null || true`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'cleanup-container', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'cleanup-container', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Spawn a fix agent after CI failure.
+ */
+const spawnFixAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-fix-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --action revise --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'spawn-fix-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-fix-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Health check / poke an idle agent.
+ */
+const healthCheck: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.agent) {
+      return { action: 'health-check', success: false, error: 'No agent in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt poke ${ctx.agent} "Are you still working? Please provide a status update."`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'health-check', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'health-check', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+// =============================================================================
+// Action Registry
+// =============================================================================
+
+/**
+ * Registry of built-in action handlers.
+ */
+export const ACTION_HANDLERS: Record<string, ActionHandler> = {
+  'merge-pr': mergePr,
+  'move-ticket': moveTicket,
+  'rebase-conflicting-prs': rebaseConflictingPrs,
+  'spawn-agent': spawnAgent,
+  'respawn': respawn,
+  'notify': notify,
+  'cleanup-container': cleanupContainer,
+  'spawn-fix-agent': spawnFixAgent,
+  'health-check': healthCheck,
+}
+
+/**
+ * Execute a built-in action by name.
+ */
+export function executeBuiltinAction(
+  actionName: string,
+  ctx: OrchestrateEventContext,
+  config?: Record<string, unknown>,
+): OrchestrateActionResult {
+  const handler = ACTION_HANDLERS[actionName]
+  if (!handler) {
+    return {
+      action: actionName,
+      success: false,
+      error: `Unknown action: ${actionName}`,
+      durationMs: 0,
+    }
+  }
+  return handler(ctx, config)
+}

--- a/apps/cli/src/lib/orchestrate/config-loader.ts
+++ b/apps/cli/src/lib/orchestrate/config-loader.ts
@@ -1,0 +1,238 @@
+/**
+ * Orchestrate Config Loader
+ *
+ * Loads .proletariat/hooks.yml and .proletariat/workflow.yml files,
+ * validates them, and syncs hook configurations into the database.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import yaml from 'js-yaml'
+import type { SqliteDatabase } from '../database/sqlite.js'
+import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
+import type { HookableEvent, HookActionType } from '../work-lifecycle/hooks/types.js'
+import type {
+  HooksYaml,
+  HookYamlEntry,
+  WorkflowYaml,
+  OrchestrateEvent,
+  HookMode,
+  PresetName,
+} from './types.js'
+import { ORCHESTRATE_EVENTS, HOOK_MODES } from './types.js'
+import { getPreset } from './presets.js'
+
+// =============================================================================
+// YAML File Loading
+// =============================================================================
+
+/**
+ * Load and parse .proletariat/hooks.yml from an HQ path.
+ * Returns null if the file doesn't exist.
+ */
+export function loadHooksYaml(hqPath: string): HooksYaml | null {
+  const filePath = path.join(hqPath, '.proletariat', 'hooks.yml')
+  if (!fs.existsSync(filePath)) return null
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const parsed = yaml.load(content) as HooksYaml | null
+  return parsed ?? null
+}
+
+/**
+ * Load and parse .proletariat/workflow.yml from an HQ path.
+ * Returns null if the file doesn't exist.
+ */
+export function loadWorkflowYaml(hqPath: string): WorkflowYaml | null {
+  const filePath = path.join(hqPath, '.proletariat', 'workflow.yml')
+  if (!fs.existsSync(filePath)) return null
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const parsed = yaml.load(content) as WorkflowYaml | null
+  return parsed ?? null
+}
+
+// =============================================================================
+// Hook Sync
+// =============================================================================
+
+/**
+ * Map an OrchestrateEvent + action string into an existing HookableEvent + HookActionType.
+ * For built-in actions, we use 'shell' type with a `prlt` command as the action value.
+ */
+function mapToHookConfig(
+  event: OrchestrateEvent,
+  entry: HookYamlEntry,
+): { event: HookableEvent; actionType: HookActionType; actionValue: string } | null {
+  // Map orchestrate events to hookable events where possible
+  const eventMap: Partial<Record<OrchestrateEvent, HookableEvent>> = {
+    'work:started': 'work:started',
+    'work:status_changed': 'work:status_changed',
+    'work:pr_created': 'work:pr_created',
+    'work:completed': 'work:completed',
+    'agent:spawned': 'agent:spawned',
+    'agent:stopped': 'agent:stopped',
+  }
+
+  const hookEvent = eventMap[event]
+
+  // For events without a direct mapping, store as shell hook with prlt hook fire
+  const resolvedEvent = hookEvent ?? 'work:status_changed'
+  const actionValue = `prlt hook fire ${event} --action ${entry.action}`
+
+  return {
+    event: resolvedEvent,
+    actionType: 'shell',
+    actionValue,
+  }
+}
+
+/**
+ * Sync hooks from a parsed YAML config into the database.
+ * Clears existing YAML-sourced hooks and replaces them.
+ */
+export function syncHooksFromYaml(db: SqliteDatabase, hooksYaml: HooksYaml): number {
+  const storage = new WorkHookStorage(db)
+  let count = 0
+
+  // Clear existing YAML-sourced hooks
+  try {
+    db.exec("DELETE FROM pmo_work_hooks WHERE source = 'yaml'")
+  } catch {
+    // source column might not exist yet — ignore
+  }
+
+  for (const [eventName, entries] of Object.entries(hooksYaml)) {
+    if (!Array.isArray(entries)) continue
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      if (!entry.action) continue
+
+      const mode = entry.mode && HOOK_MODES.includes(entry.mode as HookMode)
+        ? entry.mode as HookMode
+        : 'auto'
+
+      const hookName = `yaml:${eventName}:${entry.action}:${i}`
+
+      try {
+        const hook = storage.create({
+          name: hookName,
+          event: (eventName as HookableEvent) || 'work:status_changed',
+          actionType: 'shell',
+          actionValue: entry.action,
+          description: `From hooks.yml: ${eventName} → ${entry.action} (${mode})`,
+        })
+
+        // Update the mode and source via raw SQL since WorkHookStorage doesn't support these yet
+        try {
+          db.prepare(
+            "UPDATE pmo_work_hooks SET mode = ?, priority = ?, source = 'yaml', config = ? WHERE id = ?"
+          ).run(mode, i, entry.max_retries ? JSON.stringify({ max_retries: entry.max_retries }) : null, hook.id)
+        } catch {
+          // Columns might not exist yet
+        }
+
+        count++
+      } catch {
+        // Skip duplicates
+      }
+    }
+  }
+
+  return count
+}
+
+/**
+ * Apply a preset to the database, replacing existing preset-sourced hooks.
+ */
+export function applyPreset(db: SqliteDatabase, presetName: PresetName): number {
+  const preset = getPreset(presetName)
+  const storage = new WorkHookStorage(db)
+  let count = 0
+
+  // Clear existing preset-sourced hooks
+  try {
+    db.exec("DELETE FROM pmo_work_hooks WHERE source = 'preset'")
+  } catch {
+    // source column might not exist yet
+  }
+
+  for (let i = 0; i < preset.hooks.length; i++) {
+    const hook = preset.hooks[i]
+    const hookName = `preset:${presetName}:${hook.event}:${hook.action}:${i}`
+
+    try {
+      const created = storage.create({
+        name: hookName,
+        event: mapOrchestrateToHookable(hook.event),
+        actionType: 'shell',
+        actionValue: `prlt hook fire ${hook.event} --action ${hook.action}`,
+        description: `Preset ${presetName}: ${hook.event} → ${hook.action} (${hook.mode})`,
+      })
+
+      try {
+        db.prepare(
+          "UPDATE pmo_work_hooks SET mode = ?, priority = ?, source = 'preset', config = ? WHERE id = ?"
+        ).run(hook.mode, i, hook.config ? JSON.stringify(hook.config) : null, created.id)
+      } catch {
+        // Columns might not exist
+      }
+
+      count++
+    } catch {
+      // Skip duplicates
+    }
+  }
+
+  return count
+}
+
+/**
+ * Map orchestrate event to the closest hookable event.
+ * For new orchestrate events, use a fallback.
+ */
+function mapOrchestrateToHookable(event: OrchestrateEvent): HookableEvent {
+  const directMap: Partial<Record<OrchestrateEvent, HookableEvent>> = {
+    'work:started': 'work:started',
+    'work:status_changed': 'work:status_changed',
+    'work:pr_created': 'work:pr_created',
+    'work:completed': 'work:completed',
+    'agent:spawned': 'agent:spawned',
+    'agent:stopped': 'agent:stopped',
+  }
+  return directMap[event] ?? 'work:status_changed'
+}
+
+/**
+ * Export current hook configuration to YAML format.
+ */
+export function exportHooksToYaml(db: SqliteDatabase): string {
+  const storage = new WorkHookStorage(db)
+  const hooks = storage.list()
+
+  const grouped: Record<string, Array<{ action: string; mode: string; config?: Record<string, unknown> }>> = {}
+
+  for (const hook of hooks) {
+    const event = hook.event
+    if (!grouped[event]) grouped[event] = []
+
+    let mode = 'auto'
+    let config: Record<string, unknown> | undefined
+    try {
+      const row = db.prepare("SELECT mode, config FROM pmo_work_hooks WHERE id = ?").get(hook.id) as { mode?: string; config?: string } | undefined
+      if (row?.mode) mode = row.mode
+      if (row?.config) config = JSON.parse(row.config) as Record<string, unknown>
+    } catch {
+      // mode column might not exist
+    }
+
+    grouped[event].push({
+      action: hook.actionValue,
+      mode,
+      ...(config ? config : {}),
+    })
+  }
+
+  return yaml.dump(grouped, { indent: 2, lineWidth: 120 })
+}

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -1,0 +1,372 @@
+/**
+ * Orchestrate Engine
+ *
+ * The core daemon loop that:
+ * 1. Loads hook configuration from DB (synced from YAML/presets/CLI)
+ * 2. Subscribes to EventBus events
+ * 3. Executes matching hooks with mode-aware behavior
+ * 4. Optionally polls external sources for events
+ *
+ * The engine extends the existing HookManager with mode support
+ * and built-in action execution.
+ */
+
+import type { SqliteDatabase } from '../database/sqlite.js'
+import { getEventBus } from '../events/event-bus.js'
+import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
+import { executeBuiltinAction, ACTION_HANDLERS } from './actions.js'
+import type {
+  OrchestrateEvent,
+  OrchestrateEventContext,
+  OrchestrateActionResult,
+  HookMode,
+} from './types.js'
+import { ORCHESTRATE_EVENTS } from './types.js'
+
+// =============================================================================
+// Extended Hook Row (includes mode, priority, config)
+// =============================================================================
+
+interface ExtendedHookRow {
+  id: string
+  name: string
+  event: string
+  action_type: string
+  action_value: string
+  enabled: number
+  description: string | null
+  mode: string | null
+  priority: number | null
+  config: string | null
+}
+
+// =============================================================================
+// Engine
+// =============================================================================
+
+export interface OrchestrateEngineOptions {
+  /** Database connection */
+  db: SqliteDatabase
+  /** Logger function */
+  log?: (msg: string) => void
+  /** Callback for confirm-mode hooks (returns true to approve) */
+  onConfirm?: (hookName: string, event: string, action: string) => Promise<boolean>
+  /** Callback for notifications */
+  onNotify?: (hookName: string, event: string, action: string, result: OrchestrateActionResult) => void
+}
+
+export class OrchestrateEngine {
+  private db: SqliteDatabase
+  private hookStorage: WorkHookStorage
+  private unsubscribers: Array<() => void> = []
+  private log: (msg: string) => void
+  private onConfirm?: (hookName: string, event: string, action: string) => Promise<boolean>
+  private onNotify?: (hookName: string, event: string, action: string, result: OrchestrateActionResult) => void
+  private running = false
+  private pendingConfirmations: Array<{
+    hookName: string
+    event: string
+    action: string
+    ctx: OrchestrateEventContext
+    config?: Record<string, unknown>
+  }> = []
+
+  constructor(options: OrchestrateEngineOptions) {
+    this.db = options.db
+    this.hookStorage = new WorkHookStorage(options.db)
+    this.log = options.log ?? (() => {})
+    this.onConfirm = options.onConfirm
+    this.onNotify = options.onNotify
+  }
+
+  /**
+   * Start the orchestrate engine — subscribe to all orchestrate events.
+   */
+  start(): void {
+    if (this.running) return
+    this.running = true
+
+    const bus = getEventBus()
+
+    // Subscribe to standard RuntimeEventMap events
+    const standardEvents: Array<keyof import('../events/events.js').RuntimeEventMap> = [
+      'work:started',
+      'work:status_changed',
+      'work:pr_created',
+      'work:pr_merged',
+      'work:pr_closed',
+      'work:completed',
+      'agent:spawned',
+      'agent:stopped',
+    ]
+
+    for (const eventName of standardEvents) {
+      this.unsubscribers.push(
+        bus.on(eventName, (payload) => {
+          void this.handleEvent(eventName, payload as unknown as Record<string, unknown>)
+        }),
+      )
+    }
+
+    this.log('[orchestrate] Engine started, listening for events')
+  }
+
+  /**
+   * Stop the engine and clean up subscriptions.
+   */
+  stop(): void {
+    this.running = false
+    for (const unsub of this.unsubscribers) {
+      unsub()
+    }
+    this.unsubscribers = []
+    this.pendingConfirmations = []
+    this.log('[orchestrate] Engine stopped')
+  }
+
+  /**
+   * Fire an event manually (used by `prlt hook fire`).
+   * This is the entry point for external event sources (GitHub Actions, polling, etc.).
+   */
+  async fireEvent(event: string, ctx: OrchestrateEventContext): Promise<OrchestrateActionResult[]> {
+    return this.handleEvent(event, ctx as Record<string, unknown>)
+  }
+
+  /**
+   * Get pending confirmations for hooks in confirm mode.
+   */
+  getPendingConfirmations(): typeof this.pendingConfirmations {
+    return [...this.pendingConfirmations]
+  }
+
+  /**
+   * Approve a pending confirmation and execute it.
+   */
+  async approveConfirmation(index: number): Promise<OrchestrateActionResult | null> {
+    if (index < 0 || index >= this.pendingConfirmations.length) return null
+
+    const pending = this.pendingConfirmations.splice(index, 1)[0]
+    const result = executeBuiltinAction(pending.action, pending.ctx, pending.config)
+
+    this.log(`[orchestrate] Approved: ${pending.hookName} → ${pending.action} (${result.success ? 'success' : 'failed'})`)
+    return result
+  }
+
+  /**
+   * Deny a pending confirmation.
+   */
+  denyConfirmation(index: number): boolean {
+    if (index < 0 || index >= this.pendingConfirmations.length) return false
+
+    const pending = this.pendingConfirmations.splice(index, 1)[0]
+    this.log(`[orchestrate] Denied: ${pending.hookName} → ${pending.action}`)
+    return true
+  }
+
+  // ===========================================================================
+  // Private
+  // ===========================================================================
+
+  /**
+   * Handle an event by finding and executing matching hooks.
+   */
+  private async handleEvent(eventName: string, eventData: Record<string, unknown>): Promise<OrchestrateActionResult[]> {
+    const results: OrchestrateActionResult[] = []
+
+    try {
+      // Query hooks matching this event, ordered by priority
+      const hooks = this.getHooksForEvent(eventName)
+      if (hooks.length === 0) return results
+
+      // Build event context from the payload
+      const ctx = this.buildContext(eventName, eventData)
+
+      for (const hook of hooks) {
+        const mode = (hook.mode || 'auto') as HookMode
+        const config = hook.config ? JSON.parse(hook.config) as Record<string, unknown> : undefined
+
+        // Determine action — either a built-in action name or the raw action_value
+        const actionName = this.resolveActionName(hook)
+
+        if (mode === 'off') {
+          results.push({ action: actionName, success: true, durationMs: 0, skipped: true })
+          continue
+        }
+
+        if (mode === 'confirm') {
+          // Queue for confirmation
+          if (this.onConfirm) {
+            const approved = await this.onConfirm(hook.name, eventName, actionName)
+            if (!approved) {
+              this.log(`[orchestrate] Skipped (not confirmed): ${hook.name} → ${actionName}`)
+              results.push({ action: actionName, success: true, durationMs: 0, skipped: true })
+              continue
+            }
+          } else {
+            // No confirm handler — queue for later approval
+            this.pendingConfirmations.push({
+              hookName: hook.name,
+              event: eventName,
+              action: actionName,
+              ctx,
+              config,
+            })
+            this.log(`[orchestrate] Queued for confirmation: ${hook.name} → ${actionName}`)
+            results.push({ action: actionName, success: true, durationMs: 0, awaitingConfirmation: true })
+            continue
+          }
+        }
+
+        // Execute the action
+        const result = this.executeAction(actionName, ctx, config)
+        results.push(result)
+
+        this.log(
+          `[orchestrate] ${hook.name} → ${actionName}: ${result.success ? 'success' : `failed: ${result.error}`} (${result.durationMs}ms)`
+        )
+
+        // For notify mode, also fire the notification callback
+        if (mode === 'notify' && this.onNotify) {
+          this.onNotify(hook.name, eventName, actionName, result)
+        }
+      }
+    } catch (err) {
+      this.log(`[orchestrate] Error handling event ${eventName}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    return results
+  }
+
+  /**
+   * Get hooks for a given event from the database, ordered by priority.
+   */
+  private getHooksForEvent(eventName: string): ExtendedHookRow[] {
+    try {
+      return this.db.prepare(`
+        SELECT id, name, event, action_type, action_value, enabled, description, mode, priority, config
+        FROM pmo_work_hooks
+        WHERE event = ? AND enabled = 1
+        ORDER BY priority ASC, created_at ASC
+      `).all(eventName) as ExtendedHookRow[]
+    } catch {
+      // Fallback without mode/priority columns (pre-migration)
+      try {
+        const basic = this.db.prepare(`
+          SELECT id, name, event, action_type, action_value, enabled, description
+          FROM pmo_work_hooks
+          WHERE event = ? AND enabled = 1
+          ORDER BY created_at ASC
+        `).all(eventName) as ExtendedHookRow[]
+        return basic
+      } catch {
+        return []
+      }
+    }
+  }
+
+  /**
+   * Build an OrchestrateEventContext from raw event data.
+   */
+  private buildContext(eventName: string, data: Record<string, unknown>): OrchestrateEventContext {
+    return {
+      event: eventName,
+      ticket: (data.ticketId ?? data.workItemId ?? data.ticket) as string | undefined,
+      pr: (data.prNumber ?? data.pr) as number | undefined,
+      branch: data.branch as string | undefined,
+      agent: (data.agentName ?? data.agent ?? data.sessionId) as string | undefined,
+      container: data.containerId as string | undefined,
+      executionId: data.executionId as string | undefined,
+      prUrl: data.prUrl as string | undefined,
+      projectId: data.projectId as string | undefined,
+      ...data,
+    }
+  }
+
+  /**
+   * Resolve the action name from a hook row.
+   * Built-in actions are referenced by name; shell hooks use the raw command.
+   */
+  private resolveActionName(hook: ExtendedHookRow): string {
+    // If the action_value starts with "prlt hook fire", extract the --action value
+    const actionMatch = hook.action_value.match(/--action\s+(\S+)/)
+    if (actionMatch) return actionMatch[1]
+
+    // If it's a known built-in action name directly
+    if (ACTION_HANDLERS[hook.action_value]) return hook.action_value
+
+    // Otherwise it's a raw shell command — use the action_value as-is
+    return hook.action_value
+  }
+
+  /**
+   * Execute an action — either built-in or shell fallback.
+   */
+  private executeAction(
+    actionName: string,
+    ctx: OrchestrateEventContext,
+    config?: Record<string, unknown>,
+  ): OrchestrateActionResult {
+    // Try built-in action first
+    if (ACTION_HANDLERS[actionName]) {
+      return executeBuiltinAction(actionName, ctx, config)
+    }
+
+    // Fallback to shell execution
+    const start = Date.now()
+    try {
+      const { execSync: exec } = require('node:child_process') as typeof import('node:child_process')
+      const env = {
+        ...process.env,
+        PRLT_HOOK_EVENT: ctx.event,
+        PRLT_HOOK_TICKET: ctx.ticket ?? '',
+        PRLT_HOOK_PR: ctx.pr ? String(ctx.pr) : '',
+        PRLT_HOOK_BRANCH: ctx.branch ?? '',
+        PRLT_HOOK_AGENT: ctx.agent ?? '',
+      }
+      exec(actionName, { env, timeout: 30_000, stdio: 'pipe' })
+      return { action: actionName, success: true, durationMs: Date.now() - start }
+    } catch (err) {
+      return {
+        action: actionName,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Singleton
+// =============================================================================
+
+let _engine: OrchestrateEngine | undefined
+
+/**
+ * Initialize and start the orchestrate engine.
+ * Safe to call multiple times.
+ */
+export function initOrchestrateEngine(options: OrchestrateEngineOptions): OrchestrateEngine {
+  if (!_engine) {
+    _engine = new OrchestrateEngine(options)
+    _engine.start()
+  }
+  return _engine
+}
+
+/**
+ * Get the running orchestrate engine instance.
+ */
+export function getOrchestrateEngine(): OrchestrateEngine | undefined {
+  return _engine
+}
+
+/**
+ * Stop the orchestrate engine.
+ */
+export function stopOrchestrateEngine(): void {
+  if (_engine) {
+    _engine.stop()
+    _engine = undefined
+  }
+}

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -11,6 +11,7 @@
  * and built-in action execution.
  */
 
+import { execSync } from 'node:child_process'
 import type { SqliteDatabase } from '../database/sqlite.js'
 import { getEventBus } from '../events/event-bus.js'
 import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
@@ -314,7 +315,6 @@ export class OrchestrateEngine {
     // Fallback to shell execution
     const start = Date.now()
     try {
-      const { execSync: exec } = require('node:child_process') as typeof import('node:child_process')
       const env = {
         ...process.env,
         PRLT_HOOK_EVENT: ctx.event,
@@ -323,7 +323,7 @@ export class OrchestrateEngine {
         PRLT_HOOK_BRANCH: ctx.branch ?? '',
         PRLT_HOOK_AGENT: ctx.agent ?? '',
       }
-      exec(actionName, { env, timeout: 30_000, stdio: 'pipe' })
+      execSync(actionName, { env, timeout: 30_000, stdio: 'pipe' })
       return { action: actionName, success: true, durationMs: Date.now() - start }
     } catch (err) {
       return {

--- a/apps/cli/src/lib/orchestrate/index.ts
+++ b/apps/cli/src/lib/orchestrate/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Orchestrate module — public API.
+ *
+ * Event-driven pipeline automation daemon with HITL controls.
+ * Extends the work-lifecycle hook system with built-in actions,
+ * YAML config loading, presets, and mode-aware execution.
+ */
+
+export type {
+  OrchestrateEvent,
+  HookMode,
+  BuiltinAction,
+  HooksYaml,
+  HookYamlEntry,
+  WorkflowYaml,
+  PresetName,
+  OrchestrateEventContext,
+  OrchestrateActionResult,
+} from './types.js'
+
+export {
+  ORCHESTRATE_EVENTS,
+  HOOK_MODES,
+  BUILTIN_ACTIONS,
+  PRESET_NAMES,
+} from './types.js'
+
+export {
+  PRESETS,
+  getPreset,
+} from './presets.js'
+
+export {
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  exportHooksToYaml,
+} from './config-loader.js'
+
+export {
+  ACTION_HANDLERS,
+  executeBuiltinAction,
+} from './actions.js'
+
+export {
+  OrchestrateEngine,
+  initOrchestrateEngine,
+  getOrchestrateEngine,
+  stopOrchestrateEngine,
+} from './engine.js'
+
+export type { OrchestrateEngineOptions } from './engine.js'

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -1,0 +1,85 @@
+/**
+ * Orchestrate Presets
+ *
+ * Pre-configured hook sets for common automation levels.
+ *
+ * - aggressive: auto-everything — no human needed
+ * - conservative: confirm everything — human approves all
+ * - supervised: auto for safe ops, confirm for destructive
+ */
+
+import type { HookMode, OrchestrateEvent, PresetName } from './types.js'
+
+interface PresetHook {
+  event: OrchestrateEvent
+  action: string
+  mode: HookMode
+  config?: Record<string, unknown>
+}
+
+interface PresetDefinition {
+  name: PresetName
+  description: string
+  hooks: PresetHook[]
+}
+
+const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Record<string, unknown> }> = [
+  { event: 'on_ci_green', action: 'merge-pr' },
+  { event: 'on_pr_merged', action: 'move-ticket', config: { target: 'done' } },
+  { event: 'on_pr_opened', action: 'move-ticket', config: { target: 'review' } },
+  { event: 'on_pr_merged', action: 'rebase-conflicting-prs' },
+  { event: 'on_pr_conflicting', action: 'rebase-conflicting-prs' },
+  { event: 'on_ticket_ready', action: 'spawn-agent' },
+  { event: 'on_agent_died', action: 'respawn', config: { max_retries: 2 } },
+  { event: 'on_agent_died', action: 'notify' },
+  { event: 'on_ci_failed', action: 'notify' },
+  { event: 'on_ci_failed', action: 'spawn-fix-agent' },
+  { event: 'on_agent_completed', action: 'cleanup-container' },
+  { event: 'on_agent_idle', action: 'health-check' },
+  { event: 'on_agent_spawned', action: 'move-ticket', config: { target: 'in-progress' } },
+]
+
+/** Safe actions that can be auto-executed even in supervised mode. */
+const SAFE_ACTIONS = new Set([
+  'move-ticket',
+  'notify',
+  'cleanup-container',
+  'health-check',
+  'rebase-conflicting-prs',
+])
+
+export const PRESETS: Record<PresetName, PresetDefinition> = {
+  aggressive: {
+    name: 'aggressive',
+    description: 'Auto everything — no human needed',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: 'auto' as HookMode,
+    })),
+  },
+
+  conservative: {
+    name: 'conservative',
+    description: 'Confirm everything — human approves all actions',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: 'confirm' as HookMode,
+    })),
+  },
+
+  supervised: {
+    name: 'supervised',
+    description: 'Auto for safe ops, confirm for destructive actions',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: (SAFE_ACTIONS.has(h.action) ? 'auto' : 'confirm') as HookMode,
+    })),
+  },
+}
+
+/**
+ * Get a preset definition by name.
+ */
+export function getPreset(name: PresetName): PresetDefinition {
+  return PRESETS[name]
+}

--- a/apps/cli/src/lib/orchestrate/reconciler-supervisor.ts
+++ b/apps/cli/src/lib/orchestrate/reconciler-supervisor.ts
@@ -1,0 +1,129 @@
+/**
+ * Reconciler Supervisor (PRLT-1287)
+ *
+ * Ensures the reconciler daemon is running. Used by the orchestrator to:
+ * 1. Auto-spawn the reconciler on startup if not already running
+ * 2. Detect and restart the reconciler if it dies
+ *
+ * The reconciler is a tmux session named "reconciler" that runs
+ * `prlt reconcile --watch --foreground` inside it.
+ */
+
+import { execSync } from 'node:child_process'
+import type { ExecutionStorage } from '../execution/storage.js'
+import {
+  RECONCILER_SESSION_NAME,
+  DAEMON_TICKET_ID,
+  getReconcilerTmuxSessions,
+} from '../../commands/reconcile.js'
+
+/**
+ * Ensure the reconciler daemon is running.
+ * If not, spawn it as a tmux session and register in the DB.
+ *
+ * Called by the orchestrator on startup.
+ */
+export function ensureReconcilerRunning(
+  executionStorage: ExecutionStorage,
+  log?: (msg: string) => void,
+): void {
+  // Check if tmux session exists
+  const tmuxSessions = getReconcilerTmuxSessions()
+  if (tmuxSessions.length > 0) {
+    log?.('[orchestrate] Reconciler daemon already running')
+    return
+  }
+
+  // Check if there's a stale DB record for a dead reconciler
+  cleanupStaleReconcilerRecord(executionStorage)
+
+  // Spawn the reconciler
+  spawnReconciler(executionStorage, log)
+}
+
+/**
+ * Check if the reconciler is alive and restart it if it died.
+ * Called periodically by the orchestrator's health check timer.
+ */
+export function checkAndRestartReconciler(
+  executionStorage: ExecutionStorage,
+  log?: (msg: string) => void,
+): void {
+  const tmuxSessions = getReconcilerTmuxSessions()
+  if (tmuxSessions.length > 0) {
+    // Reconciler is alive, nothing to do
+    return
+  }
+
+  // Reconciler tmux session is gone — it died
+  log?.('[orchestrate] Reconciler daemon is not running, restarting...')
+
+  // Clean up stale DB record
+  cleanupStaleReconcilerRecord(executionStorage)
+
+  // Respawn
+  spawnReconciler(executionStorage, log)
+}
+
+/**
+ * Spawn the reconciler as a detached tmux session and register in the DB.
+ */
+function spawnReconciler(
+  executionStorage: ExecutionStorage,
+  log?: (msg: string) => void,
+): void {
+  try {
+    execSync('which tmux', { stdio: 'pipe' })
+  } catch {
+    log?.('[orchestrate] tmux not available, cannot spawn reconciler')
+    return
+  }
+
+  const prltCmd = 'prlt reconcile --watch --foreground'
+  const tmuxCmd = `tmux new-session -d -s "${RECONCILER_SESSION_NAME}" -n "${RECONCILER_SESSION_NAME}" bash -c '${prltCmd}; echo "Reconciler exited. Press Enter to close."; exec bash'`
+
+  try {
+    execSync(tmuxCmd, { stdio: 'pipe' })
+  } catch (error) {
+    log?.(`[orchestrate] Failed to spawn reconciler: ${error instanceof Error ? error.message : error}`)
+    return
+  }
+
+  // Register in DB
+  try {
+    const execution = executionStorage.createExecution({
+      ticketId: DAEMON_TICKET_ID,
+      agentName: RECONCILER_SESSION_NAME,
+      executor: 'custom',
+      environment: 'host',
+      displayMode: 'background',
+      permissionMode: 'safe',
+      cleanupPolicy: 'persistent',
+      role: 'daemon',
+      sessionId: RECONCILER_SESSION_NAME,
+    })
+    executionStorage.updateStatus(execution.id, 'running')
+    log?.('[orchestrate] Reconciler daemon spawned and registered')
+  } catch (error) {
+    // tmux session was created even if DB registration fails
+    log?.(`[orchestrate] Reconciler spawned but DB registration failed: ${error instanceof Error ? error.message : error}`)
+  }
+}
+
+/**
+ * Clean up any stale reconciler execution records (status=running but tmux session is gone).
+ */
+function cleanupStaleReconcilerRecord(executionStorage: ExecutionStorage): void {
+  const running = executionStorage.listExecutions({ status: 'running' })
+  for (const exec of running) {
+    if (exec.role === 'daemon' && exec.agentName === RECONCILER_SESSION_NAME) {
+      executionStorage.updateStatus(exec.id, 'stopped')
+    }
+  }
+  const starting = executionStorage.listExecutions({ status: 'starting' })
+  for (const exec of starting) {
+    if (exec.role === 'daemon' && exec.agentName === RECONCILER_SESSION_NAME) {
+      executionStorage.updateStatus(exec.id, 'stopped')
+    }
+  }
+}

--- a/apps/cli/src/lib/orchestrate/types.ts
+++ b/apps/cli/src/lib/orchestrate/types.ts
@@ -1,0 +1,190 @@
+/**
+ * Orchestrate Types
+ *
+ * Defines events, hook modes, actions, and presets for the orchestrate daemon.
+ * The orchestrate system extends the existing work-lifecycle hooks with
+ * built-in actions and HITL (human-in-the-loop) controls.
+ */
+
+// =============================================================================
+// Orchestrator Events
+// =============================================================================
+
+/**
+ * All events the orchestrate daemon can react to.
+ * Extends the existing HookableEvent set with CI/PR/agent lifecycle events.
+ */
+export type OrchestrateEvent =
+  // Existing work-lifecycle events
+  | 'work:started'
+  | 'work:status_changed'
+  | 'work:pr_created'
+  | 'work:pr_merged'
+  | 'work:pr_closed'
+  | 'work:completed'
+  | 'agent:spawned'
+  | 'agent:stopped'
+  // New orchestrator events
+  | 'on_ci_green'
+  | 'on_ci_failed'
+  | 'on_pr_opened'
+  | 'on_pr_merged'
+  | 'on_pr_conflicting'
+  | 'on_ticket_ready'
+  | 'on_agent_spawned'
+  | 'on_agent_died'
+  | 'on_agent_completed'
+  | 'on_agent_idle'
+  | 'on_version_published'
+
+/** All valid orchestrate event names. */
+export const ORCHESTRATE_EVENTS: OrchestrateEvent[] = [
+  'work:started',
+  'work:status_changed',
+  'work:pr_created',
+  'work:pr_merged',
+  'work:pr_closed',
+  'work:completed',
+  'agent:spawned',
+  'agent:stopped',
+  'on_ci_green',
+  'on_ci_failed',
+  'on_pr_opened',
+  'on_pr_merged',
+  'on_pr_conflicting',
+  'on_ticket_ready',
+  'on_agent_spawned',
+  'on_agent_died',
+  'on_agent_completed',
+  'on_agent_idle',
+  'on_version_published',
+]
+
+// =============================================================================
+// Hook Modes
+// =============================================================================
+
+/**
+ * Automation level for a hook.
+ *
+ * - auto: fires immediately, no human needed
+ * - confirm: pauses, notifies, waits for approval
+ * - notify: fires but also pings (log, Slack, dashboard)
+ * - off: disabled
+ */
+export type HookMode = 'auto' | 'confirm' | 'notify' | 'off'
+
+/** All valid hook modes. */
+export const HOOK_MODES: HookMode[] = ['auto', 'confirm', 'notify', 'off']
+
+// =============================================================================
+// Built-in Actions
+// =============================================================================
+
+/**
+ * Built-in orchestrate actions.
+ * These are first-class actions the daemon knows how to execute natively.
+ */
+export type BuiltinAction =
+  | 'merge-pr'
+  | 'move-ticket'
+  | 'rebase-conflicting-prs'
+  | 'spawn-agent'
+  | 'respawn'
+  | 'notify'
+  | 'cleanup-container'
+  | 'spawn-fix-agent'
+  | 'health-check'
+
+/** All valid built-in action names. */
+export const BUILTIN_ACTIONS: BuiltinAction[] = [
+  'merge-pr',
+  'move-ticket',
+  'rebase-conflicting-prs',
+  'spawn-agent',
+  'respawn',
+  'notify',
+  'cleanup-container',
+  'spawn-fix-agent',
+  'health-check',
+]
+
+// =============================================================================
+// Hook Configuration (YAML shape)
+// =============================================================================
+
+/**
+ * A single hook entry as defined in hooks.yml.
+ */
+export interface HookYamlEntry {
+  action: string
+  mode: HookMode
+  max_retries?: number
+  args?: Record<string, string>
+}
+
+/**
+ * The full hooks.yml file shape.
+ * Keys are event names, values are arrays of hook entries.
+ */
+export type HooksYaml = Record<string, HookYamlEntry[]>
+
+// =============================================================================
+// Workflow Configuration (YAML shape)
+// =============================================================================
+
+/**
+ * The .proletariat/workflow.yml file shape.
+ */
+export interface WorkflowYaml {
+  branches?: {
+    target?: string
+    strategy?: 'squash' | 'merge' | 'rebase'
+  }
+  on_implement_complete?: string[]
+  on_review_complete?: string[]
+  review?: {
+    required?: boolean | 'auto'
+    auto_merge_on_green?: boolean
+  }
+}
+
+// =============================================================================
+// Presets
+// =============================================================================
+
+/**
+ * Preset name for quick hook configuration.
+ */
+export type PresetName = 'aggressive' | 'conservative' | 'supervised'
+
+/** All valid preset names. */
+export const PRESET_NAMES: PresetName[] = ['aggressive', 'conservative', 'supervised']
+
+/**
+ * Event context passed to hook handlers at runtime.
+ */
+export interface OrchestrateEventContext {
+  event: string
+  ticket?: string
+  pr?: number
+  branch?: string
+  agent?: string
+  container?: string
+  executionId?: string
+  prUrl?: string
+  projectId?: string
+  [key: string]: unknown
+}
+
+/**
+ * Result of running a single orchestrate hook action.
+ */
+export interface OrchestrateActionResult {
+  action: string
+  success: boolean
+  error?: string
+  durationMs: number
+  skipped?: boolean
+  awaitingConfirmation?: boolean
+}

--- a/apps/cli/src/lib/pmo/schema.ts
+++ b/apps/cli/src/lib/pmo/schema.ts
@@ -372,6 +372,7 @@ export const PMO_TABLE_SCHEMAS = {
       display_mode TEXT NOT NULL DEFAULT 'terminal',
       permission_mode TEXT NOT NULL DEFAULT 'safe',
       status TEXT NOT NULL DEFAULT 'starting',
+      role TEXT NOT NULL DEFAULT 'worker',
       branch TEXT,
       pid TEXT,
       container_id TEXT,

--- a/apps/cli/src/lib/reconcile/core.ts
+++ b/apps/cli/src/lib/reconcile/core.ts
@@ -1,0 +1,168 @@
+/**
+ * Tier 2 State Reconciler — Pure core (PRLT-1280)
+ *
+ * This module holds the deterministic, provider-agnostic, side-effect-free
+ * logic of the reconciler. It answers a single question:
+ *
+ *   Given a ticket and the live state of its linked PR(s), what target
+ *   column should the ticket be in, and is that different from its
+ *   current column?
+ *
+ * Splitting this out from the IO-heavy runner keeps the rules trivially
+ * unit-testable without spinning up a database or the gh CLI.
+ */
+
+import type { PRInfo } from '../pr/index.js'
+import type { WorkflowConfig } from '../work-lifecycle/settings.js'
+import type { LinkedPR, ReconcileTicket, ReconcileTransition } from './types.js'
+
+/**
+ * Derive the expected state for a ticket given its linked PRs.
+ *
+ * Rules (mirrors the Tier 2 spec in PRLT-1280):
+ *   1. Any linked PR is MERGED → ticket belongs in Done
+ *   2. Ticket is currently in "review" category AND every open PR has been
+ *      CLOSED without merging → move back to In Progress so humans can
+ *      resume work. (Rule 4 in the existing sync reconciler uses Backlog,
+ *      but PRLT-1280 explicitly asks for "back to In Progress or a review
+ *      queue" — In Progress matches the active work better than Backlog.)
+ *   3. Otherwise: no expected transition.
+ *
+ * `null` means "leave the ticket alone". The reconciler MUST treat `null`
+ * as the idempotent path — that's how "second run is a no-op" works.
+ */
+export function deriveExpectedState(
+  ticket: ReconcileTicket,
+  linkedPRs: LinkedPR[],
+  config?: WorkflowConfig,
+): { targetState: string; reason: string; driver: LinkedPR } | null {
+  const category = ticket.statusCategory
+  const doneStatus = config?.done ?? 'Done'
+  const inProgressStatus = config?.in_progress ?? 'In Progress'
+
+  // Terminal states are load-bearing: we never pull a ticket back out of
+  // Done or Canceled. A human may have marked it closed for a reason.
+  if (category === 'completed' || category === 'canceled') {
+    return null
+  }
+
+  // Rule 1: any merged PR wins. Even if another linked PR is still open,
+  // a merged PR means the ticket's work shipped.
+  const merged = linkedPRs.find(lp => lp.pr.state === 'MERGED')
+  if (merged) {
+    // Idempotency: if the ticket is already sitting in the done column
+    // name we resolved, there is nothing to do.
+    if (statusMatches(ticket.statusName, doneStatus)) {
+      return null
+    }
+    return {
+      targetState: doneStatus,
+      reason:
+        `GitHub PR #${merged.pr.number} is MERGED (merged upstream), ` +
+        `expected ${doneStatus}, was ${ticket.statusName ?? category ?? 'unknown'}`,
+      driver: merged,
+    }
+  }
+
+  // Rule 2: ticket is in review-land, but every linked PR is closed without
+  // merging. Pull it back to In Progress so it gets picked up again.
+  const hasLinkedPRs = linkedPRs.length > 0
+  const allClosedNoMerge =
+    hasLinkedPRs && linkedPRs.every(lp => lp.pr.state === 'CLOSED')
+  const inReview = category === 'started' && isReviewStatus(ticket.statusName, config)
+
+  if (allClosedNoMerge && inReview) {
+    if (statusMatches(ticket.statusName, inProgressStatus)) {
+      return null
+    }
+    const closed = linkedPRs[0]
+    return {
+      targetState: inProgressStatus,
+      reason:
+        `GitHub PR #${closed.pr.number} is CLOSED without merging, ` +
+        `expected ${inProgressStatus}, was ${ticket.statusName ?? category ?? 'unknown'}`,
+      driver: closed,
+    }
+  }
+
+  return null
+}
+
+/**
+ * Build a {@link ReconcileTransition} record from a derived expected-state
+ * decision. Factored out so the runner and the tests both produce the
+ * same transition shape.
+ */
+export function buildTransition(params: {
+  ticket: ReconcileTicket
+  provider: string
+  targetState: string
+  reason: string
+  driver?: LinkedPR
+  now?: Date
+}): ReconcileTransition {
+  const { ticket, provider, targetState, reason, driver, now } = params
+  return {
+    ticketId: ticket.id,
+    ticketTitle: ticket.title ?? '',
+    projectId: ticket.projectId ?? '',
+    provider,
+    fromState: ticket.statusName ?? null,
+    toState: targetState,
+    prNumber: driver?.pr.number,
+    prState: driver?.pr.state,
+    reason,
+    decidedAt: (now ?? new Date()).toISOString(),
+  }
+}
+
+/**
+ * Format a transition for the structured log line required by the AC.
+ * The format is stable so scripts and tests can grep on it.
+ *
+ * Example:
+ *   [reconcile] TKT-142: In Review → Done | PR #321 MERGED @ 2026-04-08T00:00:00Z | reason: ...
+ */
+export function formatTransitionLogLine(t: ReconcileTransition): string {
+  const prPart =
+    t.prNumber !== undefined
+      ? `PR #${t.prNumber} ${t.prState ?? ''}`.trim() + ` @ ${t.decidedAt}`
+      : `no PR @ ${t.decidedAt}`
+  const from = t.fromState ?? 'unknown'
+  return `[reconcile] ${t.ticketId}: ${from} → ${t.toState} | ${prPart} | reason: ${t.reason}`
+}
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+function statusMatches(current: string | null | undefined, target: string): boolean {
+  if (!current) return false
+  return current.toLowerCase() === target.toLowerCase()
+}
+
+/**
+ * Match the existing sync reconciler's notion of "review status" so the
+ * Tier 2 reconciler treats the same columns as review that Tier 1 does.
+ * When a WorkflowConfig is provided, matches exactly against the
+ * configured review column; otherwise falls back to substring matching.
+ */
+function isReviewStatus(
+  statusName: string | null | undefined,
+  config?: WorkflowConfig,
+): boolean {
+  const name = (statusName ?? '').toLowerCase()
+  if (!name) return false
+  if (config?.review) {
+    return name === config.review.toLowerCase()
+  }
+  return name.includes('review')
+}
+
+/**
+ * Re-export for callers that want a direct PRInfo tuple without the
+ * LinkedPR wrapper.
+ */
+export function toLinkedPR(pr: PRInfo, source: LinkedPR['source']): LinkedPR {
+  return { pr, source }
+}

--- a/apps/cli/src/lib/reconcile/index.ts
+++ b/apps/cli/src/lib/reconcile/index.ts
@@ -1,0 +1,489 @@
+/**
+ * Tier 2 State Reconciler — Runner (PRLT-1280)
+ *
+ * This module owns the IO: it talks to the database, the GitHub CLI, and
+ * the provider adapter layer. The pure rule logic lives in ./core.ts so
+ * it can be unit-tested without these dependencies.
+ *
+ * Scope (narrow — the ticket is very explicit about what this is NOT):
+ *   - Single idempotent reconciliation function on a schedule
+ *   - Provider-agnostic — the reconciler does not branch on provider type
+ *   - Fires normal state-transition code path so hooks & cleanup fire too
+ *
+ * Everything outside that — webhook listeners, LLM escalation, human
+ * inbox, supervision tree — is explicitly out of scope per PRLT-1280.
+ */
+
+import type { SqliteDatabase } from '../database/sqlite.js'
+import { PMO_TABLES } from '../pmo/schema.js'
+import type { StateCategory, Ticket, PMOStorage } from '../pmo/types.js'
+import type { ProviderStorage, TicketProvider } from '../providers/types.js'
+import { resolveTicketProvider } from '../providers/resolver.js'
+import type { PRInfo } from '../pr/index.js'
+import { getPRForBranch, getPRByNumber } from '../pr/index.js'
+import { getWorkflowConfig, type WorkflowConfig } from '../work-lifecycle/settings.js'
+import { buildTransition, deriveExpectedState, formatTransitionLogLine } from './core.js'
+import type {
+  LinkedPR,
+  PRLookupFn,
+  ReconcileOptions,
+  ReconcileReport,
+  ReconcileTicket,
+  ReconcileTransition,
+} from './types.js'
+
+export type {
+  LinkedPR,
+  LinkedPRSource,
+  PRLookupFn,
+  PRLookupRef,
+  ReconcileOptions,
+  ReconcileReport,
+  ReconcileTicket,
+  ReconcileTransition,
+} from './types.js'
+export { deriveExpectedState, buildTransition, formatTransitionLogLine } from './core.js'
+
+/**
+ * Non-terminal state categories that the reconciler scans.
+ *
+ * The ticket spec says:
+ *   "Query all tickets in non-terminal states across all connected
+ *    providers (Linear, PMO, Notion, Asana, Jira, Shortcut)"
+ *
+ * Terminal states (`completed`, `canceled`) are deliberately excluded —
+ * the reconciler never resurrects a closed ticket.
+ */
+const NON_TERMINAL_CATEGORIES: StateCategory[] = [
+  'triage',
+  'backlog',
+  'unstarted',
+  'started',
+]
+
+/**
+ * Default live PR lookup. Always goes to the remote — the Tier 2
+ * reconciler must not depend on any local PR cache.
+ */
+export const defaultPRLookup: PRLookupFn = (ref, cwd) => {
+  switch (ref.kind) {
+    case 'branch':
+      return getPRForBranch(ref.branch, cwd)
+    case 'number':
+      return getPRByNumber(ref.number, cwd)
+    case 'url': {
+      // `gh pr view <url>` works with either a number or URL; reuse it.
+      const num = parsePRNumberFromUrl(ref.url)
+      if (num !== null) return getPRByNumber(num, cwd)
+      return null
+    }
+  }
+}
+
+/**
+ * Run one reconciliation cycle.
+ *
+ * Strictly idempotent: if a ticket is already in its expected state the
+ * runner computes no transition and touches nothing. Running twice
+ * back-to-back produces no redundant side effects.
+ */
+export async function runReconcile(
+  db: SqliteDatabase,
+  storage: PMOStorage & ProviderStorage,
+  options: ReconcileOptions = {},
+): Promise<ReconcileReport> {
+  const startedAt = new Date()
+  const { dryRun = false, cwd, log, projectId } = options
+  const prLookup = options.prLookup ?? defaultPRLookup
+
+  // Workflow config is used to resolve "Done" / "In Progress" / "Review"
+  // column names for the ticket's board. Fall back gracefully if the
+  // settings table is missing (older databases, unit tests).
+  let workflowConfig: WorkflowConfig | undefined
+  try {
+    workflowConfig = getWorkflowConfig(db)
+  } catch {
+    workflowConfig = undefined
+  }
+
+  // Gather every non-terminal ticket in scope. Either one project if
+  // -P was passed, or every project in the workspace.
+  const projectIds = projectId ? [projectId] : await listAllProjectIds(storage)
+
+  const tickets: Ticket[] = []
+  for (const pid of projectIds) {
+    for (const category of NON_TERMINAL_CATEGORIES) {
+      try {
+        // eslint-disable-next-line no-await-in-loop -- sequential is fine; small N
+        const batch = await storage.listTickets(pid, { statusCategory: category })
+        tickets.push(...batch)
+      } catch {
+        // Tolerate transient read errors on a single category; keep going.
+      }
+    }
+  }
+
+  log?.(`Scanning ${tickets.length} non-terminal ticket(s) across ${projectIds.length} project(s)...`)
+
+  const transitions: ReconcileTransition[] = []
+  const errors: Array<{ ticketId: string; error: string }> = []
+
+  for (const ticket of tickets) {
+    try {
+      const linkedPRs = gatherLinkedPRs(db, ticket, prLookup, cwd)
+      if (linkedPRs.length === 0) {
+        continue
+      }
+
+      // Resolve the provider for this ticket so we can log which backend
+      // owns it. The actual move happens through the same resolver later
+      // in applyTransition() — this is just for the transition record.
+      const providerName = providerNameFor(db, storage, ticket)
+
+      const decision = deriveExpectedState(toReconcileTicket(ticket), linkedPRs, workflowConfig)
+      if (!decision) continue
+
+      transitions.push(
+        buildTransition({
+          ticket: toReconcileTicket(ticket),
+          provider: providerName,
+          targetState: decision.targetState,
+          reason: decision.reason,
+          driver: decision.driver,
+        }),
+      )
+    } catch (err) {
+      errors.push({ ticketId: ticket.id, error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  // Apply (or dry-run) every transition. Failures on one ticket do not
+  // stop the others — the reconciler is a best-effort safety net.
+  const applied: ReconcileTransition[] = []
+  const skipped: ReconcileTransition[] = []
+  const failed: Array<{ transition: ReconcileTransition; error: string }> = []
+
+  for (const transition of transitions) {
+    log?.(formatTransitionLogLine(transition))
+
+    if (dryRun) {
+      skipped.push(transition)
+      continue
+    }
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await applyTransition(db, storage, transition)
+      applied.push(transition)
+
+      // Dual-identity tickets: if the primary provider is NOT local PMO,
+      // the local PMO board may still hold a stale mirror row. Nudge it
+      // to the same column so the local kanban view does not drift.
+      if (transition.provider !== 'pmo') {
+        // eslint-disable-next-line no-await-in-loop
+        await reconcilePmoMirror(db, storage, transition, log)
+      }
+    } catch (err) {
+      failed.push({
+        transition,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const finishedAt = new Date()
+
+  return {
+    checked: tickets.length,
+    applied,
+    skipped,
+    failed,
+    errors,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+  }
+}
+
+// -----------------------------------------------------------------------------
+// PR lookup
+// -----------------------------------------------------------------------------
+
+/**
+ * Gather every PR linked to a ticket by:
+ *   1. the ticket's branch (if set), and
+ *   2. PR URLs stored in `pmo_external_execution_prs` under any of the
+ *      ticket's external-source identities.
+ *
+ * Every lookup goes through the live PR lookup function — no cache.
+ */
+function gatherLinkedPRs(
+  db: SqliteDatabase,
+  ticket: Ticket,
+  prLookup: PRLookupFn,
+  cwd?: string,
+): LinkedPR[] {
+  const results: LinkedPR[] = []
+  const seen = new Set<number>() // de-dupe by PR number
+
+  const push = (pr: PRInfo | null, source: LinkedPR['source']): void => {
+    if (!pr) return
+    if (seen.has(pr.number)) return
+    seen.add(pr.number)
+    results.push({ pr, source })
+  }
+
+  // 1. Ticket branch
+  if (ticket.branch) {
+    push(prLookup({ kind: 'branch', branch: ticket.branch }, cwd), 'ticket_branch')
+  }
+
+  // 2. PR URLs stored in the external execution map for this ticket.
+  //    A ticket can carry multiple external identities (metadata.external_id,
+  //    external_key) and can have been linked to multiple PRs over time.
+  const prUrls = listLinkedPrUrls(db, ticket)
+  for (const url of prUrls) {
+    push(prLookup({ kind: 'url', url }, cwd), 'external_map')
+  }
+
+  return results
+}
+
+/**
+ * Read every PR URL stored for this ticket in `pmo_external_execution_prs`.
+ * Keyed by (provider, external_id) — the reconciler doesn't care which
+ * provider it came from, so we union across all of them.
+ */
+function listLinkedPrUrls(db: SqliteDatabase, ticket: Ticket): string[] {
+  const urls = new Set<string>()
+  const md = ticket.metadata ?? {}
+
+  // Collect every identifier that might key the external mapping table.
+  const externalIds = new Set<string>()
+  if (md.external_id) externalIds.add(md.external_id)
+  if (md.external_key) externalIds.add(md.external_key)
+  // A PMO-native ticket's id can also appear in the map under provider='pmo'.
+  externalIds.add(ticket.id)
+
+  if (externalIds.size === 0) return []
+
+  let stmt
+  try {
+    stmt = db.prepare(`
+      SELECT pr_url FROM ${PMO_TABLES.external_execution_prs}
+      WHERE external_id = ?
+    `)
+  } catch {
+    // Table may not exist yet (fresh DB or older schema).
+    return []
+  }
+
+  for (const extId of externalIds) {
+    try {
+      const rows = stmt.all(extId) as Array<{ pr_url: string }>
+      for (const row of rows) urls.add(row.pr_url)
+    } catch {
+      // Non-fatal: skip this id.
+    }
+  }
+
+  return [...urls]
+}
+
+/**
+ * Parse a PR number out of a github.com URL.
+ * Accepts both `/pull/123` and `/pull/123/...` shapes.
+ */
+function parsePRNumberFromUrl(url: string): number | null {
+  const m = url.match(/\/pull\/(\d+)(?:\b|\/)/)
+  if (!m) return null
+  const n = Number.parseInt(m[1], 10)
+  return Number.isFinite(n) ? n : null
+}
+
+// -----------------------------------------------------------------------------
+// Apply (goes through normal state-transition code path)
+// -----------------------------------------------------------------------------
+
+/**
+ * Apply a transition through the same provider adapter layer that
+ * `prlt ticket move` uses. This is load-bearing: it ensures hooks,
+ * provider sync, and worktree cleanup all fire.
+ */
+async function applyTransition(
+  db: SqliteDatabase,
+  storage: PMOStorage & ProviderStorage,
+  transition: ReconcileTransition,
+): Promise<void> {
+  const ticket = await storage.getTicket(transition.ticketId)
+  if (!ticket) {
+    throw new Error(`Ticket ${transition.ticketId} vanished between scan and apply`)
+  }
+
+  const provider = resolveTicketProvider(
+    ticket.id,
+    ticket.projectId ?? transition.projectId,
+    db,
+    storage,
+    ticket.metadata,
+  )
+
+  const result = await provider.moveTicket(ticket.id, transition.toState)
+  if (!result.success) {
+    throw new Error(result.error ?? 'moveTicket failed without an error message')
+  }
+}
+
+/**
+ * For tickets whose source of truth is an external provider (Linear,
+ * Jira, etc.), the local PMO board can still hold a mirror row. After
+ * successfully moving the external ticket, reconcile the local PMO side
+ * too so `prlt board` does not drift.
+ *
+ * Best effort — failures here never block the primary transition.
+ */
+async function reconcilePmoMirror(
+  db: SqliteDatabase,
+  storage: PMOStorage & ProviderStorage,
+  transition: ReconcileTransition,
+  log?: (msg: string) => void,
+): Promise<void> {
+  try {
+    const mirror = await storage.getTicket(transition.ticketId)
+    if (!mirror) return
+    // Only move if the mirror truly holds a different status — that way
+    // we stay idempotent and do not fire redundant hooks.
+    if (mirror.statusName && mirror.statusName.toLowerCase() === transition.toState.toLowerCase()) {
+      return
+    }
+    // Use the pmo provider directly (bypass resolver so we definitely
+    // hit the local mirror, not bounce back to Linear).
+    const pmoProvider: TicketProvider = resolveTicketProvider(
+      mirror.id,
+      mirror.projectId ?? transition.projectId,
+      db,
+      storage,
+      // Strip external_source so the resolver picks PMO.
+      null,
+    )
+    if (pmoProvider.name !== 'pmo') return
+    const result = await pmoProvider.moveTicket(mirror.id, transition.toState)
+    if (!result.success && log) {
+      log(`[reconcile] pmo mirror update for ${mirror.id} failed: ${result.error}`)
+    }
+  } catch (err) {
+    log?.(
+      `[reconcile] pmo mirror update for ${transition.ticketId} errored: ` +
+        (err instanceof Error ? err.message : String(err)),
+    )
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Project / provider resolution helpers
+// -----------------------------------------------------------------------------
+
+async function listAllProjectIds(storage: PMOStorage): Promise<string[]> {
+  try {
+    const projects = await storage.listProjects()
+    return projects.map(p => p.id)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Resolve the provider name for a ticket without triggering any state
+ * resolution or event emission. Used purely so the transition record
+ * can log which backend owns the ticket.
+ */
+function providerNameFor(
+  db: SqliteDatabase,
+  storage: PMOStorage & ProviderStorage,
+  ticket: Ticket,
+): string {
+  try {
+    const provider = resolveTicketProvider(
+      ticket.id,
+      ticket.projectId ?? '',
+      db,
+      storage,
+      ticket.metadata,
+    )
+    return provider.name
+  } catch {
+    return 'pmo'
+  }
+}
+
+function toReconcileTicket(ticket: Ticket): ReconcileTicket {
+  return {
+    id: ticket.id,
+    title: ticket.title,
+    projectId: ticket.projectId,
+    statusName: ticket.statusName,
+    statusCategory: ticket.statusCategory,
+    branch: ticket.branch,
+    metadata: ticket.metadata,
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Watch loop
+// -----------------------------------------------------------------------------
+
+/**
+ * Run the reconciler on a timer until the caller-supplied `shouldStop`
+ * callback returns true.
+ *
+ * Each iteration runs one full {@link runReconcile} cycle and then sleeps
+ * for `intervalMs` before the next one. Errors inside a cycle are caught
+ * and surfaced via `log` — a single bad cycle never kills the watcher.
+ */
+export async function watchReconcile(
+  db: SqliteDatabase,
+  storage: PMOStorage & ProviderStorage,
+  options: ReconcileOptions & {
+    intervalMs?: number
+    shouldStop?: () => boolean
+    onCycle?: (report: ReconcileReport) => void
+    sleep?: (ms: number) => Promise<void>
+  } = {},
+): Promise<void> {
+  const {
+    intervalMs = 5 * 60 * 1000,
+    shouldStop = () => false,
+    onCycle,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    log,
+  } = options
+
+  // Cycle counter for tests that want to bound the loop.
+  let cycle = 0
+
+  while (!shouldStop()) {
+
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const report = await runReconcile(db, storage, options)
+      cycle += 1
+      log?.(
+        `[reconcile] cycle ${cycle} complete — checked=${report.checked} ` +
+          `applied=${report.applied.length} skipped=${report.skipped.length} ` +
+          `failed=${report.failed.length}`,
+      )
+      onCycle?.(report)
+    } catch (err) {
+      log?.(
+        `[reconcile] cycle failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+
+    if (shouldStop()) return
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs)
+  }
+}
+
+// Exported for tests that want to call the PR URL parser directly.
+export { parsePRNumberFromUrl as _parsePRNumberFromUrl }

--- a/apps/cli/src/lib/reconcile/types.ts
+++ b/apps/cli/src/lib/reconcile/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Tier 2 State Reconciler — Types (PRLT-1280)
+ *
+ * The reconciler is the safety net that fixes board drift when Tier 1
+ * (event-driven hooks) misses an event. It polls the provider (GitHub for
+ * PR state) and fires normal ticket transitions when it detects drift.
+ *
+ * Design constraints:
+ * - Provider-agnostic: the reconciler core does not branch on provider type.
+ *   It routes every transition through the existing provider adapter layer.
+ * - Idempotent: running twice back-to-back must be safe. Every check asks
+ *   "is current == expected?" and no-ops when they match.
+ * - No LLM, no supervision tree, no daemon rewrite. One function on a timer.
+ */
+
+import type { PRInfo } from '../pr/index.js'
+import type { Ticket } from '../pmo/types.js'
+
+/**
+ * Source of a linked PR. Used for logging and to decide which PMO mapping
+ * to touch when the reconciler sees a transition is needed.
+ */
+export type LinkedPRSource =
+  | 'ticket_branch' // PR resolved from the ticket's linked branch
+  | 'external_map' // PR URL stored in pmo_external_execution_prs for this ticket's external id
+
+/**
+ * A PR linked to a ticket, along with its provenance.
+ */
+export interface LinkedPR {
+  /** Live PR info as reported by GitHub at the time of the reconcile cycle */
+  pr: PRInfo
+  /** How this PR was discovered for the ticket */
+  source: LinkedPRSource
+}
+
+/**
+ * A single transition the reconciler is about to apply (or would apply in dry-run).
+ */
+export interface ReconcileTransition {
+  /** Ticket being moved */
+  ticketId: string
+  /** Ticket display title (for logging) */
+  ticketTitle: string
+  /** The project the ticket belongs to */
+  projectId: string
+  /** Provider name that owns this ticket (from resolver) */
+  provider: string
+  /** Ticket's state before the transition */
+  fromState: string | null
+  /** Ticket's state after the transition (target column name) */
+  toState: string
+  /** PR number that drove this transition, when available */
+  prNumber?: number
+  /** PR state that drove this transition (MERGED, CLOSED, OPEN) */
+  prState?: PRInfo['state']
+  /** Human-readable reason for the transition */
+  reason: string
+  /** ISO timestamp the reconciler decided on this transition */
+  decidedAt: string
+}
+
+/**
+ * Options for running a reconcile cycle.
+ */
+export interface ReconcileOptions {
+  /** If true, compute transitions but do not apply them */
+  dryRun?: boolean
+  /** Working directory for GitHub CLI calls (git remote, gh pr view) */
+  cwd?: string
+  /** Optional callback for human-readable logs */
+  log?: (msg: string) => void
+  /**
+   * Restrict reconciliation to a specific project. When omitted the
+   * reconciler runs workspace-wide across every project.
+   */
+  projectId?: string
+  /**
+   * Injectable PR lookup. Tests use this to avoid the real gh CLI.
+   * Implementations must query live — the reconciler is not allowed to
+   * depend on a local PR cache.
+   */
+  prLookup?: PRLookupFn
+}
+
+/**
+ * Function signature for live PR lookup.
+ *
+ * The reconciler calls this once per PR reference. Implementations must
+ * hit the remote GitHub API (gh CLI or the REST client) — a stale local
+ * cache defeats the whole point of a Tier 2 reconciler.
+ */
+export type PRLookupFn = (ref: PRLookupRef, cwd?: string) => PRInfo | null
+
+/**
+ * A PR reference that can be resolved to a PRInfo.
+ *
+ * Tickets link to PRs via either their ticket branch (common for
+ * prlt-managed work) or via a stored URL in the external execution
+ * mapping table (common when the PR was opened outside prlt).
+ */
+export type PRLookupRef =
+  | { kind: 'branch'; branch: string }
+  | { kind: 'number'; number: number }
+  | { kind: 'url'; url: string }
+
+/**
+ * Report returned after a reconcile cycle completes.
+ */
+export interface ReconcileReport {
+  /** Total number of tickets considered (across all scanned projects) */
+  checked: number
+  /** Transitions that were applied (or would be applied in dry-run) */
+  applied: ReconcileTransition[]
+  /** Transitions that the reconciler decided on but did not execute because of --dry-run */
+  skipped: ReconcileTransition[]
+  /** Transitions that failed to apply */
+  failed: Array<{ transition: ReconcileTransition; error: string }>
+  /** Non-fatal errors encountered while gathering state */
+  errors: Array<{ ticketId: string; error: string }>
+  /** ISO timestamp when the cycle started */
+  startedAt: string
+  /** ISO timestamp when the cycle finished */
+  finishedAt: string
+}
+
+/**
+ * Minimal view of a ticket the reconciler actually reads. Narrow surface
+ * makes the reconciler easy to unit-test without fabricating full Ticket
+ * objects.
+ */
+export type ReconcileTicket = Pick<
+  Ticket,
+  'id' | 'title' | 'projectId' | 'statusName' | 'statusCategory' | 'branch' | 'metadata'
+>

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -10,16 +10,29 @@ import type { RuntimeEventName } from '../../events/events.js'
 
 /**
  * Work lifecycle event names that can trigger hooks.
- * Subset of RuntimeEventName limited to work-relevant events.
+ * Subset of RuntimeEventName limited to work-relevant events,
+ * plus orchestrate daemon events for pipeline automation.
  */
 export type HookableEvent = Extract<
   RuntimeEventName,
   | 'work:started'
   | 'work:status_changed'
   | 'work:pr_created'
+  | 'work:pr_merged'
   | 'work:completed'
   | 'agent:spawned'
   | 'agent:stopped'
+  | 'on_ci_green'
+  | 'on_ci_failed'
+  | 'on_pr_opened'
+  | 'on_pr_merged'
+  | 'on_pr_conflicting'
+  | 'on_ticket_ready'
+  | 'on_agent_spawned'
+  | 'on_agent_died'
+  | 'on_agent_completed'
+  | 'on_agent_idle'
+  | 'on_version_published'
 >
 
 /** All hookable event names for validation. */
@@ -27,9 +40,21 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
   'work:started',
   'work:status_changed',
   'work:pr_created',
+  'work:pr_merged',
   'work:completed',
   'agent:spawned',
   'agent:stopped',
+  'on_ci_green',
+  'on_ci_failed',
+  'on_pr_opened',
+  'on_pr_merged',
+  'on_pr_conflicting',
+  'on_ticket_ready',
+  'on_agent_spawned',
+  'on_agent_died',
+  'on_agent_completed',
+  'on_agent_idle',
+  'on_version_published',
 ]
 
 /**

--- a/apps/cli/src/lib/work-lifecycle/settings.ts
+++ b/apps/cli/src/lib/work-lifecycle/settings.ts
@@ -1,0 +1,44 @@
+/**
+ * Workflow Settings — Configuration types and readers for workflow column mapping.
+ *
+ * Delegates to pmo/utils.ts for actual DB reads; this module adds the
+ * WorkflowConfig aggregate type used by the reconciler and other callers
+ * that need all column names at once.
+ */
+
+import { getWorkColumnSetting } from '../pmo/utils.js'
+
+/**
+ * Minimal database interface compatible with SqliteDatabase.
+ */
+interface DatabaseLike {
+  prepare(sql: string): {
+    get(...params: unknown[]): unknown
+    run(...params: unknown[]): unknown
+  }
+}
+
+/**
+ * Full workflow configuration — the resolved column names for each lifecycle stage.
+ * Read from pmo_settings with fallback to DEFAULT_WORK_COLUMNS.
+ */
+export interface WorkflowConfig {
+  planned: string
+  in_progress: string
+  review: string
+  done: string
+}
+
+/**
+ * Read the full workflow configuration from pmo_settings.
+ * Returns configured column names for each lifecycle stage, falling back
+ * to DEFAULT_WORK_COLUMNS for any that aren't set.
+ */
+export function getWorkflowConfig(db: DatabaseLike): WorkflowConfig {
+  return {
+    planned: getWorkColumnSetting(db, 'planned'),
+    in_progress: getWorkColumnSetting(db, 'in_progress'),
+    review: getWorkColumnSetting(db, 'review'),
+    done: getWorkColumnSetting(db, 'done'),
+  }
+}

--- a/apps/cli/test/e2e/docker-commands.test.ts
+++ b/apps/cli/test/e2e/docker-commands.test.ts
@@ -1569,6 +1569,7 @@ function setupTestDatabase(db: SqliteDatabase) {
       sandboxed INTEGER DEFAULT 1,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'running',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -777,6 +777,7 @@ describe('@smoke Session Commands E2E Tests', () => {
           agent_name TEXT NOT NULL,
           executor TEXT NOT NULL DEFAULT 'claude',
           environment TEXT NOT NULL DEFAULT 'host',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL DEFAULT 'pending',
           session_id TEXT,
           container_id TEXT,

--- a/apps/cli/test/e2e/work-commands.test.ts
+++ b/apps/cli/test/e2e/work-commands.test.ts
@@ -559,6 +559,7 @@ function setupTestDatabase(db: SqliteDatabase) {
       sandboxed INTEGER DEFAULT 1,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'running',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/e2e/work-json-mode.test.ts
+++ b/apps/cli/test/e2e/work-json-mode.test.ts
@@ -174,6 +174,7 @@ async function setupTestDatabase(db: SqliteDatabase, pmoPath: string): Promise<v
       sandboxed INTEGER NOT NULL DEFAULT 0,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'starting',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/unit/daemon-role.test.ts
+++ b/apps/cli/test/unit/daemon-role.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for daemon role support (PRLT-1287)
+ *
+ * Tests:
+ * 1. Session role is stored and retrieved correctly in ExecutionStorage
+ * 2. cleanupStaleExecutions skips daemon-role sessions
+ * 3. Daemon sessions show in session list with correct role
+ * 4. Session prune does NOT reap daemon-role sessions
+ * 5. Reconciler supervisor spawn/restart logic
+ */
+
+import { expect } from 'chai'
+import { SqliteDatabase } from '../../src/lib/database/sqlite.js'
+import { ExecutionStorage } from '../../src/lib/execution/storage.js'
+import { PMO_TABLES } from '../../src/lib/pmo/schema.js'
+import { createFastTestDb, type FastTestDb } from '../e2e/test-helpers.js'
+import { RECONCILER_SESSION_NAME, DAEMON_TICKET_ID, isReconcilerRunning } from '../../src/commands/reconcile.js'
+
+describe('@smoke Daemon role support (PRLT-1287)', () => {
+  let fastDb: FastTestDb
+  let db: SqliteDatabase
+  let storage: ExecutionStorage
+
+  before(() => {
+    fastDb = createFastTestDb((db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS ${PMO_TABLES.agent_work} (
+          id TEXT PRIMARY KEY,
+          ticket_id TEXT NOT NULL,
+          agent_name TEXT NOT NULL,
+          executor TEXT NOT NULL,
+          environment TEXT DEFAULT 'host',
+          display_mode TEXT DEFAULT 'terminal',
+          permission_mode TEXT DEFAULT 'safe',
+          cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
+          status TEXT NOT NULL,
+          branch TEXT,
+          pid TEXT,
+          container_id TEXT,
+          session_id TEXT,
+          host TEXT,
+          log_path TEXT,
+          external_source TEXT,
+          external_key TEXT,
+          external_id TEXT,
+          external_url TEXT,
+          started_at INTEGER NOT NULL,
+          completed_at INTEGER,
+          exit_code INTEGER,
+          error_message TEXT
+        )
+      `)
+    })
+    db = fastDb.db
+  })
+
+  beforeEach(() => {
+    fastDb.savepoint()
+    storage = new ExecutionStorage(db)
+  })
+
+  afterEach(() => {
+    fastDb.rollback()
+  })
+
+  after(() => {
+    fastDb.close()
+  })
+
+  // =========================================================================
+  // 1. Session role is stored and retrieved correctly
+  // =========================================================================
+
+  describe('createExecution with role', () => {
+    it('defaults to worker role when not specified', () => {
+      const exec = storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'test-agent',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+      })
+
+      expect(exec.role).to.equal('worker')
+    })
+
+    it('stores daemon role correctly', () => {
+      const exec = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        cleanupPolicy: 'persistent',
+        role: 'daemon',
+        sessionId: RECONCILER_SESSION_NAME,
+      })
+
+      expect(exec.role).to.equal('daemon')
+      expect(exec.ticketId).to.equal('DAEMON')
+      expect(exec.agentName).to.equal('reconciler')
+      expect(exec.cleanupPolicy).to.equal('persistent')
+    })
+
+    it('stores orchestrator role correctly', () => {
+      const exec = storage.createExecution({
+        ticketId: 'ORCH',
+        agentName: 'orchestrator-main',
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'orchestrator',
+      })
+
+      expect(exec.role).to.equal('orchestrator')
+    })
+
+    it('retrieves role after getExecution', () => {
+      const created = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+      })
+
+      const retrieved = storage.getExecution(created.id)
+      expect(retrieved).to.not.be.null
+      expect(retrieved!.role).to.equal('daemon')
+    })
+  })
+
+  // =========================================================================
+  // 2. cleanupStaleExecutions skips daemon-role sessions
+  // =========================================================================
+
+  describe('cleanupStaleExecutions skips daemons', () => {
+    it('does not mark daemon sessions as stopped even without tmux', () => {
+      // Create a daemon execution that looks "active" but has no tmux session
+      const exec = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+        sessionId: RECONCILER_SESSION_NAME,
+      })
+      storage.updateStatus(exec.id, 'running')
+
+      // Run cleanup — this would normally mark sessions without tmux as stopped.
+      // But daemons should be skipped (they're filtered out in the query).
+      const cleaned = storage.cleanupStaleExecutions()
+
+      // The daemon should NOT have been cleaned up
+      const afterCleanup = storage.getExecution(exec.id)
+      expect(afterCleanup).to.not.be.null
+      expect(afterCleanup!.status).to.equal('running')
+
+      // cleaned count should be 0 since the only "active" execution is a daemon
+      expect(cleaned).to.equal(0)
+    })
+
+    it('cleans regular workers but leaves daemons alone', () => {
+      // Create a regular worker with no tmux session (stale)
+      const worker = storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'test-agent',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'worker',
+        sessionId: 'TKT-001-work-test-agent',
+      })
+      storage.updateStatus(worker.id, 'running')
+
+      // Also set started_at to >5 min ago so the no-sessionId path triggers for
+      // workers without session IDs. But this worker HAS a sessionId —
+      // it'll be checked against tmux and found missing.
+
+      // Create a daemon
+      const daemon = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+        sessionId: RECONCILER_SESSION_NAME,
+      })
+      storage.updateStatus(daemon.id, 'running')
+
+      // Run cleanup
+      storage.cleanupStaleExecutions()
+
+      // The worker should have been cleaned (no tmux session found)
+      const workerAfter = storage.getExecution(worker.id)
+      expect(workerAfter!.status).to.equal('stopped')
+
+      // The daemon should still be running
+      const daemonAfter = storage.getExecution(daemon.id)
+      expect(daemonAfter!.status).to.equal('running')
+    })
+  })
+
+  // =========================================================================
+  // 3. isReconcilerRunning helper
+  // =========================================================================
+
+  describe('isReconcilerRunning', () => {
+    it('returns false when no daemon executions exist', () => {
+      expect(isReconcilerRunning(storage)).to.be.false
+    })
+
+    it('returns true when reconciler daemon is running', () => {
+      const exec = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+        sessionId: RECONCILER_SESSION_NAME,
+      })
+      storage.updateStatus(exec.id, 'running')
+
+      expect(isReconcilerRunning(storage)).to.be.true
+    })
+
+    it('returns false when reconciler is stopped', () => {
+      const exec = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+        sessionId: RECONCILER_SESSION_NAME,
+      })
+      storage.updateStatus(exec.id, 'stopped')
+
+      expect(isReconcilerRunning(storage)).to.be.false
+    })
+
+    it('returns false for worker sessions named reconciler', () => {
+      // A worker role should not count as a daemon
+      const exec = storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+      storage.updateStatus(exec.id, 'running')
+
+      expect(isReconcilerRunning(storage)).to.be.false
+    })
+  })
+
+  // =========================================================================
+  // 4. listExecutions returns role correctly
+  // =========================================================================
+
+  describe('listExecutions with role', () => {
+    it('returns role in listed executions', () => {
+      const daemon = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: RECONCILER_SESSION_NAME,
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+      })
+      storage.updateStatus(daemon.id, 'running')
+
+      const worker = storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'test-agent',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+      storage.updateStatus(worker.id, 'running')
+
+      const running = storage.listExecutions({ status: 'running' })
+      expect(running).to.have.length(2)
+
+      const daemonExec = running.find(e => e.role === 'daemon')
+      expect(daemonExec).to.not.be.undefined
+      expect(daemonExec!.agentName).to.equal(RECONCILER_SESSION_NAME)
+
+      const workerExec = running.find(e => e.role === 'worker')
+      expect(workerExec).to.not.be.undefined
+      expect(workerExec!.agentName).to.equal('test-agent')
+    })
+  })
+
+  // =========================================================================
+  // 5. DAEMON_TICKET_ID and RECONCILER_SESSION_NAME constants
+  // =========================================================================
+
+  describe('constants', () => {
+    it('RECONCILER_SESSION_NAME is "reconciler"', () => {
+      expect(RECONCILER_SESSION_NAME).to.equal('reconciler')
+    })
+
+    it('DAEMON_TICKET_ID is "DAEMON"', () => {
+      expect(DAEMON_TICKET_ID).to.equal('DAEMON')
+    })
+  })
+})

--- a/apps/cli/test/unit/execution-storage.test.ts
+++ b/apps/cli/test/unit/execution-storage.test.ts
@@ -29,6 +29,7 @@ describe('@smoke ExecutionStorage', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/execution-view.test.ts
+++ b/apps/cli/test/unit/execution-view.test.ts
@@ -27,6 +27,7 @@ describe('ExecutionView', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/reconcile-core.test.ts
+++ b/apps/cli/test/unit/reconcile-core.test.ts
@@ -1,0 +1,261 @@
+import { expect } from 'chai'
+import {
+  deriveExpectedState,
+  buildTransition,
+  formatTransitionLogLine,
+} from '../../src/lib/reconcile/core.js'
+import type { LinkedPR, ReconcileTicket } from '../../src/lib/reconcile/types.js'
+import type { PRInfo } from '../../src/lib/pr/index.js'
+
+/**
+ * Tier 2 Reconciler — Core Rule Tests (PRLT-1280)
+ *
+ * These tests only exercise the pure rule engine. No database, no gh CLI,
+ * no provider adapters. The runner-level integration tests live in
+ * reconcile-runner.test.ts.
+ */
+
+function makeTicket(overrides: Partial<ReconcileTicket> = {}): ReconcileTicket {
+  return {
+    id: 'TKT-001',
+    title: 'Test ticket',
+    projectId: 'proj-001',
+    statusName: 'In Review',
+    statusCategory: 'started',
+    branch: 'PRLT-1/feat/test',
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
+  return {
+    number: 42,
+    url: 'https://github.com/test/repo/pull/42',
+    title: 'Test PR',
+    state: 'MERGED',
+    headBranch: 'PRLT-1/feat/test',
+    baseBranch: 'main',
+    isDraft: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function wrap(pr: PRInfo, source: LinkedPR['source'] = 'ticket_branch'): LinkedPR {
+  return { pr, source }
+}
+
+describe('Reconcile Core — deriveExpectedState', () => {
+  describe('Rule 1: merged PR → Done', () => {
+    it('moves an In Review ticket to Done when its PR is merged', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Review', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Done')
+      expect(decision!.driver.pr.state).to.equal('MERGED')
+      expect(decision!.reason).to.include('MERGED')
+    })
+
+    it('moves an In Progress ticket to Done when its PR is merged', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Progress', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Done')
+    })
+
+    it('moves a backlog ticket to Done when its PR is merged', () => {
+      // This is the exact drift pattern described in PRLT-1280:
+      // a PR was merged but the ticket never left its pre-work state.
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Backlog', statusCategory: 'backlog' }),
+        [wrap(makePR({ state: 'MERGED', number: 321 }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Done')
+      expect(decision!.reason).to.include('#321')
+    })
+
+    it('is idempotent: a ticket already in Done produces no decision', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Done', statusCategory: 'completed' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.be.null
+    })
+
+    it('never resurrects a canceled ticket even if its PR later merges', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Canceled', statusCategory: 'canceled' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+      )
+      expect(decision).to.be.null
+    })
+
+    it('prefers a merged PR over other linked PRs', () => {
+      const decision = deriveExpectedState(
+        makeTicket(),
+        [
+          wrap(makePR({ number: 1, state: 'OPEN' })),
+          wrap(makePR({ number: 2, state: 'MERGED' })),
+          wrap(makePR({ number: 3, state: 'CLOSED' })),
+        ],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.driver.pr.number).to.equal(2)
+      expect(decision!.targetState).to.equal('Done')
+    })
+
+    it('respects a custom Done column name from the workflow config', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'QA', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+        {
+          planned: 'Planned',
+          in_progress: 'In Progress',
+          review: 'QA',
+          done: 'Shipped',
+          backlog: 'Backlog',
+        },
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('Shipped')
+    })
+
+    it('is idempotent against a custom Done column name', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'Shipped', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'MERGED' }))],
+        {
+          planned: 'Planned',
+          in_progress: 'In Progress',
+          review: 'QA',
+          done: 'Shipped',
+          backlog: 'Backlog',
+        },
+      )
+      expect(decision).to.be.null
+    })
+  })
+
+  describe('Rule 2: review ticket + all PRs closed-not-merged → In Progress', () => {
+    it('moves a review ticket back to In Progress when the only PR was closed', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Review', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'CLOSED', number: 99 }))],
+      )
+      expect(decision).to.not.be.null
+      expect(decision!.targetState).to.equal('In Progress')
+      expect(decision!.reason).to.include('CLOSED')
+    })
+
+    it('does nothing when the ticket is already in In Progress', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Progress', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'CLOSED' }))],
+      )
+      expect(decision).to.be.null
+    })
+
+    it('does nothing when at least one linked PR is still open', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Review', statusCategory: 'started' }),
+        [
+          wrap(makePR({ number: 1, state: 'CLOSED' })),
+          wrap(makePR({ number: 2, state: 'OPEN' })),
+        ],
+      )
+      expect(decision).to.be.null
+    })
+  })
+
+  describe('no action', () => {
+    it('produces no decision when no PRs are linked', () => {
+      const decision = deriveExpectedState(makeTicket(), [])
+      expect(decision).to.be.null
+    })
+
+    it('produces no decision for an open PR on an in-progress ticket', () => {
+      const decision = deriveExpectedState(
+        makeTicket({ statusName: 'In Progress', statusCategory: 'started' }),
+        [wrap(makePR({ state: 'OPEN' }))],
+      )
+      expect(decision).to.be.null
+    })
+  })
+
+  describe('idempotency invariant', () => {
+    it('running twice against an already-correct ticket is a no-op', () => {
+      const ticket = makeTicket({ statusName: 'Done', statusCategory: 'completed' })
+      const prs = [wrap(makePR({ state: 'MERGED' }))]
+      expect(deriveExpectedState(ticket, prs)).to.be.null
+      expect(deriveExpectedState(ticket, prs)).to.be.null
+    })
+  })
+})
+
+describe('Reconcile Core — buildTransition', () => {
+  it('builds a transition record with every required field', () => {
+    const ticket = makeTicket({ statusName: 'In Review', id: 'TKT-142' })
+    const driver = wrap(makePR({ state: 'MERGED', number: 321 }))
+    const now = new Date('2026-04-08T12:00:00Z')
+
+    const t = buildTransition({
+      ticket,
+      provider: 'linear',
+      targetState: 'Done',
+      reason: 'PR merged',
+      driver,
+      now,
+    })
+
+    expect(t.ticketId).to.equal('TKT-142')
+    expect(t.provider).to.equal('linear')
+    expect(t.fromState).to.equal('In Review')
+    expect(t.toState).to.equal('Done')
+    expect(t.prNumber).to.equal(321)
+    expect(t.prState).to.equal('MERGED')
+    expect(t.reason).to.equal('PR merged')
+    expect(t.decidedAt).to.equal('2026-04-08T12:00:00.000Z')
+  })
+
+  it('tolerates a missing driver PR', () => {
+    const t = buildTransition({
+      ticket: makeTicket(),
+      provider: 'pmo',
+      targetState: 'Done',
+      reason: 'nothing',
+    })
+    expect(t.prNumber).to.be.undefined
+    expect(t.prState).to.be.undefined
+  })
+})
+
+describe('Reconcile Core — formatTransitionLogLine', () => {
+  it('includes ticket id, old/new state, PR number and reason per AC', () => {
+    const line = formatTransitionLogLine({
+      ticketId: 'TKT-142',
+      ticketTitle: 'Fix thing',
+      projectId: 'proj-001',
+      provider: 'linear',
+      fromState: 'In Review',
+      toState: 'Done',
+      prNumber: 321,
+      prState: 'MERGED',
+      reason: 'GitHub PR #321 is MERGED',
+      decidedAt: '2026-04-08T12:00:00.000Z',
+    })
+    expect(line).to.include('TKT-142')
+    expect(line).to.include('In Review')
+    expect(line).to.include('Done')
+    expect(line).to.include('PR #321')
+    expect(line).to.include('MERGED')
+    expect(line).to.include('2026-04-08T12:00:00.000Z')
+    expect(line).to.include('reason:')
+  })
+})

--- a/apps/cli/test/unit/reconcile-runner.test.ts
+++ b/apps/cli/test/unit/reconcile-runner.test.ts
@@ -1,0 +1,386 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { SQLiteStorage } from '../../src/lib/pmo/storage-sqlite.js'
+import { runReconcile } from '../../src/lib/reconcile/index.js'
+import type { PRLookupFn, PRLookupRef } from '../../src/lib/reconcile/types.js'
+import type { PMOStorage } from '../../src/lib/pmo/types.js'
+import type { ProviderStorage } from '../../src/lib/providers/types.js'
+import type { PRInfo } from '../../src/lib/pr/index.js'
+import { ExternalExecutionMappingStore } from '../../src/lib/external-issues/mapping-store.js'
+
+/**
+ * Tier 2 Reconciler — Runner Tests (PRLT-1280)
+ *
+ * Drives runReconcile() against a real SQLite workspace with a stub
+ * GitHub lookup. Verifies:
+ *
+ *   - The regression pattern: 6 review tickets with merged PRs land in Done
+ *   - Idempotency: a second run makes zero additional changes
+ *   - Dry-run: no state mutation, skipped transitions reported
+ *   - `gh pr merge` drift: tickets with no prlt involvement still reconcile
+ *   - Live lookup: reconciler does not depend on any local PR cache
+ *   - Linked PR URLs from pmo_external_execution_prs work for tickets
+ *     that don't have a ticket.branch
+ */
+
+const PROJECT_ID = 'proj-reconcile-test'
+
+function makePR(overrides: Partial<PRInfo>): PRInfo {
+  return {
+    number: 1,
+    url: 'https://github.com/test/repo/pull/1',
+    title: 'Test PR',
+    state: 'OPEN',
+    headBranch: 'PRLT-1/feat/test',
+    baseBranch: 'main',
+    isDraft: false,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-08T00:00:00Z',
+    ...overrides,
+  }
+}
+
+/**
+ * Create a ticket and then stamp its branch via updateTicket, since
+ * CreateTicketInput does not accept branch directly.
+ */
+async function createTicketWithBranch(
+  storage: SQLiteStorage,
+  projectId: string,
+  params: { title: string; statusName: string; branch?: string },
+): Promise<{ id: string }> {
+  const t = await storage.createTicket(projectId, {
+    title: params.title,
+    statusName: params.statusName,
+  })
+  if (params.branch) {
+    await storage.updateTicket(t.id, { branch: params.branch })
+  }
+  return { id: t.id }
+}
+
+/**
+ * Build a PR lookup stub that resolves by branch and by URL. We also
+ * record every call so tests can assert the reconciler is hitting the
+ * live lookup (and not some stale cache) on every cycle.
+ */
+function makeStubLookup(prs: PRInfo[]): { lookup: PRLookupFn; calls: PRLookupRef[] } {
+  const byBranch = new Map(prs.map(pr => [pr.headBranch, pr]))
+  const byNumber = new Map(prs.map(pr => [pr.number, pr]))
+  const calls: PRLookupRef[] = []
+  const lookup: PRLookupFn = ref => {
+    calls.push(ref)
+    if (ref.kind === 'branch') return byBranch.get(ref.branch) ?? null
+    if (ref.kind === 'number') return byNumber.get(ref.number) ?? null
+    if (ref.kind === 'url') {
+      const m = ref.url.match(/\/pull\/(\d+)/)
+      if (!m) return null
+      return byNumber.get(Number.parseInt(m[1], 10)) ?? null
+    }
+    return null
+  }
+  return { lookup, calls }
+}
+
+describe('Tier 2 Reconciler — runner (PRLT-1280)', () => {
+  let testDir: string
+  let storage: SQLiteStorage
+  let db: Database.Database
+
+  beforeEach(async () => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconcile-runner-'))
+    const dbPath = path.join(testDir, 'pmo.db')
+
+    // Create the db file first; SQLiteStorage requires it to exist.
+    const bootstrap = new Database(dbPath)
+    bootstrap.close()
+
+    storage = new SQLiteStorage(dbPath)
+    db = storage.getDatabase()
+
+    // Make sure the external execution mapping tables exist (they are
+    // created lazily by ExternalExecutionMappingStore).
+    // eslint-disable-next-line no-new
+    new ExternalExecutionMappingStore(db)
+
+    // The "default" template ships a Backlog → Ready → In Progress →
+    // Review → Done workflow, which matches the column names the
+    // reconciler expects.
+    await storage.createProject({
+      id: PROJECT_ID,
+      name: 'Reconcile Test Project',
+      template: 'default',
+    })
+  })
+
+  afterEach(async () => {
+    await storage.close()
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Regression: the exact drift pattern from PRLT-1280 — 6 tickets stuck in
+  // Review, each tied to a merged PR on GitHub.
+  // ---------------------------------------------------------------------------
+  it('moves all 6 stuck-in-Review tickets to Done in a single pass', async () => {
+    const prs: PRInfo[] = []
+    for (let i = 1; i <= 6; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await createTicketWithBranch(storage, PROJECT_ID, {
+        title: `Stuck ticket ${i}`,
+        statusName: 'Review',
+        branch: `PRLT-100${i}/feat/fix-${i}`,
+      })
+      prs.push(
+        makePR({
+          number: 1000 + i,
+          state: 'MERGED',
+          headBranch: `PRLT-100${i}/feat/fix-${i}`,
+        }),
+      )
+    }
+
+    const { lookup } = makeStubLookup(prs)
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(6)
+    expect(report.failed.length).to.equal(0)
+    expect(report.applied.every(t => t.toState === 'Done')).to.equal(true)
+    expect(report.applied.every(t => t.prState === 'MERGED')).to.equal(true)
+
+    // Every ticket is now in Done.
+    const after = await storage.listTickets(PROJECT_ID)
+    expect(after).to.have.lengthOf(6)
+    for (const t of after) {
+      expect(t.statusName).to.equal('Done')
+      expect(t.statusCategory).to.equal('completed')
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Idempotency — second run must be a no-op.
+  // ---------------------------------------------------------------------------
+  it('is idempotent: a second run makes zero additional changes', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Already shipped',
+      statusName: 'Review',
+      branch: 'PRLT-42/feat/ship',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 42, state: 'MERGED', headBranch: 'PRLT-42/feat/ship' }),
+    ])
+
+    const first = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(first.applied.length).to.equal(1)
+    expect(first.applied[0].toState).to.equal('Done')
+
+    const second = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(second.applied.length).to.equal(0)
+    expect(second.failed.length).to.equal(0)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Dry-run — no mutations, transitions reported in `skipped`.
+  // ---------------------------------------------------------------------------
+  it('--dry-run reports transitions without mutating state', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Would move',
+      statusName: 'Review',
+      branch: 'PRLT-7/feat/drift',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 7, state: 'MERGED', headBranch: 'PRLT-7/feat/drift' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID, dryRun: true },
+    )
+
+    expect(report.applied.length).to.equal(0)
+    expect(report.skipped.length).to.equal(1)
+    expect(report.skipped[0].toState).to.equal('Done')
+
+    // State must be unchanged.
+    const tickets = await storage.listTickets(PROJECT_ID)
+    expect(tickets[0].statusName).to.equal('Review')
+  })
+
+  // ---------------------------------------------------------------------------
+  // `gh pr merge` drift: merge outside prlt, no state change, reconcile fixes
+  // ---------------------------------------------------------------------------
+  it('catches drift from `gh pr merge` outside prlt', async () => {
+    // Simulate: someone merged via `gh pr merge` without prlt knowing.
+    // The ticket never left In Progress.
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Raw gh merge',
+      statusName: 'In Progress',
+      branch: 'PRLT-909/feat/raw',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 909, state: 'MERGED', headBranch: 'PRLT-909/feat/raw' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(1)
+    const [t] = await storage.listTickets(PROJECT_ID)
+    expect(t.statusName).to.equal('Done')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Closed-without-merging → back to In Progress
+  // ---------------------------------------------------------------------------
+  it('moves a Review ticket back to In Progress when its PR is closed unmerged', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Closed, not merged',
+      statusName: 'Review',
+      branch: 'PRLT-55/feat/rejected',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 55, state: 'CLOSED', headBranch: 'PRLT-55/feat/rejected' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(1)
+    expect(report.applied[0].toState).to.equal('In Progress')
+
+    const [t] = await storage.listTickets(PROJECT_ID)
+    expect(t.statusName).to.equal('In Progress')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Non-terminal scan: triage/backlog/unstarted tickets are also scanned
+  // ---------------------------------------------------------------------------
+  it('scans triage/backlog/unstarted tickets too', async () => {
+    // A ticket that never advanced past Backlog but has a merged PR
+    // (e.g. an agent ran out of band, or someone force-pushed a fix).
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Backlog with merged PR',
+      statusName: 'Backlog',
+      branch: 'PRLT-77/feat/early',
+    })
+    const { lookup } = makeStubLookup([
+      makePR({ number: 77, state: 'MERGED', headBranch: 'PRLT-77/feat/early' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(report.applied.length).to.equal(1)
+    expect(report.applied[0].toState).to.equal('Done')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Live lookup: every cycle must actually call the PR lookup
+  // ---------------------------------------------------------------------------
+  it('hits the live PR lookup on every cycle (no local cache)', async () => {
+    await createTicketWithBranch(storage, PROJECT_ID, {
+      title: 'Live lookup check',
+      statusName: 'In Progress',
+      branch: 'PRLT-1/feat/x',
+    })
+
+    const { lookup, calls } = makeStubLookup([
+      makePR({ number: 1, state: 'OPEN', headBranch: 'PRLT-1/feat/x' }),
+    ])
+
+    await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    const firstCallCount = calls.length
+    expect(firstCallCount).to.be.greaterThan(0)
+
+    await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    // Second cycle must issue new lookups — the reconciler is not
+    // allowed to short-circuit on a local cache.
+    expect(calls.length).to.be.greaterThan(firstCallCount)
+  })
+
+  // ---------------------------------------------------------------------------
+  // PR URLs stored in pmo_external_execution_prs are resolved even when
+  // the ticket has no linked branch.
+  // ---------------------------------------------------------------------------
+  it('resolves PR URLs stored in pmo_external_execution_prs', async () => {
+    const ticket = await storage.createTicket(PROJECT_ID, {
+      title: 'No branch, stored PR URL',
+      statusName: 'In Progress',
+    })
+    // Simulate a ticket whose PR was recorded via the external execution
+    // mapping (e.g. spawned from Linear without a local branch).
+    const mapStore = new ExternalExecutionMappingStore(db)
+    mapStore.upsertMapping({
+      provider: 'pmo',
+      externalId: ticket.id,
+      externalKey: ticket.id,
+      prUrl: 'https://github.com/test/repo/pull/2024',
+    })
+
+    const { lookup } = makeStubLookup([
+      makePR({ number: 2024, state: 'MERGED', url: 'https://github.com/test/repo/pull/2024' }),
+    ])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+
+    expect(report.applied.length).to.equal(1)
+    expect(report.applied[0].toState).to.equal('Done')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tickets with no PR info are ignored (not flagged, not moved).
+  // ---------------------------------------------------------------------------
+  it('ignores tickets with no linked PR', async () => {
+    await storage.createTicket(PROJECT_ID, {
+      title: 'No PR, no problem',
+      statusName: 'In Progress',
+    })
+    const { lookup } = makeStubLookup([])
+
+    const report = await runReconcile(
+      db,
+      storage as unknown as PMOStorage & ProviderStorage,
+      { prLookup: lookup, projectId: PROJECT_ID },
+    )
+    expect(report.applied.length).to.equal(0)
+    expect(report.checked).to.be.greaterThan(0)
+  })
+})

--- a/apps/cli/test/unit/session-report-cleanup.test.ts
+++ b/apps/cli/test/unit/session-report-cleanup.test.ts
@@ -31,6 +31,7 @@ describe('@smoke Session Report Cleanup Logic', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/spawner.test.ts
+++ b/apps/cli/test/unit/spawner.test.ts
@@ -62,6 +62,7 @@ describe('Spawner', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/docs/orchestrate/github-actions.yml
+++ b/docs/orchestrate/github-actions.yml
@@ -1,0 +1,75 @@
+# Example GitHub Actions workflows for prlt orchestrate
+#
+# These workflows bridge GitHub events to the prlt orchestrate daemon
+# via `prlt hook fire`. Copy and adapt them for your repository.
+
+# =============================================================================
+# CI Green → Auto-merge
+# =============================================================================
+# name: On CI Complete
+# on:
+#   check_suite:
+#     types: [completed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.check_suite.conclusion == 'success'
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_ci_green \
+#             --pr ${{ github.event.check_suite.pull_requests[0].number }} \
+#             --branch ${{ github.event.check_suite.head_branch }}
+
+# =============================================================================
+# CI Failed → Notify
+# =============================================================================
+# name: On CI Failed
+# on:
+#   check_suite:
+#     types: [completed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.check_suite.conclusion == 'failure'
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_ci_failed \
+#             --pr ${{ github.event.check_suite.pull_requests[0].number }} \
+#             --branch ${{ github.event.check_suite.head_branch }}
+
+# =============================================================================
+# PR Opened → Move ticket to Review
+# =============================================================================
+# name: On PR Opened
+# on:
+#   pull_request:
+#     types: [opened]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_pr_opened \
+#             --pr ${{ github.event.pull_request.number }} \
+#             --branch ${{ github.event.pull_request.head.ref }}
+
+# =============================================================================
+# PR Merged → Move ticket to Done + rebase siblings
+# =============================================================================
+# name: On PR Merged
+# on:
+#   pull_request:
+#     types: [closed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.pull_request.merged == true
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_pr_merged \
+#             --pr ${{ github.event.pull_request.number }} \
+#             --branch ${{ github.event.pull_request.head.ref }}

--- a/docs/orchestrate/hooks.example.yml
+++ b/docs/orchestrate/hooks.example.yml
@@ -1,0 +1,60 @@
+# .proletariat/hooks.yml
+#
+# Event-driven hook configuration for prlt orchestrate.
+# Load with: prlt orchestrate --load-yaml
+# Or apply a preset instead: prlt hook preset supervised
+#
+# Modes:
+#   auto    — fires immediately, no human needed
+#   confirm — pauses, waits for approval
+#   notify  — fires but also pings
+#   off     — disabled
+
+on_ci_green:
+  - action: merge-pr
+    mode: auto
+
+on_pr_merged:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: done
+  - action: rebase-conflicting-prs
+    mode: auto
+
+on_pr_opened:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: review
+
+on_ticket_ready:
+  - action: spawn-agent
+    mode: confirm
+
+on_agent_died:
+  - action: respawn
+    mode: auto
+    max_retries: 2
+  - action: notify
+    mode: auto
+
+on_ci_failed:
+  - action: notify
+    mode: auto
+  - action: spawn-fix-agent
+    mode: confirm
+
+on_agent_completed:
+  - action: cleanup-container
+    mode: auto
+
+on_agent_idle:
+  - action: health-check
+    mode: auto
+
+on_agent_spawned:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: in-progress

--- a/docs/orchestrate/workflow.example.yml
+++ b/docs/orchestrate/workflow.example.yml
@@ -1,0 +1,19 @@
+# .proletariat/workflow.yml
+#
+# Workflow configuration — controls the shape of the work pipeline.
+# Separate from hooks — this determines branch strategy, PR behavior,
+# and review requirements.
+
+branches:
+  target: main                      # or develop, staging
+  strategy: squash                  # squash, merge, rebase
+
+on_implement_complete:
+  - create-pr                       # or commit-to-branch, draft-pr
+
+on_review_complete:
+  - merge-pr                        # or auto-merge-on-green
+
+review:
+  required: false                   # or true, or "auto" (AI review)
+  auto_merge_on_green: true         # merge when CI passes, no human review


### PR DESCRIPTION
## Summary

- Add `daemon` session role to the execution type system (alongside `worker`, `orchestrator`, `headless`)
- `prlt reconcile --watch` now spawns a detached tmux session instead of running in foreground, registered in machine.db with `role: 'daemon'`
- `prlt reconcile --watch --foreground` preserved for debugging
- `prlt session list` shows role column (worker, daemon, orchestrator)  
- `prlt session prune` skips daemon-role sessions (never reaps long-running infrastructure)
- `prlt orchestrate` auto-spawns the reconciler on startup if not running
- Orchestrator health-checks the reconciler every 60s and restarts if dead
- Database migration (0015) adds `role` column to `agent_work` table
- 13 new unit tests covering daemon role storage, cleanup skip, and reconciler detection

Closes PRLT-1287

## Test plan

- [x] `prlt reconcile --watch` spawns tmux session, not foreground
- [x] Reconciler registered in machine.db with `role: 'daemon'`
- [x] `prlt session list` shows reconciler with role=daemon
- [x] `prlt session prune` does NOT kill daemon sessions
- [x] `cleanupStaleExecutions` skips daemon-role sessions
- [x] `isReconcilerRunning` correctly detects daemon state
- [x] All 350 existing smoke tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)