### PR TITLE
feat(PRLT-1315): Add prlt action command namespace

### DIFF
--- a/apps/cli/src/commands/action/create.ts
+++ b/apps/cli/src/commands/action/create.ts
@@ -1,0 +1,122 @@
+import { Args, Flags } from '@oclif/core'
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { getPMOContext } from '../../lib/pmo/pmo-context.js'
+import type { WorkAction } from '../../lib/pmo/types.js'
+
+export default class ActionCreate extends RuntimeCommand {
+  static description = 'Create a new custom action'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> deploy --prompt "Deploy the changes to staging"',
+    '<%= config.bin %> <%= command.id %> lint --prompt "Run linter and fix issues" --from-intent started --to-intent needs_review',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+    prompt: Flags.string({
+      description: 'Action prompt (agent instructions)',
+      required: true,
+    }),
+    description: Flags.string({
+      char: 'd',
+      description: 'Short description of the action',
+    }),
+    'from-intent': Flags.string({
+      description: 'Intent that triggers this action',
+    }),
+    'to-intent': Flags.string({
+      description: 'Intent to move ticket to after action completes',
+    }),
+    executor: Flags.string({
+      description: 'Executor override',
+      options: ['claude', 'codex', 'opencode', 'custom'],
+    }),
+    environment: Flags.string({
+      description: 'Execution environment',
+      options: ['devcontainer', 'docker', 'host', 'vm'],
+    }),
+    timeout: Flags.integer({
+      description: 'Timeout in seconds',
+    }),
+    'end-prompt': Flags.string({
+      description: 'Completion instructions prompt',
+    }),
+    'modifies-code': Flags.boolean({
+      description: 'Whether this action modifies code',
+      default: true,
+      allowNo: true,
+    }),
+  }
+
+  static args = {
+    name: Args.string({
+      description: 'Unique action name',
+      required: true,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ActionCreate)
+    const jsonMode = shouldOutputJson(flags)
+
+    const pmoContext = await getPMOContext({
+      logger: (msg) => this.log(styles.muted(msg)),
+    })
+
+    try {
+      const actionData: Partial<WorkAction> = {
+        name: args.name,
+        prompt: flags.prompt,
+        description: flags.description,
+        fromIntent: flags['from-intent'],
+        toIntent: flags['to-intent'],
+        executor: flags.executor as WorkAction['executor'],
+        environment: flags.environment as WorkAction['environment'],
+        timeout: flags.timeout,
+        endPrompt: flags['end-prompt'],
+        modifiesCode: flags['modifies-code'],
+        isBuiltin: false,
+      }
+
+      let action: WorkAction
+      try {
+        action = await pmoContext.storage.createAction(actionData)
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error)
+        if (jsonMode) {
+          outputErrorAsJson('CREATE_FAILED', msg, createMetadata('action create', flags))
+          return
+        }
+        this.error(msg)
+        return
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            action: {
+              id: action.id,
+              name: action.name,
+              description: action.description,
+              isBuiltin: action.isBuiltin,
+            },
+            message: `Action "${action.name}" created.`,
+          },
+          createMetadata('action create', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Action "${action.name}" created (id: ${action.id})`))
+    } finally {
+      await pmoContext.storage.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/action/delete.ts
+++ b/apps/cli/src/commands/action/delete.ts
@@ -1,0 +1,85 @@
+import { Args } from '@oclif/core'
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { getPMOContext } from '../../lib/pmo/pmo-context.js'
+
+export default class ActionDelete extends RuntimeCommand {
+  static description = 'Delete a custom action (built-in actions cannot be deleted)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> deploy',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+  }
+
+  static args = {
+    name: Args.string({
+      description: 'Action name or ID to delete',
+      required: true,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ActionDelete)
+    const jsonMode = shouldOutputJson(flags)
+
+    const pmoContext = await getPMOContext({
+      logger: (msg) => this.log(styles.muted(msg)),
+    })
+
+    try {
+      const action = await pmoContext.storage.getAction(args.name)
+
+      if (!action) {
+        if (jsonMode) {
+          outputErrorAsJson('NOT_FOUND', `Action "${args.name}" not found.`, createMetadata('action delete', flags))
+          return
+        }
+        this.error(`Action "${args.name}" not found.`)
+      }
+
+      if (action.isBuiltin) {
+        if (jsonMode) {
+          outputErrorAsJson('BUILTIN_ACTION', `Cannot delete built-in action "${action.name}". Built-in actions can only be edited.`, createMetadata('action delete', flags))
+          return
+        }
+        this.error(`Cannot delete built-in action "${action.name}". Built-in actions can only be edited.`)
+      }
+
+      try {
+        await pmoContext.storage.deleteAction(args.name)
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error)
+        if (jsonMode) {
+          outputErrorAsJson('DELETE_FAILED', msg, createMetadata('action delete', flags))
+          return
+        }
+        this.error(msg)
+        return
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            deleted: args.name,
+            message: `Action "${action.name}" deleted.`,
+          },
+          createMetadata('action delete', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Action "${action.name}" deleted.`))
+    } finally {
+      await pmoContext.storage.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/action/edit.ts
+++ b/apps/cli/src/commands/action/edit.ts
@@ -1,0 +1,182 @@
+import { Args, Flags } from '@oclif/core'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { getPMOContext } from '../../lib/pmo/pmo-context.js'
+
+export default class ActionEdit extends RuntimeCommand {
+  static description = 'Edit an action prompt in $EDITOR (reads from DB, writes back on save)'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> implement',
+    '<%= config.bin %> <%= command.id %> groom',
+    '<%= config.bin %> <%= command.id %> implement --prompt "New prompt text"',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+    prompt: Flags.string({
+      description: 'Set prompt directly (skip $EDITOR)',
+    }),
+    description: Flags.string({
+      char: 'd',
+      description: 'Update description',
+    }),
+    'from-intent': Flags.string({
+      description: 'Update from_intent',
+    }),
+    'to-intent': Flags.string({
+      description: 'Update to_intent',
+    }),
+    executor: Flags.string({
+      description: 'Update executor',
+      options: ['claude', 'codex', 'opencode', 'custom'],
+    }),
+    timeout: Flags.integer({
+      description: 'Update timeout in seconds',
+    }),
+  }
+
+  static args = {
+    name: Args.string({
+      description: 'Action name or ID to edit',
+      required: true,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ActionEdit)
+    const jsonMode = shouldOutputJson(flags)
+
+    const pmoContext = await getPMOContext({
+      logger: (msg) => this.log(styles.muted(msg)),
+    })
+
+    try {
+      const action = await pmoContext.storage.getAction(args.name)
+
+      if (!action) {
+        if (jsonMode) {
+          outputErrorAsJson('NOT_FOUND', `Action "${args.name}" not found.`, createMetadata('action edit', flags))
+          return
+        }
+        this.error(`Action "${args.name}" not found.`)
+      }
+
+      // Build changes from flags
+      const changes: Record<string, unknown> = {}
+      if (flags.description !== undefined) changes.description = flags.description
+      if (flags['from-intent'] !== undefined) changes.fromIntent = flags['from-intent']
+      if (flags['to-intent'] !== undefined) changes.toIntent = flags['to-intent']
+      if (flags.executor !== undefined) changes.executor = flags.executor
+      if (flags.timeout !== undefined) changes.timeout = flags.timeout
+
+      // Handle prompt: either from --prompt flag or open $EDITOR
+      if (flags.prompt !== undefined) {
+        changes.prompt = flags.prompt
+      } else if (Object.keys(changes).length === 0) {
+        // No flag-based changes — open editor for prompt
+        const editor = process.env.EDITOR || process.env.VISUAL || 'vi'
+
+        if (jsonMode) {
+          // In JSON mode we can't open an editor — require --prompt flag
+          outputErrorAsJson(
+            'EDITOR_NOT_SUPPORTED',
+            'Cannot open $EDITOR in non-interactive mode. Use --prompt flag to set the prompt directly.',
+            createMetadata('action edit', flags),
+          )
+          return
+        }
+
+        const tmpDir = os.tmpdir()
+        const tmpFile = path.join(tmpDir, `prlt-action-${action.id}.md`)
+
+        try {
+          fs.writeFileSync(tmpFile, action.prompt, 'utf-8')
+          this.log(styles.muted(`Opening ${editor}...`))
+
+          execFileSync(editor, [tmpFile], {
+            stdio: 'inherit',
+          })
+
+          const newPrompt = fs.readFileSync(tmpFile, 'utf-8')
+
+          if (newPrompt === action.prompt) {
+            this.log(styles.info('No changes made.'))
+            return
+          }
+
+          changes.prompt = newPrompt
+        } finally {
+          try {
+            fs.unlinkSync(tmpFile)
+          } catch {
+            // Ignore cleanup errors
+          }
+        }
+      }
+
+      if (Object.keys(changes).length === 0) {
+        if (jsonMode) {
+          outputSuccessAsJson(
+            { message: 'No changes to apply.', action: { id: action.id, name: action.name } },
+            createMetadata('action edit', flags),
+          )
+          return
+        }
+        this.log(styles.info('No changes to apply.'))
+        return
+      }
+
+      // Built-in actions: the storage layer blocks updateAction for built-ins.
+      // We need to update them directly since the ticket says built-ins can be edited.
+      let updated
+      try {
+        if (action.isBuiltin) {
+          // Use direct DB update for built-in actions (storage layer blocks updateAction)
+          await pmoContext.storage.updateBuiltinAction(action.id, changes)
+          updated = await pmoContext.storage.getAction(action.id)
+        } else {
+          updated = await pmoContext.storage.updateAction(action.id, changes)
+        }
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error)
+        if (jsonMode) {
+          outputErrorAsJson('UPDATE_FAILED', msg, createMetadata('action edit', flags))
+          return
+        }
+        this.error(msg)
+        return
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            action: {
+              id: updated!.id,
+              name: updated!.name,
+              description: updated!.description,
+              isBuiltin: updated!.isBuiltin,
+            },
+            message: `Action "${updated!.name}" updated.`,
+          },
+          createMetadata('action edit', flags),
+        )
+        return
+      }
+
+      this.log(styles.success(`Action "${updated!.name}" updated.`))
+    } finally {
+      await pmoContext.storage.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/action/index.ts
+++ b/apps/cli/src/commands/action/index.ts
@@ -1,0 +1,63 @@
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputPromptAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+
+export default class ActionIndex extends RuntimeCommand {
+  static description = 'Manage work actions — list, show, create, edit, delete, run'
+
+  static examples = [
+    '<%= config.bin %> action list',
+    '<%= config.bin %> action show implement',
+    '<%= config.bin %> action edit groom',
+    '<%= config.bin %> action create deploy --prompt "Deploy changes"',
+    '<%= config.bin %> action delete deploy',
+    '<%= config.bin %> action run implement PRLT-123',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(ActionIndex)
+    const jsonMode = shouldOutputJson(flags)
+
+    const subcommands = [
+      { name: 'list — List all actions', value: 'action:list', command: 'prlt action list' },
+      { name: 'show — Show full action config + prompt', value: 'action:show', command: 'prlt action show <name>' },
+      { name: 'edit — Edit action prompt in $EDITOR', value: 'action:edit', command: 'prlt action edit <name>' },
+      { name: 'create — Add a new custom action', value: 'action:create', command: 'prlt action create <name> --prompt "..."' },
+      { name: 'delete — Remove a custom action', value: 'action:delete', command: 'prlt action delete <name>' },
+      { name: 'run — Run an action on a ticket', value: 'action:run', command: 'prlt action run <name> <ticket>' },
+    ]
+
+    if (jsonMode) {
+      outputPromptAsJson(
+        {
+          type: 'list',
+          name: 'subcommand',
+          message: 'Select action subcommand:',
+          choices: subcommands,
+        },
+        createMetadata('action', flags),
+      )
+      return
+    }
+
+    const selected = await this.selectFromList({
+      message: 'Select action subcommand:',
+      items: subcommands,
+      getName: (s) => s.name,
+      getValue: (s) => s.value,
+      getCommand: (s) => `${s.command} --json`,
+    })
+
+    if (selected) {
+      await this.config.runCommand(selected)
+    }
+  }
+}

--- a/apps/cli/src/commands/action/list.ts
+++ b/apps/cli/src/commands/action/list.ts
@@ -1,0 +1,107 @@
+import { Flags } from '@oclif/core'
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles, divider } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { getPMOContext } from '../../lib/pmo/pmo-context.js'
+import type { WorkActionFilter } from '../../lib/pmo/types.js'
+
+export default class ActionList extends RuntimeCommand {
+  static description = 'List all configured actions'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --builtin',
+    '<%= config.bin %> <%= command.id %> --search groom',
+    '<%= config.bin %> <%= command.id %> --json',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+    builtin: Flags.boolean({
+      description: 'Show only built-in actions',
+      default: false,
+    }),
+    custom: Flags.boolean({
+      description: 'Show only custom actions',
+      default: false,
+    }),
+    search: Flags.string({
+      char: 's',
+      description: 'Search by name or description',
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { flags } = await this.parse(ActionList)
+    const jsonMode = shouldOutputJson(flags)
+
+    const pmoContext = await getPMOContext({
+      logger: (msg) => this.log(styles.muted(msg)),
+    })
+
+    try {
+      const filter: WorkActionFilter = {}
+      if (flags.builtin) filter.isBuiltin = true
+      if (flags.custom) filter.isBuiltin = false
+      if (flags.search) filter.search = flags.search
+
+      const actions = await pmoContext.storage.listActions(filter)
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            actions: actions.map(a => ({
+              id: a.id,
+              name: a.name,
+              description: a.description,
+              fromIntent: a.fromIntent,
+              toIntent: a.toIntent,
+              executor: a.executor,
+              timeout: a.timeout,
+              isBuiltin: a.isBuiltin,
+              isDefault: a.isDefault,
+              modifiesCode: a.modifiesCode,
+            })),
+            count: actions.length,
+          },
+          createMetadata('action list', flags),
+        )
+        return
+      }
+
+      if (actions.length === 0) {
+        this.log(styles.info('No actions found.'))
+        return
+      }
+
+      this.log(styles.title('Actions'))
+      this.log('')
+
+      for (const action of actions) {
+        const builtinBadge = action.isBuiltin ? styles.muted('[built-in]') : styles.info('[custom]')
+        const defaultBadge = action.isDefault ? styles.success(' (default)') : ''
+        this.log(`  ${styles.code(action.id)} ${builtinBadge}${defaultBadge}`)
+        if (action.description) {
+          this.log(`    ${styles.muted(action.description)}`)
+        }
+        const intent = []
+        if (action.fromIntent) intent.push(`from: ${action.fromIntent}`)
+        if (action.toIntent) intent.push(`to: ${action.toIntent}`)
+        if (intent.length > 0) {
+          this.log(`    ${styles.muted(intent.join(' → '))}`)
+        }
+        this.log('')
+      }
+
+      this.log(divider(50))
+      this.log(styles.muted(`  ${actions.length} action${actions.length === 1 ? '' : 's'}`))
+    } finally {
+      await pmoContext.storage.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/action/run.ts
+++ b/apps/cli/src/commands/action/run.ts
@@ -1,0 +1,66 @@
+import { Args } from '@oclif/core'
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { getPMOContext } from '../../lib/pmo/pmo-context.js'
+import { setInternalAction } from '../../services/action-context.js'
+
+export default class ActionRun extends RuntimeCommand {
+  static description = 'Run an action on a ticket'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> implement PRLT-123',
+    '<%= config.bin %> <%= command.id %> groom PRLT-456',
+    '<%= config.bin %> <%= command.id %> review PRLT-789',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+  }
+
+  static args = {
+    name: Args.string({
+      description: 'Action name or ID to run',
+      required: true,
+    }),
+    ticket: Args.string({
+      description: 'Ticket ID to run the action on',
+      required: true,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ActionRun)
+    const jsonMode = shouldOutputJson(flags)
+
+    const pmoContext = await getPMOContext({
+      logger: (msg) => this.log(styles.muted(msg)),
+    })
+
+    try {
+      // Verify the action exists
+      const action = await pmoContext.storage.getAction(args.name)
+
+      if (!action) {
+        if (jsonMode) {
+          outputErrorAsJson('NOT_FOUND', `Action "${args.name}" not found.`, createMetadata('action run', flags))
+          return
+        }
+        this.error(`Action "${args.name}" not found.`)
+      }
+
+      // Delegate to work:start with the action set via internal context
+      setInternalAction(args.name)
+
+      this.log(styles.muted(`Running action "${action.name}" on ${args.ticket}...`))
+
+      await this.config.runCommand('work:start', [args.ticket])
+    } finally {
+      await pmoContext.storage.close()
+    }
+  }
+}

--- a/apps/cli/src/commands/action/show.ts
+++ b/apps/cli/src/commands/action/show.ts
@@ -1,0 +1,124 @@
+import { Args } from '@oclif/core'
+import { RuntimeCommand, runtimeBaseFlags } from '../../lib/runtime-command.js'
+import { styles, divider } from '../../lib/styles.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  outputErrorAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { getPMOContext } from '../../lib/pmo/pmo-context.js'
+
+export default class ActionShow extends RuntimeCommand {
+  static description = 'Show full action configuration and prompt'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> implement',
+    '<%= config.bin %> <%= command.id %> groom --json',
+  ]
+
+  static flags = {
+    ...runtimeBaseFlags,
+  }
+
+  static args = {
+    name: Args.string({
+      description: 'Action name or ID',
+      required: true,
+    }),
+  }
+
+  async execute(): Promise<void> {
+    const { args, flags } = await this.parse(ActionShow)
+    const jsonMode = shouldOutputJson(flags)
+
+    const pmoContext = await getPMOContext({
+      logger: (msg) => this.log(styles.muted(msg)),
+    })
+
+    try {
+      const action = await pmoContext.storage.getAction(args.name)
+
+      if (!action) {
+        if (jsonMode) {
+          outputErrorAsJson('NOT_FOUND', `Action "${args.name}" not found.`, createMetadata('action show', flags))
+          return
+        }
+        this.error(`Action "${args.name}" not found.`)
+      }
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          {
+            action: {
+              id: action.id,
+              name: action.name,
+              description: action.description,
+              prompt: action.prompt,
+              endPrompt: action.endPrompt,
+              fromIntent: action.fromIntent,
+              toIntent: action.toIntent,
+              executor: action.executor,
+              environment: action.environment,
+              permissionMode: action.permissionMode,
+              timeout: action.timeout,
+              model: action.model,
+              reviewGate: action.reviewGate,
+              networkAllowlist: action.networkAllowlist,
+              modifiesCode: action.modifiesCode,
+              isDefault: action.isDefault,
+              isBuiltin: action.isBuiltin,
+              position: action.position,
+              createdAt: action.createdAt?.toISOString(),
+              updatedAt: action.updatedAt?.toISOString(),
+            },
+          },
+          createMetadata('action show', flags),
+        )
+        return
+      }
+
+      const builtinBadge = action.isBuiltin ? styles.muted('[built-in]') : styles.info('[custom]')
+      this.log(`\n${styles.title('Action')} ${styles.emphasis(action.id)} ${builtinBadge}\n`)
+      this.log(`${styles.header('Name:')}          ${action.name}`)
+      if (action.description) {
+        this.log(`${styles.header('Description:')}   ${action.description}`)
+      }
+      this.log(`${styles.header('From Intent:')}   ${action.fromIntent || 'any'}`)
+      this.log(`${styles.header('To Intent:')}     ${action.toIntent || 'none'}`)
+      this.log(`${styles.header('Executor:')}      ${action.executor || 'workspace default'}`)
+      this.log(`${styles.header('Environment:')}   ${action.environment || 'workspace default'}`)
+      this.log(`${styles.header('Timeout:')}       ${action.timeout ? `${action.timeout}s` : 'default'}`)
+      this.log(`${styles.header('Modifies Code:')} ${action.modifiesCode ? 'yes' : 'no'}`)
+      this.log(`${styles.header('Default:')}       ${action.isDefault ? 'yes' : 'no'}`)
+      if (action.model) {
+        this.log(`${styles.header('Model:')}         ${action.model}`)
+      }
+      if (action.reviewGate) {
+        this.log(`${styles.header('Review Gate:')}   ${action.reviewGate}`)
+      }
+      if (action.permissionMode) {
+        this.log(`${styles.header('Permissions:')}   ${action.permissionMode}`)
+      }
+      if (action.networkAllowlist?.length) {
+        this.log(`${styles.header('Network:')}       ${action.networkAllowlist.join(', ')}`)
+      }
+
+      this.log(`\n${styles.header('Prompt:')}`)
+      this.log(divider(60))
+      this.log(action.prompt)
+      this.log(divider(60))
+
+      if (action.endPrompt) {
+        this.log(`\n${styles.header('End Prompt:')}`)
+        this.log(divider(60))
+        this.log(action.endPrompt)
+        this.log(divider(60))
+      }
+
+      this.log('')
+    } finally {
+      await pmoContext.storage.close()
+    }
+  }
+}

--- a/apps/cli/src/lib/pmo/storage/actions.ts
+++ b/apps/cli/src/lib/pmo/storage/actions.ts
@@ -216,6 +216,44 @@ export class ActionStorage {
   }
 
   /**
+   * Update a built-in action's prompt and metadata.
+   * Built-in actions can be customized (prompt, description, timeout, etc.)
+   * but cannot be renamed or deleted.
+   */
+  async updateBuiltinAction(id: string, changes: Record<string, unknown>): Promise<WorkAction> {
+    const existing = await this.getAction(id)
+    if (!existing) {
+      throw new PMOError('NOT_FOUND', `Action not found: ${id}`)
+    }
+
+    if (!existing.isBuiltin) {
+      // Non-builtin actions should use updateAction
+      return this.updateAction(id, changes as Partial<WorkAction>)
+    }
+
+    const updateValues: Record<string, unknown> = {}
+
+    if (changes.prompt !== undefined) updateValues.prompt = changes.prompt
+    if (changes.endPrompt !== undefined) updateValues.endPrompt = changes.endPrompt || null
+    if (changes.description !== undefined) updateValues.description = changes.description || null
+    if (changes.fromIntent !== undefined) updateValues.fromIntent = changes.fromIntent || null
+    if (changes.toIntent !== undefined) updateValues.toIntent = changes.toIntent || null
+    if (changes.executor !== undefined) updateValues.executor = changes.executor || null
+    if (changes.timeout !== undefined) updateValues.timeout = changes.timeout || null
+
+    if (Object.keys(updateValues).length > 0) {
+      updateValues.updatedAt = new Date().toISOString()
+      this.ctx.drizzle
+        .update(pmoActions)
+        .set(updateValues)
+        .where(eq(pmoActions.id, id))
+        .run()
+    }
+
+    return (await this.getAction(id))!
+  }
+
+  /**
    * Delete a work action.
    */
   async deleteAction(id: string): Promise<void> {

--- a/apps/cli/src/lib/pmo/storage/index.ts
+++ b/apps/cli/src/lib/pmo/storage/index.ts
@@ -196,6 +196,10 @@ export class SQLiteStorage {
     return this.actionStorage.deleteAction(id)
   }
 
+  async updateBuiltinAction(id: string, changes: Record<string, unknown>): Promise<WorkAction> {
+    return this.actionStorage.updateBuiltinAction(id, changes)
+  }
+
   async getSuggestedAction(stateName: string): Promise<WorkAction | null> {
     return this.actionStorage.getSuggestedAction(stateName)
   }

--- a/apps/cli/test/unit/action-commands.test.ts
+++ b/apps/cli/test/unit/action-commands.test.ts
@@ -1,0 +1,351 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import { SQLiteStorage } from '../../src/lib/pmo/storage-sqlite.js'
+import type { WorkAction, WorkActionFilter } from '../../src/lib/pmo/types.js'
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createTestDb(): { storage: SQLiteStorage; db: Database.Database; testDir: string } {
+  const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'action-commands-test-'))
+  const dbPath = path.join(testDir, 'test.db')
+
+  const initDb = new Database(dbPath)
+  initDb.close()
+
+  const storage = new SQLiteStorage(dbPath)
+  const db = storage.getDatabase()
+
+  return { storage, db, testDir }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Action Commands — Storage Layer', () => {
+  let db: Database.Database
+  let testDir: string
+  let storage: SQLiteStorage
+
+  beforeEach(() => {
+    const result = createTestDb()
+    db = result.db
+    testDir = result.testDir
+    storage = result.storage
+  })
+
+  afterEach(() => {
+    try { db.close() } catch { /* */ }
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  // ─── action list ──────────────────────────────────────────
+
+  describe('listActions', () => {
+    it('returns all seeded built-in actions', async () => {
+      const actions = await storage.listActions()
+      expect(actions.length).to.be.greaterThanOrEqual(5)
+
+      const names = actions.map(a => a.id)
+      expect(names).to.include('groom')
+      expect(names).to.include('implement')
+      expect(names).to.include('review')
+      expect(names).to.include('merge')
+      expect(names).to.include('resolve')
+    })
+
+    it('filters by isBuiltin=true', async () => {
+      await storage.createAction({
+        name: 'custom-deploy',
+        prompt: 'Deploy the app',
+        isBuiltin: false,
+      })
+
+      const builtins = await storage.listActions({ isBuiltin: true })
+      expect(builtins.every(a => a.isBuiltin)).to.be.true
+    })
+
+    it('filters by isBuiltin=false', async () => {
+      await storage.createAction({
+        name: 'custom-lint',
+        prompt: 'Run the linter',
+        isBuiltin: false,
+      })
+
+      const customs = await storage.listActions({ isBuiltin: false })
+      expect(customs.length).to.be.greaterThanOrEqual(1)
+      expect(customs.every(a => !a.isBuiltin)).to.be.true
+    })
+
+    it('filters by search string', async () => {
+      const results = await storage.listActions({ search: 'groom' })
+      expect(results.length).to.be.greaterThanOrEqual(1)
+      expect(results[0].id).to.equal('groom')
+    })
+  })
+
+  // ─── action show ──────────────────────────────────────────
+
+  describe('getAction', () => {
+    it('returns full action config for built-in', async () => {
+      const action = await storage.getAction('implement')
+      expect(action).to.exist
+      expect(action!.id).to.equal('implement')
+      expect(action!.name).to.equal('Implement')
+      expect(action!.prompt).to.be.a('string').and.not.empty
+      expect(action!.isBuiltin).to.be.true
+    })
+
+    it('returns null for non-existent action', async () => {
+      const action = await storage.getAction('nonexistent-action-xyz')
+      expect(action).to.be.null
+    })
+  })
+
+  // ─── action create ──────────────��─────────────────────────
+
+  describe('createAction', () => {
+    it('creates a new custom action', async () => {
+      const action = await storage.createAction({
+        name: 'deploy',
+        prompt: 'Deploy to staging',
+        description: 'Deploy changes to staging environment',
+      })
+
+      expect(action.id).to.equal('deploy')
+      expect(action.name).to.equal('deploy')
+      expect(action.prompt).to.equal('Deploy to staging')
+      expect(action.isBuiltin).to.be.false
+    })
+
+    it('rejects duplicate names', async () => {
+      await storage.createAction({
+        name: 'my-action',
+        prompt: 'Do something',
+      })
+
+      try {
+        await storage.createAction({
+          name: 'my-action',
+          prompt: 'Do something else',
+        })
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('already exists')
+      }
+    })
+
+    it('requires name', async () => {
+      try {
+        await storage.createAction({ prompt: 'test' })
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('name is required')
+      }
+    })
+
+    it('requires prompt', async () => {
+      try {
+        await storage.createAction({ name: 'test' })
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('prompt is required')
+      }
+    })
+
+    it('creates action with intent wiring', async () => {
+      const action = await storage.createAction({
+        name: 'deploy-action',
+        prompt: 'Deploy it',
+        fromIntent: 'started',
+        toIntent: 'needs_review',
+      })
+
+      expect(action.fromIntent).to.equal('started')
+      expect(action.toIntent).to.equal('needs_review')
+    })
+  })
+
+  // ─── action delete ───────────────��───────────────────────���
+
+  describe('deleteAction', () => {
+    it('deletes a custom action', async () => {
+      await storage.createAction({
+        name: 'temp-action',
+        prompt: 'Temporary',
+      })
+
+      const before = await storage.getAction('temp-action')
+      expect(before).to.exist
+
+      await storage.deleteAction('temp-action')
+
+      const after = await storage.getAction('temp-action')
+      expect(after).to.be.null
+    })
+
+    it('refuses to delete built-in actions', async () => {
+      try {
+        await storage.deleteAction('implement')
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('built-in')
+      }
+    })
+
+    it('throws for non-existent action', async () => {
+      try {
+        await storage.deleteAction('ghost-action')
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('not found')
+      }
+    })
+  })
+
+  // ─── action edit (updateAction / updateBuiltinAction) ─────
+
+  describe('updateAction (custom)', () => {
+    it('updates prompt for custom action', async () => {
+      await storage.createAction({
+        name: 'edit-test',
+        prompt: 'Original prompt',
+      })
+
+      const updated = await storage.updateAction('edit-test', {
+        prompt: 'Updated prompt',
+      })
+
+      expect(updated.prompt).to.equal('Updated prompt')
+    })
+
+    it('updates description for custom action', async () => {
+      await storage.createAction({
+        name: 'desc-test',
+        prompt: 'Test prompt',
+        description: 'Old desc',
+      })
+
+      const updated = await storage.updateAction('desc-test', {
+        description: 'New description',
+      })
+
+      expect(updated.description).to.equal('New description')
+    })
+
+    it('refuses to update built-in action via updateAction', async () => {
+      try {
+        await storage.updateAction('implement', { prompt: 'Hacked prompt' })
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('built-in')
+      }
+    })
+  })
+
+  describe('updateBuiltinAction', () => {
+    it('updates prompt for built-in action', async () => {
+      const original = await storage.getAction('groom')
+      expect(original).to.exist
+
+      const updated = await storage.updateBuiltinAction('groom', {
+        prompt: 'Custom groom prompt for this workspace',
+      })
+
+      expect(updated.prompt).to.equal('Custom groom prompt for this workspace')
+      expect(updated.isBuiltin).to.be.true
+      expect(updated.id).to.equal('groom')
+    })
+
+    it('updates description for built-in action', async () => {
+      const updated = await storage.updateBuiltinAction('implement', {
+        description: 'Custom description',
+      })
+
+      expect(updated.description).to.equal('Custom description')
+      expect(updated.isBuiltin).to.be.true
+    })
+
+    it('throws for non-existent action', async () => {
+      try {
+        await storage.updateBuiltinAction('nope', { prompt: 'test' })
+        expect.fail('Should have thrown')
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('not found')
+      }
+    })
+
+    it('delegates to updateAction for non-builtin actions', async () => {
+      await storage.createAction({
+        name: 'custom-for-builtin-test',
+        prompt: 'Original',
+      })
+
+      const updated = await storage.updateBuiltinAction('custom-for-builtin-test', {
+        prompt: 'Updated via builtin method',
+      })
+
+      expect(updated.prompt).to.equal('Updated via builtin method')
+    })
+  })
+
+  // ─── action run (action lookup) ───────────────────────────
+
+  describe('getSuggestedAction', () => {
+    it('returns default action for backlog intent', async () => {
+      const action = await storage.getSuggestedAction('backlog')
+      expect(action).to.exist
+      expect(action!.id).to.equal('groom')
+    })
+
+    it('returns default action for ready intent', async () => {
+      const action = await storage.getSuggestedAction('ready')
+      expect(action).to.exist
+      expect(action!.id).to.equal('implement')
+    })
+
+    it('returns null for unknown intent without any matching actions', async () => {
+      const action = await storage.getSuggestedAction('nonexistent-intent-xyz')
+      // May return a fallback action with null from_intent or null
+      // The exact behavior depends on whether any actions have null from_intent
+    })
+  })
+
+  // ─── built-in actions are seeded correctly ────────────────
+
+  describe('built-in action seeding', () => {
+    it('seeds 5 built-in actions: groom, implement, review, merge, resolve', async () => {
+      const builtins = await storage.listActions({ isBuiltin: true })
+      const ids = builtins.map(a => a.id)
+
+      expect(ids).to.include('groom')
+      expect(ids).to.include('implement')
+      expect(ids).to.include('review')
+      expect(ids).to.include('merge')
+      expect(ids).to.include('resolve')
+    })
+
+    it('built-in actions have non-empty prompts', async () => {
+      const builtins = await storage.listActions({ isBuiltin: true })
+      for (const action of builtins) {
+        expect(action.prompt, `${action.id} should have a prompt`).to.be.a('string').and.not.empty
+      }
+    })
+
+    it('re-seeding is idempotent (no duplicate errors)', () => {
+      // Creating a second storage instance on the same DB triggers re-seeding
+      const dbPath = path.join(testDir, 'test.db')
+      const storage2 = new SQLiteStorage(dbPath)
+      const db2 = storage2.getDatabase()
+      // Should not throw
+      db2.close()
+    })
+  })
+})

--- a/docs/flags-audit.md
+++ b/docs/flags-audit.md
@@ -168,8 +168,11 @@
 
 | Namespace | Commands | Notes |
 |-----------|----------|-------|
+| `action` | 7 (index, list, show, create, edit, delete, run) | Action management |
+| `db` | 1 (index) | Database management |
 | `docker` | 12 (index, start, stop, restart, list, logs, shell, status, clean, prune, sync, rebuild-cache) | Full container management |
 | `execution` | 6 (index, list, view, logs, stop, config) | Execution lifecycle |
+| `gateway` | 1+ | Gateway management |
 | `branch` | 5 (index, create, list, validate, where) | Branch naming |
 | `sync` | 7 (index, start, stop, status, pause, resume, queue) | Board sync daemon |
 | `config` | 1 | Workspace settings |


### PR DESCRIPTION
## Summary

Implements the `prlt action` command namespace, making actions discoverable and editable via CLI.

### New Commands
- `prlt action list` — List all actions (built-in and custom) with filtering
- `prlt action show <name>` — Show full action config, prompt, and metadata
- `prlt action edit <name>` — Edit action prompt in $EDITOR or via --prompt flag
- `prlt action create <name>` — Add a new custom action with flags
- `prlt action delete <name>` — Remove custom actions (refuses on built-ins)
- `prlt action run <name> <ticket>` — Run an action on a ticket (delegates to work:start)

### Storage Changes
- Added `updateBuiltinAction()` to ActionStorage and SQLiteStorage facade for editing built-in action prompts
- All data stays in SQLite (pmo_actions table) — no file-based storage

### Other
- Updated flags-audit.md with action, gateway, and db command namespaces
- All commands support --json mode for AI agent compatibility
- 27 new unit tests covering all storage operations

## Acceptance Criteria
- [x] prlt action list shows all actions
- [x] prlt action show <name> shows full config + prompt
- [x] prlt action edit <name> opens in $EDITOR, saves back to DB
- [x] prlt action create <name> adds a new custom action
- [x] prlt action delete <name> removes custom actions (refuses on built-ins)
- [x] prlt action run <name> <ticket> invokes the action
- [x] All existing work commands still function (they call actions internally)
- [x] prlt init copies built-in actions into workspace DB if not present (existing seedBuiltinActions)

## Test plan
- [x] Unit tests: 27 tests covering list, show, create, delete, edit, update built-in, and seeding
- [x] Manual CLI verification of all 6 subcommands
- [x] Existing intent-based action tests still pass (26/26)
- [x] Build passes with no TS errors

Linear: PRLT-1315