### PR TITLE
ci: add AgentScore MCP dependency policy gate

### DIFF
--- a/.github/workflows/agentscore-policy-gate.yml
+++ b/.github/workflows/agentscore-policy-gate.yml
@@ -16,5 +16,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Thezenmonster/mcp-verdict-action@v1
         with:
-          packages: "@proletariat/cli"
           fail-on: block

--- a/.github/workflows/agentscore-policy-gate.yml
+++ b/.github/workflows/agentscore-policy-gate.yml
@@ -16,4 +16,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Thezenmonster/mcp-verdict-action@v1
         with:
+          packages: "@proletariat/cli"
           fail-on: block

--- a/.github/workflows/agentscore-policy-gate.yml
+++ b/.github/workflows/agentscore-policy-gate.yml
@@ -1,0 +1,19 @@
+name: AgentScore Policy Gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  mcp-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Thezenmonster/mcp-verdict-action@v1
+        with:
+          fail-on: block


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that scans \`@proletariat/cli\` on every PR and push to main.

On each run:
- Scans the package on npm for security findings
- Shows a trust verdict (allow/warn/block) with score
- Classifies AI capabilities (repo write, file access, shell exec, etc.)
- Flags capability changes between versions

## Why

\`@proletariat/cli\` has 18 MCP tools including a \`Merge\` tool with repository write capability and a command injection finding (score: 65/100). The gate makes these visible in CI and tracks changes over time.

## How it works

- No API key needed. Authenticates via GitHub OIDC.
- First run auto-provisions the repo.
- The package is listed explicitly because this repo publishes it (it is not a dependency).

## To try it

Merge this PR. Push to main. The gate runs automatically.

Ref: #1161

---
Free 30-day pilot. No lock-in. Remove the workflow file anytime.