### PR TITLE
fix(PRLT-1319): audit runtime-stubbed methods — migrate services and delete no-caller stubs

### DIFF
--- a/apps/cli/src/commands/pr/merge.ts
+++ b/apps/cli/src/commands/pr/merge.ts
@@ -135,7 +135,11 @@ export default class PRMerge extends PMOCommand {
     if (this.hasPMO) {
       try {
         const db = this.storage.getDatabase();
-        const prService = new PRService(db, this.storage as unknown as ProviderStorage & { listTickets: any; updateTicket: any });
+        const prService = new PRService(
+          db,
+          this.storage as unknown as ProviderStorage,
+          (tid, pid) => this.resolveTicketProvider(tid, pid),
+        );
         const linkResult = await prService.resolveLinkedTicket(prNumber, prInfo.headBranch, (flags as { project?: string }).project);
 
         if (linkResult.ticket) {

--- a/apps/cli/src/commands/ticket/edit.ts
+++ b/apps/cli/src/commands/ticket/edit.ts
@@ -178,9 +178,7 @@ export default class TicketEdit extends PMOCommand {
       }
 
       // Interactive mode - prompt for all editable fields
-      const board = ticket.projectId ? await this.storage.getProjectBoard(ticket.projectId) : null;
-      const columns = board ? board.columns.map(col => col.name) : [];
-      updates = await this.promptForEdits(ticket, columns);
+      updates = await this.promptForEdits(ticket, []);
     } else {
       // Use flag values
       if (flags.title) updates.title = flags.title;
@@ -195,21 +193,20 @@ export default class TicketEdit extends PMOCommand {
       if (flags.assignee) updates.assignee = flags.assignee;
     }
 
-    // Handle subtasks - sequential for consistent ordering
+    // Handle subtasks — compute the final array and send via provider updateTicket
     let subtasksChanged = false;
+    let finalSubtasks = [...(ticket.subtasks ?? [])];
     if (flags['clear-subtasks']) {
-      // Clear all subtasks first - get from ticket object
-      for (const subtask of ticket.subtasks) {
-        // eslint-disable-next-line no-await-in-loop
-        await this.storage.removeSubtask(ticketId!, subtask.id);
-      }
+      finalSubtasks = [];
       subtasksChanged = true;
     }
-
     if (flags['add-subtask'] && flags['add-subtask'].length > 0) {
       for (const subtaskTitle of flags['add-subtask']) {
-        // eslint-disable-next-line no-await-in-loop
-        await this.storage.addSubtask(ticketId!, subtaskTitle);
+        finalSubtasks.push({
+          id: `subtask-${Date.now()}-${finalSubtasks.length}`,
+          title: subtaskTitle,
+          done: false,
+        });
       }
       subtasksChanged = true;
     }
@@ -232,18 +229,23 @@ export default class TicketEdit extends PMOCommand {
       }
     }
 
-    // Handle acceptance criteria
+    // Handle acceptance criteria — compute the final array and send via provider updateTicket
     let acChanged = false;
+    let finalAC = [...(ticket.acceptanceCriteria ?? [])];
     if (flags['clear-ac']) {
-      await this.storage.clearAcceptanceCriteria(ticketId!);
+      finalAC = [];
       acChanged = true;
     }
-
     if (flags['add-ac'] && flags['add-ac'].length > 0) {
-      // Sequential for consistent ordering
       for (const criterion of flags['add-ac']) {
-        // eslint-disable-next-line no-await-in-loop
-        await this.storage.addAcceptanceCriterion(ticketId!, criterion);
+        finalAC.push({
+          id: `ac-${Date.now()}-${finalAC.length}`,
+          ticketId: ticketId!,
+          criterion,
+          verifiable: false,
+          verified: false,
+          position: finalAC.length,
+        });
       }
       acChanged = true;
     }
@@ -255,9 +257,15 @@ export default class TicketEdit extends PMOCommand {
       return;
     }
 
-    // Update the ticket with labels if changed
+    // Update the ticket with labels / subtasks / AC if changed
     if (labelsChanged) {
       (updates as { labels?: string[] }).labels = currentLabels;
+    }
+    if (subtasksChanged) {
+      (updates as { subtasks?: typeof finalSubtasks }).subtasks = finalSubtasks;
+    }
+    if (acChanged) {
+      (updates as { acceptanceCriteria?: typeof finalAC }).acceptanceCriteria = finalAC;
     }
 
     // Update the ticket through provider

--- a/apps/cli/src/lib/pmo/base-command.ts
+++ b/apps/cli/src/lib/pmo/base-command.ts
@@ -77,12 +77,14 @@ export const pmoBaseFlags = {
  *     // Runtime context (this.hqPath, this.db, this.settings) inherited from RuntimeCommand
  *     // PMO context (this.storage, this.pmoPath) added by PMOCommand
  *
- *     // For project-agnostic operations:
- *     const ticket = await this.storage.getTicketById('TKT-123');
+ *     // For a single ticket:
+ *     const provider = await this.resolveTicketProvider('PRLT-123', projectId);
+ *     const ticket = (await provider.getTicket('PRLT-123')).ticket;
  *
  *     // For project-scoped operations:
  *     const projectId = await this.requireProject();
- *     const board = await this.storage.getBoard(projectId);
+ *     const provider = this.resolveProjectProvider(projectId);
+ *     const tickets = await provider.listTickets(projectId);
  *   }
  * }
  * ```
@@ -168,8 +170,10 @@ export abstract class PMOCommand extends RuntimeCommand {
       const projectsWithTickets: typeof projects = [];
       for (const p of projects) {
         // eslint-disable-next-line no-await-in-loop -- Sequential filtering for project selection
-        const tickets = await this.storage.listTickets(p.id);
-        if (tickets.length > 0) {
+        const provider = this.resolveProjectProvider(p.id);
+        // eslint-disable-next-line no-await-in-loop
+        const result = await provider.listTickets(p.id);
+        if (result.success && result.tickets.length > 0) {
           projectsWithTickets.push(p);
         }
       }
@@ -284,15 +288,13 @@ export abstract class PMOCommand extends RuntimeCommand {
   protected async resolveTicketProvider(ticketId: string, projectId: string): Promise<TicketProvider> {
     const db = this.storage.getDatabase();
 
-    // Try local storage first for metadata
-    const ticket = await this.storage.getTicket(ticketId);
-    let metadata = ticket?.metadata ?? null;
-
-    // If no local ticket found and ticket ID looks like an external key (e.g. PRLT-1231),
-    // build synthetic metadata so the resolver routes to the correct provider.
-    if (!ticket && /^[A-Z]+-\d+$/i.test(ticketId)) {
+    // PRLT-1319: Local PMO ticket store is dead. Build synthetic metadata from
+    // the ticket ID pattern so the resolver routes to the correct provider.
+    // Any ticket ID matching PREFIX-NUMBER (e.g. PRLT-1231, ASANA-42) is treated
+    // as an external key; the resolver picks the configured external provider.
+    let metadata: Record<string, string> | null = null;
+    if (/^[A-Z]+-\d+$/i.test(ticketId)) {
       metadata = {
-        external_source: 'linear',
         external_key: ticketId,
       };
     }

--- a/apps/cli/src/lib/pmo/storage/index.ts
+++ b/apps/cli/src/lib/pmo/storage/index.ts
@@ -25,24 +25,17 @@ import { isReadOnlyHQMount } from '../../container.js'
 import {
   Board,
   BoardConfig,
-  Column,
   CreateTicketInput,
   Epic,
   EpicFilter,
-  PMOStorage,
   Project,
   ProjectFilter,
-  Spec,
-  SpecFilter,
   Subtask,
-  SyncResult,
-  SyncStatus,
   Ticket,
   TicketFilter,
   WorkAction,
   WorkActionFilter,
   Workflow,
-  WorkflowFilter,
   WorkflowRule,
   WorkflowRuleFilter,
   WorkflowStatus,
@@ -275,14 +268,16 @@ export class SQLiteStorage {
   }
 
   // ===========================================================================
-  // PRLT-1299 STUBS — Dead local ticket/workflow/board operations
+  // PRLT-1299/1319 — Dead local ticket/workflow/board operations
   //
-  // These methods existed when SQLiteStorage managed local tickets, workflows,
-  // epics, specs, columns, and board state. Those tables have been removed.
-  // The provider (Linear, Jira, etc.) is now the source of truth.
+  // These methods used to live on SQLiteStorage when it managed local tickets,
+  // workflows, epics, specs, columns, and board state. Those tables have been
+  // removed; the provider (Linear, Jira, etc.) is now the source of truth.
   //
-  // These stubs exist solely to let the codebase compile while callers are
-  // migrated to use resolveTicketProvider() / resolveProjectProvider().
+  // Methods that currently have live callers are kept here as thin runtime
+  // stubs so the code compiles while callers are migrated to the provider
+  // layer. Methods with no remaining callers are fully deleted — attempting to
+  // call them now produces a compile error, which is the whole point.
   // ===========================================================================
 
   private deadMethod(name: string): never {
@@ -292,23 +287,17 @@ export class SQLiteStorage {
     )
   }
 
-  // --- Board / Column stubs ---
+  // --- Board / Column stubs (still have callers) ---
 
   async getBoard(_projectId: string): Promise<Board> { this.deadMethod('getBoard') }
   async getBoardMarkdown(_projectId: string): Promise<string> { this.deadMethod('getBoardMarkdown') }
   getColumnNames(_projectId: string): string[] { this.deadMethod('getColumnNames') }
   async getProjectBoard(_projectId: string): Promise<Board | null> { this.deadMethod('getProjectBoard') }
-  async createColumn(_projectId: string, _name: string, _position?: number): Promise<Column> { this.deadMethod('createColumn') }
-  async renameColumn(_projectId: string, _id: string, _name: string): Promise<Column> { this.deadMethod('renameColumn') }
-  async moveColumn(_projectId: string, _id: string, _position: number): Promise<Column> { this.deadMethod('moveColumn') }
-  async deleteColumn(_projectId: string, _id: string, _cascade?: boolean): Promise<void> { this.deadMethod('deleteColumn') }
 
-  // --- Ticket stubs ---
+  // --- Ticket stubs (still have callers) ---
 
   async createTicket(_projectId: string, _ticket: CreateTicketInput): Promise<Ticket> { this.deadMethod('createTicket') }
   async getTicket(_id: string): Promise<Ticket | null> { this.deadMethod('getTicket') }
-  async getTicketById(_id: string): Promise<Ticket | null> { this.deadMethod('getTicketById') }
-  async getTicketByExternalKey(_key: string): Promise<Ticket | null> { this.deadMethod('getTicketByExternalKey') }
   async updateTicket(_id: string, _changes: Partial<Ticket>): Promise<Ticket> { this.deadMethod('updateTicket') }
   async moveTicket(_projectId: string, _id: string, _column: string, _position?: number): Promise<Ticket> { this.deadMethod('moveTicket') }
   async reorderTicket(_id: string, _opts: { position?: number; afterTicketId?: string }): Promise<Ticket> { this.deadMethod('reorderTicket') }
@@ -317,83 +306,39 @@ export class SQLiteStorage {
   async listTickets(_projectId: string | undefined, _filter?: TicketFilter): Promise<Ticket[]> { this.deadMethod('listTickets') }
   async isTicketBlocked(_ticketId: string): Promise<boolean> { this.deadMethod('isTicketBlocked') }
 
-  // --- Subtask stubs ---
+  // --- Subtask stubs (still have callers in MCP tools) ---
 
   async addSubtask(_ticketId: string, _title: string): Promise<Subtask> { this.deadMethod('addSubtask') }
   async toggleSubtask(_ticketId: string, _subtaskId: string): Promise<Subtask> { this.deadMethod('toggleSubtask') }
   async removeSubtask(_ticketId: string, _subtaskId: string): Promise<void> { this.deadMethod('removeSubtask') }
 
-  // --- Acceptance Criteria stubs ---
+  // --- Acceptance Criteria stubs (still have callers in MCP tools) ---
 
   async addAcceptanceCriterion(_ticketId: string, _criterion: string): Promise<{ id: string; criterion: string; met: boolean }> { this.deadMethod('addAcceptanceCriterion') }
   async removeAcceptanceCriterion(_ticketId: string, _criterionId: string): Promise<void> { this.deadMethod('removeAcceptanceCriterion') }
   async clearAcceptanceCriteria(_ticketId: string): Promise<void> { this.deadMethod('clearAcceptanceCriteria') }
 
-  // --- Dependency stubs ---
+  // --- Dependency stubs (still have callers in MCP tools) ---
 
   async createTicketDependency(_ticketId: string, _blockerId: string, _type: string): Promise<void> { this.deadMethod('createTicketDependency') }
   async deleteTicketDependency(_ticketId: string, _blockerId: string, _type: string): Promise<void> { this.deadMethod('deleteTicketDependency') }
   async getTicketBlockers(_ticketId: string): Promise<Ticket[]> { this.deadMethod('getTicketBlockers') }
 
-  // --- Epic stubs ---
+  // --- Epic stubs (still have callers) ---
 
   async linkTicketToEpic(_ticketId: string, _epicId: string): Promise<void> { this.deadMethod('linkTicketToEpic') }
   async unlinkTicketFromEpic(_ticketId: string): Promise<void> { this.deadMethod('unlinkTicketFromEpic') }
   async linkTicketToSpec(_ticketId: string, _specId: string): Promise<void> { this.deadMethod('linkTicketToSpec') }
-  async createEpic(_projectId: string, _epic: Partial<Epic>): Promise<Epic> { this.deadMethod('createEpic') }
   async getEpic(_id: string): Promise<Epic | null> { this.deadMethod('getEpic') }
   async listEpics(_projectId: string, _filter?: EpicFilter): Promise<Epic[]> { this.deadMethod('listEpics') }
   async getTicketsForEpic(_projectId: string, _epicId: string): Promise<Ticket[]> { this.deadMethod('getTicketsForEpic') }
 
-  // --- Workflow stubs ---
+  // --- Workflow stubs (still have callers in spawn/pull/linear import) ---
 
-  async listWorkflows(_filter?: WorkflowFilter): Promise<Workflow[]> { this.deadMethod('listWorkflows') }
-  async getWorkflow(_id: string): Promise<Workflow | null> { this.deadMethod('getWorkflow') }
   async getProjectWorkflow(_projectId: string): Promise<Workflow | null> { this.deadMethod('getProjectWorkflow') }
   async listStatuses(_workflowId: string): Promise<WorkflowStatus[]> { this.deadMethod('listStatuses') }
-  async getStatus(_id: string): Promise<WorkflowStatus | null> { this.deadMethod('getStatus') }
-  async createStatus(_workflowId: string, _status: Partial<WorkflowStatus>): Promise<WorkflowStatus> { this.deadMethod('createStatus') }
 
-  // --- Spec stubs ---
-
-  async createSpec(_spec: Partial<Spec>): Promise<Spec> { this.deadMethod('createSpec') }
-  async getSpec(_id: string): Promise<Spec | null> { this.deadMethod('getSpec') }
-  async listSpecs(_filter?: SpecFilter): Promise<Spec[]> { this.deadMethod('listSpecs') }
-  async updateSpec(_id: string, _changes: Partial<Spec>): Promise<Spec> { this.deadMethod('updateSpec') }
-  async deleteSpec(_id: string): Promise<void> { this.deadMethod('deleteSpec') }
-  async unlinkTicketFromSpec(_ticketId: string, _specId: string): Promise<void> { this.deadMethod('unlinkTicketFromSpec') }
-  async getTicketsForSpec(_projectId: string, _specId: string): Promise<Ticket[]> { this.deadMethod('getTicketsForSpec') }
-  async getSpecsForTicket(_ticketId: string): Promise<Spec[]> { this.deadMethod('getSpecsForTicket') }
-  async addSpecDependency(_specId: string, _dependsOnId: string): Promise<void> { this.deadMethod('addSpecDependency') }
-  async removeSpecDependency(_specId: string, _dependsOnId: string): Promise<void> { this.deadMethod('removeSpecDependency') }
-  async getSpecDependencies(_specId: string): Promise<Spec[]> { this.deadMethod('getSpecDependencies') }
-  async getSpecDependents(_specId: string): Promise<Spec[]> { this.deadMethod('getSpecDependents') }
-  async linkProjectToSpec(_projectId: string, _specId: string): Promise<void> { this.deadMethod('linkProjectToSpec') }
-  async unlinkProjectFromSpec(_projectId: string, _specId: string): Promise<void> { this.deadMethod('unlinkProjectFromSpec') }
-  async getSpecsForProject(_projectId: string): Promise<Spec[]> { this.deadMethod('getSpecsForProject') }
-  async getProjectsForSpec(_specId: string): Promise<Project[]> { this.deadMethod('getProjectsForSpec') }
-
-  // --- More Epic stubs ---
-
-  async reorderEpic(_projectId: string, _epicId: string, _newPosition: number): Promise<Epic> { this.deadMethod('reorderEpic') }
-  async updateEpic(_id: string, _changes: Partial<Epic>): Promise<Epic> { this.deadMethod('updateEpic') }
-  async deleteEpic(_id: string): Promise<void> { this.deadMethod('deleteEpic') }
-
-  // --- More Workflow stubs ---
-
-  async createWorkflow(_workflow: Partial<Workflow>): Promise<Workflow> { this.deadMethod('createWorkflow') }
-  async updateWorkflow(_id: string, _changes: Partial<Workflow>): Promise<Workflow> { this.deadMethod('updateWorkflow') }
-  async deleteWorkflow(_id: string): Promise<void> { this.deadMethod('deleteWorkflow') }
-  async updateStatus(_id: string, _changes: Partial<WorkflowStatus>): Promise<WorkflowStatus> { this.deadMethod('updateStatus') }
-  async deleteStatus(_id: string): Promise<void> { this.deadMethod('deleteStatus') }
-  async reorderStatus(_id: string, _newPosition: number): Promise<WorkflowStatus> { this.deadMethod('reorderStatus') }
-  async getDefaultStatus(_workflowId: string): Promise<WorkflowStatus | null> { this.deadMethod('getDefaultStatus') }
-
-  // --- Ticket template stubs ---
-
-  async createTicketTemplateFromTicket(_ticketId: string, _name: string, _description?: string): Promise<TicketTemplate> { this.deadMethod('createTicketTemplateFromTicket') }
-
-  // --- Project stubs ---
+  // --- Project ops ---
 
   async archiveProject(id: string): Promise<Project> {
     return this.projectStorage.archiveProject(id)
@@ -402,18 +347,6 @@ export class SQLiteStorage {
   async unarchiveProject(id: string): Promise<Project> {
     return this.projectStorage.unarchiveProject(id)
   }
-
-  // --- Sync stubs ---
-
-  async pull(): Promise<SyncResult> { this.deadMethod('pull') }
-  async push(): Promise<SyncResult> { this.deadMethod('push') }
-  async status(): Promise<SyncStatus> { this.deadMethod('status') }
-
-  // --- Cache stubs ---
-
-  getCacheMetadata(): { cacheBuiltAt: number; boardMtime: number; contentHash?: string } | null { this.deadMethod('getCacheMetadata') }
-  setCacheMetadata(_meta: { boardMtime: number; cacheBuiltAt: number; contentHash?: string }): void { this.deadMethod('setCacheMetadata') }
-  rebuildFromBoard(_board: { columns: Array<{ name: string; tickets: Array<unknown> }> }): void { this.deadMethod('rebuildFromBoard') }
 
   // ===========================================================================
   // Ticket Template Operations

--- a/apps/cli/src/lib/pmo/types.ts
+++ b/apps/cli/src/lib/pmo/types.ts
@@ -1002,93 +1002,103 @@ export class PMOError extends Error {
 // Storage Interface
 // =============================================================================
 
+/**
+ * PMOStorage interface.
+ *
+ * Slimmed down by PRLT-1299/PRLT-1319. The provider (Linear, Jira, etc.) is
+ * now the source of truth for tickets — use `resolveTicketProvider()` /
+ * `resolveProjectProvider()` for any ticket work.
+ *
+ * Methods below are either (a) still backed by live tables (actions, workflow
+ * rules, project metadata, ticket templates) or (b) kept as runtime stubs on
+ * SQLiteStorage while migration callers move off them. Stubs are marked
+ * `@deprecated — dead stub` in the interface so the compiler highlights any
+ * new caller. Methods with zero remaining callers have been removed entirely.
+ */
 export interface PMOStorage {
   readonly type: 'sqlite' | 'git' | 'cloud' | 'adapter'
 
   // Board Operations
   init(projectId: string, config: BoardConfig): Promise<Board>
+
+  // ---------------------------------------------------------------------------
+  // Dead runtime stubs kept here only to let existing callers typecheck until
+  // they are migrated to the provider layer. Do NOT add new usages — calling
+  // any of these throws at runtime.
+  // @deprecated Use resolveTicketProvider() / resolveProjectProvider() (PRLT-1319)
+  // ---------------------------------------------------------------------------
+
+  /** @deprecated — dead stub, throws at runtime. Use resolveProjectProvider() (PRLT-1319) */
   getBoard(projectId: string): Promise<Board>
+  /** @deprecated — dead stub, throws at runtime. Use resolveProjectProvider() (PRLT-1319) */
   getBoardMarkdown(projectId: string): Promise<string>
-
-  // Column Operations
+  /** @deprecated — dead stub, throws at runtime. Use resolveProjectProvider() (PRLT-1319) */
   getColumnNames(projectId: string): string[]
-  createColumn(projectId: string, name: string, position?: number): Promise<Column>
-  renameColumn(projectId: string, id: string, name: string): Promise<Column>
-  moveColumn(projectId: string, id: string, position: number): Promise<Column>
-  deleteColumn(projectId: string, id: string, cascade?: boolean): Promise<void>
+  /** @deprecated — dead stub, throws at runtime. Use resolveProjectProvider() (PRLT-1319) */
+  getProjectBoard(projectId: string): Promise<Board | null>
 
-  // Ticket Operations
+  /** @deprecated — dead stub, throws at runtime. Use resolveProjectProvider().createTicket() (PRLT-1319) */
   createTicket(projectId: string, ticket: CreateTicketInput): Promise<Ticket>
+  /** @deprecated — dead stub, throws at runtime. Use resolveTicketProvider().getTicket() (PRLT-1319) */
   getTicket(id: string): Promise<Ticket | null>
-  getTicketByExternalKey(externalKey: string): Promise<Ticket | null>
+  /** @deprecated — dead stub, throws at runtime. Use resolveTicketProvider().updateTicket() (PRLT-1319) */
   updateTicket(id: string, changes: Partial<Ticket>): Promise<Ticket>
+  /** @deprecated — dead stub, throws at runtime. Use resolveTicketProvider().moveTicket() (PRLT-1319) */
   moveTicket(projectId: string, id: string, column: string, position?: number): Promise<Ticket>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   reorderTicket(id: string, opts: { position?: number; afterTicketId?: string }): Promise<Ticket>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   moveTicketToProject(ticketId: string, newProjectId: string): Promise<Ticket>
+  /** @deprecated — dead stub, throws at runtime. Use resolveTicketProvider().deleteTicket() (PRLT-1319) */
   deleteTicket(id: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime. Use resolveProjectProvider().listTickets() (PRLT-1319) */
   listTickets(projectId: string | undefined, filter?: TicketFilter): Promise<Ticket[]>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  isTicketBlocked(ticketId: string): Promise<boolean>
 
-  // Subtask Operations
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   addSubtask(ticketId: string, title: string): Promise<Subtask>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   toggleSubtask(ticketId: string, subtaskId: string): Promise<Subtask>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   removeSubtask(ticketId: string, subtaskId: string): Promise<void>
 
-  // Spec Operations
-  createSpec(spec: Partial<Spec>): Promise<Spec>
-  getSpec(id: string): Promise<Spec | null>
-  listSpecs(filter?: SpecFilter): Promise<Spec[]>
-  updateSpec(id: string, changes: Partial<Spec>): Promise<Spec>
-  deleteSpec(id: string): Promise<void>
-  linkTicketToSpec(ticketId: string, specId: string): Promise<void>
-  unlinkTicketFromSpec(ticketId: string, specId: string): Promise<void>
-  getTicketsForSpec(projectId: string, specId: string): Promise<Ticket[]>
-  getSpecsForTicket(ticketId: string): Promise<Spec[]>
-  addSpecDependency(specId: string, dependsOnId: string): Promise<void>
-  removeSpecDependency(specId: string, dependsOnId: string): Promise<void>
-  getSpecDependencies(specId: string): Promise<Spec[]>
-  getSpecDependents(specId: string): Promise<Spec[]>
-  // Project-Spec associations (many-to-many, specs are global)
-  linkProjectToSpec(projectId: string, specId: string): Promise<void>
-  unlinkProjectFromSpec(projectId: string, specId: string): Promise<void>
-  getSpecsForProject(projectId: string): Promise<Spec[]>
-  getProjectsForSpec(specId: string): Promise<Project[]>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  addAcceptanceCriterion(ticketId: string, criterion: string): Promise<{ id: string; criterion: string; met: boolean }>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  removeAcceptanceCriterion(ticketId: string, criterionId: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  clearAcceptanceCriteria(ticketId: string): Promise<void>
 
-  // Epic Operations
-  createEpic(projectId: string, epic: Partial<Epic>): Promise<Epic>
-  getEpic(id: string): Promise<Epic | null>
-  listEpics(projectId: string, filter?: EpicFilter): Promise<Epic[]>
-  reorderEpic(projectId: string, epicId: string, newPosition: number): Promise<Epic>
-  updateEpic(id: string, changes: Partial<Epic>): Promise<Epic>
-  deleteEpic(id: string): Promise<void>
-  getTicketsForEpic(projectId: string, epicId: string): Promise<Ticket[]>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  createTicketDependency(ticketId: string, blockerId: string, type: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  deleteTicketDependency(ticketId: string, blockerId: string, type: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  getTicketBlockers(ticketId: string): Promise<Ticket[]>
+
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   linkTicketToEpic(ticketId: string, epicId: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   unlinkTicketFromEpic(ticketId: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  linkTicketToSpec(ticketId: string, specId: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  getEpic(id: string): Promise<Epic | null>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  listEpics(projectId: string, filter?: EpicFilter): Promise<Epic[]>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
+  getTicketsForEpic(projectId: string, epicId: string): Promise<Ticket[]>
 
-  // Workflow Operations (shared workflow definitions)
-  listWorkflows(filter?: WorkflowFilter): Promise<Workflow[]>
-  getWorkflow(id: string): Promise<Workflow | null>
-  createWorkflow(workflow: Partial<Workflow>): Promise<Workflow>
-  updateWorkflow(id: string, changes: Partial<Workflow>): Promise<Workflow>
-  deleteWorkflow(id: string): Promise<void>
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   getProjectWorkflow(projectId: string): Promise<Workflow | null>
-
-  // Workflow Status Operations (statuses within workflows = board columns)
+  /** @deprecated — dead stub, throws at runtime (PRLT-1319) */
   listStatuses(workflowId: string): Promise<WorkflowStatus[]>
-  getStatus(id: string): Promise<WorkflowStatus | null>
-  createStatus(workflowId: string, status: Partial<WorkflowStatus>): Promise<WorkflowStatus>
-  updateStatus(id: string, changes: Partial<WorkflowStatus>): Promise<WorkflowStatus>
-  deleteStatus(id: string): Promise<void>
-  reorderStatus(id: string, newPosition: number): Promise<WorkflowStatus>
-  getDefaultStatus(workflowId: string): Promise<WorkflowStatus | null>
-
-  // Note: Workflow templates have been removed. Use workflow commands directly
-  // (prlt workflow list, prlt workflow create, prlt workflow switch)
 
   // Ticket Template Operations
   listTicketTemplates(filter?: TicketTemplateFilter): Promise<TicketTemplate[]>
   getTicketTemplate(id: string): Promise<TicketTemplate | null>
   createTicketTemplate(template: Partial<TicketTemplate> & { name: string }): Promise<TicketTemplate>
-  createTicketTemplateFromTicket(ticketId: string, name: string, description?: string): Promise<TicketTemplate>
   updateTicketTemplate(id: string, changes: Partial<TicketTemplate>): Promise<TicketTemplate>
   deleteTicketTemplate(id: string): Promise<void>
 
@@ -1118,11 +1128,6 @@ export interface PMOStorage {
   listProjects(filter?: ProjectFilter): Promise<Project[]>
   archiveProject(id: string): Promise<Project>
   unarchiveProject(id: string): Promise<Project>
-
-  // Sync Operations
-  pull(): Promise<SyncResult>
-  push(): Promise<SyncResult>
-  status(): Promise<SyncStatus>
 
   // Lifecycle
   close(): Promise<void>

--- a/apps/cli/src/lib/providers/resolver.ts
+++ b/apps/cli/src/lib/providers/resolver.ts
@@ -28,7 +28,6 @@ import { TrelloMapper } from '../trello/mapper.js'
 import { isAsanaConfigured } from '../asana/config.js'
 import { AsanaMapper } from '../asana/mapper.js'
 import { isNotionConfigured } from '../notion/config.js'
-import type { StateCategory } from '../pmo/types.js'
 import type { TicketProvider, ProviderStorage } from './types.js'
 import { PMOTicketProvider } from './pmo-provider.js'
 import { LinearTicketProvider } from './linear-provider.js'
@@ -46,55 +45,15 @@ import { EventEmittingProvider, type StatusResolver } from './event-emitting-pro
  * for event emission.
  */
 function createDbStatusResolver(db: Database.Database, storage: ProviderStorage): StatusResolver {
-  // storage param kept for interface compatibility — resolver uses db directly
+  // storage param kept for interface compatibility; resolver no longer has a
+  // local workflow table to query (PRLT-1299) — status resolution is a no-op.
+  void db
   void storage
   return {
-    resolveStatusByName(projectId: string, statusName: string) {
-      try {
-        const row = db.prepare(`
-          SELECT ws.id, ws.name, ws.category
-          FROM pmo_workflow_statuses ws
-          JOIN pmo_projects p ON p.workflow_id = ws.workflow_id
-          WHERE p.id = ? AND LOWER(ws.name) = LOWER(?)
-        `).get(projectId, statusName) as { id: string; name: string; category: string } | undefined
-
-        if (row) {
-          return { id: row.id, name: row.name, category: row.category as StateCategory }
-        }
-
-        // Fallback: search by status ID
-        const byId = db.prepare(`
-          SELECT id, name, category FROM pmo_workflow_statuses WHERE id = ?
-        `).get(statusName) as { id: string; name: string; category: string } | undefined
-
-        if (byId) {
-          return { id: byId.id, name: byId.name, category: byId.category as StateCategory }
-        }
-      } catch {
-        // Non-fatal: status resolution is best-effort
-      }
+    resolveStatusByName(_projectId: string, _statusName: string) {
       return null
     },
-
-    getTicketStatus(ticketId: string) {
-      try {
-        const row = db.prepare(`
-          SELECT t.status_id, ws.name, ws.category
-          FROM pmo_tickets t
-          LEFT JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-          WHERE t.id = ?
-        `).get(ticketId) as { status_id: string | null; name: string | null; category: string | null } | undefined
-
-        if (row) {
-          return {
-            statusId: row.status_id,
-            statusName: row.name,
-            statusCategory: (row.category as StateCategory) ?? null,
-          }
-        }
-      } catch {
-        // Non-fatal: status resolution is best-effort
-      }
+    getTicketStatus(_ticketId: string) {
       return null
     },
   }

--- a/apps/cli/src/services/pr-service.ts
+++ b/apps/cli/src/services/pr-service.ts
@@ -31,7 +31,7 @@ import { ensureRemoteUpToDate } from '../lib/repos/git.js'
 import { validateBranchName } from '../lib/branch/index.js'
 import { PMO_TABLES } from '../lib/pmo/schema.js'
 import type { Ticket } from '../lib/pmo/types.js'
-import type { ProviderStorage } from '../lib/providers/types.js'
+import type { ProviderStorage, TicketProvider } from '../lib/providers/types.js'
 import { ServiceError } from './types.js'
 import type {
   CreatePROptions,
@@ -45,16 +45,24 @@ import type {
 
 /**
  * Storage interface needed by PRService.
+ *
+ * Ticket reads/writes now route through the TicketProvider layer (PRLT-1319);
+ * the storage handle is only used for shared infrastructure
+ * (workspace_settings, agent_work, etc.).
  */
-export interface PRServiceStorage extends ProviderStorage {
-  listTickets(projectId: string | undefined, filter?: unknown): Promise<Ticket[]>
-  updateTicket(id: string, changes: Partial<Ticket>): Promise<Ticket>
-}
+export type PRServiceStorage = ProviderStorage
+
+/**
+ * Callback for resolving a ticket provider given a ticket ID and project ID.
+ * Injected by the CLI command so the service never imports the resolver.
+ */
+export type ProviderResolver = (ticketId: string, projectId: string) => Promise<TicketProvider>
 
 export class PRService {
   constructor(
     private readonly db: Database.Database,
     private readonly storage: PRServiceStorage,
+    private readonly resolveProvider: ProviderResolver,
   ) {}
 
   /**
@@ -67,10 +75,17 @@ export class PRService {
 
     const { ticketId, title, body, baseBranch, draft, cwd } = options
 
-    // Resolve ticket if provided
+    // Resolve ticket if provided — local PMO store is dead (PRLT-1299), so
+    // go through the provider layer.
     let ticket: Ticket | null = null
     if (ticketId) {
-      ticket = await this.storage.getTicket(ticketId)
+      try {
+        const provider = await this.resolveProvider(ticketId, '')
+        const res = await provider.getTicket(ticketId)
+        ticket = (res.success && res.ticket) ? res.ticket : null
+      } catch {
+        ticket = null
+      }
     }
 
     // Get current branch
@@ -128,10 +143,11 @@ export class PRService {
       throw new ServiceError('EXTERNAL_FAILURE', `Failed to create PR: ${result.error}`)
     }
 
-    // Link PR to ticket
+    // Link PR to ticket — through the provider layer (PRLT-1319)
     if (ticket && result.url) {
       try {
-        await this.storage.updateTicket(ticket.id, {
+        const provider = await this.resolveProvider(ticket.id, ticket.projectId || '')
+        await provider.updateTicket(ticket.id, {
           metadata: {
             ...ticket.metadata,
             pr_url: result.url,
@@ -244,42 +260,37 @@ export class PRService {
     headBranch: string,
     projectId?: string,
   ): Promise<LinkedTicketResult> {
-    // 1. Find by PR metadata on tickets
-    const allTickets = await this.storage.listTickets(projectId)
-    const byMetadata = allTickets.find(t =>
-      t.metadata?.pr_number === String(prNumber) ||
-      t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`) ||
-      t.metadata?.pr_url?.endsWith(`/${prNumber}`)
-    )
-    if (byMetadata) return { ticket: byMetadata, source: 'metadata' }
+    void prNumber
+    // The local PMO ticket store was removed (PRLT-1299 / PRLT-1319), so we
+    // can no longer scan local tickets by PR metadata. Resolve via the branch
+    // → ticket-ID mapping (agent_work + branch name) and then go through the
+    // provider to fetch the actual ticket record.
 
-    // 2. Look up from agent_work table by branch name
+    // 1. agent_work table (still live) — branch → ticket ID
     try {
       const row = this.db.prepare(
         `SELECT ticket_id FROM ${PMO_TABLES.agent_work} WHERE branch = ? LIMIT 1`
       ).get(headBranch) as { ticket_id: string } | undefined
       if (row?.ticket_id) {
-        const ticket = await this.storage.getTicket(row.ticket_id)
-        if (ticket) return { ticket, source: 'agent_work' }
+        const provider = await this.resolveProvider(row.ticket_id, projectId ?? '')
+        const res = await provider.getTicket(row.ticket_id)
+        if (res.success && res.ticket) return { ticket: res.ticket, source: 'agent_work' }
       }
     } catch {
       // agent_work lookup failed, continue
     }
 
-    // 3. Parse ticket ID from branch name
+    // 2. Parse ticket ID from branch name
     const branchResult = validateBranchName(headBranch)
     if (branchResult.valid && branchResult.parts?.ticketId) {
       const parsedTicketId = branchResult.parts.ticketId
-
-      // Try direct lookup
-      const directTicket = await this.storage.getTicket(parsedTicketId)
-      if (directTicket) return { ticket: directTicket, source: 'branch_name' }
-
-      // Search by external_key
-      const byExternalKey = allTickets.find(t =>
-        t.metadata?.external_key === parsedTicketId
-      )
-      if (byExternalKey) return { ticket: byExternalKey, source: 'branch_name' }
+      try {
+        const provider = await this.resolveProvider(parsedTicketId, projectId ?? '')
+        const res = await provider.getTicket(parsedTicketId)
+        if (res.success && res.ticket) return { ticket: res.ticket, source: 'branch_name' }
+      } catch {
+        // Non-fatal — provider may not be configured
+      }
     }
 
     return { ticket: null }

--- a/apps/cli/src/services/ticket-service.ts
+++ b/apps/cli/src/services/ticket-service.ts
@@ -9,7 +9,7 @@
  */
 
 import type Database from 'better-sqlite3'
-import type { Ticket, TicketFilter, Board, CreateTicketInput, UpdateTicketInput } from '../lib/pmo/types.js'
+import type { Ticket, TicketFilter, CreateTicketInput, UpdateTicketInput } from '../lib/pmo/types.js'
 import type { ProviderStorage, TicketProvider, TicketProviderName, ProviderListResult } from '../lib/providers/types.js'
 import { resolveProjectProvider, resolveTicketProvider } from '../lib/providers/resolver.js'
 import { ServiceError } from './types.js'
@@ -21,7 +21,6 @@ import type { ListTicketsOptions, ListTicketsResult, GetTicketResult } from './t
  */
 export interface TicketServiceStorage extends ProviderStorage {
   getProject(id: string): Promise<{ id: string; name: string } | null>
-  getProjectBoard(projectId: string): Promise<Board | null>
   listProjectSummaries(): Promise<Array<{ id: string; name: string }>>
 }
 
@@ -60,20 +59,10 @@ export class TicketService {
       }
     }
 
-    // Validate column exists if filtering by column (PMO only)
-    if (filter.column && projectId && source !== 'linear') {
-      const board = await this.storage.getProjectBoard(projectId)
-      if (board) {
-        const validColumns = board.columns.map(c => c.name)
-        if (!validColumns.includes(filter.column)) {
-          throw new ServiceError(
-            'VALIDATION',
-            `Column "${filter.column}" not found. Valid columns: ${validColumns.join(', ')}`,
-            { validColumns },
-          )
-        }
-      }
-    }
+    // Column validation against the local PMO board was removed with the dead
+    // PMO ticket tables (PRLT-1299). The provider (Linear, Jira, etc.) will
+    // validate the column name itself when the list is performed, and local
+    // PMO no longer carries columns, so no pre-flight check is possible here.
 
     // Resolve provider and fetch
     const provider = resolveProjectProvider(
@@ -108,22 +97,13 @@ export class TicketService {
     if (offset) tickets = tickets.slice(offset)
     if (limit) tickets = tickets.slice(0, limit)
 
-    // Get board for single-project views
-    let board: Board | undefined
-    if (projectId) {
-      try {
-        const result = await this.storage.getProjectBoard(projectId)
-        if (result) board = result
-      } catch {
-        // Non-fatal — board info is optional
-      }
-    }
-
+    // Board info on local PMO was removed with the dead PMO ticket tables
+    // (PRLT-1299). Consumers of this service use tickets[*].statusName instead
+    // of the now-absent board structure.
     return {
       success: true,
       tickets,
       provider: listResult.provider,
-      board,
       totalCount,
     }
   }

--- a/apps/cli/src/services/types.ts
+++ b/apps/cli/src/services/types.ts
@@ -11,7 +11,7 @@
  * - Services have no dependency on oclif, inquirer, or any CLI framework
  */
 
-import type { Ticket, TicketFilter, Board, StateCategory } from '../lib/pmo/types.js'
+import type { Ticket, TicketFilter, StateCategory } from '../lib/pmo/types.js'
 import type { PRInfo, CreatePRResult } from '../lib/pr/index.js'
 import type { ReconcileReport, ReconcileOptions } from '../lib/reconcile/types.js'
 import type {
@@ -261,8 +261,6 @@ export interface ListTicketsResult {
   success: boolean
   tickets: Ticket[]
   provider: TicketProviderName
-  /** Board info for single-project views */
-  board?: Board
   /** Total count before pagination */
   totalCount: number
 }

--- a/apps/cli/src/services/work-service.ts
+++ b/apps/cli/src/services/work-service.ts
@@ -45,11 +45,11 @@ import type {
 
 /**
  * Storage interface needed by WorkService.
+ *
+ * Kept nominally aligned with ProviderStorage; WorkService now routes all
+ * ticket reads/writes through the provider layer (PRLT-1319).
  */
-export interface WorkServiceStorage extends ProviderStorage {
-  listTickets(projectId: string | undefined, filter?: unknown): Promise<Ticket[]>
-  updateTicket(id: string, changes: Partial<Ticket>): Promise<Ticket>
-}
+export type WorkServiceStorage = ProviderStorage
 
 /**
  * Callback for resolving a ticket provider given a ticket ID and project ID.
@@ -126,8 +126,11 @@ export class WorkService {
         ticketId = linked.id
       }
     } else if (ticketId) {
-      // Ticket provided — find its PR
-      ticket = await this.storage.getTicket(ticketId)
+      // Ticket provided — resolve via the provider (Linear / Jira / etc.)
+      // since the local PMO ticket store is gone (PRLT-1299 / PRLT-1319).
+      const provider = await this.resolveProvider(ticketId, '')
+      const getResult = await provider.getTicket(ticketId)
+      ticket = (getResult.success && getResult.ticket) ? getResult.ticket : null
       if (!ticket) {
         throw new ServiceError('NOT_FOUND', `Ticket "${ticketId}" not found.`)
       }
@@ -251,9 +254,12 @@ export class WorkService {
     // --- Transition ticket ---
     let newState: string | undefined
     if (ticket && ticketId && !noTransition) {
-      // Update PR metadata
+      // Update PR metadata through the provider (local PMO ticket store is
+      // dead — PRLT-1299). Swallow provider errors so they don't block the
+      // actual state transition below.
       try {
-        await this.storage.updateTicket(ticketId, {
+        const provider = await this.resolveProvider(ticketId, ticket.projectId || '')
+        await provider.updateTicket(ticketId, {
           metadata: {
             ...ticket.metadata,
             pr_state: 'MERGED',
@@ -261,7 +267,9 @@ export class WorkService {
           },
         })
       } catch (err) {
-        if ((err as { code?: string }).code !== 'SQLITE_READONLY') throw err
+        if ((err as { code?: string }).code !== 'SQLITE_READONLY') {
+          this.logger.warn(`Failed to record PR merge metadata: ${err instanceof Error ? err.message : String(err)}`)
+        }
       }
 
       try {
@@ -433,37 +441,36 @@ export class WorkService {
     headBranch: string,
     projectId: string | undefined,
   ): Promise<Ticket | null> {
-    // 1. PR metadata on tickets
-    const allTickets = await this.storage.listTickets(projectId)
-    const byMetadata = allTickets.find(t =>
-      t.metadata?.pr_number === String(prNumber) ||
-      t.metadata?.pr_url?.endsWith(`/pull/${prNumber}`) ||
-      t.metadata?.pr_url?.endsWith(`/${prNumber}`)
-    )
-    if (byMetadata) return byMetadata
+    void prNumber
+    // The local PMO ticket store was removed (PRLT-1299 / PRLT-1319), so we
+    // can no longer scan local tickets by PR metadata. Fall back to the
+    // agent_work table (still live) and ticket-ID parsing off the branch.
 
-    // 2. agent_work table
+    // 1. agent_work table — maps branch → ticket ID
     try {
       const row = this.db.prepare(
         `SELECT ticket_id FROM ${PMO_TABLES.agent_work} WHERE branch = ? LIMIT 1`
       ).get(headBranch) as { ticket_id: string } | undefined
       if (row?.ticket_id) {
-        const ticket = await this.storage.getTicket(row.ticket_id)
-        if (ticket) return ticket
+        const provider = await this.resolveProvider(row.ticket_id, projectId ?? '')
+        const res = await provider.getTicket(row.ticket_id)
+        if (res.success && res.ticket) return res.ticket
       }
     } catch {
       // Continue
     }
 
-    // 3. Branch name parsing
+    // 2. Branch name parsing — {ticketId}/{type}/{slug}
     const branchResult = validateBranchName(headBranch)
     if (branchResult.valid && branchResult.parts?.ticketId) {
       const parsedId = branchResult.parts.ticketId
-      const direct = await this.storage.getTicket(parsedId)
-      if (direct) return direct
-
-      const byKey = allTickets.find(t => t.metadata?.external_key === parsedId)
-      if (byKey) return byKey
+      try {
+        const provider = await this.resolveProvider(parsedId, projectId ?? '')
+        const res = await provider.getTicket(parsedId)
+        if (res.success && res.ticket) return res.ticket
+      } catch {
+        // Non-fatal — provider may not be configured
+      }
     }
 
     return null

--- a/apps/cli/test/unit/prlt-1319-stub-audit.test.ts
+++ b/apps/cli/test/unit/prlt-1319-stub-audit.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression test: audit of runtime-stubbed methods left over from PRLT-1299.
+ *
+ * PRLT-1319: PRLT-1299 removed the dead PMO ticket tables but kept many
+ * storage methods as runtime-throwing stubs. The stubs silently let callers
+ * compile and then exploded at runtime. The known break was `prlt ticket
+ * edit`, which routed through `PMOCommand.resolveTicketProvider()` → called
+ * `storage.getTicket()` (a stub) → threw before anything could happen.
+ *
+ * These tests lock in the fixes:
+ *
+ * 1. `PMOCommand.resolveTicketProvider()` must not touch the dead
+ *    `storage.getTicket` stub — it builds provider metadata from the ticket
+ *    ID pattern and workspace config instead.
+ * 2. `ticket edit` must not call any of the dead subtask / AC / board stubs
+ *    directly — subtask and acceptance-criteria updates go through the
+ *    provider's `updateTicket()` with a full final array.
+ * 3. The resolver's status DB queries must not reference dropped tables
+ *    (`pmo_workflow_statuses`, `pmo_tickets`).
+ * 4. Stubs that have no remaining callers (createColumn, listWorkflows,
+ *    getSpec, pull, push, …) must be fully deleted from `SQLiteStorage`, so
+ *    any new caller fails at compile time instead of silently blowing up at
+ *    runtime.
+ */
+
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const SRC_ROOT = path.resolve(__dirname, '../../src')
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(SRC_ROOT, rel), 'utf8')
+}
+
+describe('PRLT-1319: runtime-stubbed method audit', () => {
+  describe('resolveTicketProvider no longer calls dead storage.getTicket', () => {
+    const baseCommand = read('lib/pmo/base-command.ts')
+
+    it('does not call this.storage.getTicket() inside resolveTicketProvider()', () => {
+      // Extract the body of resolveTicketProvider and assert no storage.getTicket call.
+      const match = baseCommand.match(/protected async resolveTicketProvider[\s\S]*?\n\s{2}\}/)
+      expect(match, 'resolveTicketProvider() should exist on PMOCommand').to.not.be.null
+      const body = match![0]
+      expect(body).to.not.match(
+        /this\.storage\.getTicket\(/,
+        'PMOCommand.resolveTicketProvider() must not call the dead storage.getTicket stub',
+      )
+    })
+
+    it('builds synthetic provider metadata from the ticket ID pattern', () => {
+      const match = baseCommand.match(/protected async resolveTicketProvider[\s\S]*?\n\s{2}\}/)!
+      const body = match[0]
+      // We still derive metadata for PRLT-xxx / similar external keys so the
+      // resolver picks the configured external provider.
+      expect(body).to.match(/external_key/, 'should derive external_key from ticket ID pattern')
+    })
+  })
+
+  describe('ticket edit routes subtask / AC updates through the provider', () => {
+    const editSource = read('commands/ticket/edit.ts')
+
+    const deadStubCalls = [
+      'storage.addSubtask',
+      'storage.removeSubtask',
+      'storage.toggleSubtask',
+      'storage.addAcceptanceCriterion',
+      'storage.removeAcceptanceCriterion',
+      'storage.clearAcceptanceCriteria',
+      'storage.getProjectBoard',
+    ]
+
+    for (const dead of deadStubCalls) {
+      it(`ticket edit does not call ${dead}(...)`, () => {
+        expect(editSource).to.not.include(
+          `${dead}(`,
+          `${dead}() was removed by PRLT-1299 and must not be called from ticket edit`,
+        )
+      })
+    }
+
+    it('ticket edit calls ticketProvider.updateTicket(...) to persist changes', () => {
+      expect(editSource).to.match(
+        /ticketProvider\.updateTicket\(/,
+        'ticket edit should persist updates via the provider',
+      )
+    })
+
+    it('ticket edit builds a final subtasks array for provider.updateTicket', () => {
+      expect(editSource).to.match(/finalSubtasks/, 'should aggregate subtasks into a single updateTicket call')
+      // The final array gets attached to the updates object before the one provider.updateTicket call
+      expect(editSource).to.match(
+        /\.subtasks\s*=\s*finalSubtasks/,
+        'should attach subtasks to the updateTicket input',
+      )
+    })
+
+    it('ticket edit builds a final acceptanceCriteria array for provider.updateTicket', () => {
+      expect(editSource).to.match(/finalAC/, 'should aggregate AC into a single updateTicket call')
+      expect(editSource).to.match(
+        /\.acceptanceCriteria\s*=\s*finalAC/,
+        'should attach acceptanceCriteria to the updateTicket input',
+      )
+    })
+  })
+
+  describe('provider resolver status queries do not hit dropped tables', () => {
+    const resolverSource = read('lib/providers/resolver.ts')
+
+    const droppedTables = ['pmo_workflow_statuses', 'pmo_tickets']
+
+    for (const table of droppedTables) {
+      it(`resolver.ts does not SELECT from dropped table ${table}`, () => {
+        expect(resolverSource).to.not.match(
+          new RegExp(`FROM\\s+${table}\\b`, 'i'),
+          `${table} was dropped in migration 0024 and must not be queried`,
+        )
+        expect(resolverSource).to.not.match(
+          new RegExp(`JOIN\\s+${table}\\b`, 'i'),
+          `${table} was dropped in migration 0024 and must not be joined`,
+        )
+      })
+    }
+  })
+
+  describe('stubs with no callers are fully deleted (not just emptied)', () => {
+    const storageSource = read('lib/pmo/storage/index.ts')
+
+    // These methods had zero callers per the PRLT-1319 audit, and should be
+    // completely absent from SQLiteStorage so the compiler catches any future
+    // accidental usage.
+    const deletedStubs = [
+      'createColumn',
+      'renameColumn',
+      'moveColumn',
+      'deleteColumn',
+      'getTicketById',
+      'getTicketByExternalKey',
+      'createEpic',
+      'updateEpic',
+      'deleteEpic',
+      'reorderEpic',
+      'createSpec',
+      'getSpec',
+      'listSpecs',
+      'updateSpec',
+      'deleteSpec',
+      'unlinkTicketFromSpec',
+      'getTicketsForSpec',
+      'getSpecsForTicket',
+      'addSpecDependency',
+      'removeSpecDependency',
+      'getSpecDependencies',
+      'getSpecDependents',
+      'linkProjectToSpec',
+      'unlinkProjectFromSpec',
+      'getSpecsForProject',
+      'getProjectsForSpec',
+      'listWorkflows',
+      'getWorkflow',
+      'createWorkflow',
+      'updateWorkflow',
+      'deleteWorkflow',
+      'getStatus',
+      'createStatus',
+      'updateStatus',
+      'deleteStatus',
+      'reorderStatus',
+      'getDefaultStatus',
+      'createTicketTemplateFromTicket',
+      'pull',
+      'push',
+      'status',
+      'getCacheMetadata',
+      'setCacheMetadata',
+      'rebuildFromBoard',
+    ]
+
+    for (const stub of deletedStubs) {
+      it(`SQLiteStorage no longer declares ${stub}(`, () => {
+        // Match declarations only (method signature), not references in strings
+        // like `deadMethod('moveTicket')`.
+        const declRegex = new RegExp(`\\b(async\\s+)?${stub}\\s*\\(`)
+        expect(storageSource).to.not.match(
+          declRegex,
+          `${stub}() had no remaining callers — it must be fully deleted from SQLiteStorage`,
+        )
+      })
+    }
+  })
+
+  describe('remaining runtime stubs keep the PRLT-1299 error marker', () => {
+    const storageSource = read('lib/pmo/storage/index.ts')
+
+    it('deadMethod() still throws an error mentioning PRLT-1299', () => {
+      expect(storageSource).to.match(
+        /SQLiteStorage\.\$\{name\}\(\)\s+removed\s+\(PRLT-1299\)/,
+        'Remaining stubs should keep a PRLT-1299 marker so future audits can grep for survivors',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

PRLT-1299 removed the dead PMO ticket tables but kept ~70 storage methods as runtime-throwing stubs. These silently compiled and then exploded at runtime — the most visible symptom being `prlt ticket edit` throwing `SQLiteStorage.getTicket() removed (PRLT-1299)`.

This PR audits those stubs, migrates the highest-impact callers to the provider layer, and deletes the stubs that have no remaining callers so the compiler catches future accidental usage.

### What changed

**Critical root-cause fix** (unblocks every provider-routed command):
- `PMOCommand.resolveTicketProvider` no longer calls the dead `storage.getTicket` stub.
- `resolver.ts` status DB queries no longer SELECT FROM dropped `pmo_workflow_statuses` / `pmo_tickets` tables.

**Command migrations:**
- `prlt ticket edit` — subtask / AC / label updates now ride on a single `provider.updateTicket()` call.

**Service migrations** (all three now route through the provider):
- `TicketService` — dropped dead `getProjectBoard` column-validation and board lookup.
- `WorkService.shipWork` and `resolveLinkedTicket` — through `resolveProvider`.
- `PRService.createPR` and `resolveLinkedTicket` — through the provider.

**Stub deletion:**
- Removed ~40 stubs from `SQLiteStorage` that had zero callers in `src/`.
- Remaining stubs are annotated `@deprecated` in `PMOStorage`.

### Regression coverage
New: `apps/cli/test/unit/prlt-1319-stub-audit.test.ts` — 59 tests.

### Follow-up
Full migration of remaining ~100 call sites (MCP tools, `work/*`, etc.) is multi-PR work. Every remaining stub keeps the `(PRLT-1299)` tag and is `@deprecated`.

## Test plan
- [x] \`pnpm build\` passes
- [x] 59/59 regression tests pass
- [x] No new unit-test failures vs \`origin/main\`
- [ ] Manual smoke on Linear-backed workspace

Note: \`prlt work propose\` is broken by this very bug, so this PR used \`gh pr create\` as a one-time exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)