### PR TITLE
fix(PRLT-1276): sandbox npm prefix in tests and fix restore race condition

### DIFF
--- a/apps/cli/.mocharc.json
+++ b/apps/cli/.mocharc.json
@@ -1,6 +1,7 @@
 {
   "require": [
     "ts-node/register",
+    "test/setup/npm-sandbox.ts",
     "test/setup/native-sqlite-check.ts",
     "test/setup/worker-graceful-exit.ts"
   ],

--- a/apps/cli/src/lib/update-check.ts
+++ b/apps/cli/src/lib/update-check.ts
@@ -522,18 +522,50 @@ export function backupNpmPackageDir(): NpmPackageBackup | null {
 
 /**
  * Restore the backup created by {@link backupNpmPackageDir} after a failed
- * retry. Removes any partially-installed content at the original path,
- * renames the backup back into place, and re-creates bin symlinks that npm
- * may have removed during the failed install.
+ * retry. Moves any partially-installed content aside, renames the backup
+ * back into place, and re-creates bin symlinks that npm may have removed
+ * during the failed install.
+ *
+ * PRLT-1276 race-condition fix: we never delete the original path before
+ * confirming the backup rename succeeds. In concurrent environments
+ * (multiple agents), another process may discard our backup between our
+ * existence check and our rename. The old code deleted first then renamed,
+ * which could leave both the original and backup gone if the rename failed.
  */
 export function restoreNpmPackageBackup(info: NpmPackageBackup): boolean {
   try {
     if (info.backupPath) {
-      // Clear out any partial install from the failed retry
+      // Move (not delete) any partial install aside first, so we can
+      // roll back if the backup rename fails.
+      const tempPath = `${info.originalPath}.prlt-restore-tmp-${Date.now()}-${process.pid}`
+      let hadOriginal = false
+
       if (fs.existsSync(info.originalPath)) {
-        fs.rmSync(info.originalPath, { recursive: true, force: true })
+        try {
+          fs.renameSync(info.originalPath, tempPath)
+          hadOriginal = true
+        } catch {
+          // Can't move the original aside — leave it in place rather
+          // than risk losing both copies.
+          return false
+        }
       }
-      fs.renameSync(info.backupPath, info.originalPath)
+
+      try {
+        fs.renameSync(info.backupPath, info.originalPath)
+      } catch {
+        // Backup is gone (race with another process) or rename failed.
+        // Restore the original we just moved aside.
+        if (hadOriginal) {
+          try { fs.renameSync(tempPath, info.originalPath) } catch { /* best effort */ }
+        }
+        return false
+      }
+
+      // Rename succeeded — clean up the old partial install
+      if (hadOriginal) {
+        try { fs.rmSync(tempPath, { recursive: true, force: true }) } catch { /* best effort */ }
+      }
     }
 
     // Restore any bin symlinks that npm removed during the failed install.

--- a/apps/cli/test/setup/npm-sandbox.ts
+++ b/apps/cli/test/setup/npm-sandbox.ts
@@ -1,0 +1,20 @@
+/**
+ * Mocha root hook: global npm prefix sandbox (PRLT-1276).
+ *
+ * Sets PRLT_NPM_MODULES_DIR_OVERRIDE to a safe dummy path so that no test
+ * can accidentally operate on the host's real global npm prefix. Individual
+ * tests that exercise backup/restore logic create their own temp prefix and
+ * override the env var in beforeEach; this root hook is a safety net that
+ * catches any code path that forgets to set the override.
+ *
+ * Without this, a bug or missing setup in a single test could wipe the
+ * globally installed prlt binary — exactly the PRLT-1276 failure mode.
+ */
+
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const sandboxDir = mkdtempSync(join(tmpdir(), 'prlt-npm-test-sandbox-'))
+
+process.env.PRLT_NPM_MODULES_DIR_OVERRIDE = join(sandboxDir, 'lib', 'node_modules')

--- a/apps/cli/test/unit/npm-enotempty-retry.test.ts
+++ b/apps/cli/test/unit/npm-enotempty-retry.test.ts
@@ -70,10 +70,32 @@ function installFakePrlt(packageDir: string, binDir: string): void {
 // ---------------------------------------------------------------------------
 
 describe('npm ENOTEMPTY retry (PRLT-1228, PRLT-1276)', () => {
+  // =========================================================================
+  // PRLT-1276 regression: sandbox safety net
+  // =========================================================================
+  describe('PRLT-1276: npm sandbox safety net', () => {
+    it('PRLT_NPM_MODULES_DIR_OVERRIDE is set by the mocha root hook', () => {
+      // The npm-sandbox.ts root hook MUST set this env var before any test
+      // runs, so no test can accidentally operate on the real global npm
+      // prefix. If this fails, the root hook is missing or broken.
+      expect(process.env.PRLT_NPM_MODULES_DIR_OVERRIDE).to.be.a('string')
+      expect(process.env.PRLT_NPM_MODULES_DIR_OVERRIDE!.length).to.be.greaterThan(0)
+    })
+
+    it('getNpmGlobalModulesDir returns the override, not the real prefix', () => {
+      // With the root hook active, getNpmGlobalModulesDir() must return
+      // the sandboxed path. If it returns a path under ~/.nvm or
+      // /usr/local, the sandbox is broken.
+      const result = getNpmGlobalModulesDir()
+      expect(result).to.not.be.null
+      expect(result).to.equal(process.env.PRLT_NPM_MODULES_DIR_OVERRIDE)
+    })
+  })
+
   describe('getNpmGlobalModulesDir', () => {
     it('returns a path ending in lib/node_modules when npm is available', () => {
-      // No override — exercises the real code path. We don't care about the
-      // exact value, only that it ends with the expected suffix.
+      // Temporarily clear the override to exercise the real code path.
+      // This is READ-ONLY — getNpmGlobalModulesDir only runs `npm prefix -g`.
       const previous = process.env.PRLT_NPM_MODULES_DIR_OVERRIDE
       delete process.env.PRLT_NPM_MODULES_DIR_OVERRIDE
       try {
@@ -81,9 +103,8 @@ describe('npm ENOTEMPTY retry (PRLT-1228, PRLT-1276)', () => {
         expect(result).to.not.be.null
         expect(result!).to.match(/lib\/node_modules$/)
       } finally {
-        if (previous !== undefined) {
-          process.env.PRLT_NPM_MODULES_DIR_OVERRIDE = previous
-        }
+        // Always restore — the root hook set this, so previous is non-null
+        process.env.PRLT_NPM_MODULES_DIR_OVERRIDE = previous!
       }
     })
 
@@ -659,6 +680,69 @@ describe('npm ENOTEMPTY retry (PRLT-1228, PRLT-1276)', () => {
       // Both backups should be cleaned up
       expect(fs.existsSync(oldBackup)).to.be.false
       expect(fs.existsSync(newBackup)).to.be.false
+    })
+  })
+
+  // =========================================================================
+  // PRLT-1276: race-condition regression tests for restoreNpmPackageBackup
+  // =========================================================================
+  describe('PRLT-1276: restoreNpmPackageBackup race-condition safety', () => {
+    let fake: ReturnType<typeof createFakeNpmPrefix>
+    let previousOverride: string | undefined
+
+    beforeEach(() => {
+      fake = createFakeNpmPrefix()
+      previousOverride = process.env.PRLT_NPM_MODULES_DIR_OVERRIDE
+      process.env.PRLT_NPM_MODULES_DIR_OVERRIDE = fake.modulesDir
+    })
+
+    afterEach(() => {
+      if (previousOverride === undefined) {
+        delete process.env.PRLT_NPM_MODULES_DIR_OVERRIDE
+      } else {
+        process.env.PRLT_NPM_MODULES_DIR_OVERRIDE = previousOverride
+      }
+      fake.cleanup()
+    })
+
+    it('preserves the original when backup has been stolen by another process', () => {
+      installFakePrlt(fake.packageDir, fake.binDir)
+      fs.writeFileSync(path.join(fake.packageDir, 'marker.txt'), 'original')
+
+      // Simulate: backup was created but then deleted by a concurrent process
+      const info = backupNpmPackageDir()!
+      // Put the original back (simulating a concurrent successful install)
+      fs.mkdirSync(fake.packageDir, { recursive: true })
+      fs.writeFileSync(path.join(fake.packageDir, 'marker.txt'), 'new-install')
+      // Delete the backup (simulating concurrent discardNpmPackageBackup)
+      fs.rmSync(info.backupPath, { recursive: true, force: true })
+
+      // restoreNpmPackageBackup must NOT destroy the new install when the
+      // backup is gone — this was the PRLT-1276 race condition.
+      const ok = restoreNpmPackageBackup(info)
+      expect(ok).to.be.false
+
+      // The new install must still be intact
+      expect(fs.existsSync(fake.packageDir), 'package dir must survive').to.be.true
+      expect(fs.readFileSync(path.join(fake.packageDir, 'marker.txt'), 'utf-8')).to.equal('new-install')
+    })
+
+    it('does not leave temp rename artifacts on restore failure', () => {
+      installFakePrlt(fake.packageDir, fake.binDir)
+
+      const info = backupNpmPackageDir()!
+      // Restore original (simulating concurrent restore)
+      fs.mkdirSync(fake.packageDir, { recursive: true })
+      // Delete backup
+      fs.rmSync(info.backupPath, { recursive: true, force: true })
+
+      restoreNpmPackageBackup(info)
+
+      // No .prlt-restore-tmp-* directories should be left behind
+      const proletariatDir = path.join(fake.modulesDir, '@proletariat')
+      const entries = fs.readdirSync(proletariatDir)
+      const tempArtifacts = entries.filter(e => e.includes('prlt-restore-tmp'))
+      expect(tempArtifacts).to.have.lengthOf(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1133. Fixes the root cause of PRLT-1276 where the prlt binary gets wiped during test runs.

- **Add mocha root hook `npm-sandbox.ts`** — sets `PRLT_NPM_MODULES_DIR_OVERRIDE` before any test runs as a safety net, ensuring no test can accidentally operate on the host's real global npm prefix
- **Fix race condition in `restoreNpmPackageBackup`** — the old code deleted the original package dir before renaming the backup into place; if the backup had been stolen by a concurrent process, both copies were lost. New code uses rename-aside (not delete) so the original can be recovered if the backup rename fails
- **Add 4 regression tests** — sandbox safety net verification + race condition coverage

## Test plan

- [x] All 34 tests in `npm-enotempty-retry.test.ts` pass (including 4 new)
- [x] `pnpm build` passes
- [x] Pre-existing test failures (staleTap, runtimeCommand, reviewAgent) confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>