### PR TITLE
chore: bump version to 0.3.118

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.117",
+  "version": "0.3.118",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
PRLT-1305 (watch keepalive), PRLT-1299 (dead PMO tables removed)