### PR TITLE
feat(PRLT-1287): Reconciler as supervised daemon

### DIFF
--- a/apps/cli/src/commands/hook/export.ts
+++ b/apps/cli/src/commands/hook/export.ts
@@ -1,0 +1,69 @@
+/**
+ * prlt hook export — Export hook configuration to YAML.
+ *
+ * Dumps the current hook configuration from the database as YAML,
+ * suitable for saving to .proletariat/hooks.yml.
+ */
+
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { exportHooksToYaml } from '../../lib/orchestrate/index.js'
+
+export default class HookExport extends PMOCommand {
+  static description = 'Export hook configuration as YAML'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(HookExport)
+    const jsonMode = shouldOutputJson(flags)
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook export', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      const yamlContent = exportHooksToYaml(db)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { yaml: yamlContent },
+          createMetadata('hook export', flags),
+        )
+        return
+      }
+
+      this.log(styles.title('Hook Configuration (YAML)'))
+      this.log('')
+      this.log(yamlContent)
+      this.log(styles.muted('  Save to .proletariat/hooks.yml to version control'))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/fire.ts
+++ b/apps/cli/src/commands/hook/fire.ts
@@ -1,0 +1,172 @@
+/**
+ * prlt hook fire <event> — Manually fire an orchestrate event.
+ *
+ * This is the bridge between external event sources (GitHub Actions, polling, etc.)
+ * and the internal orchestrate engine. When an external system detects an event
+ * (e.g., CI passes), it runs `prlt hook fire on_ci_green --pr 123` to trigger
+ * the configured hooks.
+ */
+
+import { Args, Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import {
+  OrchestrateEngine,
+  ORCHESTRATE_EVENTS,
+} from '../../lib/orchestrate/index.js'
+import type { OrchestrateEventContext } from '../../lib/orchestrate/index.js'
+
+export default class HookFire extends PMOCommand {
+  static description = 'Fire an orchestrate event to trigger configured hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> on_ci_green --pr 123',
+    '<%= config.bin %> <%= command.id %> on_pr_merged --ticket TKT-100 --pr 456',
+    '<%= config.bin %> <%= command.id %> on_ticket_ready --ticket TKT-200',
+    '<%= config.bin %> <%= command.id %> on_agent_died --ticket TKT-100 --agent bold-turing',
+  ]
+
+  static args = {
+    event: Args.string({
+      description: 'Event name to fire',
+      required: true,
+      options: ORCHESTRATE_EVENTS,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+    ticket: Flags.string({
+      description: 'Ticket ID',
+      char: 't',
+    }),
+    pr: Flags.integer({
+      description: 'PR number',
+    }),
+    branch: Flags.string({
+      description: 'Branch name',
+    }),
+    agent: Flags.string({
+      description: 'Agent name',
+    }),
+    action: Flags.string({
+      description: 'Action to execute (for direct invocation)',
+    }),
+    'pr-url': Flags.string({
+      description: 'PR URL',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Show what would happen without executing',
+      default: false,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(HookFire)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook fire', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      const ctx: OrchestrateEventContext = {
+        event: args.event,
+        ticket: parsedFlags.ticket as string | undefined,
+        pr: parsedFlags.pr as number | undefined,
+        branch: parsedFlags.branch as string | undefined,
+        agent: parsedFlags.agent as string | undefined,
+        prUrl: parsedFlags['pr-url'] as string | undefined,
+      }
+
+      if (parsedFlags['dry-run']) {
+        // Show what hooks would fire
+        const hooks = db.prepare(
+          'SELECT name, event, action_type, action_value, mode FROM pmo_work_hooks WHERE event = ? AND enabled = 1 ORDER BY priority ASC'
+        ).all(args.event) as Array<{ name: string; event: string; action_type: string; action_value: string; mode?: string }>
+
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { event: args.event, hooks, context: ctx, dryRun: true },
+            createMetadata('hook fire', flags),
+          )
+          return
+        }
+
+        if (hooks.length === 0) {
+          this.log(styles.info(`No hooks configured for event: ${args.event}`))
+          return
+        }
+
+        this.log(styles.title(`Dry run: ${args.event}`))
+        this.log('')
+        for (const hook of hooks) {
+          const mode = hook.mode || 'auto'
+          this.log(`  ${styles.code(hook.name)} ${styles.muted('→')} ${hook.action_value} ${styles.muted(`(${mode})`)}`)
+        }
+        this.log('')
+        this.log(styles.muted(`${hooks.length} hook${hooks.length === 1 ? '' : 's'} would fire`))
+        return
+      }
+
+      // Create engine and fire event
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          if (!jsonMode) this.log(styles.muted(msg))
+        },
+      })
+
+      const results = await engine.fireEvent(args.event, ctx)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { event: args.event, results, context: ctx },
+          createMetadata('hook fire', flags),
+        )
+        return
+      }
+
+      if (results.length === 0) {
+        this.log(styles.info(`No hooks configured for event: ${args.event}`))
+        return
+      }
+
+      this.log(styles.title(`Fired: ${args.event}`))
+      this.log('')
+      for (const result of results) {
+        const status = result.skipped
+          ? styles.muted('skipped')
+          : result.awaitingConfirmation
+            ? styles.warning('awaiting confirmation')
+            : result.success
+              ? styles.success('success')
+              : styles.error(`failed: ${result.error}`)
+        this.log(`  ${styles.code(result.action)} ${styles.muted('→')} ${status} ${styles.muted(`(${result.durationMs}ms)`)}`)
+      }
+      this.log('')
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/index.ts
+++ b/apps/cli/src/commands/hook/index.ts
@@ -1,0 +1,60 @@
+/**
+ * prlt hook — Interactive menu for orchestrate hooks.
+ */
+
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { shouldOutputJson } from '../../lib/prompt-json.js'
+
+export default class Hook extends PMOCommand {
+  static description = 'Manage orchestrate hooks (event-driven pipeline automation)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> hook fire on_ci_green --pr 123',
+    '<%= config.bin %> hook list',
+    '<%= config.bin %> hook preset supervised',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Hook)
+    const jsonMode = shouldOutputJson(flags)
+
+    const menuChoices = [
+      { id: 'list', name: 'List configured hooks', command: 'prlt hook list --json' },
+      { id: 'fire', name: 'Fire an event', command: 'prlt hook fire --json' },
+      { id: 'preset', name: 'Apply a preset', command: 'prlt hook preset --json' },
+      { id: 'add', name: 'Add a new hook', command: 'prlt work hooks add --json' },
+      { id: 'cancel', name: 'Cancel', command: '' },
+    ]
+
+    const action = await this.selectFromList({
+      message: 'Orchestrate Hooks - What would you like to do?',
+      items: menuChoices,
+      getName: (c) => c.name,
+      getValue: (c) => c.id,
+      getCommand: (c) => c.command,
+      jsonMode: jsonMode ? { flags, commandName: 'hook' } : null,
+    })
+
+    if (action === 'cancel' || !action) return
+
+    switch (action) {
+      case 'list':
+        await this.config.runCommand('hook:list')
+        break
+      case 'fire':
+        await this.config.runCommand('hook:fire')
+        break
+      case 'preset':
+        await this.config.runCommand('hook:preset')
+        break
+      case 'add':
+        await this.config.runCommand('work:hooks:add')
+        break
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/list.ts
+++ b/apps/cli/src/commands/hook/list.ts
@@ -1,0 +1,177 @@
+/**
+ * prlt hook list — List all configured orchestrate hooks.
+ *
+ * Shows hooks with their mode, priority, and source.
+ */
+
+import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { ORCHESTRATE_EVENTS } from '../../lib/orchestrate/index.js'
+
+interface HookRow {
+  id: string
+  name: string
+  event: string
+  action_type: string
+  action_value: string
+  enabled: number
+  description: string | null
+  mode: string | null
+  priority: number | null
+  source: string | null
+  config: string | null
+  created_at: string
+}
+
+export default class HookList extends PMOCommand {
+  static description = 'List configured orchestrate hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --event on_ci_green',
+    '<%= config.bin %> <%= command.id %> --mode auto',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    event: Flags.string({
+      description: 'Filter by event name',
+    }),
+    mode: Flags.string({
+      description: 'Filter by mode (auto, confirm, notify, off)',
+      options: ['auto', 'confirm', 'notify', 'off'],
+    }),
+    source: Flags.string({
+      description: 'Filter by source (yaml, cli, preset)',
+      options: ['yaml', 'cli', 'preset'],
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(HookList)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook list', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      let sql = 'SELECT * FROM pmo_work_hooks WHERE 1=1'
+      const params: unknown[] = []
+
+      if (parsedFlags.event) {
+        sql += ' AND event = ?'
+        params.push(parsedFlags.event)
+      }
+
+      if (parsedFlags.mode) {
+        sql += ' AND mode = ?'
+        params.push(parsedFlags.mode)
+      }
+
+      if (parsedFlags.source) {
+        sql += ' AND source = ?'
+        params.push(parsedFlags.source)
+      }
+
+      sql += ' ORDER BY event ASC, priority ASC, created_at ASC'
+
+      let hooks: HookRow[]
+      try {
+        hooks = db.prepare(sql).all(...params) as HookRow[]
+      } catch {
+        // Fallback without new columns
+        hooks = db.prepare('SELECT * FROM pmo_work_hooks ORDER BY created_at ASC').all() as HookRow[]
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            hooks: hooks.map(h => ({
+              id: h.id,
+              name: h.name,
+              event: h.event,
+              actionType: h.action_type,
+              actionValue: h.action_value,
+              enabled: h.enabled === 1,
+              mode: h.mode || 'auto',
+              priority: h.priority ?? 0,
+              source: h.source || 'cli',
+              description: h.description,
+              config: h.config ? JSON.parse(h.config) : null,
+            })),
+            count: hooks.length,
+          },
+          createMetadata('hook list', flags),
+        )
+        return
+      }
+
+      if (hooks.length === 0) {
+        this.log(styles.info('No hooks configured.'))
+        this.log(styles.muted('  Add one with: prlt work hooks add'))
+        this.log(styles.muted('  Or apply a preset: prlt hook preset supervised'))
+        return
+      }
+
+      this.log(styles.title('Orchestrate Hooks'))
+      this.log('')
+
+      // Group by event
+      const grouped: Record<string, HookRow[]> = {}
+      for (const hook of hooks) {
+        if (!grouped[hook.event]) grouped[hook.event] = []
+        grouped[hook.event].push(hook)
+      }
+
+      for (const [event, eventHooks] of Object.entries(grouped)) {
+        this.log(`  ${styles.emphasis(event)}`)
+        for (const hook of eventHooks) {
+          const enabled = hook.enabled === 1
+          const mode = hook.mode || 'auto'
+          const source = hook.source || 'cli'
+          const status = !enabled
+            ? styles.muted('off')
+            : mode === 'auto'
+              ? styles.success('auto')
+              : mode === 'confirm'
+                ? styles.warning('confirm')
+                : mode === 'notify'
+                  ? styles.info('notify')
+                  : styles.muted('off')
+
+          this.log(`    ${status} ${styles.code(hook.action_value)} ${styles.muted(`[${source}]`)}`)
+          if (hook.description) {
+            this.log(`         ${styles.muted(hook.description)}`)
+          }
+        }
+        this.log('')
+      }
+
+      this.log(styles.muted(`  ${hooks.length} hook${hooks.length === 1 ? '' : 's'} configured`))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/hook/preset.ts
+++ b/apps/cli/src/commands/hook/preset.ts
@@ -1,0 +1,96 @@
+/**
+ * prlt hook preset <name> — Apply a hook preset.
+ *
+ * Presets:
+ * - aggressive: auto everything
+ * - conservative: confirm everything
+ * - supervised: auto for safe ops, confirm for destructive
+ */
+
+import { Args } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { applyPreset, PRESET_NAMES, PRESETS } from '../../lib/orchestrate/index.js'
+import type { PresetName } from '../../lib/orchestrate/index.js'
+
+export default class HookPreset extends PMOCommand {
+  static description = 'Apply a hook preset (aggressive, conservative, supervised)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> aggressive',
+    '<%= config.bin %> <%= command.id %> conservative',
+    '<%= config.bin %> <%= command.id %> supervised',
+  ]
+
+  static args = {
+    preset: Args.string({
+      description: 'Preset name to apply',
+      required: true,
+      options: PRESET_NAMES,
+    }),
+  }
+
+  static flags = {
+    ...pmoBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(HookPreset)
+    const jsonMode = shouldOutputJson(flags)
+    const presetName = args.preset as PresetName
+
+    if (!PRESET_NAMES.includes(presetName)) {
+      if (jsonMode) {
+        outputErrorAsJson('INVALID_PRESET', `Unknown preset: ${presetName}. Valid: ${PRESET_NAMES.join(', ')}`, createMetadata('hook preset', flags))
+        return
+      }
+      this.error(`Unknown preset: ${presetName}. Valid: ${PRESET_NAMES.join(', ')}`)
+    }
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('hook preset', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+
+    try {
+      const count = applyPreset(db, presetName)
+      const preset = PRESETS[presetName]
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            preset: presetName,
+            description: preset.description,
+            hooksApplied: count,
+          },
+          createMetadata('hook preset', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Applied preset: ${presetName}`))
+      this.log(styles.muted(`  ${preset.description}`))
+      this.log(styles.muted(`  ${count} hooks configured`))
+    } finally {
+      db.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -1,0 +1,300 @@
+/**
+ * prlt orchestrate — Autonomous pipeline daemon with event-driven hooks.
+ *
+ * Starts the orchestrate engine which:
+ * 1. Loads hook configuration from DB (synced from YAML/presets/CLI)
+ * 2. Subscribes to EventBus events for internal triggers
+ * 3. Optionally polls external sources (Linear, GitHub) for events
+ * 4. Executes matching hooks with mode-aware behavior (auto/confirm/notify/off)
+ *
+ * External events can also be fired via `prlt hook fire <event>`.
+ */
+
+import { Flags } from '@oclif/core'
+import * as path from 'node:path'
+import { SqliteDatabase } from '../../lib/database/sqlite.js'
+import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
+import { styles } from '../../lib/styles.js'
+import { getWorkspaceInfo } from '../../lib/agents/commands.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import {
+  OrchestrateEngine,
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  PRESET_NAMES,
+} from '../../lib/orchestrate/index.js'
+import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
+import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
+import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
+import { setupSignalHandler } from '../../lib/signal-handler.js'
+
+export default class Orchestrate extends PMOCommand {
+  static description = 'Start the autonomous pipeline daemon with event-driven hooks'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --preset supervised',
+    '<%= config.bin %> <%= command.id %> --load-yaml',
+    '<%= config.bin %> <%= command.id %> --poll-interval 300',
+    '<%= config.bin %> <%= command.id %> --once on_ci_green --pr 123',
+  ]
+
+  static flags = {
+    ...pmoBaseFlags,
+    preset: Flags.string({
+      description: 'Apply a preset before starting (aggressive, conservative, supervised)',
+      options: PRESET_NAMES,
+    }),
+    'load-yaml': Flags.boolean({
+      description: 'Load hooks from .proletariat/hooks.yml before starting',
+      default: false,
+    }),
+    'poll-interval': Flags.integer({
+      description: 'Poll interval in seconds for external event sources (0 to disable)',
+      default: 0,
+    }),
+    once: Flags.string({
+      description: 'Fire a single event and exit (useful for CI/GitHub Actions)',
+    }),
+    ticket: Flags.string({
+      description: 'Ticket ID (for --once)',
+      char: 't',
+    }),
+    pr: Flags.integer({
+      description: 'PR number (for --once)',
+    }),
+    branch: Flags.string({
+      description: 'Branch name (for --once)',
+    }),
+    agent: Flags.string({
+      description: 'Agent name (for --once)',
+    }),
+    verbose: Flags.boolean({
+      description: 'Show detailed output',
+      char: 'v',
+      default: false,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(Orchestrate)
+    const jsonMode = shouldOutputJson(flags)
+    const parsedFlags = flags as Record<string, unknown>
+
+    let workspaceInfo
+    try {
+      workspaceInfo = getWorkspaceInfo()
+    } catch {
+      if (jsonMode) {
+        outputErrorAsJson('NOT_IN_WORKSPACE', 'Not in a workspace. Run "prlt new" first.', createMetadata('orchestrate', flags))
+        return
+      }
+      this.error('Not in a workspace. Run "prlt new" first.')
+    }
+
+    const dbPath = path.join(workspaceInfo.path, '.proletariat', 'workspace.db')
+    const db = new SqliteDatabase(dbPath)
+    const verbose = parsedFlags.verbose as boolean
+
+    try {
+      // Load YAML config if requested
+      if (parsedFlags['load-yaml']) {
+        const hooksYaml = loadHooksYaml(workspaceInfo.path)
+        if (hooksYaml) {
+          const count = syncHooksFromYaml(db, hooksYaml)
+          this.log(styles.muted(`  Loaded ${count} hooks from hooks.yml`))
+        } else {
+          this.log(styles.muted('  No .proletariat/hooks.yml found'))
+        }
+
+        const workflowYaml = loadWorkflowYaml(workspaceInfo.path)
+        if (workflowYaml) {
+          this.log(styles.muted('  Loaded workflow.yml'))
+          // Store workflow config in settings for later use
+          if (workflowYaml.branches?.target) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.branches.target', ?)").run(workflowYaml.branches.target)
+            } catch { /* ignore */ }
+          }
+          if (workflowYaml.branches?.strategy) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.branches.strategy', ?)").run(workflowYaml.branches.strategy)
+            } catch { /* ignore */ }
+          }
+          if (workflowYaml.review?.auto_merge_on_green !== undefined) {
+            try {
+              db.prepare("INSERT OR REPLACE INTO workspace_settings (key, value) VALUES ('workflow.review.auto_merge_on_green', ?)").run(String(workflowYaml.review.auto_merge_on_green))
+            } catch { /* ignore */ }
+          }
+        }
+      }
+
+      // Apply preset if specified
+      if (parsedFlags.preset) {
+        const count = applyPreset(db, parsedFlags.preset as PresetName)
+        this.log(styles.muted(`  Applied preset "${parsedFlags.preset}" (${count} hooks)`))
+      }
+
+      // Create the orchestrate engine
+      const engine = new OrchestrateEngine({
+        db,
+        log: (msg) => {
+          if (verbose || jsonMode) {
+            this.log(msg)
+          }
+        },
+        onNotify: (hookName, event, action, result) => {
+          this.log(`${styles.info('[notify]')} ${hookName}: ${event} → ${action} (${result.success ? 'ok' : 'failed'})`)
+        },
+      })
+
+      // Initialize work-lifecycle systems
+      initWorkLifecycleAdapter()
+      initHookManager(db)
+
+      // One-shot mode: fire a single event and exit
+      if (parsedFlags.once) {
+        const eventName = parsedFlags.once as string
+        const results = await engine.fireEvent(eventName, {
+          event: eventName,
+          ticket: parsedFlags.ticket as string | undefined,
+          pr: parsedFlags.pr as number | undefined,
+          branch: parsedFlags.branch as string | undefined,
+          agent: parsedFlags.agent as string | undefined,
+        })
+
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { event: eventName, results, mode: 'once' },
+            createMetadata('orchestrate', flags),
+          )
+          return
+        }
+
+        this.logResults(eventName, results)
+        return
+      }
+
+      // Daemon mode: start the engine and run until stopped
+      engine.start()
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { status: 'running', mode: 'daemon' },
+          createMetadata('orchestrate', flags),
+        )
+      } else {
+        this.log('')
+        this.log(styles.title('Orchestrate daemon started'))
+        this.log(styles.muted('  Listening for events on the EventBus'))
+        this.log(styles.muted('  Press Ctrl+C to stop'))
+
+        // Show configured hooks summary
+        try {
+          const hookCount = (db.prepare('SELECT COUNT(*) as count FROM pmo_work_hooks WHERE enabled = 1').get() as { count: number })?.count ?? 0
+          this.log(styles.muted(`  ${hookCount} active hooks`))
+        } catch { /* ignore */ }
+
+        if (parsedFlags['poll-interval'] && (parsedFlags['poll-interval'] as number) > 0) {
+          this.log(styles.muted(`  Polling every ${parsedFlags['poll-interval']}s for external events`))
+        }
+        this.log('')
+      }
+
+      // Set up polling if configured
+      const pollInterval = parsedFlags['poll-interval'] as number
+      let pollTimer: ReturnType<typeof setInterval> | null = null
+
+      if (pollInterval > 0) {
+        pollTimer = setInterval(() => {
+          void this.pollExternalEvents(engine, db, verbose)
+        }, pollInterval * 1000)
+      }
+
+      // Keep the process alive until signal
+      await new Promise<void>((resolve) => {
+        const cleanup = () => {
+          engine.stop()
+          if (pollTimer) clearInterval(pollTimer)
+          this.log(styles.muted('\n  Orchestrate daemon stopped'))
+          resolve()
+        }
+
+        process.on('SIGINT', cleanup)
+        process.on('SIGTERM', cleanup)
+      })
+    } finally {
+      db.close()
+    }
+  }
+
+  /**
+   * Poll external event sources for new events.
+   * Currently a stub — real implementations would check Linear, GitHub, etc.
+   */
+  private async pollExternalEvents(
+    engine: OrchestrateEngine,
+    db: SqliteDatabase,
+    verbose: boolean,
+  ): Promise<void> {
+    if (verbose) {
+      this.log(styles.muted('[orchestrate] Polling external event sources...'))
+    }
+
+    // Check for tickets in "Ready" status → fire on_ticket_ready
+    try {
+      const readyTickets = db.prepare(`
+        SELECT t.id, t.title, ws.category
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
+        WHERE ws.category = 'todo'
+          AND t.assignee IS NULL
+          AND t.id NOT IN (
+            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
+          )
+        LIMIT 5
+      `).all() as Array<{ id: string; title: string }>
+
+      for (const ticket of readyTickets) {
+        await engine.fireEvent('on_ticket_ready', {
+          event: 'on_ticket_ready',
+          ticket: ticket.id,
+        })
+      }
+    } catch {
+      // Polling errors are non-fatal
+    }
+  }
+
+  /**
+   * Log the results of firing an event.
+   */
+  private logResults(event: string, results: OrchestrateActionResult[]): void {
+    if (results.length === 0) {
+      this.log(styles.info(`No hooks configured for event: ${event}`))
+      return
+    }
+
+    this.log(styles.title(`Event: ${event}`))
+    for (const result of results) {
+      const status = result.skipped
+        ? styles.muted('skipped')
+        : result.awaitingConfirmation
+          ? styles.warning('awaiting')
+          : result.success
+            ? styles.success('ok')
+            : styles.error('failed')
+      this.log(`  ${status} ${result.action} ${styles.muted(`${result.durationMs}ms`)}`)
+      if (result.error) {
+        this.log(`       ${styles.error(result.error)}`)
+      }
+    }
+  }
+}

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -33,8 +33,6 @@ import {
 import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
 import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
 import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
-import { setupSignalHandler } from '../../lib/signal-handler.js'
-
 export default class Orchestrate extends PMOCommand {
   static description = 'Start the autonomous pipeline daemon with event-driven hooks'
 

--- a/apps/cli/src/commands/orchestrate/index.ts
+++ b/apps/cli/src/commands/orchestrate/index.ts
@@ -12,6 +12,7 @@
 
 import { Flags } from '@oclif/core'
 import * as path from 'node:path'
+import { execSync } from 'node:child_process'
 import { SqliteDatabase } from '../../lib/database/sqlite.js'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { styles } from '../../lib/styles.js'
@@ -33,6 +34,8 @@ import {
 import type { PresetName, OrchestrateActionResult } from '../../lib/orchestrate/index.js'
 import { initHookManager } from '../../lib/work-lifecycle/hooks/index.js'
 import { initWorkLifecycleAdapter } from '../../lib/work-lifecycle/adapter.js'
+import { SessionStore } from '../../lib/session-store.js'
+import { RECONCILER_SESSION_NAME } from '../reconcile/index.js'
 export default class Orchestrate extends PMOCommand {
   static description = 'Start the autonomous pipeline daemon with event-driven hooks'
 
@@ -183,9 +186,12 @@ export default class Orchestrate extends PMOCommand {
       // Daemon mode: start the engine and run until stopped
       engine.start()
 
+      // Auto-spawn reconciler daemon if not already running
+      const reconcilerSpawned = this.ensureReconcilerDaemon(verbose)
+
       if (jsonMode) {
         outputSuccessAsJson(
-          { status: 'running', mode: 'daemon' },
+          { status: 'running', mode: 'daemon', reconciler: reconcilerSpawned },
           createMetadata('orchestrate', flags),
         )
       } else {
@@ -199,6 +205,10 @@ export default class Orchestrate extends PMOCommand {
           const hookCount = (db.prepare('SELECT COUNT(*) as count FROM pmo_work_hooks WHERE enabled = 1').get() as { count: number })?.count ?? 0
           this.log(styles.muted(`  ${hookCount} active hooks`))
         } catch { /* ignore */ }
+
+        if (reconcilerSpawned) {
+          this.log(styles.muted('  Reconciler daemon: running'))
+        }
 
         if (parsedFlags['poll-interval'] && (parsedFlags['poll-interval'] as number) > 0) {
           this.log(styles.muted(`  Polling every ${parsedFlags['poll-interval']}s for external events`))
@@ -216,11 +226,17 @@ export default class Orchestrate extends PMOCommand {
         }, pollInterval * 1000)
       }
 
+      // Set up reconciler health supervision (check every 60s)
+      const reconcilerHealthTimer = setInterval(() => {
+        this.superviseReconcilerDaemon(verbose)
+      }, 60_000)
+
       // Keep the process alive until signal
       await new Promise<void>((resolve) => {
         const cleanup = () => {
           engine.stop()
           if (pollTimer) clearInterval(pollTimer)
+          clearInterval(reconcilerHealthTimer)
           this.log(styles.muted('\n  Orchestrate daemon stopped'))
           resolve()
         }
@@ -230,6 +246,104 @@ export default class Orchestrate extends PMOCommand {
       })
     } finally {
       db.close()
+    }
+  }
+
+  /**
+   * Ensure the reconciler daemon is running. Spawns it if not.
+   * Returns true if reconciler is running (either already was or just spawned).
+   */
+  private ensureReconcilerDaemon(verbose: boolean): boolean {
+    const store = new SessionStore()
+    try {
+      const existing = store.getRunningDaemon('reconciler')
+      if (existing && store.isTmuxSessionAlive(existing.sessionName)) {
+        if (verbose) {
+          this.log(styles.muted('[orchestrate] Reconciler daemon already running'))
+        }
+        return true
+      }
+
+      // Mark stale record as done
+      if (existing) {
+        store.updateStatus(existing.id, 'done')
+      }
+
+      return this.spawnReconcilerDaemon(store, verbose)
+    } finally {
+      store.close()
+    }
+  }
+
+  /**
+   * Spawn the reconciler daemon as a tmux session.
+   */
+  private spawnReconcilerDaemon(store: SessionStore, verbose: boolean): boolean {
+    let prltPath: string
+    try {
+      prltPath = execSync('which prlt', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+    } catch {
+      prltPath = 'prlt'
+    }
+
+    try {
+      execSync(
+        `tmux new-session -d -s "${RECONCILER_SESSION_NAME}" "${prltPath} reconcile --watch --foreground --interval 30"`,
+        { stdio: 'pipe' },
+      )
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      this.log(styles.warning(`[orchestrate] Failed to spawn reconciler daemon: ${msg}`))
+      return false
+    }
+
+    store.create({
+      agentName: 'reconciler',
+      runner: 'daemon',
+      task: 'session-reconciliation',
+      workdir: process.cwd(),
+      sessionName: RECONCILER_SESSION_NAME,
+      environment: 'host',
+      permissionMode: 'safe',
+      role: 'daemon',
+      daemonType: 'reconciler',
+    })
+
+    if (verbose) {
+      this.log(styles.success('[orchestrate] Reconciler daemon spawned'))
+    }
+    return true
+  }
+
+  /**
+   * Check if reconciler daemon is still alive. Restart if dead.
+   * Called periodically by the orchestrator's health supervision timer.
+   */
+  private superviseReconcilerDaemon(verbose: boolean): void {
+    const store = new SessionStore()
+    try {
+      const existing = store.getRunningDaemon('reconciler')
+
+      if (!existing) {
+        // No record at all — spawn fresh
+        if (verbose) {
+          this.log(styles.warning('[orchestrate] Reconciler daemon not found, spawning...'))
+        }
+        this.spawnReconcilerDaemon(store, verbose)
+        return
+      }
+
+      if (store.isTmuxSessionAlive(existing.sessionName)) {
+        // Still alive, nothing to do
+        return
+      }
+
+      // Dead — mark as done and restart
+      store.updateStatus(existing.id, 'done')
+      this.log(styles.warning('[orchestrate] Reconciler daemon died, restarting...'))
+      this.spawnReconcilerDaemon(store, verbose)
+    } finally {
+      store.close()
     }
   }
 

--- a/apps/cli/src/commands/reconcile/index.ts
+++ b/apps/cli/src/commands/reconcile/index.ts
@@ -1,0 +1,242 @@
+/**
+ * prlt reconcile — Session reconciler daemon
+ *
+ * Reconciles session statuses with actual tmux sessions.
+ * Can run as a foreground process (--foreground) or spawn a supervised
+ * tmux daemon session (--watch) that survives terminal close.
+ *
+ * When running as a daemon:
+ * - Spawns itself as a tmux session
+ * - Registers in sessions.db with role='daemon', daemon_type='reconciler'
+ * - Monitored by `prlt session health`
+ * - Supervised by `prlt orchestrate` (auto-restart on crash)
+ */
+
+import { Flags } from '@oclif/core'
+import { execSync } from 'node:child_process'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import { SessionStore } from '../../lib/session-store.js'
+import { styles } from '../../lib/styles.js'
+import { onShutdown } from '../../lib/signal-handler.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+
+/** Default tmux session name for the reconciler daemon. */
+export const RECONCILER_SESSION_NAME = 'prlt-daemon-reconciler'
+
+/** Default polling interval in seconds. */
+const DEFAULT_INTERVAL = 30
+
+export default class Reconcile extends PromptCommand {
+  static description = 'Run the session reconciler (daemon or foreground)'
+
+  static examples = [
+    '<%= config.bin %> reconcile --watch',
+    '<%= config.bin %> reconcile --watch --interval 60',
+    '<%= config.bin %> reconcile --watch --foreground',
+    '<%= config.bin %> reconcile',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    watch: Flags.boolean({
+      description: 'Run in continuous watch mode (spawns as daemon unless --foreground)',
+      default: false,
+    }),
+    foreground: Flags.boolean({
+      description: 'Run in the current terminal instead of spawning a tmux daemon',
+      default: false,
+    }),
+    interval: Flags.integer({
+      description: 'Polling interval in seconds (for --watch mode)',
+      default: DEFAULT_INTERVAL,
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(Reconcile)
+    const jsonMode = shouldOutputJson(flags)
+
+    if (!flags.watch) {
+      // Single-pass reconcile (existing behavior)
+      const store = new SessionStore()
+      try {
+        store.reconcile()
+        if (jsonMode) {
+          outputSuccessAsJson({ message: 'Reconciliation complete' }, createMetadata('reconcile', flags))
+        } else {
+          this.log(styles.success('Session reconciliation complete.'))
+        }
+      } finally {
+        store.close()
+      }
+      return
+    }
+
+    // --watch mode
+    if (flags.foreground) {
+      // Run the watch loop in the current terminal
+      await this.runForeground(flags.interval, jsonMode, flags)
+    } else {
+      // Spawn as a tmux daemon session
+      await this.spawnDaemon(flags.interval, jsonMode, flags)
+    }
+  }
+
+  /**
+   * Spawn the reconciler as a detached tmux daemon session.
+   * Registers the session in sessions.db with role='daemon'.
+   */
+  private async spawnDaemon(
+    interval: number,
+    jsonMode: boolean,
+    flags: Record<string, unknown>,
+  ): Promise<void> {
+    const store = new SessionStore()
+    try {
+      // Check if a reconciler daemon is already running
+      const existing = store.getRunningDaemon('reconciler')
+      if (existing && store.isTmuxSessionAlive(existing.sessionName)) {
+        if (jsonMode) {
+          outputSuccessAsJson({
+            message: 'Reconciler daemon is already running',
+            sessionName: existing.sessionName,
+            sessionId: existing.id,
+          }, createMetadata('reconcile', flags))
+        } else {
+          this.log(styles.warning(`Reconciler daemon is already running (${existing.sessionName})`))
+          this.log(styles.muted(`  Session ID: ${existing.id}`))
+          this.log(styles.muted(`  Started: ${existing.startedAt.toLocaleString()}`))
+        }
+        return
+      }
+
+      // If there's a stale DB record, mark it done
+      if (existing && !store.isTmuxSessionAlive(existing.sessionName)) {
+        store.updateStatus(existing.id, 'done')
+      }
+
+      // Resolve the prlt binary path for the tmux script
+      const prltPath = getPrltPath()
+
+      // Create the tmux session running the reconciler in foreground mode
+      const tmuxCmd = `tmux new-session -d -s "${RECONCILER_SESSION_NAME}" "${prltPath} reconcile --watch --foreground --interval ${interval}"`
+      try {
+        execSync(tmuxCmd, { stdio: 'pipe' })
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        if (jsonMode) {
+          outputErrorAsJson('TMUX_SPAWN_FAILED', `Failed to create tmux session: ${msg}`, createMetadata('reconcile', flags))
+        } else {
+          this.log(styles.error(`Failed to create tmux session: ${msg}`))
+        }
+        return
+      }
+
+      // Register in sessions.db as a daemon
+      const session = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'session-reconciliation',
+        workdir: process.cwd(),
+        sessionName: RECONCILER_SESSION_NAME,
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      if (jsonMode) {
+        outputSuccessAsJson({
+          message: 'Reconciler daemon started',
+          sessionName: RECONCILER_SESSION_NAME,
+          sessionId: session.id,
+          interval,
+        }, createMetadata('reconcile', flags))
+      } else {
+        this.log(styles.success('Reconciler daemon started'))
+        this.log(styles.muted(`  Session: ${RECONCILER_SESSION_NAME}`))
+        this.log(styles.muted(`  Interval: ${interval}s`))
+        this.log(styles.muted(`  ID: ${session.id}`))
+        this.log('')
+        this.log(styles.muted('  Attach: prlt session attach ' + RECONCILER_SESSION_NAME))
+        this.log(styles.muted('  Stop:   prlt session stop ' + RECONCILER_SESSION_NAME))
+      }
+    } finally {
+      store.close()
+    }
+  }
+
+  /**
+   * Run the reconciler in the current terminal (foreground mode).
+   * Used for debugging or when invoked by the daemon tmux session.
+   */
+  private async runForeground(
+    interval: number,
+    jsonMode: boolean,
+    flags: Record<string, unknown>,
+  ): Promise<void> {
+    if (!jsonMode) {
+      this.log('')
+      this.log(styles.header('Reconciler (foreground)'))
+      this.log(styles.muted(`  Polling every ${interval}s`))
+      this.log(styles.muted('  Press Ctrl+C to stop'))
+      this.log('')
+    }
+
+    const poll = () => {
+      const store = new SessionStore()
+      try {
+        const runningBefore = store.list('running').length
+        store.reconcile()
+        const runningAfter = store.list('running').length
+        const reconciled = runningBefore - runningAfter
+
+        if (reconciled > 0) {
+          const timestamp = new Date().toLocaleTimeString()
+          this.log(styles.info(`[${timestamp}] Reconciled ${reconciled} stale session(s)`))
+        }
+      } finally {
+        store.close()
+      }
+    }
+
+    // Initial pass
+    poll()
+
+    // Continuous polling
+    const intervalMs = interval * 1000
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        try {
+          poll()
+        } catch (error) {
+          this.log(styles.error(`  Reconcile error: ${error}`))
+        }
+      }, intervalMs)
+
+      onShutdown(() => {
+        clearInterval(timer)
+        resolve()
+      })
+    })
+  }
+}
+
+/**
+ * Resolve the prlt binary path.
+ * Tries `which prlt` first, falls back to common locations.
+ */
+function getPrltPath(): string {
+  try {
+    return execSync('which prlt', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+  } catch {
+    // Fallback: assume it's on PATH
+    return 'prlt'
+  }
+}

--- a/apps/cli/src/commands/session/health.ts
+++ b/apps/cli/src/commands/session/health.ts
@@ -24,6 +24,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { SessionStore } from '../../lib/session-store.js'
 
 // =============================================================================
 // Types
@@ -40,6 +41,8 @@ interface AgentHealthInfo {
   containerId?: string
   elapsed: string
   paneContent?: string
+  role?: string  // daemon, worker, orchestrator, etc.
+  daemonType?: string
 }
 
 // =============================================================================
@@ -338,6 +341,34 @@ export default class SessionHealth extends PMOCommand {
             paneContent: paneContent || undefined,
           })
         }
+      }
+
+      // Daemon sessions from global SessionStore
+      const globalStore = new SessionStore()
+      try {
+        const daemonSessions = globalStore.listByRole('daemon', 'running')
+        for (const daemon of daemonSessions) {
+          const alive = globalStore.isTmuxSessionAlive(daemon.sessionName)
+          const state: AgentHealthState = alive ? 'WORKING' : 'UNKNOWN'
+
+          // Mark dead daemons so orchestrator can detect and restart
+          if (!alive) {
+            globalStore.updateStatus(daemon.id, 'done')
+          }
+
+          agents.push({
+            sessionId: daemon.sessionName,
+            ticketId: daemon.daemonType ? `DAEMON:${daemon.daemonType}` : 'DAEMON',
+            agentName: daemon.agentName,
+            state,
+            environment: 'host',
+            elapsed: formatElapsed(daemon.startedAt),
+            role: 'daemon',
+            daemonType: daemon.daemonType,
+          })
+        }
+      } finally {
+        globalStore.close()
       }
 
       // Auto-poke idle agents if --poke-idle

--- a/apps/cli/src/commands/session/list.ts
+++ b/apps/cli/src/commands/session/list.ts
@@ -15,6 +15,7 @@ import {
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { shouldOutputJson } from '../../lib/prompt-json.js'
 import { visualPadEnd } from '../../lib/string-utils.js'
+import { SessionStore } from '../../lib/session-store.js'
 
 interface VerifiedSession {
   sessionId: string
@@ -25,6 +26,8 @@ interface VerifiedSession {
   containerId?: string
   exists: boolean  // Whether the tmux session actually exists
   source: 'db' | 'discovered'  // Whether session was found in DB or discovered from tmux
+  role?: string  // Session role: worker, orchestrator, daemon, headless
+  daemonType?: string  // For daemon sessions: reconciler, etc.
 }
 
 export default class SessionList extends PMOCommand {
@@ -237,6 +240,43 @@ export default class SessionList extends PMOCommand {
         }
       }
 
+      // Daemon sessions from global SessionStore (sessions.db)
+      const globalStore = new SessionStore()
+      try {
+        const daemonSessions = globalStore.listByRole('daemon', 'running')
+        for (const daemon of daemonSessions) {
+          // Skip daemons we already matched (by session name)
+          if (matchedHostSessions.has(daemon.sessionName)) continue
+
+          const alive = globalStore.isTmuxSessionAlive(daemon.sessionName)
+
+          // Mark dead daemon sessions as done so they don't linger
+          if (!alive) {
+            globalStore.updateStatus(daemon.id, 'done')
+            if (!flags.all) continue
+          }
+
+          sessions.push({
+            sessionId: daemon.sessionName,
+            ticketId: daemon.daemonType ? `DAEMON:${daemon.daemonType}` : 'DAEMON',
+            agentName: daemon.agentName,
+            status: alive ? 'running' : 'stale',
+            environment: 'host',
+            exists: alive,
+            source: 'db',
+            role: 'daemon',
+            daemonType: daemon.daemonType,
+          })
+
+          // Track so orphan detection doesn't double-count
+          if (alive) {
+            matchedHostSessions.add(daemon.sessionName)
+          }
+        }
+      } finally {
+        globalStore.close()
+      }
+
       if (jsonMode) {
         this.log(JSON.stringify(sessions, null, 2))
         return
@@ -260,7 +300,8 @@ export default class SessionList extends PMOCommand {
         this.log('  ' + '─'.repeat(88))
 
         for (const session of sessions) {
-          const typeIcon = session.environment === 'container' ? '🐳 container' : '💻 host'
+          const typeIcon = session.role === 'daemon' ? '⚙️  daemon' :
+                          session.environment === 'container' ? '🐳 container' : '💻 host'
           const statusColor = session.status === 'running' ? styles.success :
                              session.status === 'starting' ? styles.warning :
                              session.status === 'stale' ? styles.error :

--- a/apps/cli/src/commands/session/prune.ts
+++ b/apps/cli/src/commands/session/prune.ts
@@ -25,6 +25,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { SessionStore } from '../../lib/session-store.js'
 
 interface PruneResult {
   staleExecutionsCleaned: number
@@ -149,10 +150,25 @@ export default class SessionPrune extends PMOCommand {
         }
       }
 
+      // Build set of daemon session names to protect from pruning.
+      // Daemon sessions (role='daemon') are supposed to run forever.
+      const daemonSessionNames = new Set<string>()
+      const globalStore = new SessionStore()
+      try {
+        const runningDaemons = globalStore.listByRole('daemon', 'running')
+        for (const daemon of runningDaemons) {
+          daemonSessionNames.add(daemon.sessionName)
+        }
+      } finally {
+        globalStore.close()
+      }
+
       // Find orphan host sessions (match prlt pattern but not tracked in DB)
+      // IMPORTANT: Skip daemon sessions — they are supposed to run forever
       const orphanHostSessions: string[] = []
       for (const sessionName of hostTmuxSessions) {
         if (matchedHostSessions.has(sessionName)) continue
+        if (daemonSessionNames.has(sessionName)) continue  // Protect daemons
         const parsed = parseSessionName(sessionName)
         if (parsed) {
           orphanHostSessions.push(sessionName)

--- a/apps/cli/src/lib/database/migrations/0013_agent_lifecycle_states.ts
+++ b/apps/cli/src/lib/database/migrations/0013_agent_lifecycle_states.ts
@@ -1,0 +1,34 @@
+/**
+ * Migration 0013 — Agent lifecycle states
+ *
+ * Adds lifecycle state tracking columns to agent_work table.
+ * Enables tracking of agent lifecycle events (spawned, idle, died, completed).
+ */
+
+import type { SqliteDatabase } from '../sqlite.js'
+import type { Migration } from '../migrator.js'
+
+export const agentLifecycleStates: Migration = {
+  id: '0013',
+  name: 'agent_lifecycle_states',
+  up: (db: SqliteDatabase) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_work'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(agent_work)").all() as { name: string }[]
+
+    if (!tableInfo.some(col => col.name === 'lifecycle_state')) {
+      db.exec(
+        "ALTER TABLE agent_work ADD COLUMN lifecycle_state TEXT DEFAULT 'active'"
+      )
+    }
+
+    if (!tableInfo.some(col => col.name === 'last_heartbeat_at')) {
+      db.exec(
+        "ALTER TABLE agent_work ADD COLUMN last_heartbeat_at INTEGER"
+      )
+    }
+  },
+}

--- a/apps/cli/src/lib/database/migrations/0014_orchestrate_hooks.ts
+++ b/apps/cli/src/lib/database/migrations/0014_orchestrate_hooks.ts
@@ -1,0 +1,58 @@
+/**
+ * Migration 0014 — Orchestrate Hooks
+ *
+ * Extends pmo_work_hooks with mode (auto/confirm/notify/off), priority,
+ * project_id, source, and config columns for the orchestrate daemon.
+ */
+
+import type { SqliteDatabase } from '../sqlite.js'
+import type { Migration } from '../migrator.js'
+
+export const orchestrateHooks: Migration = {
+  id: '0014',
+  name: 'orchestrate_hooks',
+  up: (db: SqliteDatabase) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get()
+    if (!tableExists) return
+
+    const tableInfo = db.prepare("PRAGMA table_info(pmo_work_hooks)").all() as { name: string }[]
+    const existingCols = new Set(tableInfo.map(col => col.name))
+
+    if (!existingCols.has('mode')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'off'))"
+      )
+    }
+
+    if (!existingCols.has('priority')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0"
+      )
+    }
+
+    if (!existingCols.has('project_id')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT"
+      )
+    }
+
+    if (!existingCols.has('source')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))"
+      )
+    }
+
+    if (!existingCols.has('config')) {
+      db.exec(
+        "ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT"
+      )
+    }
+
+    // Create index for priority-ordered lookup
+    db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)"
+    )
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -18,6 +18,8 @@ import { createMediaItems } from './0009_create_media_items.js'
 import { addTicketPosition } from './0010_add_ticket_position.js'
 import { addReviewGate } from './0011_add_review_gate.js'
 import { addActionNetworkAllowlist } from './0012_add_action_network_allowlist.js'
+import { agentLifecycleStates } from './0013_agent_lifecycle_states.js'
+import { orchestrateHooks } from './0014_orchestrate_hooks.js'
 
 /**
  * Ordered list of all migrations.
@@ -36,4 +38,6 @@ export const ALL_MIGRATIONS: Migration[] = [
   addTicketPosition,
   addReviewGate,
   addActionNetworkAllowlist,
+  agentLifecycleStates,
+  orchestrateHooks,
 ]

--- a/apps/cli/src/lib/events/events.ts
+++ b/apps/cli/src/lib/events/events.ts
@@ -116,6 +116,28 @@ export interface WorkflowRuleMatchedEvent {
 }
 
 // =============================================================================
+// Orchestrate Events
+// =============================================================================
+
+/**
+ * Generic event payload for orchestrate daemon events.
+ * These events are triggered externally (GitHub Actions, polling, prlt hook fire)
+ * and carry flexible context.
+ */
+export interface OrchestrateGenericEvent {
+  ticket?: string
+  pr?: number
+  branch?: string
+  agent?: string
+  container?: string
+  executionId?: string
+  prUrl?: string
+  projectId?: string
+  timestamp: Date
+  [key: string]: unknown
+}
+
+// =============================================================================
 // Event Map
 // =============================================================================
 
@@ -141,6 +163,19 @@ export interface RuntimeEventMap {
   'work:pr_merged': WorkPRMergedEvent
   'work:pr_closed': WorkPRClosedEvent
   'work:completed': WorkCompletedEvent
+
+  // Orchestrate events (external triggers + daemon events)
+  'on_ci_green': OrchestrateGenericEvent
+  'on_ci_failed': OrchestrateGenericEvent
+  'on_pr_opened': OrchestrateGenericEvent
+  'on_pr_merged': OrchestrateGenericEvent
+  'on_pr_conflicting': OrchestrateGenericEvent
+  'on_ticket_ready': OrchestrateGenericEvent
+  'on_agent_spawned': OrchestrateGenericEvent
+  'on_agent_died': OrchestrateGenericEvent
+  'on_agent_completed': OrchestrateGenericEvent
+  'on_agent_idle': OrchestrateGenericEvent
+  'on_version_published': OrchestrateGenericEvent
 }
 
 /** Union of all event names. */

--- a/apps/cli/src/lib/events/index.ts
+++ b/apps/cli/src/lib/events/index.ts
@@ -13,6 +13,7 @@ export type {
   AgentOutputEvent,
   TicketStatusChangedEvent,
   TicketPRLinkedEvent,
+  OrchestrateGenericEvent,
 } from './events.js'
 
 export {

--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -1,0 +1,208 @@
+/**
+ * Orchestrate Built-in Actions
+ *
+ * Implementations for the built-in hook actions that the orchestrate daemon
+ * can execute. Each action receives an event context and returns a result.
+ *
+ * Actions use prlt CLI commands where possible to keep behavior consistent
+ * with manual invocations.
+ */
+
+import { execSync } from 'node:child_process'
+import type { OrchestrateEventContext, OrchestrateActionResult } from './types.js'
+
+type ActionHandler = (ctx: OrchestrateEventContext, config?: Record<string, unknown>) => OrchestrateActionResult
+
+/**
+ * Merge a PR via `prlt work ship`.
+ */
+const mergePr: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket && !ctx.pr) {
+      return { action: 'merge-pr', success: false, error: 'No ticket or PR number in context', durationMs: Date.now() - start }
+    }
+
+    const args: string[] = ['prlt', 'work', 'ship']
+    if (ctx.ticket) args.push(ctx.ticket)
+    if (ctx.pr) args.push('--pr', String(ctx.pr))
+    args.push('--yes') // Skip confirmation
+
+    execSync(args.join(' '), { timeout: 120_000, stdio: 'pipe' })
+    return { action: 'merge-pr', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'merge-pr', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Move a ticket to a target status.
+ */
+const moveTicket: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    const target = (config?.target as string) || 'done'
+    if (!ctx.ticket) {
+      return { action: 'move-ticket', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt ticket move ${ctx.ticket} --to "${target}" --yes`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'move-ticket', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'move-ticket', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Rebase conflicting PRs after a merge.
+ */
+const rebaseConflictingPrs: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    execSync('prlt work rebase --all --yes 2>/dev/null || true', { timeout: 300_000, stdio: 'pipe' })
+    return { action: 'rebase-conflicting-prs', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'rebase-conflicting-prs', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Spawn an agent for a ticket.
+ */
+const spawnAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'spawn-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Respawn a failed/died agent.
+ */
+const respawn: ActionHandler = (ctx, config) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'respawn', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --yes --display background --force`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'respawn', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'respawn', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Send a notification about an event.
+ */
+const notify: ActionHandler = (ctx) => {
+  const start = Date.now()
+  const parts: string[] = []
+  if (ctx.event) parts.push(`[${ctx.event}]`)
+  if (ctx.ticket) parts.push(`ticket=${ctx.ticket}`)
+  if (ctx.pr) parts.push(`PR=#${ctx.pr}`)
+  if (ctx.agent) parts.push(`agent=${ctx.agent}`)
+
+  // eslint-disable-next-line no-console
+  console.log(`[orchestrate:notify] ${parts.join(' ')}`)
+  return { action: 'notify', success: true, durationMs: Date.now() - start }
+}
+
+/**
+ * Clean up a container after agent completion.
+ */
+const cleanupContainer: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.agent && !ctx.container) {
+      return { action: 'cleanup-container', success: false, error: 'No agent or container in context', durationMs: Date.now() - start }
+    }
+
+    const target = ctx.container || ctx.agent
+    execSync(`prlt docker rm ${target} --yes 2>/dev/null || true`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'cleanup-container', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'cleanup-container', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Spawn a fix agent after CI failure.
+ */
+const spawnFixAgent: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.ticket) {
+      return { action: 'spawn-fix-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt work start ${ctx.ticket} --action revise --yes --display background`, { timeout: 60_000, stdio: 'pipe' })
+    return { action: 'spawn-fix-agent', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'spawn-fix-agent', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Health check / poke an idle agent.
+ */
+const healthCheck: ActionHandler = (ctx) => {
+  const start = Date.now()
+  try {
+    if (!ctx.agent) {
+      return { action: 'health-check', success: false, error: 'No agent in context', durationMs: Date.now() - start }
+    }
+
+    execSync(`prlt poke ${ctx.agent} "Are you still working? Please provide a status update."`, { timeout: 30_000, stdio: 'pipe' })
+    return { action: 'health-check', success: true, durationMs: Date.now() - start }
+  } catch (err) {
+    return { action: 'health-check', success: false, error: err instanceof Error ? err.message : String(err), durationMs: Date.now() - start }
+  }
+}
+
+// =============================================================================
+// Action Registry
+// =============================================================================
+
+/**
+ * Registry of built-in action handlers.
+ */
+export const ACTION_HANDLERS: Record<string, ActionHandler> = {
+  'merge-pr': mergePr,
+  'move-ticket': moveTicket,
+  'rebase-conflicting-prs': rebaseConflictingPrs,
+  'spawn-agent': spawnAgent,
+  'respawn': respawn,
+  'notify': notify,
+  'cleanup-container': cleanupContainer,
+  'spawn-fix-agent': spawnFixAgent,
+  'health-check': healthCheck,
+}
+
+/**
+ * Execute a built-in action by name.
+ */
+export function executeBuiltinAction(
+  actionName: string,
+  ctx: OrchestrateEventContext,
+  config?: Record<string, unknown>,
+): OrchestrateActionResult {
+  const handler = ACTION_HANDLERS[actionName]
+  if (!handler) {
+    return {
+      action: actionName,
+      success: false,
+      error: `Unknown action: ${actionName}`,
+      durationMs: 0,
+    }
+  }
+  return handler(ctx, config)
+}

--- a/apps/cli/src/lib/orchestrate/config-loader.ts
+++ b/apps/cli/src/lib/orchestrate/config-loader.ts
@@ -1,0 +1,238 @@
+/**
+ * Orchestrate Config Loader
+ *
+ * Loads .proletariat/hooks.yml and .proletariat/workflow.yml files,
+ * validates them, and syncs hook configurations into the database.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import yaml from 'js-yaml'
+import type { SqliteDatabase } from '../database/sqlite.js'
+import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
+import type { HookableEvent, HookActionType } from '../work-lifecycle/hooks/types.js'
+import type {
+  HooksYaml,
+  HookYamlEntry,
+  WorkflowYaml,
+  OrchestrateEvent,
+  HookMode,
+  PresetName,
+} from './types.js'
+import { ORCHESTRATE_EVENTS, HOOK_MODES } from './types.js'
+import { getPreset } from './presets.js'
+
+// =============================================================================
+// YAML File Loading
+// =============================================================================
+
+/**
+ * Load and parse .proletariat/hooks.yml from an HQ path.
+ * Returns null if the file doesn't exist.
+ */
+export function loadHooksYaml(hqPath: string): HooksYaml | null {
+  const filePath = path.join(hqPath, '.proletariat', 'hooks.yml')
+  if (!fs.existsSync(filePath)) return null
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const parsed = yaml.load(content) as HooksYaml | null
+  return parsed ?? null
+}
+
+/**
+ * Load and parse .proletariat/workflow.yml from an HQ path.
+ * Returns null if the file doesn't exist.
+ */
+export function loadWorkflowYaml(hqPath: string): WorkflowYaml | null {
+  const filePath = path.join(hqPath, '.proletariat', 'workflow.yml')
+  if (!fs.existsSync(filePath)) return null
+
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const parsed = yaml.load(content) as WorkflowYaml | null
+  return parsed ?? null
+}
+
+// =============================================================================
+// Hook Sync
+// =============================================================================
+
+/**
+ * Map an OrchestrateEvent + action string into an existing HookableEvent + HookActionType.
+ * For built-in actions, we use 'shell' type with a `prlt` command as the action value.
+ */
+function mapToHookConfig(
+  event: OrchestrateEvent,
+  entry: HookYamlEntry,
+): { event: HookableEvent; actionType: HookActionType; actionValue: string } | null {
+  // Map orchestrate events to hookable events where possible
+  const eventMap: Partial<Record<OrchestrateEvent, HookableEvent>> = {
+    'work:started': 'work:started',
+    'work:status_changed': 'work:status_changed',
+    'work:pr_created': 'work:pr_created',
+    'work:completed': 'work:completed',
+    'agent:spawned': 'agent:spawned',
+    'agent:stopped': 'agent:stopped',
+  }
+
+  const hookEvent = eventMap[event]
+
+  // For events without a direct mapping, store as shell hook with prlt hook fire
+  const resolvedEvent = hookEvent ?? 'work:status_changed'
+  const actionValue = `prlt hook fire ${event} --action ${entry.action}`
+
+  return {
+    event: resolvedEvent,
+    actionType: 'shell',
+    actionValue,
+  }
+}
+
+/**
+ * Sync hooks from a parsed YAML config into the database.
+ * Clears existing YAML-sourced hooks and replaces them.
+ */
+export function syncHooksFromYaml(db: SqliteDatabase, hooksYaml: HooksYaml): number {
+  const storage = new WorkHookStorage(db)
+  let count = 0
+
+  // Clear existing YAML-sourced hooks
+  try {
+    db.exec("DELETE FROM pmo_work_hooks WHERE source = 'yaml'")
+  } catch {
+    // source column might not exist yet — ignore
+  }
+
+  for (const [eventName, entries] of Object.entries(hooksYaml)) {
+    if (!Array.isArray(entries)) continue
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]
+      if (!entry.action) continue
+
+      const mode = entry.mode && HOOK_MODES.includes(entry.mode as HookMode)
+        ? entry.mode as HookMode
+        : 'auto'
+
+      const hookName = `yaml:${eventName}:${entry.action}:${i}`
+
+      try {
+        const hook = storage.create({
+          name: hookName,
+          event: (eventName as HookableEvent) || 'work:status_changed',
+          actionType: 'shell',
+          actionValue: entry.action,
+          description: `From hooks.yml: ${eventName} → ${entry.action} (${mode})`,
+        })
+
+        // Update the mode and source via raw SQL since WorkHookStorage doesn't support these yet
+        try {
+          db.prepare(
+            "UPDATE pmo_work_hooks SET mode = ?, priority = ?, source = 'yaml', config = ? WHERE id = ?"
+          ).run(mode, i, entry.max_retries ? JSON.stringify({ max_retries: entry.max_retries }) : null, hook.id)
+        } catch {
+          // Columns might not exist yet
+        }
+
+        count++
+      } catch {
+        // Skip duplicates
+      }
+    }
+  }
+
+  return count
+}
+
+/**
+ * Apply a preset to the database, replacing existing preset-sourced hooks.
+ */
+export function applyPreset(db: SqliteDatabase, presetName: PresetName): number {
+  const preset = getPreset(presetName)
+  const storage = new WorkHookStorage(db)
+  let count = 0
+
+  // Clear existing preset-sourced hooks
+  try {
+    db.exec("DELETE FROM pmo_work_hooks WHERE source = 'preset'")
+  } catch {
+    // source column might not exist yet
+  }
+
+  for (let i = 0; i < preset.hooks.length; i++) {
+    const hook = preset.hooks[i]
+    const hookName = `preset:${presetName}:${hook.event}:${hook.action}:${i}`
+
+    try {
+      const created = storage.create({
+        name: hookName,
+        event: mapOrchestrateToHookable(hook.event),
+        actionType: 'shell',
+        actionValue: `prlt hook fire ${hook.event} --action ${hook.action}`,
+        description: `Preset ${presetName}: ${hook.event} → ${hook.action} (${hook.mode})`,
+      })
+
+      try {
+        db.prepare(
+          "UPDATE pmo_work_hooks SET mode = ?, priority = ?, source = 'preset', config = ? WHERE id = ?"
+        ).run(hook.mode, i, hook.config ? JSON.stringify(hook.config) : null, created.id)
+      } catch {
+        // Columns might not exist
+      }
+
+      count++
+    } catch {
+      // Skip duplicates
+    }
+  }
+
+  return count
+}
+
+/**
+ * Map orchestrate event to the closest hookable event.
+ * For new orchestrate events, use a fallback.
+ */
+function mapOrchestrateToHookable(event: OrchestrateEvent): HookableEvent {
+  const directMap: Partial<Record<OrchestrateEvent, HookableEvent>> = {
+    'work:started': 'work:started',
+    'work:status_changed': 'work:status_changed',
+    'work:pr_created': 'work:pr_created',
+    'work:completed': 'work:completed',
+    'agent:spawned': 'agent:spawned',
+    'agent:stopped': 'agent:stopped',
+  }
+  return directMap[event] ?? 'work:status_changed'
+}
+
+/**
+ * Export current hook configuration to YAML format.
+ */
+export function exportHooksToYaml(db: SqliteDatabase): string {
+  const storage = new WorkHookStorage(db)
+  const hooks = storage.list()
+
+  const grouped: Record<string, Array<{ action: string; mode: string; config?: Record<string, unknown> }>> = {}
+
+  for (const hook of hooks) {
+    const event = hook.event
+    if (!grouped[event]) grouped[event] = []
+
+    let mode = 'auto'
+    let config: Record<string, unknown> | undefined
+    try {
+      const row = db.prepare("SELECT mode, config FROM pmo_work_hooks WHERE id = ?").get(hook.id) as { mode?: string; config?: string } | undefined
+      if (row?.mode) mode = row.mode
+      if (row?.config) config = JSON.parse(row.config) as Record<string, unknown>
+    } catch {
+      // mode column might not exist
+    }
+
+    grouped[event].push({
+      action: hook.actionValue,
+      mode,
+      ...(config ? config : {}),
+    })
+  }
+
+  return yaml.dump(grouped, { indent: 2, lineWidth: 120 })
+}

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -1,0 +1,372 @@
+/**
+ * Orchestrate Engine
+ *
+ * The core daemon loop that:
+ * 1. Loads hook configuration from DB (synced from YAML/presets/CLI)
+ * 2. Subscribes to EventBus events
+ * 3. Executes matching hooks with mode-aware behavior
+ * 4. Optionally polls external sources for events
+ *
+ * The engine extends the existing HookManager with mode support
+ * and built-in action execution.
+ */
+
+import type { SqliteDatabase } from '../database/sqlite.js'
+import { getEventBus } from '../events/event-bus.js'
+import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
+import { executeBuiltinAction, ACTION_HANDLERS } from './actions.js'
+import type {
+  OrchestrateEvent,
+  OrchestrateEventContext,
+  OrchestrateActionResult,
+  HookMode,
+} from './types.js'
+import { ORCHESTRATE_EVENTS } from './types.js'
+
+// =============================================================================
+// Extended Hook Row (includes mode, priority, config)
+// =============================================================================
+
+interface ExtendedHookRow {
+  id: string
+  name: string
+  event: string
+  action_type: string
+  action_value: string
+  enabled: number
+  description: string | null
+  mode: string | null
+  priority: number | null
+  config: string | null
+}
+
+// =============================================================================
+// Engine
+// =============================================================================
+
+export interface OrchestrateEngineOptions {
+  /** Database connection */
+  db: SqliteDatabase
+  /** Logger function */
+  log?: (msg: string) => void
+  /** Callback for confirm-mode hooks (returns true to approve) */
+  onConfirm?: (hookName: string, event: string, action: string) => Promise<boolean>
+  /** Callback for notifications */
+  onNotify?: (hookName: string, event: string, action: string, result: OrchestrateActionResult) => void
+}
+
+export class OrchestrateEngine {
+  private db: SqliteDatabase
+  private hookStorage: WorkHookStorage
+  private unsubscribers: Array<() => void> = []
+  private log: (msg: string) => void
+  private onConfirm?: (hookName: string, event: string, action: string) => Promise<boolean>
+  private onNotify?: (hookName: string, event: string, action: string, result: OrchestrateActionResult) => void
+  private running = false
+  private pendingConfirmations: Array<{
+    hookName: string
+    event: string
+    action: string
+    ctx: OrchestrateEventContext
+    config?: Record<string, unknown>
+  }> = []
+
+  constructor(options: OrchestrateEngineOptions) {
+    this.db = options.db
+    this.hookStorage = new WorkHookStorage(options.db)
+    this.log = options.log ?? (() => {})
+    this.onConfirm = options.onConfirm
+    this.onNotify = options.onNotify
+  }
+
+  /**
+   * Start the orchestrate engine — subscribe to all orchestrate events.
+   */
+  start(): void {
+    if (this.running) return
+    this.running = true
+
+    const bus = getEventBus()
+
+    // Subscribe to standard RuntimeEventMap events
+    const standardEvents: Array<keyof import('../events/events.js').RuntimeEventMap> = [
+      'work:started',
+      'work:status_changed',
+      'work:pr_created',
+      'work:pr_merged',
+      'work:pr_closed',
+      'work:completed',
+      'agent:spawned',
+      'agent:stopped',
+    ]
+
+    for (const eventName of standardEvents) {
+      this.unsubscribers.push(
+        bus.on(eventName, (payload) => {
+          void this.handleEvent(eventName, payload as unknown as Record<string, unknown>)
+        }),
+      )
+    }
+
+    this.log('[orchestrate] Engine started, listening for events')
+  }
+
+  /**
+   * Stop the engine and clean up subscriptions.
+   */
+  stop(): void {
+    this.running = false
+    for (const unsub of this.unsubscribers) {
+      unsub()
+    }
+    this.unsubscribers = []
+    this.pendingConfirmations = []
+    this.log('[orchestrate] Engine stopped')
+  }
+
+  /**
+   * Fire an event manually (used by `prlt hook fire`).
+   * This is the entry point for external event sources (GitHub Actions, polling, etc.).
+   */
+  async fireEvent(event: string, ctx: OrchestrateEventContext): Promise<OrchestrateActionResult[]> {
+    return this.handleEvent(event, ctx as Record<string, unknown>)
+  }
+
+  /**
+   * Get pending confirmations for hooks in confirm mode.
+   */
+  getPendingConfirmations(): typeof this.pendingConfirmations {
+    return [...this.pendingConfirmations]
+  }
+
+  /**
+   * Approve a pending confirmation and execute it.
+   */
+  async approveConfirmation(index: number): Promise<OrchestrateActionResult | null> {
+    if (index < 0 || index >= this.pendingConfirmations.length) return null
+
+    const pending = this.pendingConfirmations.splice(index, 1)[0]
+    const result = executeBuiltinAction(pending.action, pending.ctx, pending.config)
+
+    this.log(`[orchestrate] Approved: ${pending.hookName} → ${pending.action} (${result.success ? 'success' : 'failed'})`)
+    return result
+  }
+
+  /**
+   * Deny a pending confirmation.
+   */
+  denyConfirmation(index: number): boolean {
+    if (index < 0 || index >= this.pendingConfirmations.length) return false
+
+    const pending = this.pendingConfirmations.splice(index, 1)[0]
+    this.log(`[orchestrate] Denied: ${pending.hookName} → ${pending.action}`)
+    return true
+  }
+
+  // ===========================================================================
+  // Private
+  // ===========================================================================
+
+  /**
+   * Handle an event by finding and executing matching hooks.
+   */
+  private async handleEvent(eventName: string, eventData: Record<string, unknown>): Promise<OrchestrateActionResult[]> {
+    const results: OrchestrateActionResult[] = []
+
+    try {
+      // Query hooks matching this event, ordered by priority
+      const hooks = this.getHooksForEvent(eventName)
+      if (hooks.length === 0) return results
+
+      // Build event context from the payload
+      const ctx = this.buildContext(eventName, eventData)
+
+      for (const hook of hooks) {
+        const mode = (hook.mode || 'auto') as HookMode
+        const config = hook.config ? JSON.parse(hook.config) as Record<string, unknown> : undefined
+
+        // Determine action — either a built-in action name or the raw action_value
+        const actionName = this.resolveActionName(hook)
+
+        if (mode === 'off') {
+          results.push({ action: actionName, success: true, durationMs: 0, skipped: true })
+          continue
+        }
+
+        if (mode === 'confirm') {
+          // Queue for confirmation
+          if (this.onConfirm) {
+            const approved = await this.onConfirm(hook.name, eventName, actionName)
+            if (!approved) {
+              this.log(`[orchestrate] Skipped (not confirmed): ${hook.name} → ${actionName}`)
+              results.push({ action: actionName, success: true, durationMs: 0, skipped: true })
+              continue
+            }
+          } else {
+            // No confirm handler — queue for later approval
+            this.pendingConfirmations.push({
+              hookName: hook.name,
+              event: eventName,
+              action: actionName,
+              ctx,
+              config,
+            })
+            this.log(`[orchestrate] Queued for confirmation: ${hook.name} → ${actionName}`)
+            results.push({ action: actionName, success: true, durationMs: 0, awaitingConfirmation: true })
+            continue
+          }
+        }
+
+        // Execute the action
+        const result = this.executeAction(actionName, ctx, config)
+        results.push(result)
+
+        this.log(
+          `[orchestrate] ${hook.name} → ${actionName}: ${result.success ? 'success' : `failed: ${result.error}`} (${result.durationMs}ms)`
+        )
+
+        // For notify mode, also fire the notification callback
+        if (mode === 'notify' && this.onNotify) {
+          this.onNotify(hook.name, eventName, actionName, result)
+        }
+      }
+    } catch (err) {
+      this.log(`[orchestrate] Error handling event ${eventName}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    return results
+  }
+
+  /**
+   * Get hooks for a given event from the database, ordered by priority.
+   */
+  private getHooksForEvent(eventName: string): ExtendedHookRow[] {
+    try {
+      return this.db.prepare(`
+        SELECT id, name, event, action_type, action_value, enabled, description, mode, priority, config
+        FROM pmo_work_hooks
+        WHERE event = ? AND enabled = 1
+        ORDER BY priority ASC, created_at ASC
+      `).all(eventName) as ExtendedHookRow[]
+    } catch {
+      // Fallback without mode/priority columns (pre-migration)
+      try {
+        const basic = this.db.prepare(`
+          SELECT id, name, event, action_type, action_value, enabled, description
+          FROM pmo_work_hooks
+          WHERE event = ? AND enabled = 1
+          ORDER BY created_at ASC
+        `).all(eventName) as ExtendedHookRow[]
+        return basic
+      } catch {
+        return []
+      }
+    }
+  }
+
+  /**
+   * Build an OrchestrateEventContext from raw event data.
+   */
+  private buildContext(eventName: string, data: Record<string, unknown>): OrchestrateEventContext {
+    return {
+      event: eventName,
+      ticket: (data.ticketId ?? data.workItemId ?? data.ticket) as string | undefined,
+      pr: (data.prNumber ?? data.pr) as number | undefined,
+      branch: data.branch as string | undefined,
+      agent: (data.agentName ?? data.agent ?? data.sessionId) as string | undefined,
+      container: data.containerId as string | undefined,
+      executionId: data.executionId as string | undefined,
+      prUrl: data.prUrl as string | undefined,
+      projectId: data.projectId as string | undefined,
+      ...data,
+    }
+  }
+
+  /**
+   * Resolve the action name from a hook row.
+   * Built-in actions are referenced by name; shell hooks use the raw command.
+   */
+  private resolveActionName(hook: ExtendedHookRow): string {
+    // If the action_value starts with "prlt hook fire", extract the --action value
+    const actionMatch = hook.action_value.match(/--action\s+(\S+)/)
+    if (actionMatch) return actionMatch[1]
+
+    // If it's a known built-in action name directly
+    if (ACTION_HANDLERS[hook.action_value]) return hook.action_value
+
+    // Otherwise it's a raw shell command — use the action_value as-is
+    return hook.action_value
+  }
+
+  /**
+   * Execute an action — either built-in or shell fallback.
+   */
+  private executeAction(
+    actionName: string,
+    ctx: OrchestrateEventContext,
+    config?: Record<string, unknown>,
+  ): OrchestrateActionResult {
+    // Try built-in action first
+    if (ACTION_HANDLERS[actionName]) {
+      return executeBuiltinAction(actionName, ctx, config)
+    }
+
+    // Fallback to shell execution
+    const start = Date.now()
+    try {
+      const { execSync: exec } = require('node:child_process') as typeof import('node:child_process')
+      const env = {
+        ...process.env,
+        PRLT_HOOK_EVENT: ctx.event,
+        PRLT_HOOK_TICKET: ctx.ticket ?? '',
+        PRLT_HOOK_PR: ctx.pr ? String(ctx.pr) : '',
+        PRLT_HOOK_BRANCH: ctx.branch ?? '',
+        PRLT_HOOK_AGENT: ctx.agent ?? '',
+      }
+      exec(actionName, { env, timeout: 30_000, stdio: 'pipe' })
+      return { action: actionName, success: true, durationMs: Date.now() - start }
+    } catch (err) {
+      return {
+        action: actionName,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Singleton
+// =============================================================================
+
+let _engine: OrchestrateEngine | undefined
+
+/**
+ * Initialize and start the orchestrate engine.
+ * Safe to call multiple times.
+ */
+export function initOrchestrateEngine(options: OrchestrateEngineOptions): OrchestrateEngine {
+  if (!_engine) {
+    _engine = new OrchestrateEngine(options)
+    _engine.start()
+  }
+  return _engine
+}
+
+/**
+ * Get the running orchestrate engine instance.
+ */
+export function getOrchestrateEngine(): OrchestrateEngine | undefined {
+  return _engine
+}
+
+/**
+ * Stop the orchestrate engine.
+ */
+export function stopOrchestrateEngine(): void {
+  if (_engine) {
+    _engine.stop()
+    _engine = undefined
+  }
+}

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -11,6 +11,7 @@
  * and built-in action execution.
  */
 
+import { execSync } from 'node:child_process'
 import type { SqliteDatabase } from '../database/sqlite.js'
 import { getEventBus } from '../events/event-bus.js'
 import { WorkHookStorage } from '../work-lifecycle/hooks/storage.js'
@@ -314,7 +315,6 @@ export class OrchestrateEngine {
     // Fallback to shell execution
     const start = Date.now()
     try {
-      const { execSync: exec } = require('node:child_process') as typeof import('node:child_process')
       const env = {
         ...process.env,
         PRLT_HOOK_EVENT: ctx.event,
@@ -323,7 +323,7 @@ export class OrchestrateEngine {
         PRLT_HOOK_BRANCH: ctx.branch ?? '',
         PRLT_HOOK_AGENT: ctx.agent ?? '',
       }
-      exec(actionName, { env, timeout: 30_000, stdio: 'pipe' })
+      execSync(actionName, { env, timeout: 30_000, stdio: 'pipe' })
       return { action: actionName, success: true, durationMs: Date.now() - start }
     } catch (err) {
       return {

--- a/apps/cli/src/lib/orchestrate/index.ts
+++ b/apps/cli/src/lib/orchestrate/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Orchestrate module — public API.
+ *
+ * Event-driven pipeline automation daemon with HITL controls.
+ * Extends the work-lifecycle hook system with built-in actions,
+ * YAML config loading, presets, and mode-aware execution.
+ */
+
+export type {
+  OrchestrateEvent,
+  HookMode,
+  BuiltinAction,
+  HooksYaml,
+  HookYamlEntry,
+  WorkflowYaml,
+  PresetName,
+  OrchestrateEventContext,
+  OrchestrateActionResult,
+} from './types.js'
+
+export {
+  ORCHESTRATE_EVENTS,
+  HOOK_MODES,
+  BUILTIN_ACTIONS,
+  PRESET_NAMES,
+} from './types.js'
+
+export {
+  PRESETS,
+  getPreset,
+} from './presets.js'
+
+export {
+  loadHooksYaml,
+  loadWorkflowYaml,
+  syncHooksFromYaml,
+  applyPreset,
+  exportHooksToYaml,
+} from './config-loader.js'
+
+export {
+  ACTION_HANDLERS,
+  executeBuiltinAction,
+} from './actions.js'
+
+export {
+  OrchestrateEngine,
+  initOrchestrateEngine,
+  getOrchestrateEngine,
+  stopOrchestrateEngine,
+} from './engine.js'
+
+export type { OrchestrateEngineOptions } from './engine.js'

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -1,0 +1,85 @@
+/**
+ * Orchestrate Presets
+ *
+ * Pre-configured hook sets for common automation levels.
+ *
+ * - aggressive: auto-everything — no human needed
+ * - conservative: confirm everything — human approves all
+ * - supervised: auto for safe ops, confirm for destructive
+ */
+
+import type { HookMode, OrchestrateEvent, PresetName } from './types.js'
+
+interface PresetHook {
+  event: OrchestrateEvent
+  action: string
+  mode: HookMode
+  config?: Record<string, unknown>
+}
+
+interface PresetDefinition {
+  name: PresetName
+  description: string
+  hooks: PresetHook[]
+}
+
+const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Record<string, unknown> }> = [
+  { event: 'on_ci_green', action: 'merge-pr' },
+  { event: 'on_pr_merged', action: 'move-ticket', config: { target: 'done' } },
+  { event: 'on_pr_opened', action: 'move-ticket', config: { target: 'review' } },
+  { event: 'on_pr_merged', action: 'rebase-conflicting-prs' },
+  { event: 'on_pr_conflicting', action: 'rebase-conflicting-prs' },
+  { event: 'on_ticket_ready', action: 'spawn-agent' },
+  { event: 'on_agent_died', action: 'respawn', config: { max_retries: 2 } },
+  { event: 'on_agent_died', action: 'notify' },
+  { event: 'on_ci_failed', action: 'notify' },
+  { event: 'on_ci_failed', action: 'spawn-fix-agent' },
+  { event: 'on_agent_completed', action: 'cleanup-container' },
+  { event: 'on_agent_idle', action: 'health-check' },
+  { event: 'on_agent_spawned', action: 'move-ticket', config: { target: 'in-progress' } },
+]
+
+/** Safe actions that can be auto-executed even in supervised mode. */
+const SAFE_ACTIONS = new Set([
+  'move-ticket',
+  'notify',
+  'cleanup-container',
+  'health-check',
+  'rebase-conflicting-prs',
+])
+
+export const PRESETS: Record<PresetName, PresetDefinition> = {
+  aggressive: {
+    name: 'aggressive',
+    description: 'Auto everything — no human needed',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: 'auto' as HookMode,
+    })),
+  },
+
+  conservative: {
+    name: 'conservative',
+    description: 'Confirm everything — human approves all actions',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: 'confirm' as HookMode,
+    })),
+  },
+
+  supervised: {
+    name: 'supervised',
+    description: 'Auto for safe ops, confirm for destructive actions',
+    hooks: SHARED_HOOKS.map(h => ({
+      ...h,
+      mode: (SAFE_ACTIONS.has(h.action) ? 'auto' : 'confirm') as HookMode,
+    })),
+  },
+}
+
+/**
+ * Get a preset definition by name.
+ */
+export function getPreset(name: PresetName): PresetDefinition {
+  return PRESETS[name]
+}

--- a/apps/cli/src/lib/orchestrate/types.ts
+++ b/apps/cli/src/lib/orchestrate/types.ts
@@ -1,0 +1,190 @@
+/**
+ * Orchestrate Types
+ *
+ * Defines events, hook modes, actions, and presets for the orchestrate daemon.
+ * The orchestrate system extends the existing work-lifecycle hooks with
+ * built-in actions and HITL (human-in-the-loop) controls.
+ */
+
+// =============================================================================
+// Orchestrator Events
+// =============================================================================
+
+/**
+ * All events the orchestrate daemon can react to.
+ * Extends the existing HookableEvent set with CI/PR/agent lifecycle events.
+ */
+export type OrchestrateEvent =
+  // Existing work-lifecycle events
+  | 'work:started'
+  | 'work:status_changed'
+  | 'work:pr_created'
+  | 'work:pr_merged'
+  | 'work:pr_closed'
+  | 'work:completed'
+  | 'agent:spawned'
+  | 'agent:stopped'
+  // New orchestrator events
+  | 'on_ci_green'
+  | 'on_ci_failed'
+  | 'on_pr_opened'
+  | 'on_pr_merged'
+  | 'on_pr_conflicting'
+  | 'on_ticket_ready'
+  | 'on_agent_spawned'
+  | 'on_agent_died'
+  | 'on_agent_completed'
+  | 'on_agent_idle'
+  | 'on_version_published'
+
+/** All valid orchestrate event names. */
+export const ORCHESTRATE_EVENTS: OrchestrateEvent[] = [
+  'work:started',
+  'work:status_changed',
+  'work:pr_created',
+  'work:pr_merged',
+  'work:pr_closed',
+  'work:completed',
+  'agent:spawned',
+  'agent:stopped',
+  'on_ci_green',
+  'on_ci_failed',
+  'on_pr_opened',
+  'on_pr_merged',
+  'on_pr_conflicting',
+  'on_ticket_ready',
+  'on_agent_spawned',
+  'on_agent_died',
+  'on_agent_completed',
+  'on_agent_idle',
+  'on_version_published',
+]
+
+// =============================================================================
+// Hook Modes
+// =============================================================================
+
+/**
+ * Automation level for a hook.
+ *
+ * - auto: fires immediately, no human needed
+ * - confirm: pauses, notifies, waits for approval
+ * - notify: fires but also pings (log, Slack, dashboard)
+ * - off: disabled
+ */
+export type HookMode = 'auto' | 'confirm' | 'notify' | 'off'
+
+/** All valid hook modes. */
+export const HOOK_MODES: HookMode[] = ['auto', 'confirm', 'notify', 'off']
+
+// =============================================================================
+// Built-in Actions
+// =============================================================================
+
+/**
+ * Built-in orchestrate actions.
+ * These are first-class actions the daemon knows how to execute natively.
+ */
+export type BuiltinAction =
+  | 'merge-pr'
+  | 'move-ticket'
+  | 'rebase-conflicting-prs'
+  | 'spawn-agent'
+  | 'respawn'
+  | 'notify'
+  | 'cleanup-container'
+  | 'spawn-fix-agent'
+  | 'health-check'
+
+/** All valid built-in action names. */
+export const BUILTIN_ACTIONS: BuiltinAction[] = [
+  'merge-pr',
+  'move-ticket',
+  'rebase-conflicting-prs',
+  'spawn-agent',
+  'respawn',
+  'notify',
+  'cleanup-container',
+  'spawn-fix-agent',
+  'health-check',
+]
+
+// =============================================================================
+// Hook Configuration (YAML shape)
+// =============================================================================
+
+/**
+ * A single hook entry as defined in hooks.yml.
+ */
+export interface HookYamlEntry {
+  action: string
+  mode: HookMode
+  max_retries?: number
+  args?: Record<string, string>
+}
+
+/**
+ * The full hooks.yml file shape.
+ * Keys are event names, values are arrays of hook entries.
+ */
+export type HooksYaml = Record<string, HookYamlEntry[]>
+
+// =============================================================================
+// Workflow Configuration (YAML shape)
+// =============================================================================
+
+/**
+ * The .proletariat/workflow.yml file shape.
+ */
+export interface WorkflowYaml {
+  branches?: {
+    target?: string
+    strategy?: 'squash' | 'merge' | 'rebase'
+  }
+  on_implement_complete?: string[]
+  on_review_complete?: string[]
+  review?: {
+    required?: boolean | 'auto'
+    auto_merge_on_green?: boolean
+  }
+}
+
+// =============================================================================
+// Presets
+// =============================================================================
+
+/**
+ * Preset name for quick hook configuration.
+ */
+export type PresetName = 'aggressive' | 'conservative' | 'supervised'
+
+/** All valid preset names. */
+export const PRESET_NAMES: PresetName[] = ['aggressive', 'conservative', 'supervised']
+
+/**
+ * Event context passed to hook handlers at runtime.
+ */
+export interface OrchestrateEventContext {
+  event: string
+  ticket?: string
+  pr?: number
+  branch?: string
+  agent?: string
+  container?: string
+  executionId?: string
+  prUrl?: string
+  projectId?: string
+  [key: string]: unknown
+}
+
+/**
+ * Result of running a single orchestrate hook action.
+ */
+export interface OrchestrateActionResult {
+  action: string
+  success: boolean
+  error?: string
+  durationMs: number
+  skipped?: boolean
+  awaitingConfirmation?: boolean
+}

--- a/apps/cli/src/lib/session-store.ts
+++ b/apps/cli/src/lib/session-store.ts
@@ -18,6 +18,8 @@ import { execSync } from 'node:child_process'
 // Types
 // =============================================================================
 
+export type SessionRole = 'worker' | 'orchestrator' | 'daemon' | 'headless'
+
 export interface SessionRecord {
   id: string
   agentName: string
@@ -28,6 +30,8 @@ export interface SessionRecord {
   environment: 'host' | 'docker' | 'podman'
   permissionMode: 'danger' | 'safe'
   status: 'running' | 'done' | 'error' | 'stopped'
+  role: SessionRole
+  daemonType?: string
   startedAt: Date
   endedAt?: Date
 }
@@ -42,6 +46,8 @@ interface SessionRow {
   environment: string
   permission_mode: string
   status: string
+  role: string | null
+  daemon_type: string | null
   started_at: number
   ended_at: number | null
 }
@@ -61,6 +67,8 @@ function rowToSession(row: SessionRow): SessionRecord {
     environment: row.environment as SessionRecord['environment'],
     permissionMode: row.permission_mode as SessionRecord['permissionMode'],
     status: row.status as SessionRecord['status'],
+    role: (row.role as SessionRole) || 'worker',
+    daemonType: row.daemon_type || undefined,
     startedAt: new Date(row.started_at),
     endedAt: row.ended_at ? new Date(row.ended_at) : undefined,
   }
@@ -96,10 +104,27 @@ export class SessionStore {
         environment TEXT NOT NULL DEFAULT 'host',
         permission_mode TEXT NOT NULL DEFAULT 'safe',
         status TEXT NOT NULL DEFAULT 'running',
+        role TEXT NOT NULL DEFAULT 'worker',
+        daemon_type TEXT,
         started_at INTEGER NOT NULL,
         ended_at INTEGER
       )
     `)
+    // Migrate existing tables that lack the new columns
+    this.migrateSchema()
+  }
+
+  private migrateSchema(): void {
+    try {
+      this.db.exec(`ALTER TABLE sessions ADD COLUMN role TEXT NOT NULL DEFAULT 'worker'`)
+    } catch {
+      // Column already exists
+    }
+    try {
+      this.db.exec(`ALTER TABLE sessions ADD COLUMN daemon_type TEXT`)
+    } catch {
+      // Column already exists
+    }
   }
 
   /**
@@ -113,14 +138,17 @@ export class SessionStore {
     sessionName: string
     environment: SessionRecord['environment']
     permissionMode: SessionRecord['permissionMode']
+    role?: SessionRole
+    daemonType?: string
   }): SessionRecord {
     const id = `SES-${Date.now().toString(36).toUpperCase()}`
     const now = Date.now()
+    const role = params.role || 'worker'
 
     this.db.prepare(`
-      INSERT INTO sessions (id, agent_name, runner, task, workdir, session_name, environment, permission_mode, status, started_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?)
-    `).run(id, params.agentName, params.runner, params.task, params.workdir, params.sessionName, params.environment, params.permissionMode, now)
+      INSERT INTO sessions (id, agent_name, runner, task, workdir, session_name, environment, permission_mode, status, role, daemon_type, started_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)
+    `).run(id, params.agentName, params.runner, params.task, params.workdir, params.sessionName, params.environment, params.permissionMode, role, params.daemonType || null, now)
 
     return {
       id,
@@ -132,6 +160,8 @@ export class SessionStore {
       environment: params.environment,
       permissionMode: params.permissionMode,
       status: 'running',
+      role,
+      daemonType: params.daemonType,
       startedAt: new Date(now),
     }
   }
@@ -222,9 +252,37 @@ export class SessionStore {
   }
 
   /**
+   * List sessions filtered by role.
+   */
+  listByRole(role: SessionRole, status?: SessionRecord['status']): SessionRecord[] {
+    let rows: SessionRow[]
+    if (status) {
+      rows = this.db.prepare<SessionRow>(
+        `SELECT * FROM sessions WHERE role = ? AND status = ? ORDER BY started_at DESC`
+      ).all(role, status)
+    } else {
+      rows = this.db.prepare<SessionRow>(
+        `SELECT * FROM sessions WHERE role = ? ORDER BY started_at DESC`
+      ).all(role)
+    }
+    return rows.map(rowToSession)
+  }
+
+  /**
+   * Get a running daemon session by its daemon type.
+   * Returns the most recent running daemon of the given type, or null.
+   */
+  getRunningDaemon(daemonType: string): SessionRecord | null {
+    const row = this.db.prepare<SessionRow>(
+      `SELECT * FROM sessions WHERE role = 'daemon' AND daemon_type = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`
+    ).get(daemonType)
+    return row ? rowToSession(row) : null
+  }
+
+  /**
    * Check if a tmux session is alive.
    */
-  private isTmuxSessionAlive(sessionName: string): boolean {
+  isTmuxSessionAlive(sessionName: string): boolean {
     try {
       execSync(`tmux has-session -t "${sessionName}" 2>/dev/null`, { stdio: 'pipe' })
       return true

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -10,16 +10,29 @@ import type { RuntimeEventName } from '../../events/events.js'
 
 /**
  * Work lifecycle event names that can trigger hooks.
- * Subset of RuntimeEventName limited to work-relevant events.
+ * Subset of RuntimeEventName limited to work-relevant events,
+ * plus orchestrate daemon events for pipeline automation.
  */
 export type HookableEvent = Extract<
   RuntimeEventName,
   | 'work:started'
   | 'work:status_changed'
   | 'work:pr_created'
+  | 'work:pr_merged'
   | 'work:completed'
   | 'agent:spawned'
   | 'agent:stopped'
+  | 'on_ci_green'
+  | 'on_ci_failed'
+  | 'on_pr_opened'
+  | 'on_pr_merged'
+  | 'on_pr_conflicting'
+  | 'on_ticket_ready'
+  | 'on_agent_spawned'
+  | 'on_agent_died'
+  | 'on_agent_completed'
+  | 'on_agent_idle'
+  | 'on_version_published'
 >
 
 /** All hookable event names for validation. */
@@ -27,9 +40,21 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
   'work:started',
   'work:status_changed',
   'work:pr_created',
+  'work:pr_merged',
   'work:completed',
   'agent:spawned',
   'agent:stopped',
+  'on_ci_green',
+  'on_ci_failed',
+  'on_pr_opened',
+  'on_pr_merged',
+  'on_pr_conflicting',
+  'on_ticket_ready',
+  'on_agent_spawned',
+  'on_agent_died',
+  'on_agent_completed',
+  'on_agent_idle',
+  'on_version_published',
 ]
 
 /**

--- a/apps/cli/test/unit/daemon-sessions.test.ts
+++ b/apps/cli/test/unit/daemon-sessions.test.ts
@@ -1,0 +1,427 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { SessionStore } from '../../src/lib/session-store.js'
+import { openDriver } from '../../src/lib/database/driver.js'
+import { parseSessionName } from '../../src/lib/execution/session-utils.js'
+
+// Ensure Date.now() advances between rapid session creates to avoid ID collision
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 2))
+
+describe('Daemon Sessions (PRLT-1287)', () => {
+  let store: SessionStore
+  let dbPath: string
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-daemon-test-')))
+    dbPath = path.join(tmpDir, 'sessions.db')
+    store = new SessionStore(dbPath)
+  })
+
+  afterEach(() => {
+    store.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  // ===========================================================================
+  // Daemon role in SessionStore
+  // ===========================================================================
+
+  describe('daemon role', () => {
+    it('creates a session with role=daemon and daemonType', () => {
+      const session = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'session-reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      expect(session.role).to.equal('daemon')
+      expect(session.daemonType).to.equal('reconciler')
+      expect(session.status).to.equal('running')
+    })
+
+    it('defaults role to worker when not specified', () => {
+      const session = store.create({
+        agentName: 'alice',
+        runner: 'claude-code',
+        task: 'implement feature',
+        workdir: '/repo',
+        sessionName: 'TKT-001-Implement-alice',
+        environment: 'host',
+        permissionMode: 'safe',
+      })
+
+      expect(session.role).to.equal('worker')
+      expect(session.daemonType).to.be.undefined
+    })
+
+    it('persists role and daemonType across reads', () => {
+      const created = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'session-reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      const retrieved = store.get(created.id)
+      expect(retrieved).to.not.be.null
+      expect(retrieved!.role).to.equal('daemon')
+      expect(retrieved!.daemonType).to.equal('reconciler')
+    })
+  })
+
+  // ===========================================================================
+  // listByRole()
+  // ===========================================================================
+
+  describe('listByRole()', () => {
+    it('returns only sessions matching the given role', async () => {
+      store.create({
+        agentName: 'alice',
+        runner: 'claude-code',
+        task: 'work',
+        workdir: '/repo',
+        sessionName: 'sess-1',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+
+      await tick()
+      store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      const daemons = store.listByRole('daemon')
+      expect(daemons).to.have.lengthOf(1)
+      expect(daemons[0].agentName).to.equal('reconciler')
+      expect(daemons[0].role).to.equal('daemon')
+
+      const workers = store.listByRole('worker')
+      expect(workers).to.have.lengthOf(1)
+      expect(workers[0].agentName).to.equal('alice')
+    })
+
+    it('filters by role and status', async () => {
+      const daemon1 = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      await tick()
+      store.create({
+        agentName: 'rebase-coordinator',
+        runner: 'daemon',
+        task: 'rebase',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-rebase',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'rebase-coordinator',
+      })
+
+      // Mark first daemon as done
+      store.updateStatus(daemon1.id, 'done')
+
+      const runningDaemons = store.listByRole('daemon', 'running')
+      expect(runningDaemons).to.have.lengthOf(1)
+      expect(runningDaemons[0].agentName).to.equal('rebase-coordinator')
+    })
+
+    it('returns empty array when no sessions match role', () => {
+      store.create({
+        agentName: 'alice',
+        runner: 'claude-code',
+        task: 'work',
+        workdir: '/repo',
+        sessionName: 'sess-1',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+
+      const daemons = store.listByRole('daemon')
+      expect(daemons).to.deep.equal([])
+    })
+  })
+
+  // ===========================================================================
+  // getRunningDaemon()
+  // ===========================================================================
+
+  describe('getRunningDaemon()', () => {
+    it('returns the running daemon for the given type', () => {
+      store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      const daemon = store.getRunningDaemon('reconciler')
+      expect(daemon).to.not.be.null
+      expect(daemon!.agentName).to.equal('reconciler')
+      expect(daemon!.daemonType).to.equal('reconciler')
+      expect(daemon!.status).to.equal('running')
+    })
+
+    it('returns null when daemon is not running', () => {
+      const created = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+      store.updateStatus(created.id, 'done')
+
+      const daemon = store.getRunningDaemon('reconciler')
+      expect(daemon).to.be.null
+    })
+
+    it('returns null when daemon type does not exist', () => {
+      const daemon = store.getRunningDaemon('nonexistent')
+      expect(daemon).to.be.null
+    })
+
+    it('returns most recent running daemon when multiple exist', async () => {
+      store.create({
+        agentName: 'reconciler-old',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler-old',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      await tick()
+      store.create({
+        agentName: 'reconciler-new',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler-new',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      const daemon = store.getRunningDaemon('reconciler')
+      expect(daemon).to.not.be.null
+      expect(daemon!.agentName).to.equal('reconciler-new')
+    })
+  })
+
+  // ===========================================================================
+  // Schema migration
+  // ===========================================================================
+
+  describe('schema migration', () => {
+    it('adds role and daemon_type columns to existing database', () => {
+      // Create a store with the old schema (no role/daemon_type columns)
+      store.close()
+
+      // Open a fresh DB, manually create the old schema without role/daemon_type
+      const rawDb = openDriver(dbPath, { foreignKeys: false })
+      rawDb.exec(`
+        DROP TABLE IF EXISTS sessions;
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          agent_name TEXT NOT NULL,
+          runner TEXT NOT NULL,
+          task TEXT NOT NULL,
+          workdir TEXT NOT NULL,
+          session_name TEXT NOT NULL,
+          environment TEXT NOT NULL DEFAULT 'host',
+          permission_mode TEXT NOT NULL DEFAULT 'safe',
+          status TEXT NOT NULL DEFAULT 'running',
+          started_at INTEGER NOT NULL,
+          ended_at INTEGER
+        )
+      `)
+      // Insert a row with the old schema
+      rawDb.prepare(`
+        INSERT INTO sessions (id, agent_name, runner, task, workdir, session_name, environment, permission_mode, status, started_at)
+        VALUES ('SES-OLD', 'alice', 'claude-code', 'test', '/repo', 'sess-1', 'host', 'safe', 'running', ?)
+      `).run(Date.now())
+      rawDb.close()
+
+      // Re-open with SessionStore — migration should add the columns
+      store = new SessionStore(dbPath)
+
+      // Verify the old row is readable with defaults
+      const old = store.get('SES-OLD')
+      expect(old).to.not.be.null
+      expect(old!.role).to.equal('worker')  // Default value
+      expect(old!.daemonType).to.be.undefined
+
+      // Verify we can create daemon sessions now
+      const daemon = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+      expect(daemon.role).to.equal('daemon')
+      expect(daemon.daemonType).to.equal('reconciler')
+    })
+  })
+
+  // ===========================================================================
+  // prlt session prune does NOT kill daemons
+  // ===========================================================================
+
+  describe('prune protection', () => {
+    it('daemon sessions are excluded from orphan detection by parseSessionName', () => {
+      // The daemon session name format (prlt-daemon-*) does NOT match
+      // the standard prlt session name format (TKT-xxx-action-agent),
+      // so parseSessionName() returns null, preventing prune from killing them.
+      const result = parseSessionName('prlt-daemon-reconciler')
+      expect(result).to.be.null  // Not parseable → won't be treated as orphan
+    })
+
+    it('daemon sessions in SessionStore are found by listByRole', async () => {
+      // Create a daemon and a worker
+      store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      await tick()
+      store.create({
+        agentName: 'alice',
+        runner: 'claude-code',
+        task: 'work',
+        workdir: '/repo',
+        sessionName: 'TKT-001-Implement-alice',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'worker',
+      })
+
+      // listByRole('daemon') returns only daemons — prune checks this
+      const daemons = store.listByRole('daemon', 'running')
+      expect(daemons).to.have.lengthOf(1)
+      expect(daemons[0].sessionName).to.equal('prlt-daemon-reconciler')
+    })
+  })
+
+  // ===========================================================================
+  // session list shows daemon with correct role
+  // ===========================================================================
+
+  describe('session list integration', () => {
+    it('daemon sessions show up with role=daemon in listing', () => {
+      const daemon = store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'session-reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      // Verify it shows up in list
+      const running = store.list('running')
+      const daemonSession = running.find(s => s.id === daemon.id)
+      expect(daemonSession).to.not.be.undefined
+      expect(daemonSession!.role).to.equal('daemon')
+      expect(daemonSession!.daemonType).to.equal('reconciler')
+    })
+
+    it('multiple daemon types can coexist', async () => {
+      store.create({
+        agentName: 'reconciler',
+        runner: 'daemon',
+        task: 'reconciliation',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-reconciler',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'reconciler',
+      })
+
+      await tick()
+      store.create({
+        agentName: 'rebase-coordinator',
+        runner: 'daemon',
+        task: 'rebase coordination',
+        workdir: '/workspace',
+        sessionName: 'prlt-daemon-rebase',
+        environment: 'host',
+        permissionMode: 'safe',
+        role: 'daemon',
+        daemonType: 'rebase-coordinator',
+      })
+
+      const daemons = store.listByRole('daemon', 'running')
+      expect(daemons).to.have.lengthOf(2)
+
+      const reconciler = store.getRunningDaemon('reconciler')
+      expect(reconciler).to.not.be.null
+      expect(reconciler!.agentName).to.equal('reconciler')
+
+      const rebase = store.getRunningDaemon('rebase-coordinator')
+      expect(rebase).to.not.be.null
+      expect(rebase!.agentName).to.equal('rebase-coordinator')
+    })
+  })
+})

--- a/docs/orchestrate/github-actions.yml
+++ b/docs/orchestrate/github-actions.yml
@@ -1,0 +1,75 @@
+# Example GitHub Actions workflows for prlt orchestrate
+#
+# These workflows bridge GitHub events to the prlt orchestrate daemon
+# via `prlt hook fire`. Copy and adapt them for your repository.
+
+# =============================================================================
+# CI Green → Auto-merge
+# =============================================================================
+# name: On CI Complete
+# on:
+#   check_suite:
+#     types: [completed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.check_suite.conclusion == 'success'
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_ci_green \
+#             --pr ${{ github.event.check_suite.pull_requests[0].number }} \
+#             --branch ${{ github.event.check_suite.head_branch }}
+
+# =============================================================================
+# CI Failed → Notify
+# =============================================================================
+# name: On CI Failed
+# on:
+#   check_suite:
+#     types: [completed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.check_suite.conclusion == 'failure'
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_ci_failed \
+#             --pr ${{ github.event.check_suite.pull_requests[0].number }} \
+#             --branch ${{ github.event.check_suite.head_branch }}
+
+# =============================================================================
+# PR Opened → Move ticket to Review
+# =============================================================================
+# name: On PR Opened
+# on:
+#   pull_request:
+#     types: [opened]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_pr_opened \
+#             --pr ${{ github.event.pull_request.number }} \
+#             --branch ${{ github.event.pull_request.head.ref }}
+
+# =============================================================================
+# PR Merged → Move ticket to Done + rebase siblings
+# =============================================================================
+# name: On PR Merged
+# on:
+#   pull_request:
+#     types: [closed]
+# jobs:
+#   hook:
+#     runs-on: ubuntu-latest
+#     if: github.event.pull_request.merged == true
+#     steps:
+#       - uses: actions/checkout@v4
+#       - run: |
+#           prlt hook fire on_pr_merged \
+#             --pr ${{ github.event.pull_request.number }} \
+#             --branch ${{ github.event.pull_request.head.ref }}

--- a/docs/orchestrate/hooks.example.yml
+++ b/docs/orchestrate/hooks.example.yml
@@ -1,0 +1,60 @@
+# .proletariat/hooks.yml
+#
+# Event-driven hook configuration for prlt orchestrate.
+# Load with: prlt orchestrate --load-yaml
+# Or apply a preset instead: prlt hook preset supervised
+#
+# Modes:
+#   auto    — fires immediately, no human needed
+#   confirm — pauses, waits for approval
+#   notify  — fires but also pings
+#   off     — disabled
+
+on_ci_green:
+  - action: merge-pr
+    mode: auto
+
+on_pr_merged:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: done
+  - action: rebase-conflicting-prs
+    mode: auto
+
+on_pr_opened:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: review
+
+on_ticket_ready:
+  - action: spawn-agent
+    mode: confirm
+
+on_agent_died:
+  - action: respawn
+    mode: auto
+    max_retries: 2
+  - action: notify
+    mode: auto
+
+on_ci_failed:
+  - action: notify
+    mode: auto
+  - action: spawn-fix-agent
+    mode: confirm
+
+on_agent_completed:
+  - action: cleanup-container
+    mode: auto
+
+on_agent_idle:
+  - action: health-check
+    mode: auto
+
+on_agent_spawned:
+  - action: move-ticket
+    mode: auto
+    args:
+      target: in-progress

--- a/docs/orchestrate/workflow.example.yml
+++ b/docs/orchestrate/workflow.example.yml
@@ -1,0 +1,19 @@
+# .proletariat/workflow.yml
+#
+# Workflow configuration — controls the shape of the work pipeline.
+# Separate from hooks — this determines branch strategy, PR behavior,
+# and review requirements.
+
+branches:
+  target: main                      # or develop, staging
+  strategy: squash                  # squash, merge, rebase
+
+on_implement_complete:
+  - create-pr                       # or commit-to-branch, draft-pr
+
+on_review_complete:
+  - merge-pr                        # or auto-merge-on-green
+
+review:
+  required: false                   # or true, or "auto" (AI review)
+  auto_merge_on_green: true         # merge when CI passes, no human review


### PR DESCRIPTION
## Summary

- **New `daemon` session role** added to `SessionStore` (sessions.db) with `role` and `daemon_type` columns, supporting schema migration for existing databases
- **New `prlt reconcile` command** with `--watch` mode (spawns tmux daemon session) and `--foreground` mode (runs in current terminal for debugging)
- **`prlt session list`** now shows daemon sessions with `⚙️ daemon` type indicator alongside agents and orchestrators
- **`prlt session health`** now monitors daemon sessions and marks dead ones for orchestrator restart
- **`prlt session prune`** explicitly protects daemon sessions — they are never reaped (supposed to run forever)
- **`prlt orchestrate`** auto-spawns the reconciler daemon on startup and supervises it every 60s, restarting within one health check cycle if it dies
- **Missing migration 0013** (agent_lifecycle_states) created to fix pre-existing build error

## Acceptance Criteria

- [x] `prlt reconcile --watch` spawns a tmux session instead of running in the foreground
- [x] Reconciler session registered in sessions.db with `role: 'daemon'`
- [x] `prlt session list` shows the reconciler alongside agents and orchestrators
- [x] `prlt session health` monitors the reconciler
- [x] Reconciler survives terminal close (lives in tmux)
- [x] `prlt orchestrate` auto-spawns the reconciler on startup if not already running
- [x] If reconciler dies, orchestrator detects and restarts it within one health check cycle
- [x] `prlt session prune` does NOT reap daemon-role sessions
- [x] New `daemon` role added to session schema (alongside orchestrator, worker, headless)
- [x] `prlt reconcile --watch --foreground` flag preserved for debugging
- [x] Tests for daemon session role, listing, pruning, schema migration

## Test plan

- [x] 15 unit tests covering daemon role CRUD, listByRole, getRunningDaemon, schema migration, prune protection, and multi-daemon coexistence
- [x] All 24 existing SessionStore tests still pass
- [ ] Manual: `prlt reconcile --watch` → verify tmux session created → close terminal → verify session survives
- [ ] Manual: Kill reconciler tmux pane → verify orchestrator restarts it within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)