### PR TITLE
feat(PRLT-1191): implement Notion ticket provider

### DIFF
--- a/apps/cli/src/lib/notion/client.ts
+++ b/apps/cli/src/lib/notion/client.ts
@@ -1,0 +1,68 @@
+import type { NotionPage, NotionDatabase } from './types.js'
+
+const NOTION_API_URL = 'https://api.notion.com/v1'
+const NOTION_API_VERSION = '2022-06-28'
+
+export class NotionClient {
+  constructor(private apiKey: string) {}
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${NOTION_API_URL}${path}`
+    const options: RequestInit = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+        'Notion-Version': NOTION_API_VERSION,
+      },
+    }
+    if (body !== undefined) {
+      options.body = JSON.stringify(body)
+    }
+    const response = await fetch(url, options)
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`Notion API ${method} ${path} failed with status ${response.status}: ${text}`)
+    }
+    return (await response.json()) as T
+  }
+
+  async verify(): Promise<{ botId: string; workspaceName: string }> {
+    const data = await this.request<{ id: string; name: string }>('GET', '/users/me')
+    return { botId: data.id, workspaceName: data.name }
+  }
+
+  async getDatabase(databaseId: string): Promise<NotionDatabase> {
+    return this.request<NotionDatabase>('GET', `/databases/${databaseId}`)
+  }
+
+  async queryDatabase(databaseId: string, options?: {
+    filter?: Record<string, unknown>
+    sorts?: Array<Record<string, unknown>>
+    startCursor?: string
+    pageSize?: number
+  }): Promise<{ results: NotionPage[]; has_more: boolean; next_cursor: string | null }> {
+    const body: Record<string, unknown> = {}
+    if (options?.filter) body.filter = options.filter
+    if (options?.sorts) body.sorts = options.sorts
+    if (options?.startCursor) body.start_cursor = options.startCursor
+    if (options?.pageSize) body.page_size = options.pageSize
+    return this.request<{ results: NotionPage[]; has_more: boolean; next_cursor: string | null }>('POST', `/databases/${databaseId}/query`, body)
+  }
+
+  async getPage(pageId: string): Promise<NotionPage> {
+    return this.request<NotionPage>('GET', `/pages/${pageId}`)
+  }
+
+  async createPage(databaseId: string, properties: Record<string, unknown>): Promise<NotionPage> {
+    return this.request<NotionPage>('POST', '/pages', { parent: { database_id: databaseId }, properties })
+  }
+
+  async updatePage(pageId: string, properties: Record<string, unknown>): Promise<NotionPage> {
+    return this.request<NotionPage>('PATCH', `/pages/${pageId}`, { properties })
+  }
+
+  async archivePage(pageId: string): Promise<void> {
+    await this.request<NotionPage>('PATCH', `/pages/${pageId}`, { archived: true })
+  }
+}

--- a/apps/cli/src/lib/notion/config.ts
+++ b/apps/cli/src/lib/notion/config.ts
@@ -1,0 +1,69 @@
+import type Database from 'better-sqlite3'
+import type { NotionConfig } from './types.js'
+import { loadProviderSources, resolveApiKey } from '../work-source/provider-sources.js'
+import { SettingsStore } from '../database/settings-store.js'
+import { getCredential, setCredential, deleteCredential, hasCredential } from '../database/credential-store.js'
+
+const NOTION_CONFIG_KEYS = {
+  apiKey: 'notion.api_key',
+  defaultDatabaseId: 'notion.default_database_id',
+  defaultDatabaseName: 'notion.default_database_name',
+  statusPropertyName: 'notion.status_property_name',
+  titlePropertyName: 'notion.title_property_name',
+} as const
+
+export function isNotionConfigured(db: Database.Database): boolean {
+  if (hasCredential(db, NOTION_CONFIG_KEYS.apiKey)) return true
+  return !!(process.env.PRLT_NOTION_API_KEY || process.env.NOTION_API_KEY)
+}
+
+export function loadNotionConfig(db: Database.Database): NotionConfig | null {
+  const apiKey = getCredential(db, NOTION_CONFIG_KEYS.apiKey)
+  if (!apiKey) return null
+  const settings = new SettingsStore(db)
+  return {
+    apiKey,
+    defaultDatabaseId: settings.get(NOTION_CONFIG_KEYS.defaultDatabaseId) ?? undefined,
+    defaultDatabaseName: settings.get(NOTION_CONFIG_KEYS.defaultDatabaseName) ?? undefined,
+    statusPropertyName: settings.get(NOTION_CONFIG_KEYS.statusPropertyName) ?? undefined,
+    titlePropertyName: settings.get(NOTION_CONFIG_KEYS.titlePropertyName) ?? undefined,
+  }
+}
+
+export function saveNotionApiKey(db: Database.Database, apiKey: string): void {
+  setCredential(db, NOTION_CONFIG_KEYS.apiKey, apiKey)
+}
+
+export function saveNotionDefaultDatabase(db: Database.Database, databaseId: string, databaseName: string): void {
+  const settings = new SettingsStore(db)
+  settings.set(NOTION_CONFIG_KEYS.defaultDatabaseId, databaseId)
+  settings.set(NOTION_CONFIG_KEYS.defaultDatabaseName, databaseName)
+}
+
+export function clearNotionConfig(db: Database.Database): void {
+  const settings = new SettingsStore(db)
+  for (const key of Object.values(NOTION_CONFIG_KEYS)) {
+    if (key === NOTION_CONFIG_KEYS.apiKey) {
+      deleteCredential(db, key)
+    } else {
+      settings.delete(key)
+    }
+  }
+}
+
+export function getNotionApiKey(db: Database.Database): string | null {
+  try {
+    const sources = loadProviderSources(db)
+    for (const source of sources) {
+      if (source.provider === 'notion') {
+        const key = resolveApiKey(db, source)
+        if (key) return key
+      }
+    }
+  } catch { /* Provider sources table may not exist */ }
+
+  const envKey = process.env.PRLT_NOTION_API_KEY || process.env.NOTION_API_KEY
+  if (envKey) return envKey
+
+  return getCredential(db, NOTION_CONFIG_KEYS.apiKey)
+}

--- a/apps/cli/src/lib/notion/index.ts
+++ b/apps/cli/src/lib/notion/index.ts
@@ -1,0 +1,22 @@
+export { NotionClient } from './client.js'
+export {
+  isNotionConfigured,
+  loadNotionConfig,
+  saveNotionApiKey,
+  saveNotionDefaultDatabase,
+  clearNotionConfig,
+  getNotionApiKey,
+} from './config.js'
+export type {
+  NotionConfig,
+  NotionPage,
+  NotionProperty,
+  NotionDatabase,
+  NotionDatabaseProperty,
+} from './types.js'
+export {
+  NOTION_STATUS_GROUP_TO_PMO_CATEGORY,
+  NOTION_STATUS_NAME_TO_PMO_CATEGORY,
+  NOTION_PRIORITY_TO_PMO,
+  PMO_PRIORITY_TO_NOTION,
+} from './types.js'

--- a/apps/cli/src/lib/notion/types.ts
+++ b/apps/cli/src/lib/notion/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Notion Integration Types
+ */
+
+export interface NotionPage {
+  id: string
+  url: string
+  created_time: string
+  last_edited_time: string
+  properties: Record<string, NotionProperty>
+}
+
+export interface NotionProperty {
+  type: string
+  title?: Array<{ plain_text: string }>
+  rich_text?: Array<{ plain_text: string }>
+  status?: { id: string; name: string; color: string } | null
+  select?: { id: string; name: string; color: string } | null
+  multi_select?: Array<{ id: string; name: string; color: string }>
+  people?: Array<{ id: string; name?: string; person?: { email?: string } }>
+  date?: { start: string; end?: string } | null
+  url?: string | null
+  number?: number | null
+  checkbox?: boolean
+  unique_id?: { prefix: string | null; number: number }
+  [key: string]: unknown
+}
+
+export interface NotionDatabase {
+  id: string
+  title: Array<{ plain_text: string }>
+  properties: Record<string, NotionDatabaseProperty>
+}
+
+export interface NotionDatabaseProperty {
+  type: string
+  status?: {
+    options: Array<{ id: string; name: string; color: string }>
+    groups: Array<{ id: string; name: string; option_ids: string[]; color: string }>
+  }
+  select?: { options: Array<{ id: string; name: string; color: string }> }
+  multi_select?: { options: Array<{ id: string; name: string; color: string }> }
+  [key: string]: unknown
+}
+
+export interface NotionConfig {
+  apiKey: string
+  defaultDatabaseId?: string
+  defaultDatabaseName?: string
+  statusPropertyName?: string
+  titlePropertyName?: string
+}
+
+export const NOTION_STATUS_GROUP_TO_PMO_CATEGORY: Record<string, string> = {
+  'To-do': 'backlog',
+  'In progress': 'started',
+  'Complete': 'completed',
+}
+
+export const NOTION_STATUS_NAME_TO_PMO_CATEGORY: Record<string, string> = {
+  'Not started': 'backlog',
+  'To do': 'backlog',
+  'Backlog': 'backlog',
+  'In progress': 'started',
+  'In Progress': 'started',
+  'In Review': 'started',
+  'Review': 'started',
+  'Done': 'completed',
+  'Complete': 'completed',
+  'Completed': 'completed',
+  'Cancelled': 'canceled',
+  'Archived': 'canceled',
+}
+
+export const NOTION_PRIORITY_TO_PMO: Record<string, string> = {
+  Urgent: 'P0',
+  High: 'P1',
+  Medium: 'P2',
+  Low: 'P3',
+}
+
+export const PMO_PRIORITY_TO_NOTION: Record<string, string> = {
+  P0: 'Urgent',
+  P1: 'High',
+  P2: 'Medium',
+  P3: 'Low',
+}

--- a/apps/cli/src/lib/providers/index.ts
+++ b/apps/cli/src/lib/providers/index.ts
@@ -27,6 +27,7 @@ export { TrelloTicketProvider } from './trello-provider.js'
 export { GitHubIssuesTicketProvider } from './github-provider.js'
 export { JiraTicketProvider } from './jira-provider.js'
 export { AsanaTicketProvider } from './asana-provider.js'
+export { NotionTicketProvider } from './notion-provider.js'
 export { EventEmittingProvider, type StatusResolver } from './event-emitting-provider.js'
 export { resolveTicketProvider, resolveProjectProvider } from './resolver.js'
 export {

--- a/apps/cli/src/lib/providers/notion-provider.ts
+++ b/apps/cli/src/lib/providers/notion-provider.ts
@@ -1,0 +1,486 @@
+/**
+ * Notion Ticket Provider
+ *
+ * Writes ticket operations directly to Notion via REST API,
+ * then updates local PMO to keep it in sync.
+ *
+ * Follows the same dual-write pattern as ClickUp/Trello providers:
+ * Notion is the source of truth, PMO is best-effort mirror.
+ */
+
+import type Database from 'better-sqlite3'
+import { NotionClient } from '../notion/client.js'
+import { getNotionApiKey, loadNotionConfig } from '../notion/config.js'
+import type { NotionPage, NotionDatabase } from '../notion/types.js'
+import {
+  NOTION_STATUS_GROUP_TO_PMO_CATEGORY,
+  NOTION_STATUS_NAME_TO_PMO_CATEGORY,
+  NOTION_PRIORITY_TO_PMO,
+  PMO_PRIORITY_TO_NOTION,
+} from '../notion/types.js'
+import type { Ticket, TicketFilter, CreateTicketInput, UpdateTicketInput } from '../pmo/types.js'
+import type {
+  TicketProvider,
+  TicketProviderName,
+  ProviderMoveResult,
+  ProviderDeleteResult,
+  ProviderListResult,
+  ProviderCreateResult,
+  ProviderGetResult,
+  ProviderUpdateResult,
+  ProviderAssignResult,
+  ProviderStorage,
+} from './types.js'
+
+export class NotionTicketProvider implements TicketProvider {
+  readonly name: TicketProviderName = 'notion'
+
+  constructor(
+    private db: Database.Database,
+    private storage: ProviderStorage,
+    private projectId: string,
+  ) {}
+
+  private getApiKeyOrFail(): string {
+    const apiKey = getNotionApiKey(this.db)
+    if (!apiKey) throw new Error('Notion API key not configured')
+    return apiKey
+  }
+
+  private getDatabaseIdOrFail(): string {
+    const config = loadNotionConfig(this.db)
+    const dbId = config?.defaultDatabaseId || process.env.PRLT_NOTION_DATABASE_ID
+    if (!dbId) throw new Error('Notion database ID is required. Set PRLT_NOTION_DATABASE_ID.')
+    return dbId
+  }
+
+  private getStatusPropertyName(): string {
+    const config = loadNotionConfig(this.db)
+    return config?.statusPropertyName || 'Status'
+  }
+
+  private getTitlePropertyName(): string {
+    const config = loadNotionConfig(this.db)
+    return config?.titlePropertyName || 'Name'
+  }
+
+  async moveTicket(ticketId: string, newState: string): Promise<ProviderMoveResult> {
+    const apiKey = getNotionApiKey(this.db)
+    if (!apiKey) {
+      return { success: false, provider: 'notion', error: 'Notion API key not configured' }
+    }
+
+    const ticket = await this.storage.getTicket(ticketId)
+    if (!ticket) {
+      return { success: false, provider: 'notion', error: `Ticket ${ticketId} not found` }
+    }
+
+    const notionPageId = ticket.metadata?.['notion.page_id']
+    if (!notionPageId) {
+      return { success: false, provider: 'notion', error: `No Notion mapping for ticket ${ticketId}` }
+    }
+
+    const client = new NotionClient(apiKey)
+    try {
+      await client.updatePage(notionPageId, {
+        [this.getStatusPropertyName()]: { status: { name: newState } },
+      })
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: `Failed to update Notion page: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+
+    // Update local PMO mirror (best-effort)
+    try {
+      await this.storage.moveTicket(this.projectId, ticketId, newState)
+    } catch {
+      // Non-fatal: Notion is the source of truth
+    }
+
+    return { success: true, provider: 'notion' }
+  }
+
+  async deleteTicket(ticketId: string): Promise<ProviderDeleteResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion API key not configured' }
+    }
+
+    const ticket = await this.storage.getTicket(ticketId)
+    const notionPageId = ticket?.metadata?.['notion.page_id']
+
+    if (notionPageId) {
+      const client = new NotionClient(apiKey)
+      try {
+        await client.archivePage(notionPageId)
+      } catch (error) {
+        return {
+          success: false,
+          provider: 'notion',
+          error: `Failed to archive Notion page: ${error instanceof Error ? error.message : String(error)}`,
+        }
+      }
+    }
+
+    // Delete the local PMO mirror
+    try {
+      await this.storage.deleteTicket(ticketId)
+    } catch {
+      // Non-fatal if Notion archive succeeded
+    }
+
+    return { success: true, provider: 'notion' }
+  }
+
+  async listTickets(_projectId?: string, filter?: TicketFilter): Promise<ProviderListResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', tickets: [], error: 'Notion API key not configured' }
+    }
+
+    let databaseId: string
+    try {
+      databaseId = this.getDatabaseIdOrFail()
+    } catch {
+      return { success: false, provider: 'notion', tickets: [], error: 'Notion database ID is required. Set PRLT_NOTION_DATABASE_ID.' }
+    }
+
+    try {
+      const client = new NotionClient(apiKey)
+      const notionFilter = filter?.column
+        ? { property: this.getStatusPropertyName(), status: { equals: filter.column } }
+        : undefined
+
+      // Paginate through all results
+      const allPages: NotionPage[] = []
+      let cursor: string | undefined
+      do {
+        const response = await client.queryDatabase(databaseId, {
+          filter: notionFilter,
+          startCursor: cursor,
+          pageSize: 100,
+        })
+        allPages.push(...response.results)
+        cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined
+      } while (cursor)
+
+      // Fetch database schema to map status groups (best-effort)
+      let statusGroupMap: Map<string, string> | undefined
+      try {
+        const dbSchema = await client.getDatabase(databaseId)
+        statusGroupMap = buildStatusGroupMap(dbSchema, this.getStatusPropertyName())
+      } catch {
+        // Non-fatal: fall back to name-based status mapping
+      }
+
+      let tickets: Ticket[] = allPages.map(page =>
+        notionPageToTicket(page, this.getTitlePropertyName(), this.getStatusPropertyName(), statusGroupMap),
+      )
+
+      // Apply client-side filters
+      if (filter?.priority) {
+        tickets = tickets.filter(t => t.priority === filter.priority)
+      }
+      if (filter?.category) {
+        tickets = tickets.filter(t => t.category === filter.category)
+      }
+      if (filter?.search) {
+        const term = filter.search.toLowerCase()
+        tickets = tickets.filter(t =>
+          t.title.toLowerCase().includes(term) ||
+          (t.description || '').toLowerCase().includes(term),
+        )
+      }
+      if (filter?.label) {
+        const label = filter.label.toLowerCase()
+        tickets = tickets.filter(t => t.labels.some(l => l.toLowerCase() === label))
+      }
+
+      return { success: true, provider: 'notion', tickets }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        tickets: [],
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async createTicket(projectId: string, input: CreateTicketInput): Promise<ProviderCreateResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion API key not configured' }
+    }
+
+    let databaseId: string
+    try {
+      databaseId = this.getDatabaseIdOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion database ID is required. Set PRLT_NOTION_DATABASE_ID.' }
+    }
+
+    const client = new NotionClient(apiKey)
+    const titleProp = this.getTitlePropertyName()
+    const statusProp = this.getStatusPropertyName()
+
+    try {
+      const properties: Record<string, unknown> = {
+        [titleProp]: { title: [{ text: { content: input.title } }] },
+      }
+      if (input.statusName) {
+        properties[statusProp] = { status: { name: input.statusName } }
+      }
+      if (input.priority) {
+        const np = PMO_PRIORITY_TO_NOTION[input.priority]
+        if (np) {
+          properties['Priority'] = { select: { name: np } }
+        }
+      }
+      if (input.labels && input.labels.length > 0) {
+        properties['Tags'] = { multi_select: input.labels.map((name: string) => ({ name })) }
+      }
+
+      const page = await client.createPage(databaseId, properties)
+
+      // Create local PMO mirror ticket
+      const pmoTicket = await this.storage.createTicket(projectId, {
+        ...input,
+        metadata: {
+          ...input.metadata,
+          external_source: 'notion',
+          external_id: page.id,
+          external_key: page.id,
+          external_url: page.url,
+          'notion.page_id': page.id,
+          'notion.database_id': databaseId,
+        },
+      })
+
+      return { success: true, provider: 'notion', ticket: pmoTicket }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async getTicket(ticketId: string): Promise<ProviderGetResult> {
+    try {
+      const ticket = await this.storage.getTicket(ticketId)
+      return { success: true, provider: 'notion', ticket }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async updateTicket(ticketId: string, input: UpdateTicketInput): Promise<ProviderUpdateResult> {
+    let apiKey: string
+    try {
+      apiKey = this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion API key not configured' }
+    }
+
+    const ticket = await this.storage.getTicket(ticketId)
+    const notionPageId = ticket?.metadata?.['notion.page_id']
+
+    if (notionPageId) {
+      const titleProp = this.getTitlePropertyName()
+      const properties: Record<string, unknown> = {}
+
+      if (input.title !== undefined) {
+        properties[titleProp] = { title: [{ text: { content: input.title } }] }
+      }
+      if (input.priority !== undefined) {
+        const np = input.priority ? PMO_PRIORITY_TO_NOTION[input.priority] : null
+        if (np) {
+          properties['Priority'] = { select: { name: np } }
+        } else {
+          properties['Priority'] = { select: null }
+        }
+      }
+
+      if (Object.keys(properties).length > 0) {
+        const client = new NotionClient(apiKey)
+        try {
+          await client.updatePage(notionPageId, properties)
+        } catch (error) {
+          return {
+            success: false,
+            provider: 'notion',
+            error: `Failed to update Notion page: ${error instanceof Error ? error.message : String(error)}`,
+          }
+        }
+      }
+    }
+
+    // Also update local PMO mirror
+    try {
+      const updated = await this.storage.updateTicket(ticketId, input as Partial<Ticket>)
+      return { success: true, provider: 'notion', ticket: updated }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  async assignTicket(ticketId: string, assignee: string): Promise<ProviderAssignResult> {
+    try {
+      this.getApiKeyOrFail()
+    } catch {
+      return { success: false, provider: 'notion', error: 'Notion API key not configured' }
+    }
+
+    // Update local PMO mirror (Notion people assignment requires user IDs — best-effort local update)
+    try {
+      await this.storage.updateTicket(ticketId, { assignee } as Partial<Ticket>)
+      return { success: true, provider: 'notion' }
+    } catch (error) {
+      return {
+        success: false,
+        provider: 'notion',
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+}
+
+/**
+ * Build a map from status option names to their group names.
+ * Used to resolve Notion's three-tier status model (To-do/In progress/Complete groups).
+ */
+export function buildStatusGroupMap(dbSchema: NotionDatabase, statusPropertyName: string): Map<string, string> {
+  const map = new Map<string, string>()
+  const statusProp = dbSchema.properties[statusPropertyName]
+  if (statusProp?.type !== 'status' || !statusProp.status) return map
+
+  for (const group of statusProp.status.groups) {
+    for (const optionId of group.option_ids) {
+      const option = statusProp.status.options.find((o: { id: string; name: string }) => o.id === optionId)
+      if (option) {
+        map.set(option.name, group.name)
+      }
+    }
+  }
+  return map
+}
+
+function extractText(prop: { type: string; title?: Array<{ plain_text: string }>; rich_text?: Array<{ plain_text: string }> } | undefined): string {
+  if (!prop) return ''
+  if (prop.type === 'title' && prop.title) {
+    return prop.title.map((t: { plain_text: string }) => t.plain_text).join('')
+  }
+  if (prop.type === 'rich_text' && prop.rich_text) {
+    return prop.rich_text.map((t: { plain_text: string }) => t.plain_text).join('')
+  }
+  return ''
+}
+
+function resolveStatusCategory(statusName: string, statusGroupMap?: Map<string, string>): string {
+  if (statusGroupMap) {
+    const groupName = statusGroupMap.get(statusName)
+    if (groupName) {
+      return NOTION_STATUS_GROUP_TO_PMO_CATEGORY[groupName] || 'started'
+    }
+  }
+  return NOTION_STATUS_NAME_TO_PMO_CATEGORY[statusName] || 'started'
+}
+
+/**
+ * Convert a Notion page to a normalized PMO Ticket.
+ */
+export function notionPageToTicket(
+  page: NotionPage,
+  titlePropertyName: string,
+  statusPropertyName: string,
+  statusGroupMap?: Map<string, string>,
+): Ticket {
+  const title = extractText(page.properties[titlePropertyName])
+
+  // Extract status
+  const statusProp = page.properties[statusPropertyName]
+  let statusName = 'Not started'
+  if (statusProp?.type === 'status' && statusProp.status) {
+    statusName = statusProp.status.name
+  } else if (statusProp?.type === 'select' && statusProp.select) {
+    statusName = statusProp.select.name
+  }
+
+  const statusCategory = resolveStatusCategory(statusName, statusGroupMap)
+
+  // Extract priority
+  const priorityProp = page.properties['Priority']
+  let priority: string | undefined
+  if (priorityProp?.type === 'select' && priorityProp.select) {
+    priority = NOTION_PRIORITY_TO_PMO[priorityProp.select.name]
+  }
+
+  // Extract description
+  const description = extractText(page.properties['Description'])
+
+  // Extract tags/labels
+  const tagsProp = page.properties['Tags']
+  const labels: string[] = []
+  if (tagsProp?.type === 'multi_select' && tagsProp.multi_select) {
+    for (const tag of tagsProp.multi_select) {
+      labels.push(tag.name)
+    }
+  }
+
+  // Extract assignee
+  const assigneeProp = page.properties['Assignee'] || page.properties['Assign']
+  let assignee: string | undefined
+  if (assigneeProp?.type === 'people' && assigneeProp.people && assigneeProp.people.length > 0) {
+    assignee = assigneeProp.people[0].name || assigneeProp.people[0].person?.email
+  }
+
+  // Extract unique ID for ticket key
+  let uniqueKey = page.id
+  const idProp = page.properties['ID']
+  if (idProp?.type === 'unique_id' && idProp.unique_id) {
+    const prefix = idProp.unique_id.prefix || ''
+    uniqueKey = prefix ? `${prefix}-${idProp.unique_id.number}` : String(idProp.unique_id.number)
+  }
+
+  return {
+    id: uniqueKey,
+    title,
+    description: description || undefined,
+    priority,
+    projectId: '',
+    statusId: statusName,
+    statusName,
+    statusCategory: statusCategory as Ticket['statusCategory'],
+    assignee,
+    subtasks: [],
+    labels,
+    metadata: {
+      external_source: 'notion',
+      external_key: uniqueKey,
+      external_id: page.id,
+      external_url: page.url,
+      'notion.page_id': page.id,
+    },
+    createdAt: new Date(page.created_time),
+    updatedAt: new Date(page.last_edited_time),
+  }
+}

--- a/apps/cli/src/lib/providers/resolver.ts
+++ b/apps/cli/src/lib/providers/resolver.ts
@@ -6,7 +6,7 @@
  *
  * All resolved providers are wrapped with EventEmittingProvider, making
  * the adapter layer the central event hub. Every provider (PMO, Linear,
- * Jira, Shortcut, Asana) is an equal peer that emits events through
+ * Jira, Shortcut, Asana, Notion) is an equal peer that emits events through
  * the same mechanism.
  *
  * Two resolution modes:
@@ -27,6 +27,7 @@ import { isTrelloConfigured } from '../trello/config.js'
 import { TrelloMapper } from '../trello/mapper.js'
 import { isAsanaConfigured } from '../asana/config.js'
 import { AsanaMapper } from '../asana/mapper.js'
+import { isNotionConfigured } from '../notion/config.js'
 import type { StateCategory } from '../pmo/types.js'
 import type { TicketProvider, ProviderStorage } from './types.js'
 import { PMOTicketProvider } from './pmo-provider.js'
@@ -36,6 +37,7 @@ import { TrelloTicketProvider } from './trello-provider.js'
 import { GitHubIssuesTicketProvider } from './github-provider.js'
 import { JiraTicketProvider } from './jira-provider.js'
 import { AsanaTicketProvider } from './asana-provider.js'
+import { NotionTicketProvider } from './notion-provider.js'
 import { EventEmittingProvider, type StatusResolver } from './event-emitting-provider.js'
 
 /**
@@ -44,6 +46,8 @@ import { EventEmittingProvider, type StatusResolver } from './event-emitting-pro
  * for event emission.
  */
 function createDbStatusResolver(db: Database.Database, storage: ProviderStorage): StatusResolver {
+  // storage param kept for interface compatibility — resolver uses db directly
+  void storage
   return {
     resolveStatusByName(projectId: string, statusName: string) {
       try {
@@ -126,6 +130,7 @@ function wrapWithEventsNoResolver(
  *
  * Uses the ticket's metadata to determine the source of truth:
  * - external_source = 'linear' + configured → Linear
+ * - external_source = 'notion' + configured → Notion
  * - Otherwise → PMO
  *
  * The resolved provider is wrapped with EventEmittingProvider so that
@@ -205,6 +210,12 @@ export function resolveTicketProvider(
     }
   }
 
+  // Check Notion
+  if (externalSource === 'notion' && isNotionConfigured(db)) {
+    const inner = new NotionTicketProvider(db, storage, projectId)
+    return wrapWithEvents(inner, db, storage, projectId)
+  }
+
   // Default: local PMO
   const inner = new PMOTicketProvider(storage, projectId)
   return wrapWithEvents(inner, db, storage, projectId)
@@ -222,7 +233,7 @@ export function resolveTicketProvider(
  * @param db - Database handle for config lookups
  * @param storage - Storage instance
  * @param projectId - The PMO project ID
- * @param source - Optional source hint ('pmo', 'linear', or 'auto')
+ * @param source - Optional source hint ('pmo', 'linear', 'notion', or 'auto')
  * @returns The appropriate TicketProvider
  */
 export function resolveProjectProvider(
@@ -263,6 +274,11 @@ export function resolveProjectProvider(
 
   if (source === 'asana') {
     const inner = new AsanaTicketProvider(db, storage, projectId)
+    return wrapWithEvents(inner, db, storage, projectId)
+  }
+
+  if (source === 'notion') {
+    const inner = new NotionTicketProvider(db, storage, projectId)
     return wrapWithEvents(inner, db, storage, projectId)
   }
 

--- a/apps/cli/src/lib/providers/types.ts
+++ b/apps/cli/src/lib/providers/types.ts
@@ -14,7 +14,7 @@ import type { StateCategory, Ticket, TicketFilter, CreateTicketInput, UpdateTick
 /**
  * Supported provider names for ticket operations.
  */
-export type TicketProviderName = 'pmo' | 'linear' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'clickup' | 'github'
+export type TicketProviderName = 'pmo' | 'linear' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'clickup' | 'github' | 'notion'
 
 /**
  * Generic result of a provider operation.

--- a/apps/cli/src/lib/work-lifecycle/events.ts
+++ b/apps/cli/src/lib/work-lifecycle/events.ts
@@ -15,7 +15,7 @@ import type { StateCategory } from '../pmo/types.js'
  * Sources that can emit work-lifecycle events.
  * PMO is just another provider, not the central hub.
  */
-export type WorkEventSource = 'pmo' | 'linear' | 'github' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'monday' | 'clickup'
+export type WorkEventSource = 'pmo' | 'linear' | 'github' | 'jira' | 'asana' | 'shortcut' | 'trello' | 'monday' | 'clickup' | 'notion'
 
 /** Emitted when work begins on a work item (status moved to 'started' category). */
 export interface WorkStartedEvent {

--- a/apps/cli/src/lib/work-source/config.ts
+++ b/apps/cli/src/lib/work-source/config.ts
@@ -14,7 +14,7 @@ const DEFAULT_SOURCE_KEY = 'work.default_source'
 /** @deprecated Old key kept for migration — use DEFAULT_SOURCE_KEY */
 const LEGACY_ACTIVE_SOURCE_KEY = 'work.active_source'
 
-export const WORK_SOURCE_PROVIDERS = ['pmo', 'linear', 'jira', 'shortcut', 'asana', 'trello', 'monday', 'clickup', 'github'] as const
+export const WORK_SOURCE_PROVIDERS = ['pmo', 'linear', 'jira', 'shortcut', 'asana', 'trello', 'monday', 'clickup', 'github', 'notion'] as const
 export type WorkSourceProvider = typeof WORK_SOURCE_PROVIDERS[number]
 
 export interface WorkSourceRef {

--- a/apps/cli/test/unit/notion-provider.test.ts
+++ b/apps/cli/test/unit/notion-provider.test.ts
@@ -1,0 +1,642 @@
+import { expect } from 'chai'
+import type { ProviderStorage } from '../../src/lib/providers/types.js'
+import type { StateCategory, Ticket, TicketFilter, CreateTicketInput } from '../../src/lib/pmo/types.js'
+import { NotionTicketProvider } from '../../src/lib/providers/notion-provider.js'
+import {
+  buildStatusGroupMap,
+  notionPageToTicket,
+} from '../../src/lib/providers/notion-provider.js'
+import {
+  NOTION_PRIORITY_TO_PMO,
+  PMO_PRIORITY_TO_NOTION,
+  NOTION_STATUS_GROUP_TO_PMO_CATEGORY,
+  NOTION_STATUS_NAME_TO_PMO_CATEGORY,
+} from '../../src/lib/notion/types.js'
+import type { NotionDatabase, NotionPage } from '../../src/lib/notion/types.js'
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+interface MockTicket {
+  id: string
+  projectId?: string
+  title?: string
+  statusName?: string
+  statusCategory?: StateCategory | null
+  metadata?: Record<string, string> | null
+}
+
+function createMockStorage(overrides?: {
+  ticket?: MockTicket | null
+  tickets?: Ticket[]
+  board?: { columns: Array<{ name: string }> } | null
+  moveError?: Error
+  deleteError?: Error
+  createError?: Error
+  updateError?: Error
+  moveCalls?: Array<{ projectId: string; ticketId: string; columnName: string }>
+  deleteCalls?: string[]
+  createCalls?: Array<{ projectId: string; input: CreateTicketInput }>
+  updateCalls?: Array<{ id: string; changes: Partial<Ticket> }>
+}): ProviderStorage {
+  const moveCalls = overrides?.moveCalls ?? []
+  const deleteCalls = overrides?.deleteCalls ?? []
+  const createCalls = overrides?.createCalls ?? []
+  const updateCalls = overrides?.updateCalls ?? []
+
+  return {
+    getTicket: async (id: string) => {
+      if (overrides?.ticket === null) return null
+      const ticket = overrides?.ticket ?? {
+        id,
+        projectId: 'test-project',
+        title: 'Test ticket',
+        statusName: 'In Progress',
+        statusCategory: 'started' as StateCategory,
+        metadata: {
+          'notion.page_id': 'page_abc123',
+          external_source: 'notion',
+          external_id: 'page_abc123',
+          external_key: 'page_abc123',
+          external_url: 'https://notion.so/page_abc123',
+        },
+      }
+      return {
+        ...ticket,
+        title: ticket.title || 'Test ticket',
+        statusId: ticket.statusName || 'backlog',
+        subtasks: [],
+        labels: [],
+        metadata: ticket.metadata || {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    getProjectBoard: async () => {
+      if (overrides?.board === null) return null
+      return overrides?.board ?? {
+        columns: [
+          { name: 'Backlog' },
+          { name: 'In Progress' },
+          { name: 'Review' },
+          { name: 'Done' },
+        ],
+      }
+    },
+    moveTicket: async (projectId: string, ticketId: string, columnName: string) => {
+      if (overrides?.moveError) throw overrides.moveError
+      moveCalls.push({ projectId, ticketId, columnName })
+      return {
+        id: ticketId,
+        title: 'Test ticket',
+        projectId,
+        statusId: columnName,
+        statusName: columnName,
+        subtasks: [],
+        labels: [],
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    deleteTicket: async (id: string) => {
+      if (overrides?.deleteError) throw overrides.deleteError
+      deleteCalls.push(id)
+    },
+    listTickets: async () => {
+      return overrides?.tickets ?? []
+    },
+    createTicket: async (projectId: string, input: CreateTicketInput) => {
+      if (overrides?.createError) throw overrides.createError
+      createCalls.push({ projectId, input })
+      return {
+        id: input.id || 'TKT-NEW',
+        title: input.title,
+        projectId,
+        statusId: input.statusName || 'backlog',
+        statusName: input.statusName || 'Backlog',
+        subtasks: [],
+        labels: input.labels || [],
+        metadata: input.metadata || {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    updateTicket: async (id: string, changes: Partial<Ticket>) => {
+      if (overrides?.updateError) throw overrides.updateError
+      updateCalls.push({ id, changes })
+      const ticket = overrides?.ticket ?? { id, projectId: 'test-project', statusName: 'In Progress' }
+      return {
+        ...ticket,
+        ...changes,
+        id,
+        title: (changes.title as string) || 'Test ticket',
+        statusId: (ticket as MockTicket).statusName || 'backlog',
+        subtasks: [],
+        labels: [],
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Ticket
+    },
+    getDatabase: () => ({
+      prepare: () => ({ get: () => undefined, all: () => [], run: () => {} }),
+      exec: () => {},
+      pragma: () => {},
+    }) as any,
+  }
+}
+
+function createMockDb(settings?: Record<string, string>): any {
+  const settingsMap = new Map(Object.entries(settings ?? {}))
+  return {
+    prepare: (sql: string) => ({
+      get: (...args: unknown[]) => {
+        if (sql.includes('workspace_settings')) {
+          const key = args[0] as string
+          const value = settingsMap.get(key)
+          return value ? { value } : undefined
+        }
+        if (sql.includes('credentials')) {
+          const key = args[0] as string
+          const value = settingsMap.get(key)
+          return value ? { value } : undefined
+        }
+        return undefined
+      },
+      all: () => [],
+      run: () => {},
+    }),
+    exec: () => {},
+    pragma: () => {},
+    name: '',
+  }
+}
+
+// =============================================================================
+// Notion Types Tests
+// =============================================================================
+
+describe('Notion Types', () => {
+  describe('NOTION_PRIORITY_TO_PMO', () => {
+    it('maps Urgent to P0', () => {
+      expect(NOTION_PRIORITY_TO_PMO['Urgent']).to.equal('P0')
+    })
+
+    it('maps High to P1', () => {
+      expect(NOTION_PRIORITY_TO_PMO['High']).to.equal('P1')
+    })
+
+    it('maps Medium to P2', () => {
+      expect(NOTION_PRIORITY_TO_PMO['Medium']).to.equal('P2')
+    })
+
+    it('maps Low to P3', () => {
+      expect(NOTION_PRIORITY_TO_PMO['Low']).to.equal('P3')
+    })
+  })
+
+  describe('PMO_PRIORITY_TO_NOTION', () => {
+    it('maps P0 to Urgent', () => {
+      expect(PMO_PRIORITY_TO_NOTION['P0']).to.equal('Urgent')
+    })
+
+    it('maps P1 to High', () => {
+      expect(PMO_PRIORITY_TO_NOTION['P1']).to.equal('High')
+    })
+
+    it('maps P2 to Medium', () => {
+      expect(PMO_PRIORITY_TO_NOTION['P2']).to.equal('Medium')
+    })
+
+    it('maps P3 to Low', () => {
+      expect(PMO_PRIORITY_TO_NOTION['P3']).to.equal('Low')
+    })
+  })
+
+  describe('NOTION_STATUS_GROUP_TO_PMO_CATEGORY', () => {
+    it('maps To-do to backlog', () => {
+      expect(NOTION_STATUS_GROUP_TO_PMO_CATEGORY['To-do']).to.equal('backlog')
+    })
+
+    it('maps In progress to started', () => {
+      expect(NOTION_STATUS_GROUP_TO_PMO_CATEGORY['In progress']).to.equal('started')
+    })
+
+    it('maps Complete to completed', () => {
+      expect(NOTION_STATUS_GROUP_TO_PMO_CATEGORY['Complete']).to.equal('completed')
+    })
+  })
+
+  describe('NOTION_STATUS_NAME_TO_PMO_CATEGORY', () => {
+    it('maps common backlog statuses', () => {
+      expect(NOTION_STATUS_NAME_TO_PMO_CATEGORY['Not started']).to.equal('backlog')
+      expect(NOTION_STATUS_NAME_TO_PMO_CATEGORY['Backlog']).to.equal('backlog')
+    })
+
+    it('maps common started statuses', () => {
+      expect(NOTION_STATUS_NAME_TO_PMO_CATEGORY['In progress']).to.equal('started')
+      expect(NOTION_STATUS_NAME_TO_PMO_CATEGORY['In Progress']).to.equal('started')
+    })
+
+    it('maps common completed statuses', () => {
+      expect(NOTION_STATUS_NAME_TO_PMO_CATEGORY['Done']).to.equal('completed')
+      expect(NOTION_STATUS_NAME_TO_PMO_CATEGORY['Complete']).to.equal('completed')
+    })
+  })
+})
+
+// =============================================================================
+// Helper Function Tests
+// =============================================================================
+
+describe('buildStatusGroupMap', () => {
+  it('maps status options to their group names', () => {
+    const dbSchema: NotionDatabase = {
+      id: 'db-1',
+      title: [{ plain_text: 'Test DB' }],
+      properties: {
+        Status: {
+          type: 'status',
+          status: {
+            options: [
+              { id: 'opt-1', name: 'Not started', color: 'default' },
+              { id: 'opt-2', name: 'In progress', color: 'blue' },
+              { id: 'opt-3', name: 'Done', color: 'green' },
+            ],
+            groups: [
+              { id: 'grp-1', name: 'To-do', option_ids: ['opt-1'], color: 'gray' },
+              { id: 'grp-2', name: 'In progress', option_ids: ['opt-2'], color: 'blue' },
+              { id: 'grp-3', name: 'Complete', option_ids: ['opt-3'], color: 'green' },
+            ],
+          },
+        },
+      },
+    }
+
+    const map = buildStatusGroupMap(dbSchema, 'Status')
+    expect(map.get('Not started')).to.equal('To-do')
+    expect(map.get('In progress')).to.equal('In progress')
+    expect(map.get('Done')).to.equal('Complete')
+  })
+
+  it('returns empty map when property is not status type', () => {
+    const dbSchema: NotionDatabase = {
+      id: 'db-1',
+      title: [{ plain_text: 'Test DB' }],
+      properties: {
+        Status: { type: 'select', select: { options: [] } },
+      },
+    }
+
+    const map = buildStatusGroupMap(dbSchema, 'Status')
+    expect(map.size).to.equal(0)
+  })
+})
+
+describe('notionPageToTicket', () => {
+  it('converts a Notion page with status property to a Ticket', () => {
+    const page: NotionPage = {
+      id: 'page-123',
+      url: 'https://notion.so/page-123',
+      created_time: '2026-01-01T00:00:00.000Z',
+      last_edited_time: '2026-01-02T00:00:00.000Z',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'My Task' }] },
+        Status: { type: 'status', status: { id: 's-1', name: 'In progress', color: 'blue' } },
+        Priority: { type: 'select', select: { id: 'p-1', name: 'High', color: 'red' } },
+        Description: { type: 'rich_text', rich_text: [{ plain_text: 'Task description' }] },
+        Tags: { type: 'multi_select', multi_select: [{ id: 't-1', name: 'bug', color: 'red' }] },
+      },
+    }
+
+    const ticket = notionPageToTicket(page, 'Name', 'Status')
+    expect(ticket.title).to.equal('My Task')
+    expect(ticket.statusName).to.equal('In progress')
+    expect(ticket.priority).to.equal('P1')
+    expect(ticket.description).to.equal('Task description')
+    expect(ticket.labels).to.deep.equal(['bug'])
+    expect(ticket.metadata.external_source).to.equal('notion')
+    expect(ticket.metadata['notion.page_id']).to.equal('page-123')
+  })
+
+  it('handles missing optional properties gracefully', () => {
+    const page: NotionPage = {
+      id: 'page-456',
+      url: 'https://notion.so/page-456',
+      created_time: '2026-01-01T00:00:00.000Z',
+      last_edited_time: '2026-01-02T00:00:00.000Z',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Minimal Task' }] },
+      },
+    }
+
+    const ticket = notionPageToTicket(page, 'Name', 'Status')
+    expect(ticket.title).to.equal('Minimal Task')
+    expect(ticket.statusName).to.equal('Not started')
+    expect(ticket.priority).to.be.undefined
+    expect(ticket.labels).to.deep.equal([])
+  })
+
+  it('extracts unique_id for ticket ID when available', () => {
+    const page: NotionPage = {
+      id: 'page-789',
+      url: 'https://notion.so/page-789',
+      created_time: '2026-01-01T00:00:00.000Z',
+      last_edited_time: '2026-01-02T00:00:00.000Z',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'ID Task' }] },
+        ID: { type: 'unique_id', unique_id: { prefix: 'TASK', number: 42 } },
+      },
+    }
+
+    const ticket = notionPageToTicket(page, 'Name', 'Status')
+    expect(ticket.id).to.equal('TASK-42')
+  })
+
+  it('uses status group mapping when provided', () => {
+    const page: NotionPage = {
+      id: 'page-abc',
+      url: 'https://notion.so/page-abc',
+      created_time: '2026-01-01T00:00:00.000Z',
+      last_edited_time: '2026-01-02T00:00:00.000Z',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Grouped Task' }] },
+        Status: { type: 'status', status: { id: 's-1', name: 'Custom Status', color: 'purple' } },
+      },
+    }
+
+    const groupMap = new Map([['Custom Status', 'Complete']])
+    const ticket = notionPageToTicket(page, 'Name', 'Status', groupMap)
+    expect(ticket.statusCategory).to.equal('completed')
+  })
+
+  it('extracts assignee from people property', () => {
+    const page: NotionPage = {
+      id: 'page-ppl',
+      url: 'https://notion.so/page-ppl',
+      created_time: '2026-01-01T00:00:00.000Z',
+      last_edited_time: '2026-01-02T00:00:00.000Z',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Assigned Task' }] },
+        Assignee: { type: 'people', people: [{ id: 'u-1', name: 'Alice', person: { email: 'alice@example.com' } }] },
+      },
+    }
+
+    const ticket = notionPageToTicket(page, 'Name', 'Status')
+    expect(ticket.assignee).to.equal('Alice')
+  })
+
+  it('uses select property as status fallback', () => {
+    const page: NotionPage = {
+      id: 'page-sel',
+      url: 'https://notion.so/page-sel',
+      created_time: '2026-01-01T00:00:00.000Z',
+      last_edited_time: '2026-01-02T00:00:00.000Z',
+      properties: {
+        Name: { type: 'title', title: [{ plain_text: 'Select Status Task' }] },
+        Status: { type: 'select', select: { id: 's-1', name: 'Done', color: 'green' } },
+      },
+    }
+
+    const ticket = notionPageToTicket(page, 'Name', 'Status')
+    expect(ticket.statusName).to.equal('Done')
+    expect(ticket.statusCategory).to.equal('completed')
+  })
+})
+
+// =============================================================================
+// NotionTicketProvider Tests
+// =============================================================================
+
+describe('NotionTicketProvider', () => {
+  it('has name property set to notion', () => {
+    const db = createMockDb()
+    const storage = createMockStorage()
+    const provider = new NotionTicketProvider(db, storage, 'test-project')
+    expect(provider.name).to.equal('notion')
+  })
+
+  describe('getTicket', () => {
+    it('returns ticket from local storage', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage({
+        ticket: {
+          id: 'TKT-001',
+          title: 'Test task',
+          projectId: 'test-project',
+          statusName: 'In Progress',
+          metadata: {
+            'notion.page_id': 'page_abc',
+            external_source: 'notion',
+            external_id: 'page_abc',
+            external_key: 'page_abc',
+            external_url: 'https://notion.so/page_abc',
+          },
+        },
+      })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.getTicket('TKT-001')
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(result.ticket).to.not.be.null
+      expect(result.ticket?.id).to.equal('TKT-001')
+    })
+
+    it('returns null ticket when not found', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage({ ticket: null })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.getTicket('TKT-MISSING')
+      expect(result.success).to.be.true
+      expect(result.ticket).to.be.null
+    })
+  })
+
+  describe('moveTicket', () => {
+    it('returns error when API key is not configured', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.moveTicket('TKT-001', 'Done')
+      expect(result.success).to.be.false
+      expect(result.provider).to.equal('notion')
+      expect(result.error).to.include('API key not configured')
+    })
+
+    it('returns error when ticket is not found', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const storage = createMockStorage({ ticket: null })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.moveTicket('TKT-MISSING', 'Done')
+      expect(result.success).to.be.false
+      expect(result.error).to.include('not found')
+    })
+
+    it('returns error when ticket has no Notion mapping', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const storage = createMockStorage({
+        ticket: {
+          id: 'TKT-001',
+          projectId: 'test-project',
+          statusName: 'In Progress',
+          metadata: {},
+        },
+      })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.moveTicket('TKT-001', 'Done')
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No Notion mapping')
+    })
+  })
+
+  describe('deleteTicket', () => {
+    it('returns error when API key is not configured', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.deleteTicket('TKT-001')
+      expect(result.success).to.be.false
+      expect(result.error).to.include('API key not configured')
+    })
+
+    it('deletes local PMO ticket when no Notion mapping exists', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const deleteCalls: string[] = []
+      const storage = createMockStorage({
+        ticket: {
+          id: 'TKT-001',
+          projectId: 'test-project',
+          statusName: 'Backlog',
+          metadata: {},
+        },
+        deleteCalls,
+      })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.deleteTicket('TKT-001')
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(deleteCalls).to.deep.equal(['TKT-001'])
+    })
+  })
+
+  describe('listTickets', () => {
+    it('returns error when API key is not configured', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.listTickets()
+      expect(result.success).to.be.false
+      expect(result.tickets).to.deep.equal([])
+      expect(result.error).to.include('API key not configured')
+    })
+
+    it('returns error when no database ID is configured', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.listTickets()
+      expect(result.success).to.be.false
+      expect(result.tickets).to.deep.equal([])
+      expect(result.error).to.include('database ID is required')
+    })
+  })
+
+  describe('createTicket', () => {
+    it('returns error when API key is not configured', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.createTicket('test-project', { title: 'New task' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('API key not configured')
+    })
+
+    it('returns error when no database ID is configured', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.createTicket('test-project', { title: 'New task' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('database ID is required')
+    })
+  })
+
+  describe('updateTicket', () => {
+    it('returns error when API key is not configured', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.updateTicket('TKT-001', { title: 'Updated' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('API key not configured')
+    })
+
+    it('updates local PMO even when no Notion mapping exists', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const updateCalls: Array<{ id: string; changes: Partial<Ticket> }> = []
+      const storage = createMockStorage({
+        ticket: {
+          id: 'TKT-001',
+          projectId: 'test-project',
+          statusName: 'In Progress',
+          metadata: {},
+        },
+        updateCalls,
+      })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.updateTicket('TKT-001', { title: 'Updated title' })
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(updateCalls).to.have.lengthOf(1)
+      expect(updateCalls[0].id).to.equal('TKT-001')
+    })
+  })
+
+  describe('assignTicket', () => {
+    it('returns error when API key is not configured', async () => {
+      const db = createMockDb()
+      const storage = createMockStorage()
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.assignTicket('TKT-001', 'user@example.com')
+      expect(result.success).to.be.false
+      expect(result.error).to.include('API key not configured')
+    })
+
+    it('updates local PMO assignee', async () => {
+      const db = createMockDb({ 'notion.api_key': 'ntn_test_123' })
+      const updateCalls: Array<{ id: string; changes: Partial<Ticket> }> = []
+      const storage = createMockStorage({
+        ticket: {
+          id: 'TKT-001',
+          projectId: 'test-project',
+          statusName: 'In Progress',
+          metadata: {},
+        },
+        updateCalls,
+      })
+      const provider = new NotionTicketProvider(db, storage, 'test-project')
+
+      const result = await provider.assignTicket('TKT-001', 'agent-123')
+      expect(result.success).to.be.true
+      expect(result.provider).to.equal('notion')
+      expect(updateCalls).to.have.lengthOf(1)
+      expect(updateCalls[0].changes).to.deep.include({ assignee: 'agent-123' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements `NotionTicketProvider` implementing the `TicketProvider` interface for Notion databases as kanban boards
- Adds `NotionClient` REST API client for Notion's pages and databases API
- Adds `notion/config.ts` for credential storage and database configuration (API key via DB credentials, env vars, or provider sources)
- Maps Notion status groups (To-do/In progress/Complete) to prlt state categories (backlog/started/completed)
- Maps Notion priority select values to PMO P0-P3 priorities
- Wires Notion into `resolveTicketProvider()` and `resolveProjectProvider()` in the resolver
- Adds `'notion'` to `TicketProviderName` type and `WORK_SOURCE_PROVIDERS`
- Supports unique_id property extraction for ticket keys

## Test plan

- [x] 38 unit tests covering:
  - Type mapping (priority, status group, status name)
  - `buildStatusGroupMap()` helper
  - `notionPageToTicket()` conversion (full properties, minimal, unique_id, group mapping, assignee, select fallback)
  - All 8 provider operations (moveTicket, deleteTicket, listTickets, createTicket, getTicket, updateTicket, assignTicket)
  - Error handling (missing API key, missing database ID, missing ticket, missing Notion mapping)
- [x] TypeScript compilation passes cleanly
- [ ] CI pipeline