### PR TITLE
chore: bump version to 0.3.120

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.119",
+  "version": "0.3.120",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
5 PRs: PRLT-1319 (stub audit), PRLT-1323 (poke lookup), PRLT-1324 (GC guard), PRLT-1316 (work→service), PRLT-1321 (watch daemon)