### PR TITLE
fix(PRLT-1313): watch diff logic broken — polls but never detects changes

### DIFF
--- a/apps/cli/src/commands/watch/index.ts
+++ b/apps/cli/src/commands/watch/index.ts
@@ -76,7 +76,14 @@ export default class Watch extends PromptCommand {
     try {
       const poller = new SimplePoller({
         db,
-        log: (msg) => { if (verbose) this.log(styles.muted(msg)) },
+        log: (msg) => {
+          // Always log warnings and repo discovery messages; other messages only in verbose mode
+          if (msg.includes('Warning') || msg.includes('Discovered')) {
+            this.log(styles.muted(msg))
+          } else if (verbose) {
+            this.log(styles.muted(msg))
+          }
+        },
         cwd: workspaceInfo.path,
       })
 
@@ -151,12 +158,11 @@ export default class Watch extends PromptCommand {
           const result = await poller.poll()
 
           if (result.message) {
-            if (verbose) {
-              this.log('')
-              this.log(styles.info('Changes detected:'))
-              this.log(result.message)
-              this.log('')
-            }
+            // Always log changes — this is the core purpose of the watcher
+            this.log('')
+            this.log(styles.info(`[watch] ${result.changes.length} change(s) detected:`))
+            this.log(result.message)
+            this.log('')
 
             // Poke the orchestrator
             this.pokeTarget(flags.target, result.message, verbose)

--- a/apps/cli/src/lib/orchestrate/simple-poller.ts
+++ b/apps/cli/src/lib/orchestrate/simple-poller.ts
@@ -10,6 +10,8 @@
  */
 
 import { execSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 import type Database from 'better-sqlite3'
 import { isGHInstalled, isGHAuthenticated, listOpenPRs, getPRChecks } from '../pr/index.js'
 import { getWorkflowConfig } from '../work-lifecycle/settings.js'
@@ -34,6 +36,8 @@ interface PRState {
   ciState: 'pending' | 'success' | 'failure' | 'unknown'
   mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
   reviewDecision: string | null
+  /** The git repo directory this PR was discovered from. */
+  repoDir: string
 }
 
 /** Tracked agent state for diffing. */
@@ -73,8 +77,11 @@ export class SimplePoller {
   private log: (msg: string) => void
   private cwd?: string
 
-  /** Last-seen PR states. */
-  private lastPRs = new Map<number, PRState>()
+  /** Git repo directories to poll for PRs. Resolved from cwd on construction. */
+  private repoDirs: string[]
+
+  /** Last-seen PR states, keyed by "repoDir:prNumber" for multi-repo support. */
+  private lastPRs = new Map<string, PRState>()
 
   /** Last-seen agent states. */
   private lastAgents = new Map<string, AgentState>()
@@ -92,6 +99,59 @@ export class SimplePoller {
     this.db = options.db
     this.log = options.log
     this.cwd = options.cwd
+    this.repoDirs = SimplePoller.resolveRepoDirs(options.cwd, options.log)
+  }
+
+  /**
+   * Resolve git repo directories to poll for PRs.
+   *
+   * If cwd is itself a git repo, use it directly.
+   * If cwd has a repos/ subdirectory (HQ workspace), scan for git repos inside.
+   * Otherwise, return empty (no GitHub polling possible).
+   */
+  static resolveRepoDirs(cwd?: string, log?: (msg: string) => void): string[] {
+    if (!cwd) return []
+
+    // Check if cwd itself is a git repo
+    if (SimplePoller.isGitRepo(cwd)) {
+      return [cwd]
+    }
+
+    // HQ workspace: check for repos/ subdirectory
+    const reposDir = path.join(cwd, 'repos')
+    if (fs.existsSync(reposDir)) {
+      try {
+        const entries = fs.readdirSync(reposDir, { withFileTypes: true })
+        const dirs = entries
+          .filter(e => e.isDirectory())
+          .map(e => path.join(reposDir, e.name))
+          .filter(d => SimplePoller.isGitRepo(d))
+
+        if (dirs.length > 0) {
+          log?.(`[watch] Discovered ${dirs.length} repo(s) in ${reposDir}`)
+          return dirs
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    log?.(`[watch] Warning: ${cwd} is not a git repo and no repos/ subdirectory found. GitHub polling disabled.`)
+    return []
+  }
+
+  /** Check if a directory is inside a git repository. */
+  private static isGitRepo(dir: string): boolean {
+    try {
+      execSync('git rev-parse --git-dir', {
+        cwd: dir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+      })
+      return true
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -124,122 +184,132 @@ export class SimplePoller {
       this.ghAvailable = isGHInstalled() && isGHAuthenticated()
     }
     if (!this.ghAvailable) return []
+    if (this.repoDirs.length === 0) return []
 
     const changes: PollChange[] = []
+    /** Keys of PRs seen this cycle (for detecting disappeared PRs). */
+    const currentPRKeys = new Set<string>()
 
-    try {
-      const openPRs = listOpenPRs(this.cwd)
-      const currentPRNumbers = new Set<number>()
+    for (const repoDir of this.repoDirs) {
+      try {
+        const openPRs = listOpenPRs(repoDir)
+        this.log(`[watch] Polled ${openPRs.length} open PR(s) from ${path.basename(repoDir)}`)
 
-      for (const pr of openPRs) {
-        currentPRNumbers.add(pr.number)
-        const ticketId = this.extractTicketFromBranch(pr.headBranch)
-        const label = `#${pr.number}${ticketId ? ` (${ticketId})` : ''}`
+        for (const pr of openPRs) {
+          const prKey = `${repoDir}:${pr.number}`
+          currentPRKeys.add(prKey)
+          const ticketId = this.extractTicketFromBranch(pr.headBranch)
+          const label = `#${pr.number}${ticketId ? ` (${ticketId})` : ''}`
 
-        // Get CI status
-        let ciState: PRState['ciState'] = 'unknown'
-        try {
-          const checks = getPRChecks(pr.number, this.cwd)
-          if (checks.length > 0) {
-            const allDone = checks.every(c => c.status === 'COMPLETED' || c.conclusion)
-            if (allDone) {
-              const allPassed = checks.every(c =>
-                c.conclusion === 'SUCCESS' || c.conclusion === 'NEUTRAL' || c.conclusion === 'SKIPPED',
-              )
-              ciState = allPassed ? 'success' : 'failure'
-            } else {
-              ciState = 'pending'
-            }
-          }
-        } catch {
-          // Non-fatal
-        }
-
-        // Get mergeable state
-        let mergeable: PRState['mergeable'] = 'UNKNOWN'
-        try {
-          const result = execSync(
-            `gh pr view ${pr.number} --json mergeable -q .mergeable`,
-            { cwd: this.cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-          ).trim()
-          if (result === 'CONFLICTING') mergeable = 'CONFLICTING'
-          else if (result === 'MERGEABLE') mergeable = 'MERGEABLE'
-        } catch {
-          // Non-fatal
-        }
-
-        // Get review decision
-        let reviewDecision: string | null = null
-        try {
-          const result = execSync(
-            `gh pr view ${pr.number} --json reviewDecision -q .reviewDecision`,
-            { cwd: this.cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-          ).trim()
-          if (result) reviewDecision = result
-        } catch {
-          // Non-fatal
-        }
-
-        const current: PRState = {
-          number: pr.number,
-          title: pr.title,
-          headBranch: pr.headBranch,
-          url: pr.url,
-          ciState,
-          mergeable,
-          reviewDecision,
-        }
-
-        // Diff against last state
-        const prev = this.lastPRs.get(pr.number)
-        if (prev) {
-          if (prev.ciState !== ciState && ciState !== 'unknown') {
-            if (ciState === 'success') {
-              changes.push({ category: 'github', summary: `${label}: CI green, ${mergeable === 'MERGEABLE' ? 'mergeable' : mergeable === 'CONFLICTING' ? 'has merge conflicts' : 'mergeable state unknown'}` })
-            } else if (ciState === 'failure') {
-              changes.push({ category: 'github', summary: `${label}: CI failed` })
-            }
-          }
-          if (prev.mergeable !== 'CONFLICTING' && mergeable === 'CONFLICTING') {
-            changes.push({ category: 'github', summary: `${label}: now has merge conflicts` })
-          }
-          if (prev.mergeable === 'CONFLICTING' && mergeable === 'MERGEABLE') {
-            changes.push({ category: 'github', summary: `${label}: conflicts resolved, now mergeable` })
-          }
-          if (prev.reviewDecision !== reviewDecision && reviewDecision) {
-            changes.push({ category: 'github', summary: `${label}: review ${reviewDecision}` })
-          }
-        }
-
-        this.lastPRs.set(pr.number, current)
-      }
-
-      // Detect PRs that disappeared (merged or closed)
-      for (const [prNum, prev] of this.lastPRs) {
-        if (!currentPRNumbers.has(prNum)) {
-          const ticketId = this.extractTicketFromBranch(prev.headBranch)
-          const label = `#${prNum}${ticketId ? ` (${ticketId})` : ''}`
-
-          // Check if it was merged
+          // Get CI status
+          let ciState: PRState['ciState'] = 'unknown'
           try {
-            const result = execSync(
-              `gh pr view ${prNum} --json state -q .state`,
-              { cwd: this.cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
-            ).trim()
-            if (result === 'MERGED') {
-              changes.push({ category: 'github', summary: `${label}: merged since last poll` })
-            } else {
-              changes.push({ category: 'github', summary: `${label}: closed since last poll` })
+            const checks = getPRChecks(pr.number, repoDir)
+            if (checks.length > 0) {
+              const allDone = checks.every(c => c.status === 'COMPLETED' || c.conclusion)
+              if (allDone) {
+                const allPassed = checks.every(c =>
+                  c.conclusion === 'SUCCESS' || c.conclusion === 'NEUTRAL' || c.conclusion === 'SKIPPED',
+                )
+                ciState = allPassed ? 'success' : 'failure'
+              } else {
+                ciState = 'pending'
+              }
             }
           } catch {
-            changes.push({ category: 'github', summary: `${label}: no longer open` })
+            // Non-fatal
           }
 
-          this.lastPRs.delete(prNum)
+          // Get mergeable state
+          let mergeable: PRState['mergeable'] = 'UNKNOWN'
+          try {
+            const result = execSync(
+              `gh pr view ${pr.number} --json mergeable -q .mergeable`,
+              { cwd: repoDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+            ).trim()
+            if (result === 'CONFLICTING') mergeable = 'CONFLICTING'
+            else if (result === 'MERGEABLE') mergeable = 'MERGEABLE'
+          } catch {
+            // Non-fatal
+          }
+
+          // Get review decision
+          let reviewDecision: string | null = null
+          try {
+            const result = execSync(
+              `gh pr view ${pr.number} --json reviewDecision -q .reviewDecision`,
+              { cwd: repoDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+            ).trim()
+            if (result) reviewDecision = result
+          } catch {
+            // Non-fatal
+          }
+
+          const current: PRState = {
+            number: pr.number,
+            title: pr.title,
+            headBranch: pr.headBranch,
+            url: pr.url,
+            ciState,
+            mergeable,
+            reviewDecision,
+            repoDir,
+          }
+
+          // Diff against last state
+          const prev = this.lastPRs.get(prKey)
+          if (!prev) {
+            // New PR detected
+            changes.push({ category: 'github', summary: `${label}: new PR opened — "${pr.title}"` })
+          } else {
+            if (prev.ciState !== ciState && ciState !== 'unknown') {
+              if (ciState === 'success') {
+                changes.push({ category: 'github', summary: `${label}: CI green, ${mergeable === 'MERGEABLE' ? 'mergeable' : mergeable === 'CONFLICTING' ? 'has merge conflicts' : 'mergeable state unknown'}` })
+              } else if (ciState === 'failure') {
+                changes.push({ category: 'github', summary: `${label}: CI failed` })
+              }
+            }
+            if (prev.mergeable !== 'CONFLICTING' && mergeable === 'CONFLICTING') {
+              changes.push({ category: 'github', summary: `${label}: now has merge conflicts` })
+            }
+            if (prev.mergeable === 'CONFLICTING' && mergeable === 'MERGEABLE') {
+              changes.push({ category: 'github', summary: `${label}: conflicts resolved, now mergeable` })
+            }
+            if (prev.reviewDecision !== reviewDecision && reviewDecision) {
+              changes.push({ category: 'github', summary: `${label}: review ${reviewDecision}` })
+            }
+          }
+
+          this.lastPRs.set(prKey, current)
         }
+      } catch (err) {
+        this.log(`[watch] GitHub poll error for ${path.basename(repoDir)}: ${err instanceof Error ? err.message : String(err)}`)
       }
-    } catch (err) {
-      this.log(`[watch] GitHub poll error: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    // Detect PRs that disappeared (merged or closed)
+    for (const [prKey, prev] of this.lastPRs) {
+      if (!currentPRKeys.has(prKey)) {
+        const ticketId = this.extractTicketFromBranch(prev.headBranch)
+        const label = `#${prev.number}${ticketId ? ` (${ticketId})` : ''}`
+
+        // Check if it was merged
+        try {
+          const result = execSync(
+            `gh pr view ${prev.number} --json state -q .state`,
+            { cwd: prev.repoDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] },
+          ).trim()
+          if (result === 'MERGED') {
+            changes.push({ category: 'github', summary: `${label}: merged since last poll` })
+          } else {
+            changes.push({ category: 'github', summary: `${label}: closed since last poll` })
+          }
+        } catch {
+          changes.push({ category: 'github', summary: `${label}: no longer open` })
+        }
+
+        this.lastPRs.delete(prKey)
+      }
     }
 
     return changes

--- a/apps/cli/test/unit/simple-poller.test.ts
+++ b/apps/cli/test/unit/simple-poller.test.ts
@@ -1,4 +1,8 @@
 import { expect } from 'chai'
+import { execSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
 import { SimplePoller } from '../../src/lib/orchestrate/simple-poller.js'
 
 // =============================================================================
@@ -61,6 +65,35 @@ function createPoller(db: ReturnType<typeof createMockDb>, log?: (msg: string) =
     log: log ?? (() => {}),
     cwd: '/nonexistent-test-dir',
   })
+}
+
+/**
+ * Create a temp directory with git init for repo discovery tests.
+ * Returns the directory path. Caller must clean up.
+ */
+function createTempGitRepo(name: string): string {
+  const dir = path.join(os.tmpdir(), `prlt-test-${name}-${Date.now()}`)
+  fs.mkdirSync(dir, { recursive: true })
+  execSync('git init', { cwd: dir, stdio: ['pipe', 'pipe', 'pipe'] })
+  return dir
+}
+
+/**
+ * Create a temp HQ-like workspace with repos/ subdirectory.
+ * Returns the workspace root path. Caller must clean up.
+ */
+function createTempHQWorkspace(repoNames: string[]): string {
+  const wsRoot = path.join(os.tmpdir(), `prlt-test-hq-${Date.now()}`)
+  const reposDir = path.join(wsRoot, 'repos')
+  fs.mkdirSync(reposDir, { recursive: true })
+
+  for (const name of repoNames) {
+    const repoDir = path.join(reposDir, name)
+    fs.mkdirSync(repoDir, { recursive: true })
+    execSync('git init', { cwd: repoDir, stdio: ['pipe', 'pipe', 'pipe'] })
+  }
+
+  return wsRoot
 }
 
 // =============================================================================
@@ -463,6 +496,82 @@ describe('SimplePoller', () => {
       const r3 = await poller.poll()
       expect(r3.changes).to.have.length(1)
       expect(r3.changes[0].summary).to.include('completed')
+    })
+  })
+
+  // ===========================================================================
+  // Repo Directory Resolution (PRLT-1313 fix)
+  // ===========================================================================
+
+  describe('resolveRepoDirs', () => {
+    it('should return empty array when cwd is undefined', () => {
+      const dirs = SimplePoller.resolveRepoDirs(undefined)
+      expect(dirs).to.deep.equal([])
+    })
+
+    it('should return [cwd] when cwd is a git repo', () => {
+      const repoDir = createTempGitRepo('single-repo')
+      try {
+        const dirs = SimplePoller.resolveRepoDirs(repoDir)
+        expect(dirs).to.have.length(1)
+        expect(dirs[0]).to.equal(repoDir)
+      } finally {
+        fs.rmSync(repoDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should discover repos in repos/ subdirectory for HQ workspace', () => {
+      const wsRoot = createTempHQWorkspace(['repo-a', 'repo-b'])
+      try {
+        const dirs = SimplePoller.resolveRepoDirs(wsRoot)
+        expect(dirs).to.have.length(2)
+        expect(dirs.map(d => path.basename(d)).sort()).to.deep.equal(['repo-a', 'repo-b'])
+      } finally {
+        fs.rmSync(wsRoot, { recursive: true, force: true })
+      }
+    })
+
+    it('should skip non-git directories in repos/', () => {
+      const wsRoot = createTempHQWorkspace(['git-repo'])
+      // Add a non-git directory alongside the git repo
+      fs.mkdirSync(path.join(wsRoot, 'repos', 'not-a-repo'), { recursive: true })
+      try {
+        const dirs = SimplePoller.resolveRepoDirs(wsRoot)
+        expect(dirs).to.have.length(1)
+        expect(path.basename(dirs[0])).to.equal('git-repo')
+      } finally {
+        fs.rmSync(wsRoot, { recursive: true, force: true })
+      }
+    })
+
+    it('should return empty array for non-git dir without repos/', () => {
+      const tmpDir = path.join(os.tmpdir(), `prlt-test-norepo-${Date.now()}`)
+      fs.mkdirSync(tmpDir, { recursive: true })
+      try {
+        const logs: string[] = []
+        const dirs = SimplePoller.resolveRepoDirs(tmpDir, (msg) => logs.push(msg))
+        expect(dirs).to.deep.equal([])
+        expect(logs.some(l => l.includes('Warning'))).to.be.true
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('should return empty array for non-existent path', () => {
+      const dirs = SimplePoller.resolveRepoDirs('/nonexistent-test-dir-12345')
+      expect(dirs).to.deep.equal([])
+    })
+
+    it('should log discovery count for HQ workspace', () => {
+      const wsRoot = createTempHQWorkspace(['alpha', 'beta', 'gamma'])
+      try {
+        const logs: string[] = []
+        const dirs = SimplePoller.resolveRepoDirs(wsRoot, (msg) => logs.push(msg))
+        expect(dirs).to.have.length(3)
+        expect(logs.some(l => l.includes('3 repo(s)'))).to.be.true
+      } finally {
+        fs.rmSync(wsRoot, { recursive: true, force: true })
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes the `prlt watch` command which polled 500+ times over 12 hours without ever detecting changes, even as 4 new PRs were opened.

**Root cause:** `SimplePoller` received `cwd` set to the HQ workspace root (e.g., `/path/to/proletariat-hq`), which is **not** a git repository. All `gh pr list` calls silently failed (caught by try/catch → returned `[]`), so every poll diffed empty vs empty = "No changes."

**Fix:**
- Added repo directory discovery: when `cwd` is not a git repo, the poller scans `<cwd>/repos/` for git repos (HQ workspace layout)
- Updated PR state tracking to key by `repoDir:prNumber` for multi-repo support
- New PRs now generate explicit "new PR opened" change events
- Always log change details (not just "changes detected") so operators can see what changed
- Always surface repo discovery warnings at startup even without `--verbose`

## Changes

- `apps/cli/src/lib/orchestrate/simple-poller.ts` — Core fix: `resolveRepoDirs()` discovers git repos from workspace; `pollGitHubPRs()` iterates over each repo; tracks `repoDir` per PR for follow-up queries
- `apps/cli/src/commands/watch/index.ts` — Always log changes and repo discovery warnings
- `apps/cli/test/unit/simple-poller.test.ts` — 7 new tests for repo directory resolution (git repo, HQ workspace, non-git, edge cases)

## Test plan

- [x] All 26 SimplePoller unit tests pass
- [x] New tests cover: single git repo, HQ workspace with multiple repos, non-git dirs, non-existent paths
- [ ] Manual: `prlt watch --target orchestrator --once --verbose` from HQ workspace should show discovered repos and detect open PRs

Resolves [PRLT-1313](https://linear.app/integrated-ventures/issue/PRLT-1313)