### PR TITLE
chore: bump version to 0.3.119

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.118",
+  "version": "0.3.119",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
PRLT-1313: watcher diff fix, PRLT-1191: Notion provider, PRLT-1302: Drizzle ORM migration