### PR TITLE
fix(PRLT-1324): guard gc from destroying live agent worktrees

### DIFF
--- a/apps/cli/src/commands/gc.ts
+++ b/apps/cli/src/commands/gc.ts
@@ -52,6 +52,14 @@ export default class GC extends PromptCommand {
       description: 'Also find and clean orphaned worktrees (agents with no running session)',
       default: false,
     }),
+    'min-age-minutes': Flags.integer({
+      description: 'Minimum age in minutes before a worktree is eligible for orphan cleanup (protects freshly-spawned agents)',
+      default: 5,
+    }),
+    'heartbeat-minutes': Flags.integer({
+      description: 'Worktrees with a heartbeat more recent than this (minutes) are skipped by orphan cleanup',
+      default: 10,
+    }),
   }
 
   async run(): Promise<void> {
@@ -161,7 +169,11 @@ export default class GC extends PromptCommand {
     // Orphan worktree cleanup (--orphans flag)
     let orphansRemoved = 0
     if (flags.orphans) {
-      const orphans = findOrphanedWorktrees(workspaceInfo.path)
+      const orphans = findOrphanedWorktrees(workspaceInfo.path, {
+        minWorktreeAgeMinutes: flags['min-age-minutes'],
+        heartbeatFreshMinutes: flags['heartbeat-minutes'],
+        log,
+      })
       if (orphans.length > 0) {
         if (!jsonMode) {
           this.log(colors.primary(`\nFound ${orphans.length} orphaned worktree(s):`))

--- a/apps/cli/src/lib/gc/index.ts
+++ b/apps/cli/src/lib/gc/index.ts
@@ -22,6 +22,14 @@ import {
   closePR,
   type PRInfo,
 } from '../pr/index.js'
+import {
+  checkWorktreeLiveness,
+  type LivenessResult,
+} from './liveness.js'
+import {
+  getHostTmuxSessionNames,
+  getContainerTmuxSessionMap,
+} from '../execution/session-utils.js'
 
 // =============================================================================
 // Types
@@ -304,6 +312,28 @@ export function collectGCCandidates(options: GCOptions): GCCandidate[] {
 // =============================================================================
 // Cleanup Execution
 // =============================================================================
+
+/**
+ * Check whether a worktree has any uncommitted changes (staged, unstaged, or
+ * untracked). Used as a last-line safety gate before worktree removal — PRLT-1324
+ * requires that a dirty working tree be preserved even if other signals say
+ * the agent is dead. If inspection fails, we err on the side of "dirty".
+ */
+function hasUncommittedChanges(worktreePath: string): boolean {
+  if (!fs.existsSync(worktreePath)) return false
+  try {
+    const output = execSync('git status --porcelain=v1 --untracked-files=normal', {
+      cwd: worktreePath,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    }).trim()
+    return output.length > 0
+  } catch {
+    // If we can't inspect, treat as dirty to preserve safety.
+    return true
+  }
+}
 
 /**
  * Delete a local git branch.
@@ -639,13 +669,19 @@ export function executeGC(
       }
     }
 
-    // 4. Remove worktree
+    // 4. Remove worktree — but never if it has uncommitted changes (PRLT-1324)
     if (execute) {
-      log?.(`Removing worktree: ${candidate.worktreePath}`)
-      if (removeWorktree(candidate.worktreePath, candidate.sourceRepoPath)) {
-        result.worktreesRemoved.push(candidate.worktreePath)
+      const dirty = hasUncommittedChanges(candidate.worktreePath)
+      if (dirty) {
+        log?.(`Skipping worktree removal (uncommitted changes): ${candidate.worktreePath}`)
+        result.skipped.push(`${candidate.branch} (uncommitted changes)`)
       } else {
-        result.errors.push(`Failed to remove worktree: ${candidate.worktreePath}`)
+        log?.(`Removing worktree: ${candidate.worktreePath}`)
+        if (removeWorktree(candidate.worktreePath, candidate.sourceRepoPath)) {
+          result.worktreesRemoved.push(candidate.worktreePath)
+        } else {
+          result.errors.push(`Failed to remove worktree: ${candidate.worktreePath}`)
+        }
       }
     } else {
       log?.(`[dry-run] Would remove worktree: ${candidate.worktreePath}`)
@@ -824,6 +860,10 @@ export function cleanupTicketWorktrees(
       containerByAgent.set(c.agentName, c)
     }
 
+    // Pre-fetch tmux sessions once per invocation.
+    const hostTmuxSessions = getHostTmuxSessionNames()
+    const containerTmuxSessions = getContainerTmuxSessionMap()
+
     for (const agentName of agentNames) {
       try {
         const container = containerByAgent.get(agentName) ?? null
@@ -853,12 +893,30 @@ export function cleanupTicketWorktrees(
           ? path.join(hqPath, agentRecord.worktree_path)
           : undefined
 
-        // Clean up each worktree
+        // Clean up each worktree — but PRLT-1324 requires a per-worktree
+        // liveness check so we never nuke work that's still being held by a
+        // process, has uncommitted changes, or has an open PR.
         for (const wt of worktrees) {
           const fullWorktreePath = path.isAbsolute(wt.worktree_path)
             ? wt.worktree_path
             : path.join(hqPath, wt.worktree_path)
           const sourceRepoPath = path.join(hqPath, 'repos', wt.repo_name)
+
+          const liveness: LivenessResult = checkWorktreeLiveness(
+            agentName,
+            fullWorktreePath,
+            wt.branch,
+            {
+              hqPath,
+              hostTmuxSessions,
+              containerTmuxSessions,
+              repoPath: sourceRepoPath,
+            },
+          )
+          if (!liveness.safeToDelete) {
+            log?.(`Skipping worktree "${fullWorktreePath}": ${liveness.reasons.join('; ')}`)
+            continue
+          }
 
           if (removeWorktree(fullWorktreePath, sourceRepoPath)) {
             log?.(`Removed worktree: ${fullWorktreePath}`)
@@ -939,24 +997,45 @@ function findAgentNamesForTicket(ticketId: string, hqPath: string): string[] {
 // =============================================================================
 
 /**
- * Find orphaned worktrees — worktrees whose agents have no active tmux session.
- * Unlike `collectGCCandidates` which checks PR status, this function checks
- * whether the agent is still running (useful for post-kill cleanup).
+ * Options for orphaned worktree discovery.
  */
-export function findOrphanedWorktrees(hqPath: string): Array<{
+export interface FindOrphanedWorktreesOptions {
+  /** Minimum worktree age in minutes (default 5) */
+  minWorktreeAgeMinutes?: number
+  /** Heartbeat freshness threshold in minutes (default 10) */
+  heartbeatFreshMinutes?: number
+  /** Log callback for skipped worktrees (reason is passed) */
+  log?: (msg: string) => void
+  /** Skip the GitHub PR check (used by tests) */
+  skipPRCheck?: boolean
+  /** Skip the lsof process-holding check (used by tests) */
+  skipProcessCheck?: boolean
+}
+
+export interface OrphanWorktree {
   worktreePath: string
   branch: string
   agentName: string
   repoName: string
   sourceRepoPath: string
-}> {
-  const orphans: Array<{
-    worktreePath: string
-    branch: string
-    agentName: string
-    repoName: string
-    sourceRepoPath: string
-  }> = []
+}
+
+/**
+ * Find orphaned worktrees — worktrees whose agents have been fully terminated.
+ *
+ * PRLT-1324: This function is the one that catastrophically deleted a live agent's
+ * worktree. It now runs the full `checkWorktreeLiveness` suite per worktree:
+ * DB status + tmux + lsof + open PR + heartbeat freshness + minimum age +
+ * uncommitted changes. If ANY signal indicates liveness, the worktree is
+ * skipped and the reason is logged.
+ */
+export function findOrphanedWorktrees(
+  hqPath: string,
+  options: FindOrphanedWorktreesOptions = {},
+): OrphanWorktree[] {
+  const { log, minWorktreeAgeMinutes, heartbeatFreshMinutes, skipPRCheck, skipProcessCheck } = options
+
+  const orphans: OrphanWorktree[] = []
 
   const reposPath = path.join(hqPath, 'repos')
   if (!fs.existsSync(reposPath)) return orphans
@@ -970,28 +1049,9 @@ export function findOrphanedWorktrees(hqPath: string): Array<{
     return orphans
   }
 
-  // Build set of active tmux session names
-  const activeSessions = new Set<string>()
-  try {
-    const output = execSync(
-      'tmux list-sessions -F "#{session_name}" 2>/dev/null || true',
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 },
-    ).trim()
-    if (output) {
-      for (const s of output.split('\n')) {
-        if (s) activeSessions.add(s)
-      }
-    }
-  } catch {
-    // tmux not available — all worktrees are orphaned
-  }
-
-  // Build container lookup
-  const containers = listAgentContainers()
-  const containerByAgent = new Map<string, ContainerInfo>()
-  for (const c of containers) {
-    containerByAgent.set(c.agentName, c)
-  }
+  // Pre-fetch tmux sessions once to avoid spawning tmux for every worktree.
+  const hostTmuxSessions = getHostTmuxSessionNames()
+  const containerTmuxSessions = getContainerTmuxSessionMap()
 
   for (const repoName of repoDirs) {
     const repoPath = path.join(reposPath, repoName)
@@ -1004,20 +1064,25 @@ export function findOrphanedWorktrees(hqPath: string): Array<{
       const agentName = extractAgentName(wt.worktreePath, hqPath)
       if (!agentName) continue
 
-      // Check if agent is alive (container running or DB status active)
-      const container = containerByAgent.get(agentName) ?? null
-      if (isAgentAlive(agentName, hqPath, container)) continue
+      // Full multi-signal liveness check. See liveness.ts for the rules.
+      const liveness = checkWorktreeLiveness(agentName, wt.worktreePath, wt.branch, {
+        hqPath,
+        minWorktreeAgeMinutes,
+        heartbeatFreshMinutes,
+        hostTmuxSessions,
+        containerTmuxSessions,
+        repoPath,
+        skipPRCheck,
+        skipProcessCheck,
+      })
 
-      // Check if any tmux session matches this agent (exact match on agent name)
-      let hasSession = false
-      for (const sessionName of activeSessions) {
-        // Session names end with the agent name: {ticketId}-{action}-{agentName}
-        if (sessionName.endsWith(`-${agentName}`)) {
-          hasSession = true
-          break
-        }
+      if (!liveness.safeToDelete) {
+        // Log every skipped worktree with the specific reasons the check failed.
+        // This is a P0 requirement (PRLT-1324): operators need to understand
+        // why a worktree was retained, especially when hunting ghost artifacts.
+        log?.(`Skipping worktree "${wt.worktreePath}" (agent: ${agentName}): ${liveness.reasons.join('; ')}`)
+        continue
       }
-      if (hasSession) continue
 
       orphans.push({
         worktreePath: wt.worktreePath,

--- a/apps/cli/src/lib/gc/liveness.ts
+++ b/apps/cli/src/lib/gc/liveness.ts
@@ -1,0 +1,367 @@
+/**
+ * GC Liveness Check (PRLT-1324)
+ *
+ * Multi-signal liveness verification for worktree garbage collection.
+ *
+ * Before GC destroys an agent's worktree, ALL of the following must be true:
+ *   1. DB record shows session as terminated (status != active/running)
+ *   2. No tmux session exists for this agent (host or container)
+ *   3. No process is holding a file inside the worktree path (lsof)
+ *   4. No open PR exists for the worktree's branch
+ *   5. Last heartbeat older than N minutes (default 10)
+ *   6. Worktree is at least N minutes old (default 5) — protects fresh spawns
+ *   7. Worktree has no uncommitted changes
+ *
+ * If ANY check fails, the worktree is skipped and the reason is logged.
+ *
+ * Rationale: PRLT-1324 — `prlt gc --orphans --execute` destroyed a live agent's
+ * worktree because the single-signal liveness check (running container OR
+ * active/running DB status) can go stale during GC's scan phase. Multi-signal
+ * verification with a minimum-age grace prevents this class of failure.
+ */
+
+import * as fs from 'node:fs'
+import { execSync } from 'node:child_process'
+import { getPRForBranch } from '../pr/index.js'
+import {
+  getHostTmuxSessionNames,
+  getContainerTmuxSessionMap,
+  flattenContainerSessions,
+} from '../execution/session-utils.js'
+import type { ContainerInfo } from '../execution/container-cleanup.js'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Individual signal results collected by the liveness check.
+ * Each field is a human-readable reason, or null if the signal is "safe to
+ * delete". A non-null value means this signal proves the worktree is live.
+ */
+export interface LivenessSignals {
+  /** DB agent record indicates active/running — non-null reason if alive */
+  dbActive: string | null
+  /** Tmux session exists for this agent — non-null reason if found */
+  tmuxAlive: string | null
+  /** Process holds a file inside the worktree — non-null reason if held */
+  processHolding: string | null
+  /** Open PR exists for this branch — non-null reason if open */
+  openPR: string | null
+  /** Recent heartbeat recorded — non-null reason if fresh */
+  recentHeartbeat: string | null
+  /** Worktree younger than minimum age — non-null reason if too young */
+  tooYoung: string | null
+  /** Uncommitted changes present in worktree — non-null reason if dirty */
+  uncommittedChanges: string | null
+}
+
+export interface LivenessResult {
+  /** True when ALL signals are safe (no live markers found) */
+  safeToDelete: boolean
+  /** The collected signal reasons */
+  signals: LivenessSignals
+  /** List of non-null reasons (for logging) */
+  reasons: string[]
+}
+
+export interface LivenessOptions {
+  /** Workspace / HQ path */
+  hqPath: string
+  /** Minimum age for worktrees in minutes before they can be deleted (default 5) */
+  minWorktreeAgeMinutes?: number
+  /** How many minutes back counts as a "recent" heartbeat (default 10) */
+  heartbeatFreshMinutes?: number
+  /** Pre-fetched container info to avoid redundant docker calls */
+  container?: ContainerInfo | null
+  /** Pre-fetched host tmux session names */
+  hostTmuxSessions?: string[]
+  /** Pre-fetched container tmux sessions map */
+  containerTmuxSessions?: Map<string, string[]>
+  /**
+   * Repo path to cwd into for the `gh pr view` call.
+   * If omitted, getPRForBranch will infer from git cwd.
+   */
+  repoPath?: string
+  /** Skip the PR check — useful for tests that can't reach GitHub */
+  skipPRCheck?: boolean
+  /** Skip the process-holding (lsof) check — useful for tests */
+  skipProcessCheck?: boolean
+}
+
+// =============================================================================
+// Individual Signal Checks
+// =============================================================================
+
+/**
+ * Check whether the agent's DB record indicates it is still alive.
+ * Returns a reason string when alive, null when terminated/missing.
+ */
+export function checkDbStatus(agentName: string, hqPath: string): string | null {
+  try {
+    // Lazy require to keep the liveness module importable in environments
+    // without a workspace database (e.g. unit tests on /tmp/nonexistent).
+    const { getAgent } = require('../database/agents.js') as typeof import('../database/agents.js')
+    const agent = getAgent(hqPath, agentName)
+    if (!agent) return null
+    if (agent.status === 'active' || agent.status === 'running') {
+      return `DB agent status is "${agent.status}"`
+    }
+    return null
+  } catch {
+    // DB access failed — do NOT assume dead. Be defensive: return null
+    // so the combined check falls back to other signals. (Other signals
+    // must still pass before deletion is permitted.)
+    return null
+  }
+}
+
+/**
+ * Check for a tmux session that belongs to this agent. Looks at both host
+ * sessions and container sessions. Session names follow the
+ * `{ticketId}-{action}-{agentName}` convention, so any session ending in
+ * `-{agentName}` (or equal to `{agentName}`) is treated as a match.
+ */
+export function checkTmuxSession(
+  agentName: string,
+  hostSessions: string[],
+  containerTmux: Map<string, string[]>,
+): string | null {
+  const suffix = `-${agentName}`
+
+  for (const s of hostSessions) {
+    if (s === agentName || s.endsWith(suffix)) {
+      return `host tmux session "${s}" is alive`
+    }
+  }
+
+  for (const { sessionName, containerId } of flattenContainerSessions(containerTmux)) {
+    if (sessionName === agentName || sessionName.endsWith(suffix)) {
+      return `container tmux session "${sessionName}" is alive (container: ${containerId.slice(0, 12)})`
+    }
+  }
+
+  return null
+}
+
+/**
+ * Check whether a process holds any file inside the worktree path.
+ * Uses `lsof +D` which walks the directory tree. Returns a reason when a
+ * process is found, or null when the path is quiescent.
+ *
+ * Non-fatal: if lsof isn't available or the call fails for any reason
+ * other than "found files", returns null. This is deliberate — the
+ * liveness check is a suite, and other signals will still gate deletion.
+ */
+export function checkProcessHolding(worktreePath: string): string | null {
+  if (!fs.existsSync(worktreePath)) return null
+
+  try {
+    // lsof +D returns files under the directory. Exit code 0 means matches found,
+    // exit code 1 means no matches. -t restricts output to PIDs only for quick parsing.
+    const output = execSync(`lsof +D ${escapeShellArg(worktreePath)} -t`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 15000,
+    }).trim()
+
+    if (!output) return null
+
+    const pids = output.split('\n').filter(Boolean)
+    if (pids.length === 0) return null
+    return `${pids.length} process(es) hold files inside worktree (pids: ${pids.slice(0, 3).join(',')}${pids.length > 3 ? '…' : ''})`
+  } catch (err) {
+    const exitCode = (err as { status?: number }).status
+    // Exit code 1 = no matches, treat as safe
+    if (exitCode === 1) return null
+    // Anything else (lsof missing, timeout, permission error) is inconclusive.
+    // Be defensive: treat as not-holding so that other signals gate deletion.
+    return null
+  }
+}
+
+/**
+ * Check whether a PR is currently open for this branch. Returns a reason
+ * when OPEN, null when MERGED/CLOSED/absent.
+ */
+export function checkOpenPR(
+  branch: string,
+  repoPath?: string,
+): string | null {
+  try {
+    const pr = getPRForBranch(branch, repoPath)
+    if (pr && pr.state === 'OPEN') {
+      return `PR #${pr.number} is OPEN for branch "${branch}"`
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check whether this agent has recorded a heartbeat recently.
+ * Returns a reason when a heartbeat within the threshold is found.
+ */
+export function checkRecentHeartbeat(
+  agentName: string,
+  hqPath: string,
+  thresholdMinutes: number,
+): string | null {
+  try {
+    const { openWorkspaceDatabase } = require('../database/workspace.js') as typeof import('../database/workspace.js')
+    const db = openWorkspaceDatabase(hqPath)
+    try {
+      const tableExists = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_work'",
+      ).get()
+      if (!tableExists) return null
+
+      const cols = db.prepare("PRAGMA table_info(agent_work)").all() as { name: string }[]
+      if (!cols.some(c => c.name === 'last_heartbeat')) return null
+
+      const row = db.prepare(
+        `SELECT last_heartbeat FROM agent_work
+         WHERE agent_name = ? AND last_heartbeat IS NOT NULL
+         ORDER BY last_heartbeat DESC
+         LIMIT 1`,
+      ).get(agentName) as { last_heartbeat: string | null } | undefined
+
+      if (!row || !row.last_heartbeat) return null
+
+      const hbTime = new Date(row.last_heartbeat).getTime()
+      if (Number.isNaN(hbTime)) return null
+
+      const ageMs = Date.now() - hbTime
+      const ageMinutes = ageMs / 60000
+      if (ageMinutes <= thresholdMinutes) {
+        return `recent heartbeat (${ageMinutes.toFixed(1)}m ago, threshold ${thresholdMinutes}m)`
+      }
+      return null
+    } finally {
+      db.close()
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check whether the worktree was created within the minimum-age grace period.
+ * Uses directory mtime as a proxy for "age". Returns a reason when too young.
+ */
+export function checkWorktreeAge(
+  worktreePath: string,
+  minMinutes: number,
+): string | null {
+  // minMinutes <= 0 disables the age guard entirely (used by tests and
+  // operators who explicitly want no grace period).
+  if (minMinutes <= 0) return null
+  if (!fs.existsSync(worktreePath)) return null
+  try {
+    const stats = fs.statSync(worktreePath)
+    // Use the earlier of mtime/ctime to capture the oldest evidence of existence.
+    const mtimeMs = stats.mtimeMs
+    const ctimeMs = stats.ctimeMs
+    const birthMs = Math.min(mtimeMs, ctimeMs)
+    const ageMs = Date.now() - birthMs
+    const ageMinutes = ageMs / 60000
+    if (ageMinutes < minMinutes) {
+      return `worktree is ${ageMinutes.toFixed(1)}m old (< ${minMinutes}m minimum)`
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check whether a worktree has uncommitted changes (including untracked files).
+ * Returns a reason when dirty, null when clean.
+ *
+ * Important: we refuse to delete any worktree with uncommitted work, even if
+ * every other signal says the agent is dead — the user's in-progress code
+ * must be preserved for manual recovery.
+ */
+export function checkUncommittedChanges(worktreePath: string): string | null {
+  if (!fs.existsSync(worktreePath)) return null
+  try {
+    const output = execSync('git status --porcelain=v1 --untracked-files=normal', {
+      cwd: worktreePath,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    }).trim()
+    if (!output) return null
+    const lines = output.split('\n').filter(Boolean)
+    return `${lines.length} uncommitted change(s) in worktree`
+  } catch {
+    // If we cannot inspect the worktree, err on the side of safety.
+    return 'unable to inspect git status — skipping for safety'
+  }
+}
+
+// =============================================================================
+// Combined Liveness Check
+// =============================================================================
+
+/**
+ * Run the full multi-signal liveness check for a worktree.
+ *
+ * Returns `safeToDelete: true` only when ALL checks agree. Otherwise returns
+ * the list of reasons for the caller to log.
+ */
+export function checkWorktreeLiveness(
+  agentName: string,
+  worktreePath: string,
+  branch: string,
+  options: LivenessOptions,
+): LivenessResult {
+  const {
+    hqPath,
+    minWorktreeAgeMinutes = 5,
+    heartbeatFreshMinutes = 10,
+    hostTmuxSessions,
+    containerTmuxSessions,
+    repoPath,
+    skipPRCheck = false,
+    skipProcessCheck = false,
+  } = options
+
+  const hostSessions = hostTmuxSessions ?? getHostTmuxSessionNames()
+  const containerMap = containerTmuxSessions ?? getContainerTmuxSessionMap()
+
+  const signals: LivenessSignals = {
+    dbActive: checkDbStatus(agentName, hqPath),
+    tmuxAlive: checkTmuxSession(agentName, hostSessions, containerMap),
+    processHolding: skipProcessCheck ? null : checkProcessHolding(worktreePath),
+    openPR: skipPRCheck ? null : checkOpenPR(branch, repoPath),
+    recentHeartbeat: checkRecentHeartbeat(agentName, hqPath, heartbeatFreshMinutes),
+    tooYoung: checkWorktreeAge(worktreePath, minWorktreeAgeMinutes),
+    uncommittedChanges: checkUncommittedChanges(worktreePath),
+  }
+
+  const reasons: string[] = []
+  for (const value of Object.values(signals)) {
+    if (value) reasons.push(value)
+  }
+
+  return {
+    safeToDelete: reasons.length === 0,
+    signals,
+    reasons,
+  }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Minimal shell argument escape for paths containing spaces/special chars.
+ * We only use this with a path that we control via fs.existsSync first.
+ */
+function escapeShellArg(arg: string): string {
+  // Wrap in single quotes and escape any single quotes inside.
+  return `'${arg.replace(/'/g, `'\\''`)}'`
+}

--- a/apps/cli/test/unit/gc-liveness.test.ts
+++ b/apps/cli/test/unit/gc-liveness.test.ts
@@ -1,0 +1,436 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { execSync } from 'node:child_process'
+import {
+  checkWorktreeLiveness,
+  checkTmuxSession,
+  checkDbStatus,
+  checkRecentHeartbeat,
+  checkWorktreeAge,
+  checkUncommittedChanges,
+  checkOpenPR,
+  checkProcessHolding,
+} from '../../src/lib/gc/liveness.js'
+import {
+  findOrphanedWorktrees,
+} from '../../src/lib/gc/index.js'
+
+/**
+ * PRLT-1324 Regression Tests
+ *
+ * `prlt gc --orphans --execute` destroyed a live agent's worktree because the
+ * single-signal liveness check (running container OR active DB status) was
+ * insufficient. This suite validates the hardened multi-signal liveness check:
+ *
+ *   1. DB record terminated
+ *   2. AND no tmux session exists for this agent
+ *   3. AND no process holding the worktree path
+ *   4. AND no open PR for the branch
+ *   5. AND last heartbeat older than threshold
+ *   6. AND worktree at least N minutes old
+ *   7. AND no uncommitted changes
+ *
+ * Any single failing signal must cause the worktree to be preserved and the
+ * reason logged.
+ */
+
+// =============================================================================
+// Individual signal checks
+// =============================================================================
+
+describe('@smoke GC liveness — individual signal checks', () => {
+  describe('checkTmuxSession', () => {
+    it('detects host tmux session matching agent suffix', () => {
+      const reason = checkTmuxSession(
+        'glad-sweeney',
+        ['PRLT-100-implement-glad-sweeney'],
+        new Map(),
+      )
+      expect(reason).to.not.be.null
+      expect(reason).to.include('glad-sweeney')
+    })
+
+    it('detects host tmux session matching agent name exactly', () => {
+      const reason = checkTmuxSession(
+        'glad-sweeney',
+        ['glad-sweeney'],
+        new Map(),
+      )
+      expect(reason).to.not.be.null
+    })
+
+    it('detects container tmux session matching agent suffix', () => {
+      const containerMap = new Map<string, string[]>([
+        ['abc123def456', ['PRLT-100-review-glad-sweeney']],
+      ])
+      const reason = checkTmuxSession('glad-sweeney', [], containerMap)
+      expect(reason).to.not.be.null
+      expect(reason).to.include('glad-sweeney')
+      expect(reason).to.include('abc123def456'.slice(0, 12))
+    })
+
+    it('returns null when no session matches', () => {
+      const reason = checkTmuxSession(
+        'glad-sweeney',
+        ['other-agent', 'PRLT-100-implement-bold-turing'],
+        new Map([['x', ['unrelated-session']]]),
+      )
+      expect(reason).to.be.null
+    })
+
+    it('does not match a session whose name merely contains the agent name as a substring', () => {
+      // "glad-sweeney-2" does not end with "-glad-sweeney" so it must not match
+      const reason = checkTmuxSession(
+        'glad-sweeney',
+        ['bold-turing-glad-sweeney-2'],
+        new Map(),
+      )
+      expect(reason).to.be.null
+    })
+  })
+
+  describe('checkWorktreeAge', () => {
+    it('flags freshly-created directories as too young', () => {
+      const tmp = fs.mkdtempSync(path.join('/tmp', 'gc-age-young-'))
+      try {
+        const reason = checkWorktreeAge(tmp, 5)
+        expect(reason).to.not.be.null
+        expect(reason).to.include('< 5m minimum')
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      }
+    })
+
+    it('returns null when minimum is zero', () => {
+      const tmp = fs.mkdtempSync(path.join('/tmp', 'gc-age-zero-'))
+      try {
+        const reason = checkWorktreeAge(tmp, 0)
+        expect(reason).to.be.null
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      }
+    })
+
+    it('returns null when directory does not exist', () => {
+      const reason = checkWorktreeAge('/tmp/definitely-not-real-1324', 5)
+      expect(reason).to.be.null
+    })
+  })
+
+  describe('checkUncommittedChanges', () => {
+    it('reports uncommitted changes when working tree is dirty', () => {
+      const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-dirty-')))
+      try {
+        execSync('git init -q', { cwd: tmp, stdio: 'pipe' })
+        execSync('git checkout -b main -q', { cwd: tmp, stdio: 'pipe' })
+        fs.writeFileSync(path.join(tmp, 'README.md'), '# test')
+        execSync('git -c user.name=test -c user.email=t@t add .', { cwd: tmp, stdio: 'pipe' })
+        execSync('git -c user.name=test -c user.email=t@t commit -q -m initial', {
+          cwd: tmp,
+          stdio: 'pipe',
+        })
+        // Create an uncommitted change
+        fs.writeFileSync(path.join(tmp, 'dirty.txt'), 'work in progress')
+        const reason = checkUncommittedChanges(tmp)
+        expect(reason).to.not.be.null
+        expect(reason).to.include('uncommitted')
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      }
+    })
+
+    it('returns null on clean working tree', () => {
+      const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-clean-')))
+      try {
+        execSync('git init -q', { cwd: tmp, stdio: 'pipe' })
+        execSync('git checkout -b main -q', { cwd: tmp, stdio: 'pipe' })
+        fs.writeFileSync(path.join(tmp, 'README.md'), '# test')
+        execSync('git -c user.name=test -c user.email=t@t add .', { cwd: tmp, stdio: 'pipe' })
+        execSync('git -c user.name=test -c user.email=t@t commit -q -m initial', {
+          cwd: tmp,
+          stdio: 'pipe',
+        })
+        const reason = checkUncommittedChanges(tmp)
+        expect(reason).to.be.null
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      }
+    })
+
+    it('reports untracked files as uncommitted changes (the most common agent-in-progress signal)', () => {
+      const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-untracked-')))
+      try {
+        execSync('git init -q', { cwd: tmp, stdio: 'pipe' })
+        execSync('git checkout -b main -q', { cwd: tmp, stdio: 'pipe' })
+        fs.writeFileSync(path.join(tmp, 'README.md'), '# test')
+        execSync('git -c user.name=test -c user.email=t@t add .', { cwd: tmp, stdio: 'pipe' })
+        execSync('git -c user.name=test -c user.email=t@t commit -q -m initial', {
+          cwd: tmp,
+          stdio: 'pipe',
+        })
+        fs.writeFileSync(path.join(tmp, 'WIP.md'), 'in progress work')
+        const reason = checkUncommittedChanges(tmp)
+        expect(reason).to.not.be.null
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      }
+    })
+
+    it('returns a safety reason when the path is not a git repo', () => {
+      const tmp = fs.mkdtempSync(path.join('/tmp', 'gc-notrepo-'))
+      try {
+        const reason = checkUncommittedChanges(tmp)
+        // When git status fails, we err on the side of safety
+        expect(reason).to.not.be.null
+        expect(reason).to.include('safety')
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('checkDbStatus', () => {
+    it('returns null when the DB path does not exist', () => {
+      const reason = checkDbStatus('any-agent', '/tmp/definitely-not-real-1324')
+      expect(reason).to.be.null
+    })
+  })
+
+  describe('checkRecentHeartbeat', () => {
+    it('returns null when the DB does not exist', () => {
+      const reason = checkRecentHeartbeat('any-agent', '/tmp/definitely-not-real-1324', 10)
+      expect(reason).to.be.null
+    })
+  })
+
+  describe('checkOpenPR', () => {
+    it('does not throw on branch lookup failure', () => {
+      // Non-existent repo/branch — returns null gracefully.
+      expect(() => checkOpenPR('nonexistent-branch-gc-1324', '/tmp')).to.not.throw()
+    })
+  })
+
+  describe('checkProcessHolding', () => {
+    it('returns null when the path does not exist', () => {
+      const reason = checkProcessHolding('/tmp/definitely-not-real-1324')
+      expect(reason).to.be.null
+    })
+
+    it('does not throw on unknown paths', () => {
+      expect(() => checkProcessHolding('/tmp/definitely-not-real-1324')).to.not.throw()
+    })
+  })
+})
+
+// =============================================================================
+// PRLT-1324 regression: live agent worktree must not be deleted by GC
+// =============================================================================
+
+describe('@smoke GC PRLT-1324 — live agent protection', () => {
+  it('does not mark a worktree with a matching tmux session as orphan', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-live-')))
+    try {
+      const reposDir = path.join(tmp, 'repos')
+      const repoDir = path.join(reposDir, 'test-repo')
+      fs.mkdirSync(repoDir, { recursive: true })
+
+      execSync('git init -q', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git checkout -b main -q', { cwd: repoDir, stdio: 'pipe' })
+      fs.writeFileSync(path.join(repoDir, 'README.md'), '# test')
+      execSync('git -c user.name=test -c user.email=t@t add .', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git -c user.name=test -c user.email=t@t commit -q -m init', { cwd: repoDir, stdio: 'pipe' })
+
+      const agentDir = path.join(tmp, 'agents', 'temp', 'glad-sweeney', 'test-repo')
+      fs.mkdirSync(path.dirname(agentDir), { recursive: true })
+      execSync(`git worktree add "${agentDir}" -b agent-glad-sweeney`, {
+        cwd: repoDir,
+        stdio: 'pipe',
+      })
+
+      const logs: string[] = []
+      // The agent is "live" because a tmux session exists with the agent suffix.
+      // We simulate this by passing the host session list manually via the
+      // liveness module — but findOrphanedWorktrees auto-discovers, so we use
+      // the liveness module directly to verify the rule, then verify that
+      // findOrphanedWorktrees with minWorktreeAgeMinutes=0 also skips it when
+      // uncommitted changes are present.
+      fs.writeFileSync(path.join(agentDir, 'wip.ts'), 'in progress work')
+
+      const orphans = findOrphanedWorktrees(tmp, {
+        minWorktreeAgeMinutes: 0,
+        skipPRCheck: true,
+        skipProcessCheck: true,
+        log: (m) => logs.push(m),
+      })
+
+      // The worktree is dirty → must never be deleted.
+      expect(orphans).to.have.length(0)
+      expect(logs.some(l => l.includes('uncommitted'))).to.be.true
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('protects a freshly-spawned agent (< minWorktreeAgeMinutes) from GC', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-young-')))
+    try {
+      const reposDir = path.join(tmp, 'repos')
+      const repoDir = path.join(reposDir, 'test-repo')
+      fs.mkdirSync(repoDir, { recursive: true })
+
+      execSync('git init -q', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git checkout -b main -q', { cwd: repoDir, stdio: 'pipe' })
+      fs.writeFileSync(path.join(repoDir, 'README.md'), '# test')
+      execSync('git -c user.name=test -c user.email=t@t add .', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git -c user.name=test -c user.email=t@t commit -q -m init', { cwd: repoDir, stdio: 'pipe' })
+
+      const agentDir = path.join(tmp, 'agents', 'temp', 'fresh-agent', 'test-repo')
+      fs.mkdirSync(path.dirname(agentDir), { recursive: true })
+      execSync(`git worktree add "${agentDir}" -b agent-fresh-agent`, {
+        cwd: repoDir,
+        stdio: 'pipe',
+      })
+
+      const logs: string[] = []
+      // Default minWorktreeAgeMinutes is 5 — the worktree is brand new.
+      const orphans = findOrphanedWorktrees(tmp, {
+        skipPRCheck: true,
+        skipProcessCheck: true,
+        log: (m) => logs.push(m),
+      })
+
+      // Must be skipped due to age, even though no tmux/DB/etc. signals exist.
+      expect(orphans).to.have.length(0)
+      expect(logs.some(l => l.includes('5m minimum') || l.includes('< 5m'))).to.be.true
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('skips worktrees with uncommitted changes regardless of other signals', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-dirty-wt-')))
+    try {
+      const reposDir = path.join(tmp, 'repos')
+      const repoDir = path.join(reposDir, 'test-repo')
+      fs.mkdirSync(repoDir, { recursive: true })
+
+      execSync('git init -q', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git checkout -b main -q', { cwd: repoDir, stdio: 'pipe' })
+      fs.writeFileSync(path.join(repoDir, 'README.md'), '# test')
+      execSync('git -c user.name=test -c user.email=t@t add .', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git -c user.name=test -c user.email=t@t commit -q -m init', { cwd: repoDir, stdio: 'pipe' })
+
+      const agentDir = path.join(tmp, 'agents', 'temp', 'dirty-agent', 'test-repo')
+      fs.mkdirSync(path.dirname(agentDir), { recursive: true })
+      execSync(`git worktree add "${agentDir}" -b agent-dirty-agent`, {
+        cwd: repoDir,
+        stdio: 'pipe',
+      })
+
+      // Seed the worktree with an uncommitted file — this is the classic
+      // "agent in the middle of work" scenario.
+      fs.writeFileSync(path.join(agentDir, 'new-feature.ts'), 'export const x = 1')
+
+      const orphans = findOrphanedWorktrees(tmp, {
+        minWorktreeAgeMinutes: 0, // bypass age guard
+        skipPRCheck: true,
+        skipProcessCheck: true,
+      })
+
+      expect(orphans).to.have.length(0)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns safeToDelete=false from checkWorktreeLiveness when any signal is alive', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-combined-')))
+    try {
+      execSync('git init -q', { cwd: tmp, stdio: 'pipe' })
+      execSync('git checkout -b main -q', { cwd: tmp, stdio: 'pipe' })
+      fs.writeFileSync(path.join(tmp, 'README.md'), '# test')
+      execSync('git -c user.name=test -c user.email=t@t add .', { cwd: tmp, stdio: 'pipe' })
+      execSync('git -c user.name=test -c user.email=t@t commit -q -m init', { cwd: tmp, stdio: 'pipe' })
+      fs.writeFileSync(path.join(tmp, 'dirty.txt'), 'in-progress')
+
+      const result = checkWorktreeLiveness('some-agent', tmp, 'some-branch', {
+        hqPath: '/tmp/definitely-not-real-1324',
+        minWorktreeAgeMinutes: 0, // bypass age
+        hostTmuxSessions: [],
+        containerTmuxSessions: new Map(),
+        skipPRCheck: true,
+        skipProcessCheck: true,
+      })
+
+      expect(result.safeToDelete).to.be.false
+      expect(result.reasons).to.have.length.at.least(1)
+      expect(result.reasons.some(r => r.includes('uncommitted'))).to.be.true
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('returns safeToDelete=true when all signals are safe', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-safe-')))
+    try {
+      execSync('git init -q', { cwd: tmp, stdio: 'pipe' })
+      execSync('git checkout -b main -q', { cwd: tmp, stdio: 'pipe' })
+      fs.writeFileSync(path.join(tmp, 'README.md'), '# test')
+      execSync('git -c user.name=test -c user.email=t@t add .', { cwd: tmp, stdio: 'pipe' })
+      execSync('git -c user.name=test -c user.email=t@t commit -q -m init', { cwd: tmp, stdio: 'pipe' })
+
+      const result = checkWorktreeLiveness('ghost-agent', tmp, 'ghost-branch', {
+        hqPath: '/tmp/definitely-not-real-1324',
+        minWorktreeAgeMinutes: 0, // bypass age
+        hostTmuxSessions: [],
+        containerTmuxSessions: new Map(),
+        skipPRCheck: true,
+        skipProcessCheck: true,
+      })
+
+      expect(result.safeToDelete).to.be.true
+      expect(result.reasons).to.have.length(0)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('logs a skip reason for every preserved worktree (operator visibility)', () => {
+    const tmp = fs.realpathSync(fs.mkdtempSync(path.join('/tmp', 'gc-log-')))
+    try {
+      const reposDir = path.join(tmp, 'repos')
+      const repoDir = path.join(reposDir, 'test-repo')
+      fs.mkdirSync(repoDir, { recursive: true })
+
+      execSync('git init -q', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git checkout -b main -q', { cwd: repoDir, stdio: 'pipe' })
+      fs.writeFileSync(path.join(repoDir, 'README.md'), '# test')
+      execSync('git -c user.name=test -c user.email=t@t add .', { cwd: repoDir, stdio: 'pipe' })
+      execSync('git -c user.name=test -c user.email=t@t commit -q -m init', { cwd: repoDir, stdio: 'pipe' })
+
+      const agentDir = path.join(tmp, 'agents', 'temp', 'logged-agent', 'test-repo')
+      fs.mkdirSync(path.dirname(agentDir), { recursive: true })
+      execSync(`git worktree add "${agentDir}" -b agent-logged-agent`, {
+        cwd: repoDir,
+        stdio: 'pipe',
+      })
+
+      const logs: string[] = []
+      // Leave defaults so the 5m age guard triggers.
+      findOrphanedWorktrees(tmp, {
+        skipPRCheck: true,
+        skipProcessCheck: true,
+        log: (m) => logs.push(m),
+      })
+
+      // Each skipped worktree must contribute at least one log entry naming
+      // the worktree path and the reason(s) for skipping.
+      const skipLog = logs.find(l => l.includes('logged-agent'))
+      expect(skipLog, `expected a skip log for logged-agent, got: ${logs.join('\n')}`).to.not.be.undefined
+      expect(skipLog!).to.include('Skipping')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/cli/test/unit/gc-ticket-cleanup.test.ts
+++ b/apps/cli/test/unit/gc-ticket-cleanup.test.ts
@@ -243,8 +243,15 @@ describe('GC findOrphanedWorktrees with git repo', () => {
         stdio: 'pipe',
       })
 
-      // Now find orphans — the worktree has no running tmux session
-      const orphans = findOrphanedWorktrees(tmpDir)
+      // Now find orphans — the worktree has no running tmux session.
+      // PRLT-1324: bypass the 5-minute minimum-age grace for this unit test by
+      // passing minWorktreeAgeMinutes: 0 (the worktree is brand new). Also
+      // skip the PR check (requires gh auth) and lsof check (can be flaky in CI).
+      const orphans = findOrphanedWorktrees(tmpDir, {
+        minWorktreeAgeMinutes: 0,
+        skipPRCheck: true,
+        skipProcessCheck: true,
+      })
 
       // Should find the orphaned worktree
       expect(orphans).to.have.length(1)


### PR DESCRIPTION
Fixes PRLT-1324. Multi-signal liveness check for worktree GC — DB + tmux + lsof + open PR + heartbeat + min-age + uncommitted-changes. See commit for details.