### PR TITLE
refactor(PRLT-1316): remove --action flag from work start; route internal actions via action-context service

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -634,7 +634,7 @@ prlt work spawn TKT-010 TKT-011 TKT-012
 Have an agent refine ticket requirements:
 
 ```bash
-prlt work start TKT-042 --action groom
+prlt work groom TKT-042
 ```
 
 Agent adds acceptance criteria, subtasks, estimates.

--- a/apps/cli/src/commands/work/asana.ts
+++ b/apps/cli/src/commands/work/asana.ts
@@ -8,6 +8,7 @@ import {
 import {
   shouldOutputJson,
 } from '../../lib/prompt-json.js'
+import { setInternalAction } from '../../services/action-context.js'
 import {
   ExternalIssueAdapterError,
   type NormalizedIssueEnvelope,
@@ -30,12 +31,13 @@ function buildWorkStartArgs(options: {
   runOnHost?: boolean
   skipPermissions?: boolean
   createPr?: boolean
-  action?: string
   message?: string
   json?: boolean
   machine?: boolean
   yes?: boolean
 }): string[] {
+  // Note: action is no longer forwarded via `--action` (removed in PRLT-1316).
+  // Callers should route the action through setInternalAction() instead.
   const args = [options.ticketId, '--project', options.projectId, '--ephemeral']
 
   if (options.executor) args.push('--executor', options.executor)
@@ -43,7 +45,6 @@ function buildWorkStartArgs(options: {
   if (options.runOnHost) args.push('--run-on-host')
   if (options.skipPermissions) args.push('--skip-permissions')
   if (options.createPr) args.push('--create-pr')
-  if (options.action) args.push('--action', options.action)
   if (options.message) args.push('--message', options.message)
   if (options.json) args.push('--json')
   if (options.machine) args.push('--machine')
@@ -242,13 +243,14 @@ export default class WorkAsana extends PMOCommand {
       runOnHost: flags['run-on-host'],
       skipPermissions: flags['skip-permissions'],
       createPr: flags['create-pr'],
-      action: flags.action,
       message: contextMessage,
       json: flags.json,
       machine: flags.machine,
       yes: flags.yes,
     })
 
+    // Action is routed through the internal action-context channel (PRLT-1316).
+    if (flags.action) setInternalAction(flags.action)
     await this.config.runCommand('work:start', args)
   }
 }

--- a/apps/cli/src/commands/work/groom.ts
+++ b/apps/cli/src/commands/work/groom.ts
@@ -6,6 +6,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { setInternalAction } from '../../services/action-context.js'
 
 export default class WorkGroom extends PMOCommand {
   static description = 'Enrich a ticket with requirements, acceptance criteria, and subtasks'
@@ -84,11 +85,13 @@ export default class WorkGroom extends PMOCommand {
       ticketIds = [selected]
     }
 
-    // Launch work start with groom action for each ticket
+    // Launch work start with groom action for each ticket. The action is
+    // passed through the internal action-context channel rather than an
+    // `--action` CLI flag (PRLT-1316) so users can't bypass the verb layer.
     for (const ticketId of ticketIds) {
       this.log(styles.info(`\nLaunching groom for ${styles.emphasis(ticketId)}...`))
 
-      const workStartArgs = [ticketId, '--action', 'groom']
+      const workStartArgs = [ticketId]
       if (projectId) {
         workStartArgs.push('--project', projectId)
       }
@@ -96,6 +99,7 @@ export default class WorkGroom extends PMOCommand {
         workStartArgs.push('--json')
       }
 
+      setInternalAction('groom')
       // eslint-disable-next-line no-await-in-loop
       await this.config.runCommand('work:start', workStartArgs)
     }

--- a/apps/cli/src/commands/work/implement.ts
+++ b/apps/cli/src/commands/work/implement.ts
@@ -6,6 +6,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { setInternalAction } from '../../services/action-context.js'
 
 export default class WorkImplement extends PMOCommand {
   static description = 'Spawn agent to implement, continue, revise, or test a ticket (context-driven)'
@@ -89,11 +90,15 @@ export default class WorkImplement extends PMOCommand {
       ticketIds = [selected]
     }
 
-    // Launch work start with implement action for each ticket
+    // Launch work start with implement action for each ticket. The action is
+    // passed through the internal action-context channel rather than an
+    // `--action` CLI flag (PRLT-1316) so users can't bypass the verb layer.
+    // (Note: 'implement' is also the default, so this is essentially a no-op
+    // handoff, but we set it explicitly to make the routing clear.)
     for (const ticketId of ticketIds) {
       this.log(styles.info(`\nLaunching implement for ${styles.emphasis(ticketId)}...`))
 
-      const workStartArgs = [ticketId, '--action', 'implement']
+      const workStartArgs = [ticketId]
       if (projectId) {
         workStartArgs.push('--project', projectId)
       }
@@ -104,6 +109,7 @@ export default class WorkImplement extends PMOCommand {
         workStartArgs.push('--json')
       }
 
+      setInternalAction('implement')
       // eslint-disable-next-line no-await-in-loop
       await this.config.runCommand('work:start', workStartArgs)
     }

--- a/apps/cli/src/commands/work/jira.ts
+++ b/apps/cli/src/commands/work/jira.ts
@@ -8,6 +8,7 @@ import {
 import {
   shouldOutputJson,
 } from '../../lib/prompt-json.js'
+import { setInternalAction } from '../../services/action-context.js'
 import {
   ExternalIssueAdapterError,
   type NormalizedIssueEnvelope,
@@ -29,12 +30,13 @@ function buildWorkStartArgs(options: {
   runOnHost?: boolean
   skipPermissions?: boolean
   createPr?: boolean
-  action?: string
   message?: string
   json?: boolean
   machine?: boolean
   yes?: boolean
 }): string[] {
+  // Note: action is no longer forwarded via `--action` (removed in PRLT-1316).
+  // Callers should route the action through setInternalAction() instead.
   const args = [options.ticketId, '--project', options.projectId, '--ephemeral']
 
   if (options.executor) args.push('--executor', options.executor)
@@ -42,7 +44,6 @@ function buildWorkStartArgs(options: {
   if (options.runOnHost) args.push('--run-on-host')
   if (options.skipPermissions) args.push('--skip-permissions')
   if (options.createPr) args.push('--create-pr')
-  if (options.action) args.push('--action', options.action)
   if (options.message) args.push('--message', options.message)
   if (options.json) args.push('--json')
   if (options.machine) args.push('--machine')
@@ -254,13 +255,14 @@ export default class WorkJira extends PMOCommand {
       runOnHost: flags['run-on-host'],
       skipPermissions: flags['skip-permissions'],
       createPr: flags['create-pr'],
-      action: flags.action,
       message: contextMessage,
       json: flags.json,
       machine: flags.machine,
       yes: flags.yes,
     })
 
+    // Action is routed through the internal action-context channel (PRLT-1316).
+    if (flags.action) setInternalAction(flags.action)
     await this.config.runCommand('work:start', args)
   }
 }

--- a/apps/cli/src/commands/work/linear.ts
+++ b/apps/cli/src/commands/work/linear.ts
@@ -8,6 +8,7 @@ import {
 import {
   shouldOutputJson,
 } from '../../lib/prompt-json.js'
+import { setInternalAction } from '../../services/action-context.js'
 import {
   ExternalIssueAdapterError,
   type NormalizedIssueEnvelope,
@@ -31,12 +32,13 @@ function buildWorkStartArgs(options: {
   runOnHost?: boolean
   skipPermissions?: boolean
   createPr?: boolean
-  action?: string
   message?: string
   json?: boolean
   machine?: boolean
   yes?: boolean
 }): string[] {
+  // Note: action is no longer forwarded via `--action` (removed in PRLT-1316).
+  // Callers should route the action through setInternalAction() instead.
   const args = [options.ticketId, '--project', options.projectId, '--ephemeral']
 
   if (options.executor) args.push('--executor', options.executor)
@@ -44,7 +46,6 @@ function buildWorkStartArgs(options: {
   if (options.runOnHost) args.push('--run-on-host')
   if (options.skipPermissions) args.push('--skip-permissions')
   if (options.createPr) args.push('--create-pr')
-  if (options.action) args.push('--action', options.action)
   if (options.message) args.push('--message', options.message)
   if (options.json) args.push('--json')
   if (options.machine) args.push('--machine')
@@ -266,13 +267,14 @@ export default class WorkLinear extends PMOCommand {
       runOnHost: flags['run-on-host'],
       skipPermissions: flags['skip-permissions'],
       createPr: flags['create-pr'],
-      action: flags.action,
       message: contextMessage,
       json: flags.json,
       machine: flags.machine,
       yes: flags.yes,
     })
 
+    // Action is routed through the internal action-context channel (PRLT-1316).
+    if (flags.action) setInternalAction(flags.action)
     await this.config.runCommand('work:start', args)
   }
 }

--- a/apps/cli/src/commands/work/resolve.ts
+++ b/apps/cli/src/commands/work/resolve.ts
@@ -6,6 +6,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js';
+import { setInternalAction } from '../../services/action-context.js';
 
 export default class WorkResolve extends PMOCommand {
   static description = 'Agent-assisted resolution of ambiguity questions on tickets (spawns interactive agent)';
@@ -84,11 +85,13 @@ export default class WorkResolve extends PMOCommand {
       ticketIds = [selected];
     }
 
-    // Launch work start with resolve action for each ticket
+    // Launch work start with resolve action for each ticket. The action is
+    // passed through the internal action-context channel rather than an
+    // `--action` CLI flag (PRLT-1316) so users can't bypass the verb layer.
     for (const ticketId of ticketIds) {
       this.log(styles.info(`\nLaunching agent-assisted resolve for ${styles.emphasis(ticketId)}...`));
 
-      const workStartArgs = [ticketId, '--action', 'resolve'];
+      const workStartArgs = [ticketId];
       if (projectId) {
         workStartArgs.push('--project', projectId);
       }
@@ -96,6 +99,7 @@ export default class WorkResolve extends PMOCommand {
         workStartArgs.push('--json');
       }
 
+      setInternalAction('resolve');
       // eslint-disable-next-line no-await-in-loop
       await this.config.runCommand('work:start', workStartArgs);
     }

--- a/apps/cli/src/commands/work/review.ts
+++ b/apps/cli/src/commands/work/review.ts
@@ -6,6 +6,7 @@ import {
   outputErrorAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js'
+import { setInternalAction } from '../../services/action-context.js'
 
 export default class WorkReview extends PMOCommand {
   static description = 'Evaluate the output/PR for a ticket (model decides whether to comment, fix, or both)'
@@ -87,11 +88,13 @@ export default class WorkReview extends PMOCommand {
       ticketIds = [selected]
     }
 
-    // Launch work start with review action for each ticket
+    // Launch work start with review action for each ticket. The action is
+    // passed through the internal action-context channel rather than an
+    // `--action` CLI flag (PRLT-1316) so users can't bypass the verb layer.
     for (const ticketId of ticketIds) {
       this.log(styles.info(`\nLaunching review for ${styles.emphasis(ticketId)}...`))
 
-      const workStartArgs = [ticketId, '--action', 'review']
+      const workStartArgs = [ticketId]
       if (projectId) {
         workStartArgs.push('--project', projectId)
       }
@@ -99,6 +102,7 @@ export default class WorkReview extends PMOCommand {
         workStartArgs.push('--json')
       }
 
+      setInternalAction('review')
       // eslint-disable-next-line no-await-in-loop
       await this.config.runCommand('work:start', workStartArgs)
     }

--- a/apps/cli/src/commands/work/shortcut.ts
+++ b/apps/cli/src/commands/work/shortcut.ts
@@ -21,6 +21,7 @@ import {
   buildShortcutSpawnContextMessage,
 } from '../../lib/external-issues/shortcut.js'
 import { getShortcutApiToken, loadShortcutConfig } from '../../lib/shortcut/index.js'
+import { setInternalAction } from '../../services/action-context.js'
 
 function buildWorkStartArgs(options: {
   ticketId: string
@@ -30,12 +31,13 @@ function buildWorkStartArgs(options: {
   runOnHost?: boolean
   skipPermissions?: boolean
   createPr?: boolean
-  action?: string
   message?: string
   json?: boolean
   machine?: boolean
   yes?: boolean
 }): string[] {
+  // Note: action is no longer forwarded via `--action` (removed in PRLT-1316).
+  // Callers should route the action through setInternalAction() instead.
   const args = [options.ticketId, '--project', options.projectId, '--ephemeral']
 
   if (options.executor) args.push('--executor', options.executor)
@@ -43,7 +45,6 @@ function buildWorkStartArgs(options: {
   if (options.runOnHost) args.push('--run-on-host')
   if (options.skipPermissions) args.push('--skip-permissions')
   if (options.createPr) args.push('--create-pr')
-  if (options.action) args.push('--action', options.action)
   if (options.message) args.push('--message', options.message)
   if (options.json) args.push('--json')
   if (options.machine) args.push('--machine')
@@ -240,13 +241,14 @@ export default class WorkShortcut extends PMOCommand {
       runOnHost: flags['run-on-host'],
       skipPermissions: flags['skip-permissions'],
       createPr: flags['create-pr'],
-      action: flags.action,
       message: contextMessage,
       json: flags.json,
       machine: flags.machine,
       yes: flags.yes,
     })
 
+    // Action is routed through the internal action-context channel (PRLT-1316).
+    if (flags.action) setInternalAction(flags.action)
     await this.config.runCommand('work:start', args)
   }
 }

--- a/apps/cli/src/commands/work/spawn.ts
+++ b/apps/cli/src/commands/work/spawn.ts
@@ -38,6 +38,7 @@ import {
   loadDefaultWorkSource,
   getRegisteredWorkSources,
 } from '../../lib/work-source/index.js'
+import { setInternalAction } from '../../services/action-context.js'
 import {
   isJiraConfigured,
   loadJiraConfig,
@@ -2230,11 +2231,11 @@ export default class WorkSpawn extends PMOCommand {
             if (batchRunOnHost) startArgs.push('--run-on-host')
             if (flags.force) startArgs.push('--force')
             if (flags.focus) startArgs.push('--focus')
-            // Pass action/prompt - custom action uses --prompt, others use --action
+            // Pass action/prompt - custom action uses --prompt; other actions
+            // ride on the internal action-context channel since PRLT-1316
+            // removed the `--action` CLI flag from `work start`.
             if (batchAction === 'custom' && batchCustomMessage) {
               startArgs.push('--prompt', batchCustomMessage)
-            } else if (batchAction) {
-              startArgs.push('--action', batchAction)
             }
             // Pass --message for additional instructions (non-custom actions)
             if (flags.message && batchAction !== 'custom') {
@@ -2253,11 +2254,10 @@ export default class WorkSpawn extends PMOCommand {
             startArgs.push('--permission-mode', batchPermissionMode)
             if (batchCreatePr) startArgs.push('--create-pr')
             if (batchNoPr) startArgs.push('--no-pr')
-            // Pass action/prompt - custom action uses --prompt, others use --action
+            // Pass action/prompt - custom action uses --prompt; other actions
+            // ride on the internal action-context channel (PRLT-1316).
             if (batchAction === 'custom' && batchCustomMessage) {
               startArgs.push('--prompt', batchCustomMessage)
-            } else {
-              startArgs.push('--action', batchAction || 'implement')
             }
             // Pass --message for additional instructions (non-custom actions)
             if (flags.message && batchAction !== 'custom') {
@@ -2269,6 +2269,14 @@ export default class WorkSpawn extends PMOCommand {
             if (flags.focus) startArgs.push('--focus')
           }
 
+          // Route the chosen action via the internal channel (not a CLI flag).
+          // `custom` actions use --prompt instead, so skip.
+          if (batchAction && batchAction !== 'custom') {
+            setInternalAction(batchAction)
+          } else if (!batchAction && !(flags['per-ticket'])) {
+            // Batch mode default: implement
+            setInternalAction('implement')
+          }
           // eslint-disable-next-line no-await-in-loop
           await this.config.runCommand('work:start', startArgs)
 

--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -108,6 +108,7 @@ import { handlePostExecutionTransition } from '../../lib/work-lifecycle/index.js
 import { runPreflightChecks, formatPreflightReport } from '../../lib/execution/preflight.js'
 import { startPromptWatcher } from '../../lib/execution/prompt-watcher.js'
 import { getEventBus } from '../../lib/events/event-bus.js'
+import { resolveInternalAction } from '../../services/action-context.js'
 
 /**
  * Try to execute a git command, return true if successful
@@ -310,10 +311,6 @@ export default class WorkStart extends PMOCommand {
       char: 'e',
       description: 'Override executor',
       options: ['claude-code', 'codex', 'custom'],
-    }),
-    action: Flags.string({
-      description: 'Action to perform (internal — use work groom/implement/review/resolve instead)',
-      hidden: true,
     }),
     prompt: Flags.string({
       char: 'p',
@@ -599,6 +596,15 @@ export default class WorkStart extends PMOCommand {
   async execute(): Promise<void> {
     const { args, flags, argv } = await this.parse(WorkStart)
     let projectId = (flags as { project?: string }).project
+
+    // Resolve the action once, up front. The `--action` CLI flag was removed
+    // in PRLT-1316; dedicated verbs (`work review`, `work groom`,
+    // `work implement`, `work resolve`) and the orchestrator signal the
+    // intended action via the internal action-context channel (module
+    // singleton for in-process, PRLT_INTERNAL_ACTION env var for subprocess).
+    // Users invoking `prlt work start <ticket>` directly always get
+    // 'implement', the configured start action.
+    const internalAction: string | undefined = resolveInternalAction() ?? undefined
 
     // Check for conflicting PR flags
     if (flags['create-pr'] && flags['no-pr']) {
@@ -948,12 +954,13 @@ export default class WorkStart extends PMOCommand {
 
       // In JSON mode with explicit flags, implement two-step confirm-then-execute protocol
       if (jsonMode) {
-        // Check if all required flags for non-interactive execution are provided
-        const hasAction = !!(flags.action || flags.prompt)
+        // Check if all required flags for non-interactive execution are provided.
+        // Action is now always resolved (explicit prompt, internal action, or
+        // the 'implement' default), so it's no longer part of the check.
         const hasDisplay = !!(flags.display || flags['run-on-host'])
         const hasPermissions = !!(flags['permission-mode'] || flags['skip-permissions'])
         const hasAgent = !!(flags.ephemeral || flags.agent)
-        const allFlagsProvided = hasAction && hasDisplay && hasPermissions && hasAgent
+        const allFlagsProvided = hasDisplay && hasPermissions && hasAgent
 
         if (allFlagsProvided && !flags.yes) {
           // All flags provided but no --yes: return confirmation_needed with plan
@@ -983,9 +990,10 @@ export default class WorkStart extends PMOCommand {
             }
           }
 
-          // Build the confirm command with --yes
+          // Build the confirm command with --yes. The `--action` flag was
+          // removed in PRLT-1316 — internal action (if any) is preserved via
+          // the process env var, not propagated onto the re-entry command.
           let confirmCmd = `prlt work start ${ticketId}`
-          if (flags.action) confirmCmd += ` --action ${flags.action}`
           if (flags.prompt) confirmCmd += ` --prompt "${flags.prompt}"`
           if (flags.display) confirmCmd += ` --display ${flags.display}`
           if (flags['run-on-host']) confirmCmd += ' --run-on-host'
@@ -1008,7 +1016,7 @@ export default class WorkStart extends PMOCommand {
               title: ticket.title,
               status: ticket.statusName,
             },
-            action: flags.action || 'implement',
+            action: internalAction || 'implement',
             display: flags.display || (flags['run-on-host'] ? 'host' : 'devcontainer'),
             permissions: (flags['permission-mode'] || (flags['skip-permissions'] ? 'danger' : 'safe')),
             agent: flags.agent || 'ephemeral',
@@ -1469,9 +1477,11 @@ export default class WorkStart extends PMOCommand {
         epicTitle = epic?.title
       }
 
-      // Determine action for this work session
-      // The --action flag is hidden/internal — used by dedicated commands (work groom, work review, etc.)
-      // When called directly, work start always uses 'implement'
+      // Determine action for this work session.
+      // The `--action` CLI flag was removed in PRLT-1316. Internal callers
+      // (work groom/review/implement/resolve, the orchestrator) route through
+      // the action-context channel — see resolveInternalAction() above.
+      // When `work start` is invoked directly it always uses 'implement'.
       let selectedAction: WorkAction | null = null
       let customPrompt: string | undefined
 
@@ -1479,8 +1489,7 @@ export default class WorkStart extends PMOCommand {
         // Custom prompt overrides everything
         customPrompt = flags.prompt
       } else {
-        // Use specified action (internal routing) or default to 'implement'
-        const actionId = flags.action || 'implement'
+        const actionId = internalAction || 'implement'
         selectedAction = await this.storage.getAction(actionId)
         if (!selectedAction) {
           db.close()
@@ -2299,9 +2308,11 @@ export default class WorkStart extends PMOCommand {
         if (isExistingBranch) {
           // Ticket already has a branch linked - just use it
           this.log(styles.muted(`Using existing branch: ${branch}`))
-        } else if (flags.action || flags.force || jsonMode) {
-          // Non-interactive / JSON mode - auto-create branch
-          // JSON mode agents can't interactively enter branch names
+        } else if (internalAction || flags.force || jsonMode) {
+          // Non-interactive / internal-action / JSON mode - auto-create branch.
+          // JSON mode agents can't interactively enter branch names, and
+          // internal callers (work review/groom/resolve/implement, orchestrator)
+          // never want an interactive branch prompt.
           finalBranch = branch
           this.log(styles.muted(`Branch: ${finalBranch}`))
         } else {
@@ -2889,7 +2900,8 @@ export default class WorkStart extends PMOCommand {
     const buildStartArgs = (ticketId: string, projId: string): string[] => {
       const startArgs: string[] = [ticketId, '--project', projId, '--ephemeral']
 
-      if (flags.action) startArgs.push('--action', flags.action as string)
+      // `--action` was removed in PRLT-1316; batch siblings inherit the
+      // action from PRLT_INTERNAL_ACTION (if one was set by the caller).
       if (flags.prompt) startArgs.push('--prompt', flags.prompt as string)
       if (flags.message) startArgs.push('--message', flags.message as string)
       if (flags.display) startArgs.push('--display', flags.display as string)

--- a/apps/cli/src/lib/execution/runners/prompt-builder.ts
+++ b/apps/cli/src/lib/execution/runners/prompt-builder.ts
@@ -114,7 +114,7 @@ const ORCHESTRATOR_COMMAND_REGISTRY: CommandCategory[] = [
   {
     title: 'Agent Lifecycle',
     commands: [
-      { cmd: 'prlt work start <ticket> --ephemeral --skip-permissions --create-pr --verify-ci --display background --action implement --run-on-host --yes', desc: 'Spawn an agent for a ticket', checkPath: 'work/start' },
+      { cmd: 'prlt work start <ticket> --ephemeral --skip-permissions --create-pr --verify-ci --display background --run-on-host --yes', desc: 'Spawn an agent for a ticket', checkPath: 'work/start' },
       { cmd: 'prlt session list', desc: 'List running sessions', checkPath: 'session/list' },
       { cmd: 'prlt session inspect <agent>', desc: 'Inspect session details', checkPath: 'session/inspect' },
       { cmd: 'prlt session poke <agent> \'message\'', desc: 'Send message to agent', checkPath: 'session/poke' },
@@ -234,9 +234,9 @@ function buildOrchestratorBody(hqName: string, context: ExecutionContext): strin
   prompt += buildOrchestratorCommandReference()
   prompt += `## Spawning Agents\n`
   prompt += `\`\`\`\n`
-  prompt += `script -q /dev/null prlt work start <ticket-id> --ephemeral --skip-permissions --create-pr --verify-ci --display background --action implement --run-on-host --yes\n`
+  prompt += `script -q /dev/null prlt work start <ticket-id> --ephemeral --skip-permissions --create-pr --verify-ci --display background --run-on-host --yes\n`
   prompt += `\`\`\`\n`
-  prompt += `- Review: \`--action review\` (model decides whether to comment, fix, or both)\n\n`
+  prompt += `- Review: use the \`prlt work review <ticket-id>\` verb (model decides whether to comment, fix, or both)\n\n`
   prompt += buildOrchestratorAntiPatterns()
   prompt += buildIntegrationCommandsSection(context.connectedIntegrations)
   prompt += `## Workflow\n`

--- a/apps/cli/src/lib/orchestrate/actions.ts
+++ b/apps/cli/src/lib/orchestrate/actions.ts
@@ -54,6 +54,33 @@ export function setChainExecutorForTesting(executor: ChainExecutor | null): void
 export const AGENT_SPAWN_TIMEOUT_MS = 180_000
 
 /**
+ * Env var channel read by `work start` to know which action to run, since
+ * the public `--action` flag was removed in PRLT-1316. Exported so tests
+ * can assert on it.
+ */
+export const INTERNAL_ACTION_ENV = 'PRLT_INTERNAL_ACTION'
+
+/**
+ * Run `fn` with PRLT_INTERNAL_ACTION set to `action`, then restore the prior
+ * value (or clear it if it was unset). Child processes spawned inside `fn`
+ * inherit the env var — this is how the orchestrator tells a subprocess
+ * `work start` which action to fire without a user-visible CLI flag.
+ */
+export function runWithInternalAction<T>(action: string, fn: () => T): T {
+  const previous = process.env[INTERNAL_ACTION_ENV]
+  process.env[INTERNAL_ACTION_ENV] = action
+  try {
+    return fn()
+  } finally {
+    if (previous === undefined) {
+      delete process.env[INTERNAL_ACTION_ENV]
+    } else {
+      process.env[INTERNAL_ACTION_ENV] = previous
+    }
+  }
+}
+
+/**
  * Merge a PR via `prlt work ship`.
  *
  * Walks the JSON prompt chain so that any prompts emitted by `prlt work ship`
@@ -281,9 +308,10 @@ const cleanupContainer: ActionHandler = (ctx) => {
 }
 
 /**
- * Spawn a fix agent after CI failure. Uses --action revise so the agent
- * launches into the revise role prompt; everything else (environment,
- * display, permission mode, …) comes from prompt-chain defaults.
+ * Spawn a fix agent after CI failure. Selects the `revise` role prompt via the
+ * PRLT_INTERNAL_ACTION env var (see PRLT-1316 — the public flag for picking an
+ * action was removed so users cannot bypass the verb layer). Everything else
+ * (environment, display, permission mode, …) comes from prompt-chain defaults.
  */
 const spawnFixAgent: ActionHandler = (ctx, config) => {
   const start = Date.now()
@@ -291,12 +319,12 @@ const spawnFixAgent: ActionHandler = (ctx, config) => {
     return { action: 'spawn-fix-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
   }
 
-  const result = walkPromptChain({
-    baseCommand: `prlt work start ${ctx.ticket} --action revise`,
+  const result = runWithInternalAction('revise', () => walkPromptChain({
+    baseCommand: `prlt work start ${ctx.ticket}`,
     defaults: resolveActionDefaults('spawn-fix-agent', config),
     timeoutMs: AGENT_SPAWN_TIMEOUT_MS,
     executor: chainExecutor,
-  })
+  }))
 
   return {
     action: 'spawn-fix-agent',
@@ -311,7 +339,9 @@ const spawnFixAgent: ActionHandler = (ctx, config) => {
  *
  * Review agents are non-destructive — they read the diff and post comments,
  * so they default to host environment (faster, no container spin-up) and
- * safe permission mode. --action review pins the read-only role prompt.
+ * safe permission mode. The `review` role prompt is pinned via the
+ * PRLT_INTERNAL_ACTION env var (see PRLT-1316 — the public flag for picking
+ * an action was removed).
  */
 const spawnReviewAgent: ActionHandler = (ctx, config) => {
   const start = Date.now()
@@ -319,12 +349,12 @@ const spawnReviewAgent: ActionHandler = (ctx, config) => {
     return { action: 'spawn-review-agent', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
   }
 
-  const result = walkPromptChain({
-    baseCommand: `prlt work start ${ctx.ticket} --action review`,
+  const result = runWithInternalAction('review', () => walkPromptChain({
+    baseCommand: `prlt work start ${ctx.ticket}`,
     defaults: resolveActionDefaults('spawn-review-agent', config),
     timeoutMs: AGENT_SPAWN_TIMEOUT_MS,
     executor: chainExecutor,
-  })
+  }))
 
   return {
     action: 'spawn-review-agent',
@@ -355,7 +385,8 @@ const healthCheck: ActionHandler = (ctx) => {
  * Resolve a merge conflict on a PR by poking the running agent or respawning a stopped one.
  * If the agent is running, it gets poked with a rebase instruction.
  * If the agent is stopped, it gets respawned via the JSON prompt chain
- * with --action resolve.
+ * with the `resolve` role prompt (pinned via PRLT_INTERNAL_ACTION since
+ * PRLT-1316 dropped the public flag for picking an action).
  * No action is taken on PRs with no associated ticket.
  */
 const resolveConflict: ActionHandler = (ctx, config) => {
@@ -375,12 +406,12 @@ const resolveConflict: ActionHandler = (ctx, config) => {
     // Poke failed — agent is likely not running, respawn it via prompt chain
   }
 
-  const result = walkPromptChain({
-    baseCommand: `prlt work start ${ctx.ticket} --action resolve`,
+  const result = runWithInternalAction('resolve', () => walkPromptChain({
+    baseCommand: `prlt work start ${ctx.ticket}`,
     defaults: resolveActionDefaults('resolve-conflict', config),
     timeoutMs: AGENT_SPAWN_TIMEOUT_MS,
     executor: chainExecutor,
-  })
+  }))
 
   return {
     action: 'resolve-conflict',

--- a/apps/cli/src/services/action-context.ts
+++ b/apps/cli/src/services/action-context.ts
@@ -1,0 +1,64 @@
+/**
+ * Action Context — internal channel for routing a specific action to `work start`.
+ *
+ * Background (PRLT-1316): the `--action` CLI flag on `work start` was a leaky
+ * abstraction — it let users bypass dedicated verbs (`work review`,
+ * `work groom`, `work resolve`, `work implement`) by naming an action directly.
+ *
+ * Removing the flag left one gap: dedicated verbs still delegate into
+ * `work:start` and need to tell it which action to run. This module is that
+ * internal channel. It is deliberately NOT exposed as a CLI flag, help output,
+ * or documented user API.
+ *
+ * Two carriers are supported so this works across both oclif command
+ * delegation (same process) and subprocess delegation (orchestrator):
+ *
+ *   1. `setInternalAction(action)` — in-process, cleared on first read
+ *   2. `PRLT_INTERNAL_ACTION` env var — survives subprocess boundary
+ *
+ * Precedence: in-process state > env var. The in-process slot is cleared after
+ * being read so stale values can't leak into an unrelated `work start`
+ * invocation later in the same process.
+ */
+
+let inProcessAction: string | null = null
+
+/**
+ * Record the action a sibling command wants `work:start` to execute.
+ * Only read once — cleared after {@link resolveInternalAction} returns it.
+ */
+export function setInternalAction(action: string): void {
+  inProcessAction = action
+}
+
+/**
+ * Read and clear the internal action slot. Falls back to the
+ * `PRLT_INTERNAL_ACTION` env var for subprocess invocations.
+ */
+export function resolveInternalAction(): string | null {
+  const action = inProcessAction ?? process.env.PRLT_INTERNAL_ACTION ?? null
+  inProcessAction = null
+  return action
+}
+
+/**
+ * Resolve the action id for a `work start` invocation.
+ *
+ * @param explicit — optional explicit id (kept for the service-layer API;
+ *                   CLI callers pass undefined because `--action` is gone)
+ * @param fallback — default when nothing is set (defaults to `'implement'`)
+ */
+export function resolveActionId(
+  explicit: string | undefined,
+  fallback: string = 'implement',
+): string {
+  return explicit ?? resolveInternalAction() ?? fallback
+}
+
+/**
+ * Test helper — forcibly clear the in-process slot. Production code should
+ * never need this; it exists so tests can assert clean state between cases.
+ */
+export function __clearInternalActionForTests(): void {
+  inProcessAction = null
+}

--- a/apps/cli/src/services/index.ts
+++ b/apps/cli/src/services/index.ts
@@ -24,6 +24,12 @@ export { ReconcileService } from './reconcile-service.js'
 export { PRService } from './pr-service.js'
 export type { PRServiceStorage } from './pr-service.js'
 
+export {
+  setInternalAction,
+  resolveInternalAction,
+  resolveActionId,
+} from './action-context.js'
+
 export { ServiceError } from './types.js'
 export type {
   ServiceErrorCode,

--- a/apps/cli/test/unit/action-context.test.ts
+++ b/apps/cli/test/unit/action-context.test.ts
@@ -1,0 +1,141 @@
+import { expect } from 'chai'
+import {
+  setInternalAction,
+  resolveInternalAction,
+  resolveActionId,
+  __clearInternalActionForTests,
+} from '../../src/services/action-context.js'
+
+/**
+ * Tests for the internal action-context channel introduced in PRLT-1316
+ * when the user-facing `--action` flag was removed from `work start`.
+ *
+ * The channel has two carriers:
+ *   1. In-process slot (set via setInternalAction, cleared on first read)
+ *   2. PRLT_INTERNAL_ACTION env var (read as a fallback, NOT cleared —
+ *      it survives subprocess boundaries and the parent decides its lifetime)
+ *
+ * All tests reset both carriers in beforeEach to prevent leakage between cases.
+ */
+describe('action-context (PRLT-1316)', () => {
+  const ENV_VAR = 'PRLT_INTERNAL_ACTION'
+  let originalEnv: string | undefined
+
+  beforeEach(() => {
+    originalEnv = process.env[ENV_VAR]
+    delete process.env[ENV_VAR]
+    __clearInternalActionForTests()
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[ENV_VAR]
+    } else {
+      process.env[ENV_VAR] = originalEnv
+    }
+    __clearInternalActionForTests()
+  })
+
+  // ---------------------------------------------------------------------------
+  // resolveInternalAction — raw channel
+  // ---------------------------------------------------------------------------
+
+  describe('resolveInternalAction', () => {
+    it('returns null when nothing is set', () => {
+      expect(resolveInternalAction()).to.equal(null)
+    })
+
+    it('returns value set via setInternalAction', () => {
+      setInternalAction('review')
+      expect(resolveInternalAction()).to.equal('review')
+    })
+
+    it('single-use: clears the in-process slot after reading', () => {
+      setInternalAction('groom')
+      expect(resolveInternalAction()).to.equal('groom')
+      // Second call returns null — value was consumed
+      expect(resolveInternalAction()).to.equal(null)
+    })
+
+    it('falls back to PRLT_INTERNAL_ACTION env var when in-process slot is empty', () => {
+      process.env[ENV_VAR] = 'resolve'
+      expect(resolveInternalAction()).to.equal('resolve')
+    })
+
+    it('env var is NOT cleared by a read (survives subprocess lifetime)', () => {
+      process.env[ENV_VAR] = 'revise'
+      resolveInternalAction()
+      // env var remains — the subprocess parent owns its lifetime
+      expect(process.env[ENV_VAR]).to.equal('revise')
+    })
+
+    it('in-process slot wins over env var when both are set', () => {
+      process.env[ENV_VAR] = 'implement'
+      setInternalAction('review')
+      expect(resolveInternalAction()).to.equal('review')
+    })
+
+    it('after in-process read, falls through to env var on next call', () => {
+      process.env[ENV_VAR] = 'revise'
+      setInternalAction('review')
+      // First call drains the in-process slot
+      expect(resolveInternalAction()).to.equal('review')
+      // Second call falls back to env var
+      expect(resolveInternalAction()).to.equal('revise')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // resolveActionId — defaulting helper used by work start
+  // ---------------------------------------------------------------------------
+
+  describe('resolveActionId', () => {
+    it('returns explicit when provided (used by service-layer callers)', () => {
+      expect(resolveActionId('groom')).to.equal('groom')
+    })
+
+    it('explicit wins even when internal slot is set', () => {
+      setInternalAction('review')
+      expect(resolveActionId('groom')).to.equal('groom')
+    })
+
+    it('falls back to internal action when explicit is undefined', () => {
+      setInternalAction('review')
+      expect(resolveActionId(undefined)).to.equal('review')
+    })
+
+    it('defaults to "implement" when nothing is set', () => {
+      expect(resolveActionId(undefined)).to.equal('implement')
+    })
+
+    it('honors a custom fallback', () => {
+      expect(resolveActionId(undefined, 'custom-default')).to.equal('custom-default')
+    })
+
+    it('explicit overrides fallback', () => {
+      expect(resolveActionId('review', 'implement')).to.equal('review')
+    })
+
+    it('falls back to env var before defaulting to "implement"', () => {
+      process.env[ENV_VAR] = 'resolve'
+      expect(resolveActionId(undefined)).to.equal('resolve')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Regression — the scenario PRLT-1316 exists to prevent
+  // ---------------------------------------------------------------------------
+
+  describe('regression: state does not leak across unrelated work-start invocations', () => {
+    it('a stale in-process value from a previous command cannot dirty the next run', () => {
+      // Sibling verb sets then reads the action — typical flow
+      setInternalAction('review')
+      const first = resolveActionId(undefined)
+      expect(first).to.equal('review')
+
+      // A subsequent, unrelated `work start` call sees no leaked state
+      const second = resolveActionId(undefined)
+      expect(second).to.equal('implement')
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-actions.test.ts
+++ b/apps/cli/test/unit/orchestrate-actions.test.ts
@@ -6,6 +6,7 @@ import {
   executeBuiltinAction,
   ACTION_HANDLERS,
   AGENT_SPAWN_TIMEOUT_MS,
+  INTERNAL_ACTION_ENV,
   setChainExecutorForTesting,
 } from '../../src/lib/orchestrate/actions.js'
 import type { ChainExecutor } from '../../src/lib/orchestrate/prompt-chain.js'
@@ -176,8 +177,13 @@ describe('Orchestrate Built-in Actions', () => {
 
   describe('CLI invocation strings (via prompt chain executor)', () => {
     let calls: string[] = []
+    let envSnapshots: Array<string | undefined> = []
     const successExecutor: ChainExecutor = (command) => {
       calls.push(command)
+      // Capture the env var state at executor dispatch time. The
+      // orchestrator sets PRLT_INTERNAL_ACTION around walkPromptChain so
+      // subprocesses inherit it; we verify that by snapshotting here.
+      envSnapshots.push(process.env[INTERNAL_ACTION_ENV])
       return {
         stdout: JSON.stringify({
           type: 'success',
@@ -193,11 +199,13 @@ describe('Orchestrate Built-in Actions', () => {
 
     beforeEach(() => {
       calls = []
+      envSnapshots = []
       setChainExecutorForTesting(successExecutor)
     })
 
     afterEach(() => {
       setChainExecutorForTesting(null)
+      delete process.env[INTERNAL_ACTION_ENV]
     })
 
     it('merge-pr should call: prlt work ship <ticket> --pr <number> --json (no --yes)', () => {
@@ -246,24 +254,32 @@ describe('Orchestrate Built-in Actions', () => {
       expect(calls[0]).to.not.include('--display')
     })
 
-    it('spawn-fix-agent should call: prlt work start <ticket> --action revise --json', () => {
+    it('spawn-fix-agent should call: prlt work start <ticket> --json with PRLT_INTERNAL_ACTION=revise', () => {
       const result = executeBuiltinAction('spawn-fix-agent', {
         event: 'on_ci_failed',
         ticket: 'PRLT-400',
       })
       expect(result.success).to.be.true
-      expect(calls[0]).to.equal('prlt work start PRLT-400 --action revise --json')
+      // PRLT-1316: action is no longer a CLI flag; it rides on an env var.
+      expect(calls[0]).to.equal('prlt work start PRLT-400 --json')
+      expect(calls[0]).to.not.include('--action')
       expect(calls[0]).to.not.include('--yes')
+      expect(envSnapshots[0]).to.equal('revise')
+      // env var is restored after the call
+      expect(process.env[INTERNAL_ACTION_ENV]).to.be.undefined
     })
 
-    it('spawn-review-agent should call: prlt work start <ticket> --action review --json', () => {
+    it('spawn-review-agent should call: prlt work start <ticket> --json with PRLT_INTERNAL_ACTION=review', () => {
       const result = executeBuiltinAction('spawn-review-agent', {
         event: 'on_pr_opened',
         ticket: 'PRLT-450',
       })
       expect(result.success).to.be.true
-      expect(calls[0]).to.equal('prlt work start PRLT-450 --action review --json')
+      expect(calls[0]).to.equal('prlt work start PRLT-450 --json')
+      expect(calls[0]).to.not.include('--action')
       expect(calls[0]).to.not.include('--yes')
+      expect(envSnapshots[0]).to.equal('review')
+      expect(process.env[INTERNAL_ACTION_ENV]).to.be.undefined
     })
 
     it('move-ticket should call: prlt ticket move <ticket> "<target>" --json', () => {
@@ -412,18 +428,21 @@ describe('Orchestrate Built-in Actions', () => {
       expect(src).to.not.include('--display background')
     })
 
-    it('spawn-fix-agent must not hardcode --yes or --display flags', () => {
+    it('spawn-fix-agent must not hardcode --yes or --display flags and must route revise via internal action', () => {
       const src = getHandlerSource('spawnFixAgent')
       expect(src).to.include('walkPromptChain')
-      expect(src).to.include('--action revise')
+      // PRLT-1316: --action is gone, role prompt is pinned via env var.
+      expect(src).to.include("runWithInternalAction('revise'")
+      expect(src).to.not.include('--action')
       expect(src).to.not.include('--yes')
       expect(src).to.not.include('--display background')
     })
 
-    it('spawn-review-agent must not hardcode --yes or --display flags', () => {
+    it('spawn-review-agent must not hardcode --yes or --display flags and must route review via internal action', () => {
       const src = getHandlerSource('spawnReviewAgent')
       expect(src).to.include('walkPromptChain')
-      expect(src).to.include('--action review')
+      expect(src).to.include("runWithInternalAction('review'")
+      expect(src).to.not.include('--action')
       expect(src).to.not.include('--yes')
       expect(src).to.not.include('--display background')
     })

--- a/apps/cli/test/unit/orchestrate-prompt-chain.test.ts
+++ b/apps/cli/test/unit/orchestrate-prompt-chain.test.ts
@@ -628,6 +628,9 @@ describe('DEFAULT_PROMPT_CHOICES value validity (PRLT-1274)', () => {
     // Review agents set modifiesCode=false which would normally skip prChoice
     // entirely, but we guard the default anyway in case a future code path
     // re-emits the prompt for review-style actions.
+    // PRLT-1316: `--action` was removed from the public CLI. Internal
+    // orchestrator callers set the action via PRLT_INTERNAL_ACTION now, so
+    // the follow-up commands emitted by work start no longer include it.
     let i = 0
     const responses: ChainExecutorResult[] = [
       jsonResult({
@@ -636,8 +639,8 @@ describe('DEFAULT_PROMPT_CHOICES value validity (PRLT-1274)', () => {
           type: 'list',
           name: 'environment',
           choices: [
-            { value: 'devcontainer', command: 'prlt work start TKT-1 --action review --environment devcontainer --json' },
-            { value: 'host', command: 'prlt work start TKT-1 --action review --run-on-host --json' },
+            { value: 'devcontainer', command: 'prlt work start TKT-1 --environment devcontainer --json' },
+            { value: 'host', command: 'prlt work start TKT-1 --run-on-host --json' },
           ],
         },
       }, 2),
@@ -647,8 +650,8 @@ describe('DEFAULT_PROMPT_CHOICES value validity (PRLT-1274)', () => {
           type: 'list',
           name: 'permission-mode',
           choices: [
-            { value: 'danger', command: 'prlt work start TKT-1 --action review --run-on-host --permission-mode danger --json' },
-            { value: 'safe', command: 'prlt work start TKT-1 --action review --run-on-host --permission-mode safe --json' },
+            { value: 'danger', command: 'prlt work start TKT-1 --run-on-host --permission-mode danger --json' },
+            { value: 'safe', command: 'prlt work start TKT-1 --run-on-host --permission-mode safe --json' },
           ],
         },
       }, 2),
@@ -658,8 +661,8 @@ describe('DEFAULT_PROMPT_CHOICES value validity (PRLT-1274)', () => {
           type: 'list',
           name: 'prChoice',
           choices: [
-            { value: 'yes', command: 'prlt work start TKT-1 --action review --run-on-host --permission-mode safe --create-pr --json' },
-            { value: 'no', command: 'prlt work start TKT-1 --action review --run-on-host --permission-mode safe --json' },
+            { value: 'yes', command: 'prlt work start TKT-1 --run-on-host --permission-mode safe --create-pr --json' },
+            { value: 'no', command: 'prlt work start TKT-1 --run-on-host --permission-mode safe --json' },
           ],
         },
       }, 2),
@@ -672,7 +675,7 @@ describe('DEFAULT_PROMPT_CHOICES value validity (PRLT-1274)', () => {
     }
 
     const result = walkPromptChain({
-      baseCommand: 'prlt work start TKT-1 --action review',
+      baseCommand: 'prlt work start TKT-1',
       defaults: resolveActionDefaults('spawn-review-agent'),
       executor: exec,
     })

--- a/apps/cli/test/unit/review-agent.test.ts
+++ b/apps/cli/test/unit/review-agent.test.ts
@@ -38,25 +38,26 @@ describe('Reviewer Agents (PRLT-1226)', () => {
       expect(result.error).to.include('No ticket')
     })
 
-    it('should invoke prlt work start with --action review', () => {
+    it('should invoke prlt work start (with review role routed via internal action env var)', () => {
       const result = executeBuiltinAction('spawn-review-agent', {
         event: 'on_pr_opened',
         ticket: 'PRLT-1226',
       })
       // Will fail in test env since prlt isn't available, but error contains the command.
-      // walkPromptChain wraps commands in backticks and appends --json.
+      // PRLT-1316: --action is no longer a CLI flag; the review role is
+      // pinned via PRLT_INTERNAL_ACTION.
       expect(result.success).to.be.false
-      expect(result.error).to.include('prlt work start PRLT-1226 --action review --json')
+      expect(result.error).to.include('prlt work start PRLT-1226 --json')
+      expect(result.error).to.not.include('--action')
     })
 
-    it('should use --action review (not implement, not revise)', () => {
+    it('should not leak action into the command line (review role rides on env var)', () => {
       const result = executeBuiltinAction('spawn-review-agent', {
         event: 'on_pr_opened',
         ticket: 'TKT-TEST',
       })
-      expect(result.error).to.include('--action review')
-      expect(result.error).to.not.include('--action implement')
-      expect(result.error).to.not.include('--action revise')
+      // Make sure `--action <anything>` is gone from the invocation string
+      expect(result.error).to.not.include('--action')
     })
   })
 

--- a/apps/cli/test/unit/run-with-internal-action.test.ts
+++ b/apps/cli/test/unit/run-with-internal-action.test.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai'
+import {
+  runWithInternalAction,
+  INTERNAL_ACTION_ENV,
+} from '../../src/lib/orchestrate/actions.js'
+
+/**
+ * Tests for runWithInternalAction — the orchestrator-side helper introduced in
+ * PRLT-1316 to propagate the action selection to a subprocess via the
+ * PRLT_INTERNAL_ACTION env var (since `--action` is no longer a CLI flag).
+ *
+ * The helper must:
+ *   - set the env var for the duration of the callback,
+ *   - restore whatever was there (including undefined) afterward,
+ *   - not swallow exceptions from the callback.
+ */
+describe('runWithInternalAction (PRLT-1316)', () => {
+  let original: string | undefined
+
+  beforeEach(() => {
+    original = process.env[INTERNAL_ACTION_ENV]
+    delete process.env[INTERNAL_ACTION_ENV]
+  })
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[INTERNAL_ACTION_ENV]
+    } else {
+      process.env[INTERNAL_ACTION_ENV] = original
+    }
+  })
+
+  it('exposes PRLT_INTERNAL_ACTION inside the callback', () => {
+    let captured: string | undefined
+    runWithInternalAction('review', () => {
+      captured = process.env[INTERNAL_ACTION_ENV]
+    })
+    expect(captured).to.equal('review')
+  })
+
+  it('clears the env var after the callback when it was unset before', () => {
+    runWithInternalAction('groom', () => {
+      // nothing
+    })
+    expect(process.env[INTERNAL_ACTION_ENV]).to.be.undefined
+  })
+
+  it('restores the prior env value instead of blanking it', () => {
+    process.env[INTERNAL_ACTION_ENV] = 'original-value'
+    runWithInternalAction('revise', () => {
+      expect(process.env[INTERNAL_ACTION_ENV]).to.equal('revise')
+    })
+    expect(process.env[INTERNAL_ACTION_ENV]).to.equal('original-value')
+  })
+
+  it('still restores the env var when the callback throws', () => {
+    expect(() =>
+      runWithInternalAction('resolve', () => {
+        throw new Error('boom')
+      })
+    ).to.throw('boom')
+    // env var must be cleaned up even on exception path
+    expect(process.env[INTERNAL_ACTION_ENV]).to.be.undefined
+  })
+
+  it('returns the callback result', () => {
+    const result = runWithInternalAction('review', () => 42)
+    expect(result).to.equal(42)
+  })
+
+  it('isolates nested invocations: inner overrides and restores outer', () => {
+    const trace: Array<string | undefined> = []
+    runWithInternalAction('review', () => {
+      trace.push(process.env[INTERNAL_ACTION_ENV])
+      runWithInternalAction('revise', () => {
+        trace.push(process.env[INTERNAL_ACTION_ENV])
+      })
+      trace.push(process.env[INTERNAL_ACTION_ENV])
+    })
+    expect(trace).to.deep.equal(['review', 'revise', 'review'])
+    expect(process.env[INTERNAL_ACTION_ENV]).to.be.undefined
+  })
+})

--- a/apps/cli/test/unit/work-start-action-flag-removed.test.ts
+++ b/apps/cli/test/unit/work-start-action-flag-removed.test.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai'
+import WorkStart from '../../src/commands/work/start.js'
+
+/**
+ * Regression test for PRLT-1316.
+ *
+ * The `--action` flag on `work start` was removed because it let users
+ * bypass the verb layer (`work groom`, `work review`, `work resolve`,
+ * `work implement`) by naming an action directly, duplicating the future
+ * `prlt action run` entry point.
+ *
+ * If the flag ever sneaks back into the class definition, this test fails.
+ */
+describe('work start: --action flag removed (PRLT-1316)', () => {
+  it('does not declare an `action` oclif flag', () => {
+    const flags = (WorkStart as unknown as { flags: Record<string, unknown> }).flags
+    expect(flags).to.be.an('object')
+    expect(flags).to.not.have.property('action',
+      '`--action` was removed in PRLT-1316 — use `work groom/review/implement/resolve` instead of adding this flag back.'
+    )
+  })
+
+  it('still declares `prompt` (the supported override)', () => {
+    // `--prompt` is the legitimate override for custom prompts and was NOT
+    // removed. Keep this assertion as a guardrail so we don't accidentally
+    // nuke it along with --action in a future refactor.
+    const flags = (WorkStart as unknown as { flags: Record<string, unknown> }).flags
+    expect(flags).to.have.property('prompt')
+  })
+
+  it('still declares `session-action` (a separate concern — session conflict handling)', () => {
+    // `--session-action` controls how to handle an existing tmux session
+    // (attach/spawn/kill/cancel). It is unrelated to the removed `--action`
+    // flag; keep it distinguishable to prevent regressions.
+    const flags = (WorkStart as unknown as { flags: Record<string, unknown> }).flags
+    expect(flags).to.have.property('session-action')
+  })
+})

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -350,8 +350,10 @@ prlt work start --from-issue --key ENG-123   # Uses Linear from active source
 
 # Examples — general
 prlt work start TKT-001
-prlt work start TKT-001 --mode docker --action implement
+prlt work start TKT-001 --mode docker
 prlt work start TKT-001 --create-pr        # Explicitly create PR
+# For non-'implement' actions use the dedicated verb (work groom/review/resolve),
+# not `work start` directly — the `--action` flag was removed in PRLT-1316.
 ```
 
 #### `prlt work spawn`

--- a/docs/concepts/work.md
+++ b/docs/concepts/work.md
@@ -101,15 +101,26 @@ Specify what the agent should do:
 | `custom` | Custom action with provided prompt |
 
 ```bash
-# Implement the ticket
-prlt work start TKT-001 --action implement
+# Implement the ticket (default action — `work start` always uses 'implement')
+prlt work start TKT-001
+prlt work implement TKT-001            # equivalent dedicated verb
 
-# Groom the ticket
-prlt work start TKT-001 --action groom
+# Groom the ticket — use the dedicated verb, not `work start`
+prlt work groom TKT-001
 
-# Custom prompt
+# Review an existing PR
+prlt work review TKT-001
+
+# Resolve ambiguity questions on a ticket
+prlt work resolve TKT-001
+
+# Custom prompt (overrides the default action prompt)
 prlt work start TKT-001 --prompt "Review the code for security issues"
 ```
+
+> The public `--action` flag was removed in PRLT-1316. Use the dedicated verbs
+> above (`work groom`, `work review`, `work implement`, `work resolve`)
+> whenever you need a non-`implement` role prompt.
 
 ## Monitoring Work
 

--- a/docs/workflows/ticket-lifecycle.md
+++ b/docs/workflows/ticket-lifecycle.md
@@ -78,7 +78,7 @@ Requirements:
 Have an agent groom the ticket:
 
 ```bash
-prlt work start TKT-042 --action groom
+prlt work groom TKT-042
 ```
 
 The agent will:
@@ -171,7 +171,7 @@ gh pr review --request-changes -b "Please add input validation"
 Agent can address feedback:
 
 ```bash
-prlt work start TKT-042 --action implement --force
+prlt work start TKT-042 --force
 # Agent reads PR comments and makes changes
 ```
 
@@ -249,7 +249,7 @@ prlt ticket create \
   --priority P0
 
 # Start immediately (skip grooming for urgent bugs)
-prlt work start TKT-043 --action implement
+prlt work start TKT-043
 ```
 
 ### Documentation Flow
@@ -259,8 +259,8 @@ prlt ticket create \
   --title "Document API endpoints" \
   --category docs
 
-# Use docs action
-prlt work start TKT-044 --action implement
+# Implement
+prlt work start TKT-044
 ```
 
 ### Refactor Flow


### PR DESCRIPTION
## Summary

Removes the hidden `--action` CLI flag from `prlt work start` and replaces it
with an explicit, internal-only **action-context service** for sibling verbs
and the orchestrator. The `--action` flag was a leaky abstraction that let
users bypass the verb layer (`work review`, `work groom`, `work resolve`,
`work implement`) by naming an action directly — duplicating the future
`prlt action run` entry point and muddying the CLI surface.

### Design

New module `apps/cli/src/services/action-context.ts` exposes:

- `setInternalAction(action)` — in-process slot, single-use (cleared on first read) so stale values cannot leak into unrelated `work start` invocations later in the same process.
- `resolveInternalAction()` — falls through to `PRLT_INTERNAL_ACTION` env var so subprocess callers (the orchestrator) can propagate action selection across process boundaries.
- `resolveActionId(explicit, fallback)` — defaulting helper used at the service-layer seam.

On the orchestrator side, `runWithInternalAction(action, fn)` in `lib/orchestrate/actions.ts` sets the env var for the duration of a callback and always restores the prior value (even on exception).

### Changes

- `work/start.ts` — `--action` flag removed; `flags.action` reads replaced with the resolved internal-action; JSON-mode "all flags provided" gate no longer requires action (there is always a default); branch-create auto-create gate switched from `flags.action` to `internalAction`; batch-spawn forwarder no longer propagates the removed flag.
- `work/review.ts`, `work/groom.ts`, `work/implement.ts`, `work/resolve.ts` — dedicated verbs now `setInternalAction(...)` before delegating to `work:start` instead of passing `--action`.
- `work/asana.ts`, `work/linear.ts`, `work/jira.ts`, `work/shortcut.ts` — external-issue commands keep their own `--action` flag (user-facing for those verbs) but route it through `setInternalAction` when calling `work:start`; `buildWorkStartArgs()` no longer accepts the removed flag.
- `work/spawn.ts` — batch spawn now routes `batchAction` through `setInternalAction` instead of `--action`; `custom` actions continue to use `--prompt`.
- `lib/orchestrate/actions.ts` — `spawnFixAgent`, `spawnReviewAgent`, and `resolveConflict` wrap `walkPromptChain(...)` with `runWithInternalAction(...)` so the subprocess inherits `PRLT_INTERNAL_ACTION`.
- `lib/execution/runners/prompt-builder.ts` — removed `--action implement` from the orchestrator-agent prompt examples.
- Docs: `cli-reference.md`, `concepts/work.md`, `workflows/ticket-lifecycle.md`, `apps/cli/README.md` updated to recommend dedicated verbs.

### Tests (new)

- `test/unit/action-context.test.ts` — 15 tests covering in-process slot, env var fallback, single-use semantics, precedence rules, and the anti-leakage regression case.
- `test/unit/run-with-internal-action.test.ts` — 6 tests covering env var set/restore, exception safety, and nested invocations.
- `test/unit/work-start-action-flag-removed.test.ts` — 3 tests asserting the `action` oclif flag is gone (and that `--prompt` / `--session-action` remain).

### Tests (updated)

- `orchestrate-actions.test.ts` — CLI invocation strings for `spawn-fix-agent` / `spawn-review-agent` no longer include `--action`; new assertions verify the env var is set at executor dispatch time and restored afterward; source-level regression tests verify handlers use `runWithInternalAction(...)`.
- `orchestrate-prompt-chain.test.ts` — updated simulated prompt responses to drop `--action` from follow-up commands (work start no longer emits them).
- `review-agent.test.ts` — asserts invocation strings no longer carry `--action`.

### AC status

- [x] `--action` flag removed from `work start`
- [x] All affected existing tests updated and pass
- [x] Service helpers live in `src/services/` and are reusable from CLI, hooks, and (subprocess-wise) the orchestrator
- [x] Business-logic extraction continues incrementally via the new service seam; the 3599-line `work/start.ts` is large enough that converting it to a <100-line thin wrapper is a multi-PR effort (follow-up ticket recommended)

### Scope note

The ticket also asks for "every work command < 100 lines (CLI parsing + output formatting only)". `work/start.ts` (3599 lines) and `work/spawn.ts` (2428 lines) both carry significant embedded business logic that can't be moved cleanly in a single PR without a much deeper reshape of the execution pipeline (devcontainer plumbing, mirror executions, flag resolution chains, preflight checks). This PR establishes the service-layer seam cited in the ticket (`action-context`) and clears out the `--action` flag; moving the rest of the body into `WorkService.startWork(...)` should be tracked as a follow-up — it builds directly on the seam introduced here.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm -C apps/cli test:unit` for affected files — all new + modified tests pass (200/200 across affected suites; 6 pre-existing failures unrelated to this PR: flags-audit-coverage, runtime-command HQ detection, orchestrate-poller, update-check — none touch `work start` / service layer / `--action` code paths)
- [ ] Verify CI is green on this PR

Linear: PRLT-1316