### PR TITLE
chore: bump version to 0.3.114

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.113",
+  "version": "0.3.114",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Publishes PRLT-1276 (binary wipe fix), PRLT-1296 (Docker credential fix), PRLT-1253 (LLM orchestrator daemon).