### PR TITLE
fix(PRLT-1335): branch picker bypasses -y flag and --display background

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -112,6 +112,25 @@ import { getEventBus } from '../../lib/events/event-bus.js'
 import { resolveInternalAction } from '../../services/action-context.js'
 
 /**
+ * Determine if branch creation should be auto-selected (skip the interactive
+ * branch picker). Returns true when the invocation is non-interactive:
+ * - internalAction: called from work review/groom/implement/resolve/orchestrator
+ * - force: --force flag
+ * - jsonMode: --json machine mode
+ * - yes: -y/--yes flag (skip confirmations & pickers)
+ * - backgroundDisplay: --display background (non-interactive by definition)
+ */
+export function shouldAutoCreateBranch(opts: {
+  internalAction: string | undefined
+  force: boolean
+  jsonMode: boolean
+  yes: boolean
+  backgroundDisplay: boolean
+}): boolean {
+  return !!(opts.internalAction || opts.force || opts.jsonMode || opts.yes || opts.backgroundDisplay)
+}
+
+/**
  * Try to execute a git command, return true if successful
  */
 function tryGitCommand(cmd: string, cwd: string): boolean {
@@ -2309,11 +2328,18 @@ export default class WorkStart extends PMOCommand {
         if (isExistingBranch) {
           // Ticket already has a branch linked - just use it
           this.log(styles.muted(`Using existing branch: ${branch}`))
-        } else if (internalAction || flags.force || jsonMode) {
-          // Non-interactive / internal-action / JSON mode - auto-create branch.
+        } else if (shouldAutoCreateBranch({
+          internalAction,
+          force: !!flags.force,
+          jsonMode,
+          yes: !!flags.yes,
+          backgroundDisplay: flags.display === 'background',
+        })) {
+          // Non-interactive / internal-action / JSON mode / -y / background - auto-create branch.
           // JSON mode agents can't interactively enter branch names, and
           // internal callers (work review/groom/resolve/implement, orchestrator)
-          // never want an interactive branch prompt.
+          // never want an interactive branch prompt. The -y flag and
+          // --display background are non-interactive by definition.
           finalBranch = branch
           this.log(styles.muted(`Branch: ${finalBranch}`))
         } else {

--- a/apps/cli/test/unit/branch-picker-noninteractive.test.ts
+++ b/apps/cli/test/unit/branch-picker-noninteractive.test.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai'
+import { shouldAutoCreateBranch } from '../../src/commands/work/start.js'
+
+/**
+ * Regression tests for PRLT-1335.
+ *
+ * The branch picker prompt in `work start` was blocking non-interactive
+ * spawns even when -y or --display background was set. The -y flag skipped
+ * confirmation prompts but not selection pickers, causing the orchestrator's
+ * spawn flow to hang.
+ *
+ * shouldAutoCreateBranch() centralises the "is this invocation non-interactive?"
+ * check so we can unit-test it directly.
+ */
+describe('work start: branch picker non-interactive bypass (PRLT-1335)', () => {
+  const baseOpts = {
+    internalAction: undefined as string | undefined,
+    force: false,
+    jsonMode: false,
+    yes: false,
+    backgroundDisplay: false,
+  }
+
+  describe('shouldAutoCreateBranch', () => {
+    it('returns false when all flags are off (interactive mode)', () => {
+      expect(shouldAutoCreateBranch(baseOpts)).to.equal(false)
+    })
+
+    it('returns true when -y/--yes flag is set', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, yes: true })).to.equal(true)
+    })
+
+    it('returns true when --display background is set', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, backgroundDisplay: true })).to.equal(true)
+    })
+
+    it('returns true when --force flag is set', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, force: true })).to.equal(true)
+    })
+
+    it('returns true when jsonMode is active', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, jsonMode: true })).to.equal(true)
+    })
+
+    it('returns true when internalAction is set', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, internalAction: 'implement' })).to.equal(true)
+    })
+
+    it('returns true when both -y and --display background are set', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, yes: true, backgroundDisplay: true })).to.equal(true)
+    })
+
+    it('returns true when -y and --force are combined', () => {
+      expect(shouldAutoCreateBranch({ ...baseOpts, yes: true, force: true })).to.equal(true)
+    })
+  })
+
+  describe('flag declarations (guardrails)', () => {
+    // Import WorkStart lazily to check flag definitions
+    let flags: Record<string, unknown>
+
+    before(async () => {
+      const { default: WorkStart } = await import('../../src/commands/work/start.js')
+      flags = (WorkStart as unknown as { flags: Record<string, unknown> }).flags
+    })
+
+    it('declares the -y/--yes flag', () => {
+      expect(flags).to.have.property('yes')
+    })
+
+    it('declares the --display flag', () => {
+      expect(flags).to.have.property('display')
+    })
+
+    it('declares the --force flag', () => {
+      expect(flags).to.have.property('force')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix branch picker prompt blocking non-interactive spawns in `prlt work start`
- `-y` flag and `--display background` now auto-select "create new branch" (skipping the interactive picker)
- Extract `shouldAutoCreateBranch()` helper for testable non-interactive detection

## Problem

`prlt work start <ticket> -y --display background` still hit an interactive branch picker prompt, causing the orchestrator's spawn flow to hang. The `-y` flag skipped confirmation prompts but not selection pickers.

## Changes

- **`apps/cli/src/commands/work/start.ts`**: Add `shouldAutoCreateBranch()` exported helper that returns `true` when any non-interactive signal is present (`internalAction`, `--force`, `--json`, `--yes`, `--display background`). Replace inline condition with call to this helper.
- **`apps/cli/test/unit/branch-picker-noninteractive.test.ts`**: 11 unit tests covering all flag combinations and flag declaration guardrails.

## Test plan

- [x] `shouldAutoCreateBranch` returns false in fully interactive mode
- [x] `shouldAutoCreateBranch` returns true for each individual non-interactive signal
- [x] `shouldAutoCreateBranch` returns true for combined flags
- [x] Flag declarations (`--yes`, `--display`, `--force`) verified present on WorkStart
- [x] Existing `work-start-action-flag-removed` tests still pass

Closes PRLT-1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)