### PR TITLE
chore: bump version to 0.3.115

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.114",
+  "version": "0.3.115",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
Publishes PRLT-1276 (sandboxed test npm), PRLT-1297 (service layer extraction), PRLT-1253 (LLM orchestrator daemon).