### PR TITLE
feat(PRLT-1287): Reconciler as supervised daemon — register in machine.db, spawn from orchestrator, survive terminal close

### DIFF
--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -35,6 +35,12 @@ import {
 } from '../../lib/orchestrate/index.js'
 import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
 import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
+import { ExecutionStorage } from '../../lib/execution/index.js'
+import {
+  isReconcilerRunning,
+  spawnReconcilerDaemon,
+  registerReconcilerExecution,
+} from '../reconcile/index.js'
 export default class Orchestrate extends PromptCommand {
   static description = 'Start the autonomous pipeline daemon with event-driven hooks'
 
@@ -233,6 +239,37 @@ export default class Orchestrate extends PromptCommand {
       // Daemon mode: start the engine and run until stopped
       engine.start()
 
+      // =====================================================================
+      // Auto-spawn the reconciler daemon if not already running
+      // =====================================================================
+      const executionStorage = new ExecutionStorage(db)
+      if (!isReconcilerRunning()) {
+        const sessionName = spawnReconcilerDaemon(workspaceInfo.path, 30)
+        if (sessionName) {
+          registerReconcilerExecution(executionStorage, sessionName)
+          if (!jsonMode) {
+            this.log(styles.muted('  Reconciler daemon started'))
+          }
+        } else if (!jsonMode) {
+          this.log(styles.warning('  Failed to start reconciler daemon'))
+        }
+      } else if (!jsonMode) {
+        this.log(styles.muted('  Reconciler daemon already running'))
+      }
+
+      // Periodic reconciler health check — restart if it dies
+      const reconcilerHealthTimer = setInterval(() => {
+        if (!isReconcilerRunning()) {
+          const sessionName = spawnReconcilerDaemon(workspaceInfo.path, 30)
+          if (sessionName) {
+            registerReconcilerExecution(executionStorage, sessionName)
+            if (verbose) {
+              this.log(styles.warning('[orchestrate] Reconciler died — restarted'))
+            }
+          }
+        }
+      }, 60_000) // Check every 60 seconds
+
       // Prevent oclif from killing the daemon — oclif's error handler calls
       // process.exit(0) after run() resolves, which terminates the daemon.
       // Override process.exit to ignore clean exits while the daemon is running.
@@ -299,6 +336,7 @@ export default class Orchestrate extends PromptCommand {
       await new Promise<void>((resolve) => {
         const cleanup = () => {
           clearInterval(keepAlive)
+          clearInterval(reconcilerHealthTimer)
           daemonRunning = false
           process.exit = originalExit
           engine.stop()

--- a/apps/cli/src/commands/reconcile/index.ts
+++ b/apps/cli/src/commands/reconcile/index.ts
@@ -1,0 +1,353 @@
+/**
+ * prlt reconcile — Session reconciliation daemon
+ *
+ * Reconciles session state (DB vs tmux reality) on a periodic interval.
+ * By default, spawns as a background tmux session registered with role=daemon.
+ * Use --foreground for debugging (runs in current terminal).
+ */
+
+import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
+import { openWorkspaceDatabase } from '../../lib/database/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import { ExecutionStorage } from '../../lib/execution/index.js'
+import { SessionStore } from '../../lib/session-store.js'
+import { onShutdown } from '../../lib/signal-handler.js'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+
+/** Tmux session name for the reconciler daemon */
+export const RECONCILER_SESSION_NAME = 'prlt-daemon-reconciler'
+
+/** Sentinel ticket ID for daemon executions (daemons don't work on tickets) */
+export const DAEMON_TICKET_ID = 'DAEMON'
+
+/**
+ * Check if the reconciler daemon is already running.
+ */
+export function isReconcilerRunning(): boolean {
+  try {
+    execSync(`tmux has-session -t "${RECONCILER_SESSION_NAME}" 2>/dev/null`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Spawn the reconciler as a tmux daemon session.
+ * Returns the tmux session name on success, null on failure.
+ */
+export function spawnReconcilerDaemon(hqPath: string, intervalSeconds: number): string | null {
+  if (isReconcilerRunning()) {
+    return RECONCILER_SESSION_NAME
+  }
+
+  try {
+    // Spawn a detached tmux session running the reconciler in foreground mode
+    const cmd = `cd "${hqPath}" && prlt reconcile --foreground --interval ${intervalSeconds}`
+    execSync(
+      `tmux new-session -d -s "${RECONCILER_SESSION_NAME}" -n "${RECONCILER_SESSION_NAME}" "${cmd}"`,
+      { stdio: 'pipe', timeout: 10000 },
+    )
+    return RECONCILER_SESSION_NAME
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Register the reconciler daemon in the agent_work table.
+ */
+export function registerReconcilerExecution(
+  executionStorage: ExecutionStorage,
+  sessionName: string,
+): string {
+  // Check if there's already a running daemon execution
+  const existing = executionStorage.listExecutions({
+    status: 'running',
+    role: 'daemon',
+  })
+  const reconcilerExec = existing.find(e => e.agentName === 'reconciler')
+  if (reconcilerExec) {
+    return reconcilerExec.id
+  }
+
+  const exec = executionStorage.createExecution({
+    ticketId: DAEMON_TICKET_ID,
+    agentName: 'reconciler',
+    executor: 'custom',
+    environment: 'host',
+    displayMode: 'background',
+    permissionMode: 'safe',
+    cleanupPolicy: 'persistent',
+    role: 'daemon',
+    sessionId: sessionName,
+  })
+
+  // Immediately mark as running (daemons start instantly)
+  executionStorage.updateStatus(exec.id, 'running')
+  return exec.id
+}
+
+export default class Reconcile extends PromptCommand {
+  static description = 'Start the session reconciliation daemon'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --foreground',
+    '<%= config.bin %> <%= command.id %> --interval 60',
+    '<%= config.bin %> <%= command.id %> --foreground --interval 10',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    foreground: Flags.boolean({
+      description: 'Run in current terminal instead of spawning a tmux session (for debugging)',
+      default: false,
+    }),
+    interval: Flags.integer({
+      description: 'Reconciliation interval in seconds',
+      default: 30,
+    }),
+    status: Flags.boolean({
+      description: 'Show reconciler daemon status and exit',
+      default: false,
+    }),
+    stop: Flags.boolean({
+      description: 'Stop the reconciler daemon',
+      default: false,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Reconcile)
+    const jsonMode = shouldOutputJson(flags)
+
+    // Status check
+    if (flags.status) {
+      const running = isReconcilerRunning()
+      if (jsonMode) {
+        outputSuccessAsJson({ running, sessionName: RECONCILER_SESSION_NAME }, createMetadata('reconcile', flags))
+      } else {
+        this.log('')
+        if (running) {
+          this.log(styles.success(`Reconciler daemon is running (session: ${RECONCILER_SESSION_NAME})`))
+        } else {
+          this.log(styles.muted('Reconciler daemon is not running.'))
+        }
+        this.log('')
+      }
+      return
+    }
+
+    // Stop the daemon
+    if (flags.stop) {
+      return this.stopDaemon(jsonMode, flags)
+    }
+
+    // Get workspace info
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('reconcile', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    if (flags.foreground) {
+      return this.runForeground(workspaceInfo.path, flags.interval, jsonMode, flags)
+    }
+
+    return this.spawnDaemon(workspaceInfo.path, flags.interval, jsonMode, flags)
+  }
+
+  /**
+   * Run the reconciler in the current terminal (foreground/debug mode).
+   */
+  private async runForeground(
+    hqPath: string,
+    intervalSeconds: number,
+    jsonMode: boolean,
+    flags: Record<string, unknown>,
+  ): Promise<void> {
+    const db = openWorkspaceDatabase(hqPath)
+    const executionStorage = new ExecutionStorage(db)
+    const sessionStore = new SessionStore()
+
+    if (!jsonMode) {
+      this.log('')
+      this.log(styles.title('Reconciler running in foreground'))
+      this.log(styles.muted(`  Interval: ${intervalSeconds}s`))
+      this.log(styles.muted('  Press Ctrl+C to stop'))
+      this.log('')
+    }
+
+    const reconcile = () => {
+      const timestamp = new Date().toLocaleTimeString()
+      try {
+        // Reconcile global session store (sessions.db)
+        sessionStore.reconcile()
+
+        // Reconcile workspace execution records (agent_work)
+        const cleaned = executionStorage.cleanupStaleExecutions()
+
+        if (!jsonMode && cleaned > 0) {
+          this.log(styles.info(`[${timestamp}] Cleaned ${cleaned} stale execution(s)`))
+        } else if (!jsonMode) {
+          this.log(styles.muted(`[${timestamp}] All sessions healthy`))
+        }
+      } catch (error) {
+        if (!jsonMode) {
+          this.log(styles.error(`[${timestamp}] Reconciliation error: ${error}`))
+        }
+      }
+    }
+
+    // Initial reconciliation
+    reconcile()
+
+    // Periodic reconciliation loop
+    const intervalMs = intervalSeconds * 1000
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(reconcile, intervalMs)
+
+      onShutdown(() => {
+        clearInterval(timer)
+        sessionStore.close()
+        db.close()
+        if (!jsonMode) {
+          this.log(styles.muted('\nReconciler stopped.'))
+        }
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Spawn the reconciler as a tmux daemon session.
+   */
+  private async spawnDaemon(
+    hqPath: string,
+    intervalSeconds: number,
+    jsonMode: boolean,
+    flags: Record<string, unknown>,
+  ): Promise<void> {
+    // Check if already running
+    if (isReconcilerRunning()) {
+      if (jsonMode) {
+        outputSuccessAsJson({
+          status: 'already_running',
+          sessionName: RECONCILER_SESSION_NAME,
+        }, createMetadata('reconcile', flags))
+        return
+      }
+      this.log('')
+      this.log(styles.warning(`Reconciler daemon is already running (session: ${RECONCILER_SESSION_NAME})`))
+      this.log(styles.muted('  Use --stop to stop it, or --foreground to run in current terminal.'))
+      this.log('')
+      return
+    }
+
+    // Spawn the tmux session
+    const sessionName = spawnReconcilerDaemon(hqPath, intervalSeconds)
+    if (!sessionName) {
+      if (jsonMode) {
+        outputErrorAsJson('SPAWN_FAILED', 'Failed to spawn reconciler tmux session', createMetadata('reconcile', flags))
+        return
+      }
+      this.log(styles.error('Failed to spawn reconciler tmux session.'))
+      this.log(styles.muted('  Is tmux installed? Try: which tmux'))
+      return
+    }
+
+    // Register in agent_work
+    const db = openWorkspaceDatabase(hqPath)
+    try {
+      const executionStorage = new ExecutionStorage(db)
+      registerReconcilerExecution(executionStorage, sessionName)
+    } finally {
+      db.close()
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        status: 'started',
+        sessionName,
+        interval: intervalSeconds,
+      }, createMetadata('reconcile', flags))
+      return
+    }
+
+    this.log('')
+    this.log(styles.success(`Reconciler daemon started (session: ${sessionName})`))
+    this.log(styles.muted(`  Interval: ${intervalSeconds}s`))
+    this.log(styles.muted(`  Attach: tmux attach -t ${sessionName}`))
+    this.log(styles.muted(`  Stop:   prlt reconcile --stop`))
+    this.log('')
+  }
+
+  /**
+   * Stop the reconciler daemon.
+   */
+  private async stopDaemon(jsonMode: boolean, flags: Record<string, unknown>): Promise<void> {
+    if (!isReconcilerRunning()) {
+      if (jsonMode) {
+        outputSuccessAsJson({ status: 'not_running' }, createMetadata('reconcile', flags))
+        return
+      }
+      this.log(styles.muted('Reconciler daemon is not running.'))
+      return
+    }
+
+    try {
+      execSync(`tmux kill-session -t "${RECONCILER_SESSION_NAME}"`, { stdio: 'pipe', timeout: 5000 })
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('STOP_FAILED', 'Failed to kill reconciler tmux session', createMetadata('reconcile', flags))
+        return
+      }
+      this.log(styles.error('Failed to stop reconciler daemon.'))
+      return
+    }
+
+    // Mark execution as stopped in agent_work
+    try {
+      const workspaceInfo = getWorkspaceInfo()
+      const db = openWorkspaceDatabase(workspaceInfo.path)
+      try {
+        const executionStorage = new ExecutionStorage(db)
+        const daemonExecs = executionStorage.listExecutions({
+          status: 'running',
+          role: 'daemon',
+        })
+        for (const exec of daemonExecs) {
+          if (exec.agentName === 'reconciler') {
+            executionStorage.updateStatus(exec.id, 'stopped')
+          }
+        }
+      } finally {
+        db.close()
+      }
+    } catch {
+      // Best-effort cleanup of DB records
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({ status: 'stopped' }, createMetadata('reconcile', flags))
+      return
+    }
+
+    this.log(styles.success('Reconciler daemon stopped.'))
+  }
+}

--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -25,6 +25,7 @@ interface VerifiedSession {
   sessionId: string
   ticketId: string
   agentName: string
+  role: string     // worker, orchestrator, daemon
   status: string
   environment: 'host' | 'container'
   containerId?: string
@@ -173,6 +174,7 @@ export default class SessionList extends PromptCommand {
             sessionId: actualSessionId,
             ticketId: exec.ticketId,
             agentName: exec.agentName,
+            role: exec.role || 'worker',
             status: exists ? exec.status : 'stale',
             environment: isContainer ? 'container' : 'host',
             containerId,
@@ -209,6 +211,7 @@ export default class SessionList extends PromptCommand {
               sessionId: exec.sessionId,
               ticketId: exec.ticketId,
               agentName: exec.agentName,
+              role: exec.role || 'worker',
               status: 'running',
               environment: isContainer ? 'container' : 'host',
               containerId,
@@ -262,6 +265,7 @@ export default class SessionList extends PromptCommand {
             sessionId: actualSessionId,
             ticketId: mExec.ticketId || mExec.id,
             agentName: mExec.agentName,
+            role: 'worker',
             status: exists ? mExec.status : 'stale',
             environment: isContainer ? 'container' : 'host',
             containerId: mExec.containerId,
@@ -290,6 +294,7 @@ export default class SessionList extends PromptCommand {
               sessionId: sessionName,
               ticketId: parsed.ticketId,
               agentName: parsed.agentName,
+              role: 'worker',
               status: 'orphan',
               environment: 'host',
               exists: true,
@@ -308,6 +313,7 @@ export default class SessionList extends PromptCommand {
               sessionId: sessionName,
               ticketId: parsed.ticketId,
               agentName: parsed.agentName,
+              role: 'worker',
               status: 'orphan',
               environment: 'container',
               containerId,
@@ -331,10 +337,11 @@ export default class SessionList extends PromptCommand {
         this.log(
           styles.muted(
             '  ' +
-            visualPadEnd('Session', 34) +
+            visualPadEnd('Session', 30) +
             visualPadEnd('Ticket', 12) +
+            visualPadEnd('Role', 14) +
             visualPadEnd('Agent', 18) +
-            visualPadEnd('Type', 15) +
+            visualPadEnd('Type', 12) +
             'Status'
           )
         )
@@ -354,17 +361,21 @@ export default class SessionList extends PromptCommand {
             statusText = 'died'
           }
 
+          // Show '—' for ticket ID on daemon sessions
+          const displayTicketId = session.role === 'daemon' ? '\u2014' : session.ticketId
+
           // Truncate long session names to fit column
-          const displaySession = session.sessionId.length > 32
-            ? session.sessionId.substring(0, 29) + '...'
+          const displaySession = session.sessionId.length > 28
+            ? session.sessionId.substring(0, 25) + '...'
             : session.sessionId
 
           this.log(
             '  ' +
-            visualPadEnd(displaySession, 34) +
-            visualPadEnd(session.ticketId, 12) +
+            visualPadEnd(displaySession, 30) +
+            visualPadEnd(displayTicketId, 12) +
+            visualPadEnd(session.role, 14) +
             visualPadEnd(session.agentName, 18) +
-            visualPadEnd(typeIcon, 15) +
+            visualPadEnd(typeIcon, 12) +
             statusColor(statusText)
           )
         }

--- a/apps/cli/src/commands/session/prune.ts
+++ b/apps/cli/src/commands/session/prune.ts
@@ -28,6 +28,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { RECONCILER_SESSION_NAME } from '../reconcile/index.js'
 
 interface PruneResult {
   staleExecutionsCleaned: number
@@ -158,6 +159,17 @@ export default class SessionPrune extends PromptCommand {
 
       const matchedHostSessions = new Set<string>()
       const matchedContainerSessions = new Set<string>()
+
+      // Protect daemon sessions from being killed as orphans.
+      // Daemon sessions (reconciler, etc.) use a known naming pattern.
+      matchedHostSessions.add(RECONCILER_SESSION_NAME)
+
+      // Also protect any active daemon executions tracked in the DB
+      for (const exec of activeExecutions) {
+        if (exec.role === 'daemon' && exec.sessionId) {
+          matchedHostSessions.add(exec.sessionId)
+        }
+      }
 
       for (const exec of activeExecutions) {
         const isContainer = isContainerEnvironment(exec.environment)

--- a/apps/cli/src/lib/database/migrations/0023_add_daemon_role.ts
+++ b/apps/cli/src/lib/database/migrations/0023_add_daemon_role.ts
@@ -1,0 +1,29 @@
+/**
+ * Migration 0023 — Add daemon role to agent_work
+ *
+ * Adds a `role` column to the agent_work table to distinguish between
+ * worker, orchestrator, and daemon sessions. Daemons are long-running
+ * infrastructure processes (reconciler, rebase coordinator, etc.) that
+ * should not be pruned and survive orchestrator restarts.
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const addDaemonRole: Migration = {
+  id: '0023',
+  name: 'add_daemon_role',
+  up: (db: Database.Database) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_work'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(agent_work)").all() as { name: string }[]
+    if (tableInfo.some(col => col.name === 'role')) {
+      return // Column already exists
+    }
+
+    db.exec("ALTER TABLE agent_work ADD COLUMN role TEXT NOT NULL DEFAULT 'worker'")
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -28,6 +28,7 @@ import { gcArtifactCleanup } from './0019_gc_artifact_cleanup.js'
 import { transitionMap } from './0020_transition_map.js'
 import { notificationSystem } from './0021_notification_system.js'
 import { hookModeTiers } from './0022_hook_mode_tiers.js'
+import { addDaemonRole } from './0023_add_daemon_role.js'
 
 /**
  * Ordered list of all migrations.
@@ -56,4 +57,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   transitionMap,
   notificationSystem,
   hookModeTiers,
+  addDaemonRole,
 ]

--- a/apps/cli/src/lib/execution/storage.ts
+++ b/apps/cli/src/lib/execution/storage.ts
@@ -13,6 +13,7 @@ import { getEventBus } from '../events/event-bus.js'
 import {
   AgentWork,
   ExecutionStatus,
+  ExecutionRole,
   ExecutorType,
   ExecutionEnvironment,
   DisplayMode,
@@ -53,6 +54,7 @@ interface AgentWorkRow {
   display_mode: string
   permission_mode: string
   cleanup_policy: string
+  role: string | null
   status: string
   branch: string | null
   pid: string | null
@@ -87,6 +89,7 @@ function rowToAgentWork(row: AgentWorkRow): AgentWork {
     displayMode: (row.display_mode || 'terminal') as DisplayMode,
     permissionMode: (row.permission_mode || 'safe') as PermissionMode,
     cleanupPolicy: (row.cleanup_policy || 'on-exit') as CleanupPolicy,
+    role: (row.role || 'worker') as ExecutionRole,
     status: row.status as ExecutionStatus,
     branch: row.branch || undefined,
     pid: row.pid || undefined,
@@ -138,6 +141,7 @@ export class ExecutionStorage {
     displayMode: DisplayMode
     permissionMode: PermissionMode
     cleanupPolicy?: CleanupPolicy
+    role?: ExecutionRole
     branch?: string
     pid?: string
     containerId?: string
@@ -158,9 +162,9 @@ export class ExecutionStorage {
     this.db.prepare(`
       INSERT INTO ${T.agent_work} (
         id, ticket_id, agent_name, executor, environment, display_mode, permission_mode,
-        cleanup_policy, status, branch, pid, container_id, session_id, host, log_path,
+        cleanup_policy, role, status, branch, pid, container_id, session_id, host, log_path,
         external_source, external_key, external_id, external_url, started_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       params.ticketId,
@@ -170,6 +174,7 @@ export class ExecutionStorage {
       params.displayMode,
       params.permissionMode,
       params.cleanupPolicy || 'on-exit',
+      params.role || 'worker',
       params.branch || null,
       params.pid || null,
       params.containerId || null,
@@ -299,6 +304,8 @@ export class ExecutionStorage {
     status?: ExecutionStatus
     agentName?: string
     ticketId?: string
+    role?: ExecutionRole
+    excludeRole?: ExecutionRole
     limit?: number
   }): AgentWork[] {
     let query = `SELECT * FROM ${T.agent_work} WHERE 1=1`
@@ -315,6 +322,14 @@ export class ExecutionStorage {
     if (filter?.ticketId) {
       query += ` AND (ticket_id = ? OR external_key = ?)`
       params.push(filter.ticketId, filter.ticketId)
+    }
+    if (filter?.role) {
+      query += ` AND COALESCE(role, 'worker') = ?`
+      params.push(filter.role)
+    }
+    if (filter?.excludeRole) {
+      query += ` AND COALESCE(role, 'worker') != ?`
+      params.push(filter.excludeRole)
     }
 
     query += ` ORDER BY started_at DESC`

--- a/apps/cli/src/lib/execution/storage.ts
+++ b/apps/cli/src/lib/execution/storage.ts
@@ -430,6 +430,10 @@ export class ExecutionStorage {
     const bus = getEventBus()
 
     for (const exec of activeExecutions) {
+      // Never mark daemon executions as stale — they're supposed to run forever
+      // and will be restarted by the orchestrator if they die
+      if (exec.role === 'daemon') continue
+
       if (!exec.sessionId) {
         // Executions without sessionId might be stale from early termination
         // Check if they're older than 5 minutes and mark as stopped

--- a/apps/cli/src/lib/execution/types.ts
+++ b/apps/cli/src/lib/execution/types.ts
@@ -138,6 +138,21 @@ export type ExecutionStatus =
   | 'stopped'     // Manually terminated
 
 // =============================================================================
+// Execution Role
+// =============================================================================
+
+/**
+ * ExecutionRole — What kind of session this is.
+ * - worker: Standard agent working on a ticket (default)
+ * - orchestrator: Pipeline orchestrator managing agents
+ * - daemon: Long-running infrastructure process (reconciler, rebase coordinator, etc.)
+ */
+export type ExecutionRole =
+  | 'worker'        // Standard ticket worker (default)
+  | 'orchestrator'  // Pipeline orchestrator
+  | 'daemon'        // Long-running infrastructure daemon
+
+// =============================================================================
 // Agent Work Record
 // =============================================================================
 
@@ -151,6 +166,7 @@ export interface AgentWork {
   sessionManager?: SessionManager // How session is managed inside environment (tmux/direct)
   permissionMode: PermissionMode  // Permission mode used for this execution
   cleanupPolicy: CleanupPolicy   // Container cleanup policy for this execution
+  role: ExecutionRole            // Session role: worker, orchestrator, or daemon
   status: ExecutionStatus
   branch?: string
   pid?: string

--- a/apps/cli/src/lib/pmo/schema.ts
+++ b/apps/cli/src/lib/pmo/schema.ts
@@ -387,7 +387,8 @@ export const PMO_TABLE_SCHEMAS = {
       completed_at TIMESTAMP,
       exit_code INTEGER,
       error_message TEXT,
-      cleanup_policy TEXT NOT NULL DEFAULT 'on-exit'
+      cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker'
     )`,
 
   // Runtime ticket cache (provider-agnostic, replaces PMO dependency for agent_work)

--- a/apps/cli/test/e2e/docker-commands.test.ts
+++ b/apps/cli/test/e2e/docker-commands.test.ts
@@ -1569,6 +1569,7 @@ function setupTestDatabase(db: Database.Database) {
       sandboxed INTEGER DEFAULT 1,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'running',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/e2e/session-commands.test.ts
+++ b/apps/cli/test/e2e/session-commands.test.ts
@@ -724,7 +724,8 @@ describe('@smoke Session Commands E2E Tests', () => {
           session_id TEXT,
           container_id TEXT,
           started_at TEXT,
-          completed_at TEXT
+          completed_at TEXT,
+          role TEXT NOT NULL DEFAULT 'worker'
         );
 
         INSERT INTO agent_work (id, ticket_id, agent_name, executor, environment, status, session_id, started_at)

--- a/apps/cli/test/e2e/sync-commands.test.ts
+++ b/apps/cli/test/e2e/sync-commands.test.ts
@@ -359,6 +359,7 @@ function setupTestDatabase(db: Database.Database): void {
       sandboxed INTEGER DEFAULT 1,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'running',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/e2e/work-commands.test.ts
+++ b/apps/cli/test/e2e/work-commands.test.ts
@@ -559,6 +559,7 @@ function setupTestDatabase(db: Database.Database) {
       sandboxed INTEGER DEFAULT 1,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'running',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/e2e/work-json-mode.test.ts
+++ b/apps/cli/test/e2e/work-json-mode.test.ts
@@ -174,6 +174,7 @@ async function setupTestDatabase(db: Database.Database, pmoPath: string): Promis
       sandboxed INTEGER NOT NULL DEFAULT 0,
       permission_mode TEXT DEFAULT 'safe',
       cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+      role TEXT NOT NULL DEFAULT 'worker',
       status TEXT NOT NULL DEFAULT 'starting',
       branch TEXT,
       pid TEXT,

--- a/apps/cli/test/unit/daemon-role.test.ts
+++ b/apps/cli/test/unit/daemon-role.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for the daemon role system (PRLT-1287)
+ *
+ * Covers:
+ * - ExecutionStorage: daemon role in create/list/filter
+ * - cleanupStaleExecutions: skips daemon sessions
+ * - Reconciler helpers: isReconcilerRunning, RECONCILER_SESSION_NAME, DAEMON_TICKET_ID
+ */
+
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import { ExecutionStorage } from '../../src/lib/execution/storage.js'
+import { PMO_TABLES } from '../../src/lib/pmo/schema.js'
+import { createFastTestDb, type FastTestDb } from '../e2e/test-helpers.js'
+import {
+  RECONCILER_SESSION_NAME,
+  DAEMON_TICKET_ID,
+} from '../../src/commands/reconcile/index.js'
+
+describe('Daemon Role System (PRLT-1287)', () => {
+  let fastDb: FastTestDb
+  let db: Database.Database
+  let storage: ExecutionStorage
+
+  before(() => {
+    fastDb = createFastTestDb((db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS ${PMO_TABLES.agent_work} (
+          id TEXT PRIMARY KEY,
+          ticket_id TEXT NOT NULL,
+          agent_name TEXT NOT NULL,
+          executor TEXT NOT NULL,
+          environment TEXT DEFAULT 'host',
+          display_mode TEXT DEFAULT 'terminal',
+          permission_mode TEXT DEFAULT 'safe',
+          cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
+          status TEXT NOT NULL,
+          branch TEXT,
+          pid TEXT,
+          container_id TEXT,
+          session_id TEXT,
+          host TEXT,
+          log_path TEXT,
+          external_source TEXT,
+          external_key TEXT,
+          external_id TEXT,
+          external_url TEXT,
+          started_at INTEGER NOT NULL,
+          completed_at INTEGER,
+          exit_code INTEGER,
+          error_message TEXT,
+          last_heartbeat TEXT,
+          lifecycle_state TEXT,
+          retries INTEGER
+        )
+      `)
+    })
+    db = fastDb.db
+  })
+
+  beforeEach(() => {
+    fastDb.savepoint()
+    storage = new ExecutionStorage(db)
+  })
+
+  afterEach(() => {
+    fastDb.rollback()
+  })
+
+  after(() => {
+    fastDb.close()
+  })
+
+  // ===========================================================================
+  // Constants
+  // ===========================================================================
+
+  describe('constants', () => {
+    it('RECONCILER_SESSION_NAME follows daemon naming convention', () => {
+      expect(RECONCILER_SESSION_NAME).to.equal('prlt-daemon-reconciler')
+    })
+
+    it('DAEMON_TICKET_ID is DAEMON', () => {
+      expect(DAEMON_TICKET_ID).to.equal('DAEMON')
+    })
+  })
+
+  // ===========================================================================
+  // ExecutionStorage: role field
+  // ===========================================================================
+
+  describe('ExecutionStorage role support', () => {
+    it('defaults role to worker when not specified', () => {
+      const exec = storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'test-agent',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        permissionMode: 'safe',
+      })
+      expect(exec.role).to.equal('worker')
+    })
+
+    it('creates execution with daemon role', () => {
+      const exec = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: 'reconciler',
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+        sessionId: RECONCILER_SESSION_NAME,
+      })
+      expect(exec.role).to.equal('daemon')
+      expect(exec.agentName).to.equal('reconciler')
+      expect(exec.ticketId).to.equal(DAEMON_TICKET_ID)
+    })
+
+    it('creates execution with orchestrator role', () => {
+      const exec = storage.createExecution({
+        ticketId: 'ORCH',
+        agentName: 'main',
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'orchestrator',
+      })
+      expect(exec.role).to.equal('orchestrator')
+    })
+
+    it('filters by role', () => {
+      // Create one of each role
+      storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'worker-agent',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+      storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: 'reconciler',
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+      })
+
+      const workers = storage.listExecutions({ role: 'worker' })
+      expect(workers).to.have.lengthOf(1)
+      expect(workers[0].agentName).to.equal('worker-agent')
+
+      const daemons = storage.listExecutions({ role: 'daemon' })
+      expect(daemons).to.have.lengthOf(1)
+      expect(daemons[0].agentName).to.equal('reconciler')
+    })
+
+    it('excludeRole filters out a specific role', () => {
+      storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'worker-agent',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        permissionMode: 'safe',
+      })
+      storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: 'reconciler',
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+      })
+
+      const nonDaemons = storage.listExecutions({ excludeRole: 'daemon' })
+      expect(nonDaemons).to.have.lengthOf(1)
+      expect(nonDaemons[0].agentName).to.equal('worker-agent')
+    })
+  })
+
+  // ===========================================================================
+  // cleanupStaleExecutions: skips daemons
+  // ===========================================================================
+
+  describe('cleanupStaleExecutions skips daemons', () => {
+    it('does not mark daemon executions as stale even without sessionId', () => {
+      // Create a daemon execution with no session ID and old start time
+      const exec = storage.createExecution({
+        ticketId: DAEMON_TICKET_ID,
+        agentName: 'reconciler',
+        executor: 'custom',
+        environment: 'host',
+        displayMode: 'background',
+        permissionMode: 'safe',
+        role: 'daemon',
+      })
+      storage.updateStatus(exec.id, 'running')
+
+      // Manually backdate it to look stale (>5 min old with no session)
+      db.prepare(`UPDATE ${PMO_TABLES.agent_work} SET started_at = ? WHERE id = ?`)
+        .run(Date.now() - 10 * 60 * 1000, exec.id)
+
+      const cleaned = storage.cleanupStaleExecutions()
+      expect(cleaned).to.equal(0)
+
+      // Verify daemon is still running
+      const running = storage.listExecutions({ status: 'running', role: 'daemon' })
+      expect(running).to.have.lengthOf(1)
+      expect(running[0].id).to.equal(exec.id)
+    })
+
+    it('still marks worker executions as stale', () => {
+      // Create a worker execution with no session ID and old start time
+      const exec = storage.createExecution({
+        ticketId: 'TKT-001',
+        agentName: 'test-worker',
+        executor: 'claude-code',
+        environment: 'host',
+        displayMode: 'terminal',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+      storage.updateStatus(exec.id, 'running')
+
+      // Backdate it to look stale
+      db.prepare(`UPDATE ${PMO_TABLES.agent_work} SET started_at = ? WHERE id = ?`)
+        .run(Date.now() - 10 * 60 * 1000, exec.id)
+
+      const cleaned = storage.cleanupStaleExecutions()
+      expect(cleaned).to.equal(1)
+
+      // Verify worker is now stopped
+      const running = storage.listExecutions({ status: 'running', role: 'worker' })
+      expect(running).to.have.lengthOf(0)
+    })
+  })
+
+  // ===========================================================================
+  // Session list: role in VerifiedSession
+  // ===========================================================================
+
+  describe('daemon display formatting', () => {
+    it('daemon ticket ID should show as DAEMON not a ticket', () => {
+      // Verify our sentinel value is distinct from ticket IDs
+      expect(DAEMON_TICKET_ID).to.not.match(/^TKT-/)
+      expect(DAEMON_TICKET_ID).to.not.match(/^PRLT-/)
+    })
+
+    it('reconciler session name does not match prlt session naming pattern', () => {
+      // The parseSessionName function expects {ticketId}-{action}-{agentName}
+      // Daemon sessions use prlt-daemon-{type} which should NOT match,
+      // preventing them from being treated as orphans
+      expect(RECONCILER_SESSION_NAME).to.match(/^prlt-daemon-/)
+      expect(RECONCILER_SESSION_NAME).to.not.match(/^TKT-/)
+      expect(RECONCILER_SESSION_NAME).to.not.match(/^[A-Z]+-\d+-/)
+    })
+  })
+})

--- a/apps/cli/test/unit/execution-storage.test.ts
+++ b/apps/cli/test/unit/execution-storage.test.ts
@@ -29,6 +29,7 @@ describe('@smoke ExecutionStorage', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/execution-view.test.ts
+++ b/apps/cli/test/unit/execution-view.test.ts
@@ -27,6 +27,7 @@ describe('ExecutionView', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/heartbeat-watcher.test.ts
+++ b/apps/cli/test/unit/heartbeat-watcher.test.ts
@@ -35,6 +35,7 @@ describe('@smoke Heartbeat + Timeout Detection', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/orchestrate-daemon-supervised.test.ts
+++ b/apps/cli/test/unit/orchestrate-daemon-supervised.test.ts
@@ -56,7 +56,8 @@ function createTestDb(): Database.Database {
       status TEXT NOT NULL DEFAULT 'starting',
       lifecycle_state TEXT,
       container_id TEXT,
-      last_heartbeat TEXT
+      last_heartbeat TEXT,
+      role TEXT NOT NULL DEFAULT 'worker'
     )
   `)
   db.exec(`

--- a/apps/cli/test/unit/orchestrate-poller.test.ts
+++ b/apps/cli/test/unit/orchestrate-poller.test.ts
@@ -55,7 +55,8 @@ function createTestDb(): Database.Database {
       status TEXT NOT NULL DEFAULT 'starting',
       lifecycle_state TEXT,
       container_id TEXT,
-      last_heartbeat TEXT
+      last_heartbeat TEXT,
+      role TEXT NOT NULL DEFAULT 'worker'
     )
   `)
 

--- a/apps/cli/test/unit/session-db-first.test.ts
+++ b/apps/cli/test/unit/session-db-first.test.ts
@@ -57,6 +57,7 @@ describe('@smoke Session DB-First (PRLT-1139)', () => {
             display_mode TEXT DEFAULT 'terminal',
             permission_mode TEXT DEFAULT 'safe',
             cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+            role TEXT NOT NULL DEFAULT 'worker',
             status TEXT NOT NULL,
             branch TEXT,
             pid TEXT,

--- a/apps/cli/test/unit/session-report-cleanup.test.ts
+++ b/apps/cli/test/unit/session-report-cleanup.test.ts
@@ -31,6 +31,7 @@ describe('@smoke Session Report Cleanup Logic', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/session-report-safety-net.test.ts
+++ b/apps/cli/test/unit/session-report-safety-net.test.ts
@@ -36,6 +36,7 @@ describe('@smoke PRLT-1129: Session Report Safety Net', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/spawner.test.ts
+++ b/apps/cli/test/unit/spawner.test.ts
@@ -62,6 +62,7 @@ describe('Spawner', () => {
           display_mode TEXT DEFAULT 'terminal',
           permission_mode TEXT DEFAULT 'safe',
           cleanup_policy TEXT NOT NULL DEFAULT 'on-exit',
+          role TEXT NOT NULL DEFAULT 'worker',
           status TEXT NOT NULL,
           branch TEXT,
           pid TEXT,

--- a/apps/cli/test/unit/workflow-config.test.ts
+++ b/apps/cli/test/unit/workflow-config.test.ts
@@ -433,7 +433,8 @@ describe('Poller Ready Status Resolution', () => {
         id TEXT PRIMARY KEY,
         ticket_id TEXT NOT NULL,
         agent_name TEXT NOT NULL,
-        status TEXT NOT NULL DEFAULT 'starting'
+        status TEXT NOT NULL DEFAULT 'starting',
+        role TEXT NOT NULL DEFAULT 'worker'
       )
     `)
     return db


### PR DESCRIPTION
## Summary

- Add `daemon` execution role to the session system (alongside `worker` and `orchestrator`)
- Create `prlt reconcile` command that spawns a tmux-based reconciler daemon
- Reconciler registers in `agent_work` with `role: 'daemon'` and survives terminal close
- `prlt session list` shows daemon sessions with role column and `—` for ticket ID
- `prlt session prune` protects daemon sessions from being reaped
- `prlt orchestrate` auto-spawns the reconciler on startup and restarts it if it dies
- Database migration 0023 adds `role` column to `agent_work` table

## Test plan

- [x] Unit tests: daemon role create/list/filter on ExecutionStorage
- [x] Unit tests: `cleanupStaleExecutions` skips daemon sessions
- [x] Unit tests: daemon session naming prevents orphan detection
- [x] Smoke tests: 599 passing, 0 failures
- [x] Build: compiles clean with no errors

Linear: https://linear.app/integrated-ventures/issue/PRLT-1287/reconciler-as-supervised-daemon-register-in-machinedb-spawn-from