### PR TITLE
fix(PRLT-1331): fix docker agent worktree creation — propagate errors, detect empty repos

### DIFF
--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -661,6 +661,23 @@ export async function createEphemeralAgent(
     // PRLT-1322: Surface failures loudly — previously we silently fell back to
     // empty directories, which caused containers to launch with empty /workspace
     // and left agents unable to work on any code.
+    // PRLT-1331: Also fail when repositories list is empty but repos/ dir exists
+    // on disk — this indicates a database inconsistency (getWorkspaceRepositories
+    // returned empty despite real repos being present).
+    if (fs.existsSync(reposPath) && workspaceInfo.repositories.length === 0) {
+      const diskRepos = fs.readdirSync(reposPath).filter(
+        entry => fs.statSync(path.join(reposPath, entry)).isDirectory()
+      );
+      if (diskRepos.length > 0) {
+        cleanupFailedEphemeralAgent(agentDir, workspaceInfo, mountMode);
+        throw new Error(
+          `No repositories registered in workspace database, but repos/ directory ` +
+          `contains: [${diskRepos.join(', ')}]. The agent would launch with an ` +
+          `empty /workspace. Run "prlt repo add" to register repositories, or ` +
+          `check that the workspace database is intact.`
+        );
+      }
+    }
     if (fs.existsSync(reposPath) && workspaceInfo.repositories.length > 0) {
       const repoFailures: string[] = [];
       for (const repo of workspaceInfo.repositories) {

--- a/apps/cli/src/lib/agents/index.ts
+++ b/apps/cli/src/lib/agents/index.ts
@@ -190,7 +190,9 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
                   });
                   createdRepos.push(repo.name);
                 } catch (cloneError) {
-                  console.log(chalk.yellow(`  Warning: Clone failed for ${repo.name}: ${cloneError}`));
+                  // PRLT-1331: Log detailed clone error (previously just a warning)
+                  const errMsg = cloneError instanceof Error ? cloneError.message : String(cloneError);
+                  console.log(chalk.red(`  Clone failed for ${repo.name}: ${errMsg}`));
                 }
               } else {
                 // WORKTREE MODE: Create git worktree (original behavior)
@@ -233,9 +235,11 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
                     stdio: 'inherit'
                   });
                   createdRepos.push(repo.name);
-                } catch {
-                  // Branch might already exist, try to use it or clean up
-                  console.log(chalk.yellow(`  Branch ${branchName} already exists, attempting to reuse or clean up...`));
+                } catch (worktreeError) {
+                  // PRLT-1331: Log the actual error for diagnostics
+                  const worktreeErrMsg = worktreeError instanceof Error ? worktreeError.message : String(worktreeError);
+                  console.log(chalk.yellow(`  Worktree creation failed for ${repo.name}: ${worktreeErrMsg}`));
+                  console.log(chalk.yellow(`  Branch ${branchName} may already exist, attempting to reuse or clean up...`));
                   try {
                     // Try without creating a new branch (use existing)
                     execSync(`git worktree add "${targetDir}" ${branchName}`, {
@@ -256,12 +260,23 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
                       });
                       createdRepos.push(repo.name);
                     } catch (finalError) {
-                      throw new Error(`Failed to create worktree after cleanup: ${finalError}`);
+                      throw new Error(`Failed to create worktree for ${repo.name} after cleanup: ${finalError}`);
                     }
                   }
                 }
               }
             }
+          }
+
+          // PRLT-1331: Fail loudly when no repos were populated.
+          // Previously this silently produced an empty agent directory,
+          // causing Docker containers to launch with empty /workspace.
+          if (createdRepos.length === 0 && repos.length > 0) {
+            throw new Error(
+              `No repositories were created for agent "${agent}". ` +
+              `Expected ${repos.length} repo(s) but all failed. ` +
+              `Check that source repos exist in ${reposDir} and have commits.`
+            );
           }
 
           // Create devcontainer config for isolated execution
@@ -282,7 +297,11 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
 
           console.log(chalk.green(`✅ Agent ${agent} created with ${createdRepos.length} ${modeLabel}(s)`));
         } catch (error) {
+          // PRLT-1331: Log the error AND re-throw so callers know the agent
+          // was not created successfully. Previously this silently swallowed
+          // errors, leaving empty agent directories.
           console.log(chalk.red(`Failed to create agent ${agent}: ${error}`));
+          throw error;
         }
       }
     } else {
@@ -434,7 +453,9 @@ export async function createAgentWorktrees(workspacePath: string, agents: string
 
         console.log(chalk.green(`✅ Agent ${agent} created with ${modeLabel}`));
       } catch (error) {
+        // PRLT-1331: Re-throw so callers know agent creation failed
         console.log(chalk.red(`Failed to create agent ${agent}: ${error}`));
+        throw error;
       }
     }
   }

--- a/apps/cli/test/unit/docker-worktree-creation.test.ts
+++ b/apps/cli/test/unit/docker-worktree-creation.test.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { execSync } from 'node:child_process'
+import Database from 'better-sqlite3'
+
+import { createEphemeralAgent, type WorkspaceInfo } from '../../src/lib/agents/commands.js'
+import { createAgentWorktrees } from '../../src/lib/agents/index.js'
+import { CREATE_TABLES_SQL } from '../../src/lib/database/index.js'
+
+/**
+ * PRLT-1331: Docker agent worktree creation must fail loudly instead of
+ * silently producing empty agent directories. Validates both
+ * createAgentWorktrees (staff path) and createEphemeralAgent (ephemeral path).
+ */
+describe('Docker agent worktree creation (PRLT-1331)', () => {
+  let testDir: string
+
+  function setupWorkspaceDb(workspacePath: string): void {
+    const dbDir = path.join(workspacePath, '.proletariat')
+    fs.mkdirSync(dbDir, { recursive: true })
+    const dbPath = path.join(dbDir, 'workspace.db')
+    const db = new Database(dbPath)
+    db.pragma('foreign_keys = ON')
+    db.exec(CREATE_TABLES_SQL)
+    db.prepare(`
+      INSERT INTO workspace (id, type, workspace_name, has_pmo, created_at)
+      VALUES (1, 'hq', 'test-workspace', 0, ?)
+    `).run(new Date().toISOString())
+    db.close()
+  }
+
+  function addRepoToDb(workspacePath: string, repoName: string): void {
+    const dbPath = path.join(workspacePath, '.proletariat', 'workspace.db')
+    const db = new Database(dbPath)
+    db.prepare(`
+      INSERT OR IGNORE INTO repositories (name, path, type, added_at)
+      VALUES (?, ?, 'main', ?)
+    `).run(repoName, `repos/${repoName}`, new Date().toISOString())
+    db.close()
+  }
+
+  function makeWorkspaceInfo(workspacePath: string, repos: Array<{ name: string }> = []): WorkspaceInfo {
+    return {
+      path: workspacePath,
+      type: 'hq',
+      workspaceName: 'test-workspace',
+      hasPMO: false,
+      agents: [],
+      repositories: repos.map(r => ({
+        name: r.name,
+        path: path.join(workspacePath, 'repos', r.name),
+        type: 'main' as const,
+        added_at: new Date().toISOString(),
+      })),
+      agentsPath: path.join(workspacePath, 'agents', 'staff'),
+      activeThemeId: null,
+      persistentAgentsDir: 'staff',
+      ephemeralAgentsDir: 'temp',
+    }
+  }
+
+  function createGitRepo(repoPath: string): void {
+    fs.mkdirSync(repoPath, { recursive: true })
+    execSync('git init -q', { cwd: repoPath, stdio: 'pipe' })
+    execSync('git config user.email "test@example.com"', { cwd: repoPath, stdio: 'pipe' })
+    execSync('git config user.name "test"', { cwd: repoPath, stdio: 'pipe' })
+    fs.writeFileSync(path.join(repoPath, 'README.md'), '# test repo\n')
+    execSync('git add README.md', { cwd: repoPath, stdio: 'pipe' })
+    execSync('git commit -q -m init', { cwd: repoPath, stdio: 'pipe' })
+  }
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-worktree-creation-'))
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('createAgentWorktrees — error propagation', () => {
+    it('throws when source repo does not exist on disk', async () => {
+      setupWorkspaceDb(testDir)
+      addRepoToDb(testDir, 'proletariat')
+
+      const agentsPath = path.join(testDir, 'agents', 'staff')
+      fs.mkdirSync(agentsPath, { recursive: true })
+
+      let caught: unknown
+      try {
+        await createAgentWorktrees(agentsPath, ['test-agent'], testDir, {
+          skipDevcontainer: true,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught, 'expected createAgentWorktrees to throw when no repos created').to.exist
+      const message = caught instanceof Error ? caught.message : String(caught)
+      expect(message).to.match(/No repositories were created/)
+    })
+
+    it('throws when source repo has no commits', async () => {
+      setupWorkspaceDb(testDir)
+      addRepoToDb(testDir, 'proletariat')
+      const repoPath = path.join(testDir, 'repos', 'proletariat')
+      fs.mkdirSync(repoPath, { recursive: true })
+      fs.writeFileSync(path.join(repoPath, 'README.md'), '# not a git repo\n')
+
+      const agentsPath = path.join(testDir, 'agents', 'staff')
+      fs.mkdirSync(agentsPath, { recursive: true })
+
+      let caught: unknown
+      try {
+        await createAgentWorktrees(agentsPath, ['test-agent'], testDir, {
+          skipDevcontainer: true,
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught, 'expected createAgentWorktrees to throw').to.exist
+      const message = caught instanceof Error ? caught.message : String(caught)
+      expect(message).to.match(/No repositories were created/)
+    })
+
+    it('succeeds and creates worktree from a real git repo', async () => {
+      setupWorkspaceDb(testDir)
+      addRepoToDb(testDir, 'proletariat')
+      createGitRepo(path.join(testDir, 'repos', 'proletariat'))
+
+      const agentsPath = path.join(testDir, 'agents', 'staff')
+      fs.mkdirSync(agentsPath, { recursive: true })
+
+      await createAgentWorktrees(agentsPath, ['test-agent'], testDir, {
+        skipDevcontainer: true,
+      })
+
+      const worktreeDir = path.join(agentsPath, 'test-agent', 'proletariat')
+      expect(fs.existsSync(worktreeDir), 'worktree dir exists').to.equal(true)
+      const entries = fs.readdirSync(worktreeDir)
+      expect(entries, 'worktree is non-empty').to.include('README.md')
+    })
+  })
+
+  describe('createEphemeralAgent — empty repositories list', () => {
+    it('throws when repos/ has directories but DB repositories list is empty', async () => {
+      setupWorkspaceDb(testDir)
+      createGitRepo(path.join(testDir, 'repos', 'proletariat'))
+
+      const workspaceInfo = makeWorkspaceInfo(testDir, [])
+
+      let caught: unknown
+      try {
+        await createEphemeralAgent(workspaceInfo, {
+          skipDevcontainer: true,
+          mountMode: 'worktree',
+        })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught, 'expected createEphemeralAgent to throw on empty repos list').to.exist
+      const message = caught instanceof Error ? caught.message : String(caught)
+      expect(message).to.match(/No repositories registered/)
+      expect(message).to.match(/proletariat/)
+    })
+
+    it('cleans up agent dir after detecting empty repos list', async () => {
+      setupWorkspaceDb(testDir)
+      createGitRepo(path.join(testDir, 'repos', 'proletariat'))
+
+      const workspaceInfo = makeWorkspaceInfo(testDir, [])
+      const agentsTempDir = path.join(testDir, 'agents', 'temp')
+
+      const before = fs.existsSync(agentsTempDir)
+        ? fs.readdirSync(agentsTempDir)
+        : []
+
+      try {
+        await createEphemeralAgent(workspaceInfo, {
+          skipDevcontainer: true,
+          mountMode: 'worktree',
+        })
+      } catch {
+        // expected
+      }
+
+      const after = fs.existsSync(agentsTempDir)
+        ? fs.readdirSync(agentsTempDir)
+        : []
+
+      expect(after.filter(n => !before.includes(n))).to.deep.equal([])
+    })
+  })
+
+  describe('createEphemeralAgent — success path', () => {
+    it('creates a populated worktree in agents/temp/<name>/<repo>', async () => {
+      setupWorkspaceDb(testDir)
+      addRepoToDb(testDir, 'proletariat')
+      createGitRepo(path.join(testDir, 'repos', 'proletariat'))
+
+      const workspaceInfo = makeWorkspaceInfo(testDir, [{ name: 'proletariat' }])
+
+      const result = await createEphemeralAgent(workspaceInfo, {
+        skipDevcontainer: true,
+        mountMode: 'worktree',
+      })
+
+      const worktreeDir = path.join(result.worktreePath, 'proletariat')
+      expect(fs.existsSync(worktreeDir), 'worktree dir exists').to.equal(true)
+      const entries = fs.readdirSync(worktreeDir)
+      expect(entries, 'worktree contains repo files').to.include('README.md')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes PRLT-1331: Docker agent worktree creation silently fails, producing empty agent directories.

### Root Causes Fixed
- **`createAgentWorktrees`**: Outer try/catch swallowed ALL errors — worktree creation failures were logged but never propagated to callers. Agent directories were created empty with only `.devcontainer/`
- **`createAgentWorktrees`**: No validation that `createdRepos` is non-empty when repos exist in DB
- **`createEphemeralAgent`**: When `workspaceInfo.repositories` was empty (DB inconsistency), the worktree creation block was skipped entirely with no error

### Changes
- `createAgentWorktrees` now re-throws errors instead of swallowing them
- Added validation: if `repos.length > 0` but `createdRepos.length === 0`, throws descriptive error
- `createEphemeralAgent` now detects when repos/ has directories on disk but DB has no repositories, and throws instead of creating an empty agent
- Improved error logging: worktree/clone failures now include the actual error message
- Added 6 unit tests covering error propagation and regression

## Test plan
- [x] `createAgentWorktrees` throws when source repo missing from disk
- [x] `createAgentWorktrees` throws when source repo has no commits
- [x] `createAgentWorktrees` succeeds with real git repo (regression)
- [x] `createEphemeralAgent` throws when repos/ exists but DB empty
- [x] `createEphemeralAgent` cleans up after empty repos detection
- [x] `createEphemeralAgent` success path works (regression)
- [x] Existing PRLT-1322 tests still pass (9/9)

Closes PRLT-1331

> Note: `prlt work propose` and `prlt pr create` failed due to pre-existing PRLT-1299 (SQLiteStorage removal). Used `gh pr create` as fallback.