### PR TITLE
chore: bump version to 0.3.113

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.112",
+  "version": "0.3.113",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Publishes PRLT-1253 (LLM orchestrator daemon), PRLT-1288 (reconciler branch search), PRLT-1283 (pr merge lifecycle), PRLT-1281 (auto-dismiss prompts).