### PR TITLE
fix(PRLT-1330): Homebrew ABI mismatch auto-rebuild + formula auto-update reliability

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Wait for npm CDN propagation when triggered by publish workflow.
+      # The tarball is usually available within 30-60s of publish, but can
+      # take longer during npm registry congestion.
+      - name: Wait for npm CDN propagation
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: sleep 60
+
       - name: Resolve version
         id: version
         run: |

--- a/apps/cli/src/lib/database/native-validation.ts
+++ b/apps/cli/src/lib/database/native-validation.ts
@@ -1,3 +1,7 @@
+import { execSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
 export interface BetterSqlite3RuntimeInfo {
   nodeVersion: string
   nodeMajor: number | null
@@ -10,6 +14,16 @@ export interface BetterSqlite3RuntimeInfo {
 export interface BetterSqlite3ValidationOptions {
   context: string
   loadModule?: () => Promise<{ default: new (path: string) => BetterSqlite3DatabaseLike }>
+  /**
+   * When true, skip auto-rebuild on ABI mismatch. Used to prevent infinite
+   * recursion when the rebuild itself fails.
+   */
+  skipAutoRebuild?: boolean
+  /**
+   * Override for the rebuild command executor. Defaults to execSync.
+   * Injected in tests.
+   */
+  execRebuild?: (cmd: string, opts: { cwd: string; stdio: 'pipe' }) => void
 }
 
 interface BetterSqlite3DatabaseLike {
@@ -98,6 +112,17 @@ function isBunNodeGypError(error: unknown): boolean {
 }
 
 /**
+ * Detect whether an error is specifically an ABI / NODE_MODULE_VERSION mismatch,
+ * which is the class of error that an `npm rebuild` can fix.
+ */
+export function isAbiMismatchError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const msg = error.message.toLowerCase()
+  return msg.includes('node_module_version') ||
+    msg.includes('was compiled against a different node.js version')
+}
+
+/**
  * Detect whether an error is caused by a missing or incompatible better-sqlite3
  * native binding (.node file) rather than a normal SQLite operational error.
  *
@@ -141,6 +166,54 @@ export function throwIfNativeBindingError(error: unknown, context: string): void
   }
 }
 
+/**
+ * Locate the package directory containing better-sqlite3.
+ * Walks up from this file's dirname looking for node_modules/better-sqlite3.
+ * Returns the package root that owns the node_modules, or null.
+ */
+export function findBetterSqlite3InstallDir(): string | null {
+  let dir = __dirname
+  for (let i = 0; i < 20; i++) {
+    const candidate = path.join(dir, 'node_modules', 'better-sqlite3')
+    if (fs.existsSync(candidate)) {
+      return dir
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+/**
+ * Attempt to rebuild better-sqlite3 against the running Node ABI.
+ * Returns true if the rebuild command succeeded, false otherwise.
+ */
+export function attemptAutoRebuild(options: BetterSqlite3ValidationOptions): boolean {
+  const installDir = findBetterSqlite3InstallDir()
+  if (!installDir) {
+    return false
+  }
+
+  const exec = options.execRebuild ?? ((cmd: string, opts: { cwd: string; stdio: 'pipe' }) => execSync(cmd, opts))
+
+  try {
+    process.stderr.write(
+      `\x1b[33mABI mismatch detected \u2014 rebuilding better-sqlite3 for Node ${process.version}\u2026\x1b[0m\n`
+    )
+    exec('npm rebuild better-sqlite3', { cwd: installDir, stdio: 'pipe' })
+    process.stderr.write(
+      `\x1b[32mRebuild complete.\x1b[0m\n`
+    )
+    return true
+  } catch {
+    process.stderr.write(
+      `\x1b[31mAuto-rebuild failed. Run manually: cd ${installDir} && npm rebuild better-sqlite3\x1b[0m\n`
+    )
+    return false
+  }
+}
+
 export async function validateBetterSqlite3NativeBinding(options: BetterSqlite3ValidationOptions): Promise<void> {
   const loadModule = options.loadModule ?? (async () => import('better-sqlite3'))
   const runtime = getBetterSqlite3RuntimeInfo()
@@ -152,6 +225,19 @@ export async function validateBetterSqlite3NativeBinding(options: BetterSqlite3V
     db.pragma('foreign_keys = ON')
     db.close()
   } catch (error) {
+    // If this is an ABI mismatch and auto-rebuild hasn't been attempted yet,
+    // try to rebuild better-sqlite3 against the current Node version.
+    if (!options.skipAutoRebuild && isAbiMismatchError(error)) {
+      const rebuilt = attemptAutoRebuild(options)
+      if (rebuilt) {
+        // Rebuild succeeded — re-validate (with skipAutoRebuild to prevent loop)
+        return validateBetterSqlite3NativeBinding({
+          ...options,
+          skipAutoRebuild: true,
+        })
+      }
+    }
+
     throw new Error(buildBetterSqlite3ValidationMessage(error, runtime, options.context))
   }
 }

--- a/apps/cli/src/lib/database/native-validation.ts
+++ b/apps/cli/src/lib/database/native-validation.ts
@@ -45,7 +45,7 @@ function parseNodeMajor(version: string): number | null {
  */
 function detectBunRuntime(): boolean {
   return typeof (process.versions as Record<string, string | undefined>).bun === 'string'
-    || typeof (globalThis as Record<string, unknown>).Bun !== 'undefined'
+    || (globalThis as Record<string, unknown>).Bun !== undefined
 }
 
 export function getBetterSqlite3RuntimeInfo(): BetterSqlite3RuntimeInfo {
@@ -200,16 +200,16 @@ export function attemptAutoRebuild(options: BetterSqlite3ValidationOptions): boo
 
   try {
     process.stderr.write(
-      `\x1b[33mABI mismatch detected \u2014 rebuilding better-sqlite3 for Node ${process.version}\u2026\x1b[0m\n`
+      `\u001B[33mABI mismatch detected \u2014 rebuilding better-sqlite3 for Node ${process.version}\u2026\u001B[0m\n`
     )
     exec('npm rebuild better-sqlite3', { cwd: installDir, stdio: 'pipe' })
     process.stderr.write(
-      `\x1b[32mRebuild complete.\x1b[0m\n`
+      `\u001B[32mRebuild complete.\u001B[0m\n`
     )
     return true
   } catch {
     process.stderr.write(
-      `\x1b[31mAuto-rebuild failed. Run manually: cd ${installDir} && npm rebuild better-sqlite3\x1b[0m\n`
+      `\u001B[31mAuto-rebuild failed. Run manually: cd ${installDir} && npm rebuild better-sqlite3\u001B[0m\n`
     )
     return false
   }

--- a/apps/cli/src/lib/database/native-validation.ts
+++ b/apps/cli/src/lib/database/native-validation.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 export interface BetterSqlite3RuntimeInfo {
   nodeVersion: string
@@ -172,7 +173,7 @@ export function throwIfNativeBindingError(error: unknown, context: string): void
  * Returns the package root that owns the node_modules, or null.
  */
 export function findBetterSqlite3InstallDir(): string | null {
-  let dir = __dirname
+  let dir = path.dirname(fileURLToPath(import.meta.url))
   for (let i = 0; i < 20; i++) {
     const candidate = path.join(dir, 'node_modules', 'better-sqlite3')
     if (fs.existsSync(candidate)) {

--- a/apps/cli/test/unit/native-validation.test.ts
+++ b/apps/cli/test/unit/native-validation.test.ts
@@ -1,8 +1,13 @@
 import { expect } from 'chai'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
 import {
   buildBetterSqlite3ValidationMessage,
   isBetterSqlite3NativeError,
+  isAbiMismatchError,
   validateBetterSqlite3NativeBinding,
+  attemptAutoRebuild,
+  findBetterSqlite3InstallDir,
 } from '../../src/lib/database/native-validation.js'
 
 describe('better-sqlite3 native validation', () => {
@@ -86,5 +91,193 @@ describe('better-sqlite3 native validation', () => {
     expect(capturedError!.message).to.include('test bootstrap')
     expect(capturedError!.message).to.include('dlopen failure')
     expect(capturedError!.message).to.include('Fix steps:')
+  })
+})
+
+describe('isAbiMismatchError', () => {
+  it('detects NODE_MODULE_VERSION mismatch', () => {
+    const error = new Error(
+      'The module was compiled against NODE_MODULE_VERSION 127. ' +
+      'This version of Node.js requires NODE_MODULE_VERSION 141.'
+    )
+    expect(isAbiMismatchError(error)).to.be.true
+  })
+
+  it('detects "compiled against a different Node.js version"', () => {
+    const error = new Error('was compiled against a different Node.js version')
+    expect(isAbiMismatchError(error)).to.be.true
+  })
+
+  it('returns false for non-ABI errors', () => {
+    expect(isAbiMismatchError(new Error('dlopen failure'))).to.be.false
+    expect(isAbiMismatchError(new Error('MODULE_NOT_FOUND'))).to.be.false
+    expect(isAbiMismatchError('not an error')).to.be.false
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isAbiMismatchError(null)).to.be.false
+    expect(isAbiMismatchError(undefined)).to.be.false
+    expect(isAbiMismatchError(42)).to.be.false
+  })
+})
+
+describe('attemptAutoRebuild', () => {
+  it('returns false when install dir is not found', () => {
+    // findBetterSqlite3InstallDir walks from __dirname, but we can test
+    // the rebuild path by providing an execRebuild that should never be called
+    let execCalled = false
+    const result = attemptAutoRebuild({
+      context: 'test',
+      execRebuild: () => { execCalled = true },
+    })
+    // If install dir is found (we're running from the repo), the exec will be called
+    // Either way, the function should return a boolean
+    expect(typeof result).to.equal('boolean')
+    // We can't guarantee install dir is/isn't found in test, so just verify no crash
+  })
+
+  it('calls execRebuild with correct command when install dir exists', () => {
+    // Since we're running from the repo, better-sqlite3 should be findable
+    const installDir = findBetterSqlite3InstallDir()
+    if (!installDir) {
+      // Skip if running in an environment without better-sqlite3
+      return
+    }
+
+    let capturedCmd = ''
+    let capturedCwd = ''
+    const result = attemptAutoRebuild({
+      context: 'test',
+      execRebuild: (cmd, opts) => {
+        capturedCmd = cmd
+        capturedCwd = opts.cwd
+      },
+    })
+
+    expect(result).to.be.true
+    expect(capturedCmd).to.equal('npm rebuild better-sqlite3')
+    expect(capturedCwd).to.equal(installDir)
+  })
+
+  it('returns false when execRebuild throws', () => {
+    const installDir = findBetterSqlite3InstallDir()
+    if (!installDir) {
+      return
+    }
+
+    const result = attemptAutoRebuild({
+      context: 'test',
+      execRebuild: () => { throw new Error('rebuild failed') },
+    })
+
+    expect(result).to.be.false
+  })
+})
+
+describe('validateBetterSqlite3NativeBinding with auto-rebuild', () => {
+  it('attempts auto-rebuild on ABI mismatch error', async () => {
+    let rebuildAttempted = false
+    let loadCount = 0
+
+    try {
+      await validateBetterSqlite3NativeBinding({
+        context: 'abi-test',
+        loadModule: async () => {
+          loadCount++
+          throw new Error(
+            'The module was compiled against NODE_MODULE_VERSION 127. ' +
+            'This version of Node.js requires NODE_MODULE_VERSION 141.'
+          )
+        },
+        execRebuild: () => { rebuildAttempted = true },
+      })
+    } catch {
+      // Expected to throw after rebuild fails to fix the issue
+    }
+
+    expect(rebuildAttempted).to.be.true
+    // Should have tried loading twice: once before rebuild, once after
+    expect(loadCount).to.equal(2)
+  })
+
+  it('does not attempt auto-rebuild for non-ABI errors', async () => {
+    let rebuildAttempted = false
+
+    try {
+      await validateBetterSqlite3NativeBinding({
+        context: 'non-abi-test',
+        loadModule: async () => {
+          throw new Error('Could not locate the bindings file')
+        },
+        execRebuild: () => { rebuildAttempted = true },
+      })
+    } catch {
+      // Expected to throw
+    }
+
+    expect(rebuildAttempted).to.be.false
+  })
+
+  it('skips auto-rebuild when skipAutoRebuild is true', async () => {
+    let rebuildAttempted = false
+
+    try {
+      await validateBetterSqlite3NativeBinding({
+        context: 'skip-test',
+        skipAutoRebuild: true,
+        loadModule: async () => {
+          throw new Error(
+            'The module was compiled against NODE_MODULE_VERSION 127.'
+          )
+        },
+        execRebuild: () => { rebuildAttempted = true },
+      })
+    } catch {
+      // Expected to throw
+    }
+
+    expect(rebuildAttempted).to.be.false
+  })
+
+  it('succeeds after rebuild fixes the ABI mismatch', async () => {
+    let loadCount = 0
+
+    // First load fails with ABI mismatch, second load succeeds (simulating rebuild fix)
+    await validateBetterSqlite3NativeBinding({
+      context: 'fix-test',
+      loadModule: async () => {
+        loadCount++
+        if (loadCount === 1) {
+          throw new Error(
+            'The module was compiled against NODE_MODULE_VERSION 127.'
+          )
+        }
+        // Second call succeeds
+        return {
+          default: class MockDB {
+            pragma() { return null }
+            close() {}
+          } as unknown as new (path: string) => { pragma(sql: string): unknown; close(): void },
+        }
+      },
+      execRebuild: () => { /* simulate successful rebuild */ },
+    })
+
+    expect(loadCount).to.equal(2)
+  })
+})
+
+describe('findBetterSqlite3InstallDir', () => {
+  it('returns a string or null', () => {
+    const result = findBetterSqlite3InstallDir()
+    expect(result === null || typeof result === 'string').to.be.true
+  })
+
+  it('returned dir contains node_modules/better-sqlite3 when non-null', () => {
+    const result = findBetterSqlite3InstallDir()
+    if (result !== null) {
+      const candidate = path.join(result, 'node_modules', 'better-sqlite3')
+      expect(fs.existsSync(candidate)).to.be.true
+    }
   })
 })

--- a/docs/homebrew-verification.md
+++ b/docs/homebrew-verification.md
@@ -6,67 +6,64 @@ Verification evidence for `prlt` Homebrew formula across macOS architectures.
 
 - **Tap:** `chrismcdermut/proletariat`
 - **Formula:** `prlt`
-- **Version:** 0.3.36
-- **Source:** `https://registry.npmjs.org/@proletariat/cli/-/cli-0.3.36.tgz`
-- **SHA256:** `93659cc1c8dda29735895baf1be55515158ad3632c7320b4cc8ba64913fa1b34`
+- **Source:** `https://registry.npmjs.org/@proletariat/cli/-/cli-{VERSION}.tgz`
 - **License:** Apache-2.0
 - **Dependency:** `node` (Homebrew-managed)
+
+## Node Version Compatibility
+
+The formula installs Homebrew's Node as a dependency but rebuilds `better-sqlite3`
+against whatever Node is on PATH at install time. This means:
+
+- If the user has nvm/fnm active, `post_install` builds against their chosen Node
+- If no nvm/fnm is active, it uses Homebrew's Node (default)
+
+### Runtime ABI Self-Healing
+
+If the user switches Node versions after installation (e.g. via `nvm use`), prlt
+detects the ABI mismatch at startup and automatically runs `npm rebuild better-sqlite3`
+to recompile the native module for the new Node version. This is transparent and
+requires no manual intervention.
 
 ## Architecture Support
 
 ### macOS arm64 (Apple Silicon)
 
-The formula installs via `npm install` with Homebrew's Node.js. All native dependencies (notably `better-sqlite3`) use `prebuild-install` which provides prebuilt binaries for `darwin-arm64`.
-
-**Verification:**
-
 ```
 $ brew install chrismcdermut/proletariat/prlt
 ==> Fetching chrismcdermut/proletariat/prlt
 ==> Installing prlt from chrismcdermut/proletariat
-==> npm install --global --prefix=/opt/homebrew/Cellar/prlt/0.3.36/libexec ...
+==> npm install --global --prefix=/opt/homebrew/Cellar/prlt/{VERSION}/libexec ...
 $ prlt --version
-@proletariat/cli/0.3.36 darwin-arm64 node-v22.x.x
-$ file $(which prlt)
-/opt/homebrew/bin/prlt: ... symbolic link
+@proletariat/cli/{VERSION} darwin-arm64 node-v{XX}.x.x
 ```
 
 - Homebrew prefix: `/opt/homebrew` (arm64 default)
 - Native module `better-sqlite3` compiles/prebuilds for `darwin-arm64`
-- `prebuild-install` downloads prebuilt `.node` binary; falls back to `node-gyp rebuild` if unavailable
 
 ### macOS x86_64 (Intel)
-
-Same formula, same install path. Homebrew on Intel uses `/usr/local` prefix.
-
-**Verification:**
 
 ```
 $ brew install chrismcdermut/proletariat/prlt
 ==> Fetching chrismcdermut/proletariat/prlt
 ==> Installing prlt from chrismcdermut/proletariat
-==> npm install --global --prefix=/usr/local/Cellar/prlt/0.3.36/libexec ...
+==> npm install --global --prefix=/usr/local/Cellar/prlt/{VERSION}/libexec ...
 $ prlt --version
-@proletariat/cli/0.3.36 darwin-x64 node-v22.x.x
-$ file $(which prlt)
-/usr/local/bin/prlt: ... symbolic link
+@proletariat/cli/{VERSION} darwin-x64 node-v{XX}.x.x
 ```
 
 - Homebrew prefix: `/usr/local` (x86_64 default)
 - Native module `better-sqlite3` compiles/prebuilds for `darwin-x64`
-- `prebuild-install` downloads prebuilt `.node` binary; falls back to `node-gyp rebuild` if unavailable
 
-## Integrity Verification
+## Auto-Update
 
-| Check | Result |
-|-------|--------|
-| Formula URL matches npm registry | `https://registry.npmjs.org/@proletariat/cli/-/cli-0.3.36.tgz` |
-| SHA256 matches downloaded tarball | `93659cc1c8dda29735895baf1be55515158ad3632c7320b4cc8ba64913fa1b34` |
-| Formula version matches npm `latest` | `0.3.36` |
-| No bundled native binaries in tarball | Confirmed — native deps built at install time |
-| `better-sqlite3` uses `prebuild-install` | Confirmed — prebuilt binaries for darwin-arm64 and darwin-x64 |
-| Formula `depends_on "node"` | Confirmed |
-| Formula test block verifies `--version` | Confirmed |
+The Homebrew formula is automatically updated within minutes of every npm publish:
+
+1. The `publish` workflow publishes to npm
+2. The `bump homebrew formula` workflow triggers on publish completion
+3. It waits 60s for npm CDN propagation, then fetches the tarball with exponential backoff
+4. The formula is updated with the new version, URL, and SHA256
+5. The change is pushed directly to the tap repository
 
 ## Upgrade Path
 

--- a/scripts/bump-homebrew-formula.sh
+++ b/scripts/bump-homebrew-formula.sh
@@ -37,9 +37,9 @@ echo "==> Bumping Homebrew formula to version ${VERSION}"
 TARBALL_URL="https://registry.npmjs.org/${NPM_PACKAGE}/-/cli-${VERSION}.tgz"
 echo "==> Fetching tarball: ${TARBALL_URL}"
 
-# Retry a few times — the tarball may not be available immediately after publish
-MAX_RETRIES=5
-RETRY_DELAY=10
+# Retry with exponential backoff — npm CDN can take 60-90s to propagate
+MAX_RETRIES=6
+RETRY_DELAY=15
 for i in $(seq 1 "$MAX_RETRIES"); do
   HTTP_CODE=$(curl -s -o /tmp/prlt-tarball.tgz -w '%{http_code}' -L "$TARBALL_URL")
   if [ "$HTTP_CODE" = "200" ]; then
@@ -51,6 +51,8 @@ for i in $(seq 1 "$MAX_RETRIES"); do
   fi
   echo "    Tarball not ready (HTTP ${HTTP_CODE}), retrying in ${RETRY_DELAY}s… (${i}/${MAX_RETRIES})"
   sleep "$RETRY_DELAY"
+  # Exponential backoff: 15, 30, 60, 120, 240
+  RETRY_DELAY=$((RETRY_DELAY * 2))
 done
 
 SHA256=$(shasum -a 256 /tmp/prlt-tarball.tgz | awk '{print $1}')
@@ -81,10 +83,10 @@ fi
 
 echo "==> Updating formula…"
 
-# Write the complete formula to ensure post_install is always present.
-# Homebrew's std_npm_args passes --ignore-scripts by default, which prevents
-# better-sqlite3's native module from being compiled. The post_install step
-# rebuilds the native module after npm install completes.
+# The formula uses `depends_on "node"` as recommended (not required).
+# This installs Homebrew's Node but doesn't fail if the user prefers nvm/fnm.
+# The post_install rebuilds better-sqlite3 against whatever Node is on PATH.
+# The CLI also has a runtime ABI check that auto-rebuilds on version mismatch.
 cat > "$FORMULA_FILE" <<FORMULA
 class Prlt < Formula
   desc "Agent orchestration platform for AI labor"
@@ -97,21 +99,32 @@ class Prlt < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink Dir["\#{libexec}/bin/*"]
   end
 
   def post_install
     # Homebrew's std_npm_args uses --ignore-scripts, which skips better-sqlite3's
-    # native module compilation. Rebuild it here so the CLI can use SQLite.
+    # native module compilation. Rebuild it against the Node currently on PATH
+    # (which may be the user's nvm/fnm Node rather than Homebrew's).
     cd libexec/"lib/node_modules/@proletariat/cli" do
       system "npm", "rebuild", "better-sqlite3"
     end
   end
 
+  def caveats
+    <<~EOS
+      If you switch Node versions (e.g. via nvm or fnm), prlt will
+      automatically rebuild its native modules on the next run.
+
+      To manually rebuild:
+        cd \#{libexec}/lib/node_modules/@proletariat/cli && npm rebuild better-sqlite3
+    EOS
+  end
+
   test do
-    assert_match version.to_s, shell_output("#{bin}/prlt --version")
+    assert_match version.to_s, shell_output("\#{bin}/prlt --version")
     # Verify better-sqlite3 native module works by creating an HQ (uses SQLite)
-    assert_match '"success": true', shell_output("#{bin}/prlt new --json --name test-hq --no-pmo")
+    assert_match '"success": true', shell_output("\#{bin}/prlt new --json --name test-hq --no-pmo")
   end
 end
 FORMULA


### PR DESCRIPTION
## Summary

Fixes two issues with the Homebrew formula:

1. **ABI mismatch self-healing**: When the user switches Node versions (via nvm/fnm), the `better-sqlite3` native module crashes with `NODE_MODULE_VERSION` mismatch. Now prlt detects this at startup and automatically runs `npm rebuild better-sqlite3` to recompile against the current Node — no manual intervention needed.

2. **Formula auto-update reliability**: Added 60s CDN propagation delay before the homebrew bump workflow attempts to fetch the tarball, plus exponential backoff (15s → 240s over 6 retries) in the bump script itself.

### Changes

- **`apps/cli/src/lib/database/native-validation.ts`**: Added `isAbiMismatchError()`, `findBetterSqlite3InstallDir()`, and `attemptAutoRebuild()`. The existing `validateBetterSqlite3NativeBinding()` now auto-rebuilds on ABI mismatch before giving up.
- **`scripts/bump-homebrew-formula.sh`**: Exponential backoff for tarball retries (was fixed 10s x5, now 15s doubling x6). Added `caveats` block to formula informing users about auto-rebuild.
- **`.github/workflows/bump-homebrew.yml`**: Added 60s sleep for npm CDN propagation when triggered by the publish workflow.
- **`docs/homebrew-verification.md`**: Updated to reflect auto-rebuild and auto-update behavior.

## Test plan

- [x] Unit tests for `isAbiMismatchError` — detects NODE_MODULE_VERSION and "compiled against different version" errors
- [x] Unit tests for `attemptAutoRebuild` — verifies correct command, handles failure gracefully
- [x] Unit tests for `validateBetterSqlite3NativeBinding` with auto-rebuild — rebuild attempted on ABI mismatch, skipped for other errors, respects `skipAutoRebuild` flag, succeeds after rebuild fixes issue
- [x] Unit tests for `findBetterSqlite3InstallDir` — returns correct path
- [x] All 18 native validation tests pass

Closes PRLT-1330