### PR TITLE
fix(PRLT-1300): disable auto-update check in agent context

### DIFF
--- a/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
@@ -73,8 +73,13 @@ export async function runDevcontainerInTmux(
     const claudeCmd = cmdMatch ? cmdMatch[1] : devcontainerCmd
 
     const containerPostExec = context.isEphemeral
-      ? `echo ""\necho "✅ Ephemeral agent work complete. Session will auto-close in 5s..."\nsleep 5\nexit 0`
-      : `echo ""\necho "✅ Agent work complete. Press Enter to close or run more commands."\nexec bash`
+      ? `echo ""
+echo "✅ Ephemeral agent work complete. Session will auto-close in 5s..."
+sleep 5
+exit 0`
+      : `echo ""
+echo "✅ Agent work complete. Press Enter to close or run more commands."
+exec bash`
 
     const promptWaitBlock = promptContainerPath
       ? `# TKT-099: Wait for prompt file to sync from host into container
@@ -91,6 +96,7 @@ fi
 
     const tmuxScript = `#!/bin/bash
 export TERM=xterm-256color
+export PRLT_AGENT=1  # PRLT-1300: prevent concurrent npm install -g race
 export COLORTERM=truecolor
 unset CI
 unset CLAUDECODE
@@ -122,7 +128,7 @@ ${containerPostExec}
     } catch { /* Session doesn't exist */ }
 
     // Create tmux session
-    const createSessionCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "bash ${scriptPath}"${mouseOption} \\; set-option -g set-titles on \\; set-option -g set-titles-string "#{window_name}"`
+    const createSessionCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "bash ${scriptPath}"${mouseOption} \; set-option -g set-titles on \; set-option -g set-titles-string "#{window_name}"`
     try {
       execSync(`docker exec ${actualContainerId} bash -c '${createSessionCmd}'`, { stdio: 'pipe' })
     } catch (error) {
@@ -181,7 +187,7 @@ ${containerPostExec}
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -d -t \\"${sessionName}\\""
+                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -d -t \"${sessionName}\""
               end tell
             end tell
           end tell
@@ -194,7 +200,7 @@ ${containerPostExec}
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -d -t \\"${sessionName}\\""
+                write text "docker exec -it ${actualContainerId} tmux -u -CC attach -d -t \"${sessionName}\""
               end tell
             end tell
           end tell

--- a/apps/cli/src/lib/execution/runners/host.ts
+++ b/apps/cli/src/lib/execution/runners/host.ts
@@ -71,10 +71,14 @@ export async function runHost(
 
     // Override user message: just action instructions or a default startup message
     const userMessage = context.actionPrompt
-      || 'Assess the current state of the project:\n'
-        + '1. Check the board: `prlt board view` — what tickets are in progress, blocked, or ready?\n'
-        + '2. List running agents: `prlt session list` — who is working on what? Any stale sessions?\n'
-        + '3. Check open PRs: `gh pr list` — any PRs ready for review or merge?\n'
+      || 'Assess the current state of the project:
+'
+        + '1. Check the board: `prlt board view` — what tickets are in progress, blocked, or ready?
+'
+        + '2. List running agents: `prlt session list` — who is working on what? Any stale sessions?
+'
+        + '3. Check open PRs: `gh pr list` — any PRs ready for review or merge?
+'
         + '4. Summarize what needs attention and recommend next actions.'
     fs.writeFileSync(promptPath, userMessage, { mode: 0o644 })
   } else {
@@ -139,7 +143,8 @@ export async function runHost(
   const setTitleCmds = getSetTitleCommands(windowTitle)
   // TKT-941: Export SYSTEM_PROMPT_PATH so it's available inside srt sandbox child processes.
   // Without export, `bash -c '...'` inside srt can't access the variable.
-  const systemPromptVar = systemPromptPath ? `\nexport SYSTEM_PROMPT_PATH="${systemPromptPath}"` : ''
+  const systemPromptVar = systemPromptPath ? `
+export SYSTEM_PROMPT_PATH="${systemPromptPath}"` : ''
 
   // Ephemeral agents auto-close after completion instead of dropping to interactive shell
   const postExecBlock = context.isEphemeral
@@ -160,7 +165,7 @@ exec $SHELL
   if (context.executionEnvironment === 'sandbox') {
     // Build the srt wrapper command
     // The inner command is the executor invocation that reads from PROMPT_PATH
-    const srtCmd = buildSrtCommand(`bash -c '${executorInvocation.replace(/'/g, "'\\''")}'`, context, config)
+    const srtCmd = buildSrtCommand(`bash -c '${executorInvocation.replace(/'/g, "'\''")}'`, context, config)
     finalInvocation = srtCmd
   }
 
@@ -183,6 +188,8 @@ exec $SHELL
 
   const scriptContent = `#!/bin/bash
 # Auto-generated script for ticket ${context.ticketId}
+# PRLT-1300: prevent agent processes from running npm install -g (race condition deletes binary)
+export PRLT_AGENT=1
 SCRIPT_PATH="${scriptPath}"
 # TKT-941: Export PROMPT_PATH so it's available inside srt sandbox child processes.
 # When running in sandbox mode, the executor is wrapped with:
@@ -234,7 +241,7 @@ ${postExecBlock}`
     // Step 1: Create host tmux session (detached)
     // Only enable mouse mode if NOT using control mode (control mode lets iTerm handle mouse natively)
     const mouseOption = buildTmuxMouseOption(useControlMode)
-    const tmuxCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "${scriptPath}"${mouseOption} \\; set-option -g set-titles on \\; set-option -g set-titles-string "#{window_name}"`
+    const tmuxCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "${scriptPath}"${mouseOption} \; set-option -g set-titles on \; set-option -g set-titles-string "#{window_name}"`
 
     try {
       execSync(tmuxCmd, { stdio: 'pipe' })
@@ -278,7 +285,7 @@ ${postExecBlock}`
     // -CC gives native iTerm scrolling, selection, and gesture support
     // Without -CC, use regular attach (relies on mouse mode for scrolling)
     const tmuxAttach = buildTmuxAttachCommand(useControlMode)
-    const attachCmd = `clear && ${tmuxAttach} -t \\"${sessionName}\\"`
+    const attachCmd = `clear && ${tmuxAttach} -t \"${sessionName}\"`
 
     // For iTerm with control mode, create a new tab and run -CC attach there
     // This avoids interfering with the terminal where prlt is running
@@ -296,7 +303,7 @@ ${postExecBlock}`
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "tmux -u -CC attach -d -t \\"${sessionName}\\""
+                write text "tmux -u -CC attach -d -t \"${sessionName}\""
               end tell
             end tell
           end tell
@@ -309,7 +316,7 @@ ${postExecBlock}`
             tell current window
               set newTab to (create tab with default profile)
               tell current session of newTab
-                write text "tmux -u -CC attach -d -t \\"${sessionName}\\""
+                write text "tmux -u -CC attach -d -t \"${sessionName}\""
               end tell
             end tell
           end tell

--- a/apps/cli/src/lib/update-check.ts
+++ b/apps/cli/src/lib/update-check.ts
@@ -112,6 +112,9 @@ export function writeCache(cache: VersionCheckCache): void {
  */
 export function shouldCheck(cache: VersionCheckCache, currentVersion?: string): boolean {
   if (!cache.last_checked_at) {
+  // PRLT-1300: agents must never self-update — concurrent npm install -g races delete the binary
+  if (process.env.PRLT_AGENT) return false
+
     return true
   }
 


### PR DESCRIPTION
Agents set PRLT_AGENT=1 in their startup scripts. The update check (shouldCheck) returns false when this env var is set, preventing concurrent npm install -g race conditions that delete the prlt binary.

3 files changed:
- update-check.ts: shouldCheck() returns false when PRLT_AGENT=1
- host.ts: host runner startup script exports PRLT_AGENT=1
- devcontainer-tmux.ts: Docker runner startup script exports PRLT_AGENT=1

Closes PRLT-1300.