### PR TITLE
PRLT-1301: Isolate agent test DB with workspace sandbox root hook

### DIFF
--- a/apps/cli/.mocharc.json
+++ b/apps/cli/.mocharc.json
@@ -2,6 +2,7 @@
   "require": [
     "ts-node/register",
     "test/setup/npm-sandbox.ts",
+    "test/setup/workspace-sandbox.ts",
     "test/setup/native-sqlite-check.ts",
     "test/setup/worker-graceful-exit.ts"
   ],

--- a/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
@@ -97,6 +97,7 @@ fi
     const tmuxScript = `#!/bin/bash
 export TERM=xterm-256color
 export PRLT_AGENT=1  # PRLT-1300: prevent concurrent npm install -g race
+export PRLT_TEST_WORKSPACE_DB="/tmp/prlt-test-workspace-$$.db"  # PRLT-1301: isolate agent test DB
 export COLORTERM=truecolor
 unset CI
 unset CLAUDECODE

--- a/apps/cli/src/lib/execution/runners/host.ts
+++ b/apps/cli/src/lib/execution/runners/host.ts
@@ -185,6 +185,8 @@ exec $SHELL
 # Auto-generated script for ticket ${context.ticketId}
 # PRLT-1300: prevent agent processes from running npm install -g (race condition deletes binary)
 export PRLT_AGENT=1
+# PRLT-1301: provide isolated test DB path so agent tests never touch the real workspace.db
+export PRLT_TEST_WORKSPACE_DB="/tmp/prlt-test-workspace-$$.db"
 SCRIPT_PATH="${scriptPath}"
 # TKT-941: Export PROMPT_PATH so it's available inside srt sandbox child processes.
 # When running in sandbox mode, the executor is wrapped with:

--- a/apps/cli/test/setup/workspace-sandbox.ts
+++ b/apps/cli/test/setup/workspace-sandbox.ts
@@ -1,0 +1,63 @@
+/**
+ * Mocha root hook: workspace DB sandbox (PRLT-1301).
+ *
+ * Prevents any test from accidentally discovering or modifying the real
+ * HQ workspace.db. This is a safety net — similar to npm-sandbox.ts for
+ * the global npm prefix.
+ *
+ * Problem: Agents running in worktrees inside the HQ directory tree can
+ * walk up the directory tree and find the real workspace DB at
+ * .proletariat/workspace.db. Two critical incidents (PRLT-1284, PRLT-1299)
+ * were caused by agent tests running migrations or deleting rows on the
+ * live DB.
+ *
+ * Solution: Create a sandboxed workspace directory with a fresh, schema-only
+ * DB and point all workspace resolution at it via PRLT_HQ_PATH + PRLT_TEST_ENV.
+ * Agent prlt CLI commands are unaffected (they don't load mocha root hooks).
+ *
+ * If PRLT_TEST_WORKSPACE_DB is set (by agent startup scripts), the sandbox
+ * DB is created at that path. Otherwise a temp path is generated.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, copyFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { getOrCreateWorkspaceTemplate } from './template-db.js'
+
+const sandboxDir = mkdtempSync(join(tmpdir(), 'prlt-workspace-sandbox-'))
+const proletariatDir = join(sandboxDir, '.proletariat')
+mkdirSync(proletariatDir, { recursive: true })
+
+// Determine DB path: use agent-provided path or default to sandbox dir
+const dbPath = process.env.PRLT_TEST_WORKSPACE_DB || join(proletariatDir, 'workspace.db')
+
+// If using a custom DB path, ensure its parent directory exists
+if (process.env.PRLT_TEST_WORKSPACE_DB) {
+  const { dirname } = await import('node:path')
+  const parentDir = dirname(dbPath)
+  if (!existsSync(parentDir)) {
+    mkdirSync(parentDir, { recursive: true })
+  }
+}
+
+// Initialize DB with current schema (no data) using the cached template
+const templatePath = getOrCreateWorkspaceTemplate()
+copyFileSync(templatePath, dbPath)
+
+// Write config.json so isValidHQ() recognizes this as a valid HQ
+writeFileSync(
+  join(proletariatDir, 'config.json'),
+  JSON.stringify({ version: '1.0.0', schemaVersion: 1, type: 'hq' }, null, 2)
+)
+
+// Create minimal HQ directory structure (agents dirs needed by some tests)
+mkdirSync(join(sandboxDir, 'agents', 'staff'), { recursive: true })
+mkdirSync(join(sandboxDir, 'agents', 'temp'), { recursive: true })
+
+// Point workspace resolution at the sandbox
+// PRLT_HQ_PATH is only respected when PRLT_TEST_ENV=true (see workspace.ts)
+process.env.PRLT_HQ_PATH = sandboxDir
+process.env.PRLT_TEST_ENV = 'true'
+
+// Export the sandbox path so tests can verify isolation
+process.env.PRLT_TEST_WORKSPACE_DB = dbPath

--- a/apps/cli/test/unit/auto-bootstrap-pmo.test.ts
+++ b/apps/cli/test/unit/auto-bootstrap-pmo.test.ts
@@ -236,6 +236,29 @@ describe('PRLT-1239: Auto-bootstrap PMO on first use', () => {
   });
 
   describe('findPMO() auto-bootstrap integration', () => {
+    // PRLT-1301: Save/restore env vars so the workspace-sandbox root hook
+    // doesn't interfere with findPMO's HQ resolution in these tests.
+    let savedHqPath: string | undefined;
+    let savedTestEnv: string | undefined;
+
+    beforeEach(() => {
+      savedHqPath = process.env.PRLT_HQ_PATH;
+      savedTestEnv = process.env.PRLT_TEST_ENV;
+    });
+
+    afterEach(() => {
+      if (savedHqPath !== undefined) {
+        process.env.PRLT_HQ_PATH = savedHqPath;
+      } else {
+        delete process.env.PRLT_HQ_PATH;
+      }
+      if (savedTestEnv !== undefined) {
+        process.env.PRLT_TEST_ENV = savedTestEnv;
+      } else {
+        delete process.env.PRLT_TEST_ENV;
+      }
+    });
+
     it('auto-bootstraps when HQ has workspace.db without PMO tables', () => {
       const hqPath = path.join(tmpDir, 'test-hq');
       const dbPath = createHQStructure(hqPath);
@@ -244,6 +267,10 @@ describe('PRLT-1239: Auto-bootstrap PMO on first use', () => {
       // Save and override cwd — use realpath to normalize macOS /private/var symlinks
       const originalCwd = process.cwd();
       process.chdir(hqPath);
+
+      // Clear HQ env vars so findPMO uses cwd-based discovery (which triggers auto-bootstrap)
+      delete process.env.PRLT_HQ_PATH;
+      delete process.env.PRLT_TEST_ENV;
 
       try {
         const pmoPath = findPMO();
@@ -270,6 +297,10 @@ describe('PRLT-1239: Auto-bootstrap PMO on first use', () => {
       const originalCwd = process.cwd();
       process.chdir(emptyDir);
 
+      // Clear HQ env vars so findPMO relies on cwd-based discovery (which should find nothing)
+      delete process.env.PRLT_HQ_PATH;
+      delete process.env.PRLT_TEST_ENV;
+
       try {
         const pmoPath = findPMO();
         expect(pmoPath).to.be.null;
@@ -280,6 +311,31 @@ describe('PRLT-1239: Auto-bootstrap PMO on first use', () => {
   });
 
   describe('Error messages', () => {
+    // PRLT-1301: Save/restore env vars so the workspace-sandbox root hook
+    // doesn't interfere with "no HQ" error path testing.
+    let savedHqPath: string | undefined;
+    let savedTestEnv: string | undefined;
+
+    beforeEach(() => {
+      savedHqPath = process.env.PRLT_HQ_PATH;
+      savedTestEnv = process.env.PRLT_TEST_ENV;
+      delete process.env.PRLT_HQ_PATH;
+      delete process.env.PRLT_TEST_ENV;
+    });
+
+    afterEach(() => {
+      if (savedHqPath !== undefined) {
+        process.env.PRLT_HQ_PATH = savedHqPath;
+      } else {
+        delete process.env.PRLT_HQ_PATH;
+      }
+      if (savedTestEnv !== undefined) {
+        process.env.PRLT_TEST_ENV = savedTestEnv;
+      } else {
+        delete process.env.PRLT_TEST_ENV;
+      }
+    });
+
     it('getPMOContext error message does not reference "prlt pmo init"', async () => {
       // getPMOContext should throw with updated error message when no workspace found
       const { getPMOContext } = await import('../../src/lib/pmo/pmo-context.js');

--- a/apps/cli/test/unit/workspace-sandbox.test.ts
+++ b/apps/cli/test/unit/workspace-sandbox.test.ts
@@ -1,0 +1,141 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { findHQRoot } from '../../src/lib/workspace.js'
+import { getDatabasePath } from '../../src/lib/database/workspace.js'
+import { runDrizzleMigrations } from '../../src/lib/database/migrator.js'
+import { ALL_MIGRATIONS } from '../../src/lib/database/migrations/index.js'
+
+describe('PRLT-1301: workspace DB sandbox', () => {
+  // =========================================================================
+  // Root hook safety net verification
+  // =========================================================================
+  describe('workspace-sandbox root hook', () => {
+    it('PRLT_TEST_WORKSPACE_DB is set by the mocha root hook', () => {
+      // The workspace-sandbox.ts root hook MUST set this env var before any
+      // test runs, so no test can accidentally operate on the real HQ
+      // workspace.db. If this fails, the root hook is missing or broken.
+      expect(process.env.PRLT_TEST_WORKSPACE_DB).to.be.a('string')
+      expect(process.env.PRLT_TEST_WORKSPACE_DB!.length).to.be.greaterThan(0)
+    })
+
+    it('PRLT_HQ_PATH points to the sandbox directory', () => {
+      expect(process.env.PRLT_HQ_PATH).to.be.a('string')
+      expect(process.env.PRLT_HQ_PATH!).to.include('prlt-workspace-sandbox-')
+    })
+
+    it('PRLT_TEST_ENV is set to enable PRLT_HQ_PATH resolution', () => {
+      expect(process.env.PRLT_TEST_ENV).to.equal('true')
+    })
+
+    it('sandbox DB file exists and has valid schema', () => {
+      const dbPath = process.env.PRLT_TEST_WORKSPACE_DB!
+      expect(fs.existsSync(dbPath)).to.be.true
+
+      const db = new Database(dbPath, { readonly: true })
+      try {
+        // Verify core tables exist
+        const tables = db.prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).all() as { name: string }[]
+        const tableNames = tables.map(t => t.name)
+
+        expect(tableNames).to.include('workspace')
+        expect(tableNames).to.include('agents')
+        expect(tableNames).to.include('repositories')
+        expect(tableNames).to.include('prlt_migrations')
+      } finally {
+        db.close()
+      }
+    })
+
+    it('sandbox DB has schema but no data rows', () => {
+      const dbPath = process.env.PRLT_TEST_WORKSPACE_DB!
+      const db = new Database(dbPath, { readonly: true })
+      try {
+        const count = db.prepare('SELECT COUNT(*) as cnt FROM workspace').get() as { cnt: number }
+        expect(count.cnt).to.equal(0)
+      } finally {
+        db.close()
+      }
+    })
+
+    it('sandbox directory has valid HQ config.json', () => {
+      const hqPath = process.env.PRLT_HQ_PATH!
+      const configPath = path.join(hqPath, '.proletariat', 'config.json')
+      expect(fs.existsSync(configPath)).to.be.true
+
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+      expect(config.type).to.equal('hq')
+    })
+
+    it('findHQRoot returns the sandbox, not the real HQ', () => {
+      const hqPath = findHQRoot()
+      expect(hqPath).to.equal(process.env.PRLT_HQ_PATH)
+      // Verify it does NOT point to the real proletariat-hq directory
+      expect(hqPath).to.include('prlt-workspace-sandbox-')
+    })
+  })
+
+  // =========================================================================
+  // Regression test: migrations must not affect real HQ DB
+  // =========================================================================
+  describe('migration isolation', () => {
+    it('running a migration in test does NOT modify the real HQ workspace.db', () => {
+      // This test creates a fresh in-memory DB, runs all migrations,
+      // then adds a custom table. The point is to verify that no code path
+      // in test execution can reach the real workspace.db.
+
+      // 1. Snapshot the sandbox DB before migration
+      const sandboxDbPath = process.env.PRLT_TEST_WORKSPACE_DB!
+      const beforeStat = fs.statSync(sandboxDbPath)
+
+      // 2. Create a separate temp DB and run a "test migration" on it
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-migration-test-'))
+      const testDbPath = path.join(tmpDir, 'test-migration.db')
+      const testDb = new Database(testDbPath)
+      testDb.pragma('foreign_keys = ON')
+      runDrizzleMigrations(testDb, ALL_MIGRATIONS)
+
+      // Add a custom table (simulating an agent's migration work)
+      testDb.exec('CREATE TABLE test_agent_table (id INTEGER PRIMARY KEY, value TEXT)')
+      testDb.exec("INSERT INTO test_agent_table VALUES (1, 'test')")
+      testDb.close()
+
+      // 3. Verify the sandbox DB was NOT modified by the migration
+      const sandboxDb = new Database(sandboxDbPath, { readonly: true })
+      try {
+        const tables = sandboxDb.prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='test_agent_table'"
+        ).all()
+        expect(tables).to.have.length(0, 'test_agent_table should NOT exist in sandbox DB')
+      } finally {
+        sandboxDb.close()
+      }
+
+      // 4. Verify getDatabasePath resolves to sandbox, not real HQ
+      const hqPath = process.env.PRLT_HQ_PATH!
+      const resolvedDbPath = getDatabasePath(hqPath)
+      expect(resolvedDbPath).to.include('prlt-workspace-sandbox-')
+
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    })
+
+    it('workspace resolution never escapes to real HQ directory tree', () => {
+      // Even if we try to resolve from a directory inside the real HQ,
+      // findHQRoot should return the sandbox (via PRLT_HQ_PATH) not the real HQ
+      const hqRoot = findHQRoot()
+      expect(hqRoot).to.not.be.null
+      expect(hqRoot!).to.include('prlt-workspace-sandbox-')
+
+      // The sandbox path should be in /tmp, not in the real project tree
+      expect(hqRoot!).to.satisfy(
+        (p: string) => p.startsWith(os.tmpdir()) || p.startsWith('/private' + os.tmpdir()),
+        `Expected sandbox path to be in temp dir, got: ${hqRoot}`
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds workspace-sandbox.ts mocha root hook that creates an isolated workspace DB for all test runs, preventing tests from discovering or modifying the real HQ workspace.db
- Sets PRLT_TEST_WORKSPACE_DB env var in agent startup scripts (host.ts, devcontainer-tmux.ts) so agents have a dedicated test DB path
- Fixes auto-bootstrap-pmo tests to properly save/restore env vars with the new sandbox

## Problem

Agents working in worktrees inside the HQ directory tree could discover and modify the live workspace DB. Two critical incidents (PRLT-1284, PRLT-1299) were caused by agent tests running migrations or deleting rows on the real DB.

## How it works

1. **Mocha root hook** (workspace-sandbox.ts): Creates a temp directory with .proletariat/ structure, initializes a schema-only workspace.db from the cached template, and sets PRLT_HQ_PATH + PRLT_TEST_ENV so all workspace resolution points to the sandbox
2. **Agent startup**: Sets PRLT_TEST_WORKSPACE_DB=/tmp/prlt-test-workspace-$$.db so agent test runs use a unique isolated DB
3. **prlt CLI commands**: Unaffected — they don't load mocha root hooks

## Test plan

- [x] 9 new unit tests verify sandbox setup, schema integrity, and migration isolation
- [x] Regression test confirms migrations in tests don't affect sandbox DB
- [x] findHQRoot returns sandbox path, not real HQ
- [x] Full unit test suite passes (4219 passing, 8 pre-existing failures unrelated to this change)