### PR TITLE
feat(PRLT-1265): orchestrator thread registration — register Claude/Codex sessions as LLM tier endpoints

### DIFF
--- a/apps/cli/src/commands/db/repair.ts
+++ b/apps/cli/src/commands/db/repair.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core'
 import * as fs from 'node:fs'
+import * as path from 'node:path'
 import Database from 'better-sqlite3'
 import { styles } from '../../lib/styles.js'
 import {
@@ -13,10 +14,10 @@ import { runDrizzleMigrations } from '../../lib/database/migrator.js'
 import { ALL_MIGRATIONS } from '../../lib/database/migrations/index.js'
 import {
   getRegisteredHeadquarters,
-  getActiveWorkspace,
 } from '../../lib/machine-config.js'
+import { findHQRoot } from '../../lib/workspace.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
-import { shouldOutputJson } from '../../lib/prompt-json.js'
+import { shouldOutputJson, type JsonFlags } from '../../lib/prompt-json.js'
 
 export default class DbRepair extends Command {
   static description = 'Check database integrity and repair corruption'
@@ -25,6 +26,7 @@ export default class DbRepair extends Command {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --check-only',
     '<%= config.bin %> <%= command.id %> --workspace /path/to/hq',
+    '<%= config.bin %> <%= command.id %> --all',
   ]
 
   static flags = {
@@ -35,18 +37,74 @@ export default class DbRepair extends Command {
     }),
     workspace: Flags.string({
       char: 'w',
-      description: 'Path to workspace (defaults to active workspace)',
+      description: 'Path to workspace (defaults to current HQ)',
+    }),
+    all: Flags.boolean({
+      description: 'Scan all registered HQs on the machine',
+      default: false,
     }),
   }
 
   async run(): Promise<void> {
     const { flags } = await this.parse(DbRepair)
 
-    const workspacePath = this.resolveWorkspacePath(flags.workspace)
-    if (!workspacePath) {
-      this.error('No workspace found. Run "prlt new" first or specify --workspace.')
+    if (flags.all) {
+      await this.repairAllHQs(flags)
+      return
     }
 
+    const workspacePath = this.resolveWorkspacePath(flags.workspace)
+    if (!workspacePath) {
+      this.error(
+        'Not in an HQ directory. Run from inside an HQ, specify --workspace /path/to/hq, or use --all to scan all HQs.'
+      )
+    }
+
+    const hqName = path.basename(workspacePath)
+    await this.repairSingleHQ(workspacePath, hqName, flags)
+  }
+
+  private async repairAllHQs(flags: { 'check-only': boolean } & JsonFlags): Promise<void> {
+    const hqs = getRegisteredHeadquarters()
+
+    if (hqs.length === 0) {
+      this.error('No registered HQs found. Run "prlt new" first.')
+    }
+
+    const validHQs = hqs.filter(hq => fs.existsSync(hq.path))
+    if (validHQs.length === 0) {
+      this.error('No valid HQs found on disk. All registered HQ paths are missing.')
+    }
+
+    if (shouldOutputJson(flags)) {
+      const results: Record<string, unknown>[] = []
+      for (const hq of validHQs) {
+        const dbPath = getDatabasePath(hq.path)
+        if (!fs.existsSync(dbPath)) {
+          results.push({ hq: hq.name, hqPath: hq.path, status: 'no_database' })
+          continue
+        }
+        const result = this.runCheck(dbPath, flags['check-only'])
+        results.push({ hq: hq.name, hqPath: hq.path, dbPath, ...result })
+      }
+      this.log(JSON.stringify(results, null, 2))
+      return
+    }
+
+    this.log(`\n${styles.header('Database Repair — All HQs')}`)
+    this.log('\u2500'.repeat(50))
+    this.log(styles.muted(`Scanning ${validHQs.length} registered HQ(s)\n`))
+
+    for (const hq of validHQs) {
+      await this.repairSingleHQ(hq.path, hq.name, flags)
+    }
+  }
+
+  private async repairSingleHQ(
+    workspacePath: string,
+    hqName: string,
+    flags: { 'check-only': boolean } & JsonFlags,
+  ): Promise<void> {
     const dbPath = getDatabasePath(workspacePath)
     if (!fs.existsSync(dbPath)) {
       this.error(`Database not found: ${dbPath}`)
@@ -57,6 +115,7 @@ export default class DbRepair extends Command {
       const result = this.runCheck(dbPath, flags['check-only'])
       this.log(JSON.stringify({
         ...result,
+        hq: hqName,
         dbPath,
         workspace: workspacePath,
       }, null, 2))
@@ -65,6 +124,7 @@ export default class DbRepair extends Command {
 
     this.log(`\n${styles.header('Database Repair')}`)
     this.log('\u2500'.repeat(50))
+    this.log(styles.muted(`HQ: ${hqName} (${workspacePath})`))
     this.log(styles.muted(`Database: ${dbPath}`))
 
     // List available backups from backups/ directory
@@ -207,23 +267,19 @@ export default class DbRepair extends Command {
     this.log('')
   }
 
+  /**
+   * Resolve workspace path scoped to current HQ only (PRLT-1340).
+   * Does NOT fall back to other registered HQs — that was the cross-HQ bleed bug.
+   */
   private resolveWorkspacePath(explicit?: string): string | null {
     if (explicit) {
       return fs.existsSync(explicit) ? explicit : null
     }
 
-    // Try active workspace first (returns a path string or null)
-    const active = getActiveWorkspace()
-    if (active && fs.existsSync(active)) {
-      return active
-    }
-
-    // Fall back to first registered HQ
-    const hqs = getRegisteredHeadquarters()
-    for (const hq of hqs) {
-      if (fs.existsSync(hq.path)) {
-        return hq.path
-      }
+    // Use findHQRoot which walks up from cwd to find the enclosing HQ
+    const hqPath = findHQRoot()
+    if (hqPath && fs.existsSync(hqPath)) {
+      return hqPath
     }
 
     return null

--- a/apps/cli/src/commands/orchestrator/index.ts
+++ b/apps/cli/src/commands/orchestrator/index.ts
@@ -39,6 +39,8 @@ export default class Orchestrator extends PromptCommand {
           { name: 'Attach to running session', value: 'attach', command: 'prlt orchestrator attach --json' },
           { name: 'Start orchestrator', value: 'start', command: 'prlt orchestrator start --json' },
           { name: 'Check orchestrator status', value: 'status', command: 'prlt orchestrator status --json' },
+          { name: 'List registered threads', value: 'list', command: 'prlt orchestrator list --json' },
+          { name: 'Show event routes', value: 'routes', command: 'prlt orchestrator routes --json' },
           { name: 'Stop orchestrator', value: 'stop', command: 'prlt orchestrator stop --json' },
           { name: 'Cancel', value: 'cancel' },
         ]
@@ -46,6 +48,8 @@ export default class Orchestrator extends PromptCommand {
           { name: 'Start orchestrator', value: 'start', command: 'prlt orchestrator start --json' },
           { name: 'Attach to orchestrator', value: 'attach', command: 'prlt orchestrator attach --json' },
           { name: 'Check orchestrator status', value: 'status', command: 'prlt orchestrator status --json' },
+          { name: 'List registered threads', value: 'list', command: 'prlt orchestrator list --json' },
+          { name: 'Show event routes', value: 'routes', command: 'prlt orchestrator routes --json' },
           { name: 'Stop orchestrator', value: 'stop', command: 'prlt orchestrator stop --json' },
           { name: 'Cancel', value: 'cancel' },
         ]
@@ -70,6 +74,12 @@ export default class Orchestrator extends PromptCommand {
         break
       case 'status':
         await this.config.runCommand('orchestrator:status', [])
+        break
+      case 'list':
+        await this.config.runCommand('orchestrator:list', [])
+        break
+      case 'routes':
+        await this.config.runCommand('orchestrator:routes', [])
         break
       case 'stop':
         await this.config.runCommand('orchestrator:stop', [])

--- a/apps/cli/src/commands/orchestrator/list.ts
+++ b/apps/cli/src/commands/orchestrator/list.ts
@@ -1,0 +1,84 @@
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB, type OrchestratorThreadRecord } from '../../lib/machine-db.js'
+
+export default class OrchestratorList extends PromptCommand {
+  static description = 'List registered orchestrator threads'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --all',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(OrchestratorList)
+    const jsonMode = shouldOutputJson(flags)
+
+    let threads: OrchestratorThreadRecord[]
+    try {
+      const machineDb = new MachineDB()
+      try {
+        threads = machineDb.listThreads()
+      } finally {
+        machineDb.close()
+      }
+    } catch {
+      if (jsonMode) {
+        outputSuccessAsJson({ threads: [] }, createMetadata('orchestrator list', flags as Record<string, unknown>))
+        return
+      }
+      this.log(styles.muted('No orchestrator threads registered.'))
+      return
+    }
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        threads: threads.map(threadToJson),
+      }, createMetadata('orchestrator list', flags as Record<string, unknown>))
+      return
+    }
+
+    this.log('')
+    if (threads.length === 0) {
+      this.log(styles.muted('No orchestrator threads registered.'))
+      this.log(styles.muted('Start one with: prlt orchestrator start'))
+      this.log('')
+      return
+    }
+
+    this.log(styles.header(`Registered orchestrator threads (${threads.length})`))
+    this.log('')
+
+    for (const thread of threads) {
+      const statusIcon = thread.status === 'active' ? styles.success('active') : styles.muted('inactive')
+      const routeLabel = thread.routes ? thread.routes.join(', ') : '(catch-all)'
+      this.log(`   ${thread.name} — ${statusIcon}`)
+      this.log(styles.muted(`     Address: ${thread.address}`))
+      this.log(styles.muted(`     Routes:  ${routeLabel}`))
+      this.log(styles.muted(`     Since:   ${thread.registeredAt.toISOString()}`))
+      this.log(styles.muted(`     Seen:    ${thread.lastSeen.toISOString()}`))
+      this.log('')
+    }
+  }
+}
+
+function threadToJson(t: OrchestratorThreadRecord): Record<string, unknown> {
+  return {
+    name: t.name,
+    address: t.address,
+    routes: t.routes,
+    status: t.status,
+    registeredAt: t.registeredAt.toISOString(),
+    lastSeen: t.lastSeen.toISOString(),
+  }
+}

--- a/apps/cli/src/commands/orchestrator/routes.ts
+++ b/apps/cli/src/commands/orchestrator/routes.ts
@@ -1,0 +1,129 @@
+import { Flags } from '@oclif/core'
+import { PromptCommand } from '../../lib/prompt-command.js'
+import { machineOutputFlags } from '../../lib/pmo/index.js'
+import {
+  shouldOutputJson,
+  outputSuccessAsJson,
+  createMetadata,
+} from '../../lib/prompt-json.js'
+import { styles } from '../../lib/styles.js'
+import { MachineDB, type OrchestratorThreadRecord } from '../../lib/machine-db.js'
+
+export default class OrchestratorRoutes extends PromptCommand {
+  static description = 'Show which events route to which orchestrator threads'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --event on_pr_opened',
+  ]
+
+  static flags = {
+    ...machineOutputFlags,
+    event: Flags.string({
+      char: 'e',
+      description: 'Check which orchestrator handles a specific event',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(OrchestratorRoutes)
+    const jsonMode = shouldOutputJson(flags)
+
+    let threads: OrchestratorThreadRecord[]
+    const machineDb = new MachineDB()
+    try {
+      threads = machineDb.listThreads({ status: 'active' })
+
+      // If --event is specified, find the specific handler
+      if (flags.event) {
+        const handler = machineDb.findThreadForEvent(flags.event)
+        if (jsonMode) {
+          outputSuccessAsJson({
+            event: flags.event,
+            handler: handler ? {
+              name: handler.name,
+              address: handler.address,
+              routes: handler.routes,
+              isCatchAll: handler.routes === null,
+            } : null,
+          }, createMetadata('orchestrator routes', flags as Record<string, unknown>))
+          return
+        }
+
+        this.log('')
+        if (handler) {
+          const routeType = handler.routes === null ? '(catch-all)' : '(explicit route)'
+          this.log(`   ${flags.event} → ${handler.name} ${styles.muted(routeType)}`)
+          this.log(styles.muted(`   Address: ${handler.address}`))
+        } else {
+          this.log(styles.muted(`   No orchestrator handles event "${flags.event}"`))
+        }
+        this.log('')
+        return
+      }
+    } finally {
+      machineDb.close()
+    }
+
+    if (jsonMode) {
+      const routeMap = buildRouteMap(threads)
+      outputSuccessAsJson({
+        threads: threads.map(t => ({
+          name: t.name,
+          routes: t.routes,
+          isCatchAll: t.routes === null,
+          address: t.address,
+        })),
+        routeMap,
+      }, createMetadata('orchestrator routes', flags as Record<string, unknown>))
+      return
+    }
+
+    this.log('')
+    if (threads.length === 0) {
+      this.log(styles.muted('No active orchestrator threads.'))
+      this.log(styles.muted('Start one with: prlt orchestrator start'))
+      this.log('')
+      return
+    }
+
+    this.log(styles.header('Event routing table'))
+    this.log('')
+
+    // Show explicit routes first
+    const explicit = threads.filter(t => t.routes !== null)
+    const catchAlls = threads.filter(t => t.routes === null)
+
+    for (const thread of explicit) {
+      for (const route of thread.routes!) {
+        this.log(`   ${route} → ${thread.name}`)
+      }
+    }
+
+    if (catchAlls.length > 0) {
+      if (explicit.length > 0) this.log('')
+      for (const thread of catchAlls) {
+        this.log(`   ${styles.muted('(everything else)')} → ${thread.name}`)
+      }
+    }
+
+    this.log('')
+  }
+}
+
+function buildRouteMap(threads: OrchestratorThreadRecord[]): Record<string, string> {
+  const map: Record<string, string> = {}
+  for (const t of threads) {
+    if (t.routes) {
+      for (const route of t.routes) {
+        map[route] = t.name
+      }
+    }
+  }
+  // Mark catch-all
+  const catchAll = threads.find(t => t.routes === null)
+  if (catchAll) {
+    map['*'] = catchAll.name
+  }
+  return map
+}

--- a/apps/cli/src/commands/orchestrator/start.ts
+++ b/apps/cli/src/commands/orchestrator/start.ts
@@ -31,6 +31,7 @@ import {
   updateMirrorExecution,
   closeMirrorExecution,
 } from '../../lib/machine-db-mirror.js'
+import { MachineDB } from '../../lib/machine-db.js'
 import { getWorkspaceInfo } from '../../lib/agents/commands.js'
 import {
   loadExecutionConfig,
@@ -272,6 +273,10 @@ export default class OrchestratorStart extends RuntimeCommand {
       description: 'Run orchestrator on host (default behavior)',
       default: false,
       exclusive: ['docker'],
+    }),
+    routes: Flags.string({
+      char: 'r',
+      description: 'Comma-separated event names this orchestrator handles (e.g. "on_pr_opened,on_review_requested"). Omit for catch-all.',
     }),
   }
 
@@ -726,6 +731,29 @@ export default class OrchestratorStart extends RuntimeCommand {
         containerId: result.containerId,
       })
       closeMirrorExecution(mirrorHandle)
+
+      // PRLT-1265: Register as LLM tier endpoint in orchestrator_threads.
+      // The address encodes how the daemon can reach this session.
+      try {
+        const machineDb = new MachineDB()
+        try {
+          const address = environment === 'docker' && result.containerId
+            ? `container:${result.containerId}/tmux:${result.sessionId || sessionName}`
+            : `host:tmux:${result.sessionId || sessionName}`
+          const routeList = flags.routes
+            ? flags.routes.split(',').map(r => r.trim()).filter(Boolean)
+            : undefined
+          machineDb.registerThread({
+            name: orchestratorName,
+            address,
+            routes: routeList,
+          })
+        } finally {
+          machineDb.close()
+        }
+      } catch {
+        // Non-fatal — thread routing won't work but orchestrator is running
+      }
 
       if (jsonMode) {
         outputSuccessAsJson({

--- a/apps/cli/src/commands/orchestrator/stop.ts
+++ b/apps/cli/src/commands/orchestrator/stop.ts
@@ -229,6 +229,7 @@ export default class OrchestratorStop extends PromptCommand {
     // PRLT-1275: Update the machine.db mirror row so cross-HQ consumers
     // (e.g. prlt session list from /tmp, the renderer) see the orchestrator
     // as stopped. Non-fatal — machine.db is secondary.
+    // PRLT-1265: Also deregister the orchestrator thread.
     try {
       const machineDb = new MachineDB()
       try {
@@ -240,6 +241,10 @@ export default class OrchestratorStop extends PromptCommand {
           for (const row of rows) {
             machineDb.updateStatus(row.id, 'stopped')
           }
+        }
+        // Deregister orchestrator thread
+        if (orchestratorName) {
+          machineDb.updateThreadStatus(orchestratorName, 'inactive')
         }
       } finally {
         machineDb.close()

--- a/apps/cli/src/lib/machine-db.ts
+++ b/apps/cli/src/lib/machine-db.ts
@@ -73,6 +73,60 @@ export interface MessagingRouteRecord {
   lastUsedAt: Date | undefined
 }
 
+// =============================================================================
+// Orchestrator thread types (PRLT-1265)
+// =============================================================================
+
+export type OrchestratorThreadStatus = 'active' | 'inactive'
+
+export interface OrchestratorThreadRow {
+  name: string
+  address: string
+  routes: string | null
+  status: string
+  registered_at: number
+  last_seen: number
+}
+
+export interface OrchestratorThreadRecord {
+  name: string
+  address: string
+  routes: string[] | null
+  status: OrchestratorThreadStatus
+  registeredAt: Date
+  lastSeen: Date
+}
+
+export interface PendingLlmDecisionRow {
+  id: string
+  event_name: string
+  hook_name: string
+  action: string
+  context_json: string
+  status: string
+  orchestrator_name: string | null
+  queued_at: number
+  timeout_ms: number
+  resolved_at: number | null
+  decision: string | null
+}
+
+export type LlmDecisionStatus = 'pending' | 'approved' | 'denied' | 'escalated' | 'timed_out'
+
+export interface PendingLlmDecisionRecord {
+  id: string
+  eventName: string
+  hookName: string
+  action: string
+  contextJson: string
+  status: LlmDecisionStatus
+  orchestratorName: string | null
+  queuedAt: Date
+  timeoutMs: number
+  resolvedAt: Date | null
+  decision: string | null
+}
+
 export interface MachineExecution {
   id: string
   prompt: string
@@ -276,6 +330,36 @@ export class MachineDB {
 
       CREATE INDEX IF NOT EXISTS idx_messaging_routes_agent
         ON messaging_routes(agent_session_id);
+
+      -- Orchestrator thread registry (PRLT-1265) — registers Claude/Codex
+      -- sessions as LLM tier endpoints with event routing.
+      CREATE TABLE IF NOT EXISTS orchestrator_threads (
+        name TEXT PRIMARY KEY,
+        address TEXT NOT NULL,
+        routes TEXT,
+        status TEXT NOT NULL DEFAULT 'active',
+        registered_at INTEGER NOT NULL,
+        last_seen INTEGER NOT NULL
+      );
+
+      -- Pending LLM decisions (PRLT-1265) — persists tier-2 decisions
+      -- that need orchestrator review. Survives daemon restarts.
+      CREATE TABLE IF NOT EXISTS pending_llm_decisions (
+        id TEXT PRIMARY KEY,
+        event_name TEXT NOT NULL,
+        hook_name TEXT NOT NULL,
+        action TEXT NOT NULL,
+        context_json TEXT NOT NULL DEFAULT '{}',
+        status TEXT NOT NULL DEFAULT 'pending',
+        orchestrator_name TEXT,
+        queued_at INTEGER NOT NULL,
+        timeout_ms INTEGER NOT NULL DEFAULT 300000,
+        resolved_at INTEGER,
+        decision TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_pending_llm_status
+        ON pending_llm_decisions(status);
     `)
 
     // Migrate existing databases that don't have the persistent columns
@@ -741,6 +825,182 @@ export class MachineDB {
     return row?.n ?? 0
   }
 
+  // ===========================================================================
+  // Orchestrator threads (PRLT-1265)
+  // ===========================================================================
+
+  /**
+   * Register an orchestrator thread. If one with the same name already exists,
+   * it is replaced (the orchestrator was restarted).
+   */
+  registerThread(params: {
+    name: string
+    address: string
+    routes?: string[]
+    status?: OrchestratorThreadStatus
+  }): OrchestratorThreadRecord {
+    const now = Date.now()
+    const routesStr = params.routes?.length ? params.routes.join(',') : null
+    this.db.prepare(`
+      INSERT INTO orchestrator_threads (name, address, routes, status, registered_at, last_seen)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(name) DO UPDATE SET
+        address = excluded.address,
+        routes = excluded.routes,
+        status = excluded.status,
+        last_seen = excluded.last_seen
+    `).run(params.name, params.address, routesStr, params.status ?? 'active', now, now)
+    return this.getThread(params.name)!
+  }
+
+  /** Get a single thread by name. */
+  getThread(name: string): OrchestratorThreadRecord | null {
+    const row = this.db.prepare<OrchestratorThreadRow>(
+      'SELECT * FROM orchestrator_threads WHERE name = ?'
+    ).get(name)
+    return row ? threadRowToRecord(row) : null
+  }
+
+  /** List all threads, optionally filtering by status. */
+  listThreads(filter?: { status?: OrchestratorThreadStatus }): OrchestratorThreadRecord[] {
+    if (filter?.status) {
+      const rows = this.db.prepare(
+        'SELECT * FROM orchestrator_threads WHERE status = ? ORDER BY registered_at DESC'
+      ).all(filter.status) as unknown as OrchestratorThreadRow[]
+      return rows.map(threadRowToRecord)
+    }
+    const rows = this.db.prepare(
+      'SELECT * FROM orchestrator_threads ORDER BY registered_at DESC'
+    ).all() as unknown as OrchestratorThreadRow[]
+    return rows.map(threadRowToRecord)
+  }
+
+  /** Update a thread's status (active/inactive). */
+  updateThreadStatus(name: string, status: OrchestratorThreadStatus): void {
+    this.db.prepare(
+      'UPDATE orchestrator_threads SET status = ?, last_seen = ? WHERE name = ?'
+    ).run(status, Date.now(), name)
+  }
+
+  /** Stamp a thread's last_seen to now — called on heartbeat/poke. */
+  touchThread(name: string): void {
+    this.db.prepare(
+      'UPDATE orchestrator_threads SET last_seen = ? WHERE name = ?'
+    ).run(Date.now(), name)
+  }
+
+  /** Remove a thread registration entirely. */
+  removeThread(name: string): void {
+    this.db.prepare('DELETE FROM orchestrator_threads WHERE name = ?').run(name)
+  }
+
+  /**
+   * Find the orchestrator thread that handles a given event name.
+   * Checks routes (comma-separated event lists). A thread with NULL routes
+   * is the catch-all (matches any event not claimed by a specific thread).
+   * Returns the most specific match first, falling back to catch-all.
+   */
+  findThreadForEvent(eventName: string): OrchestratorThreadRecord | null {
+    // First try to find a thread with an explicit route for this event
+    const rows = this.db.prepare(
+      "SELECT * FROM orchestrator_threads WHERE status = 'active' ORDER BY registered_at ASC"
+    ).all() as unknown as OrchestratorThreadRow[]
+
+    let catchAll: OrchestratorThreadRow | null = null
+    for (const row of rows) {
+      if (!row.routes) {
+        // NULL routes = catch-all
+        if (!catchAll) catchAll = row
+        continue
+      }
+      const routeList = row.routes.split(',').map(r => r.trim())
+      if (routeList.includes(eventName)) {
+        return threadRowToRecord(row)
+      }
+    }
+    return catchAll ? threadRowToRecord(catchAll) : null
+  }
+
+  // ===========================================================================
+  // Pending LLM decisions (PRLT-1265)
+  // ===========================================================================
+
+  /**
+   * Queue a new pending LLM decision. Returns the created record.
+   */
+  createPendingLlmDecision(params: {
+    eventName: string
+    hookName: string
+    action: string
+    contextJson?: string
+    orchestratorName?: string
+    timeoutMs?: number
+  }): PendingLlmDecisionRecord {
+    const id = `LLMD-${randomUUID().substring(0, 8).toUpperCase()}`
+    const now = Date.now()
+    this.db.prepare(`
+      INSERT INTO pending_llm_decisions (
+        id, event_name, hook_name, action, context_json,
+        status, orchestrator_name, queued_at, timeout_ms
+      ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+    `).run(
+      id,
+      params.eventName,
+      params.hookName,
+      params.action,
+      params.contextJson ?? '{}',
+      params.orchestratorName ?? null,
+      now,
+      params.timeoutMs ?? 300000,
+    )
+    return this.getPendingLlmDecision(id)!
+  }
+
+  /** Get a single pending decision by ID. */
+  getPendingLlmDecision(id: string): PendingLlmDecisionRecord | null {
+    const row = this.db.prepare<PendingLlmDecisionRow>(
+      'SELECT * FROM pending_llm_decisions WHERE id = ?'
+    ).get(id)
+    return row ? llmDecisionRowToRecord(row) : null
+  }
+
+  /** List pending decisions (optionally filtered by status). */
+  listPendingLlmDecisions(filter?: { status?: LlmDecisionStatus }): PendingLlmDecisionRecord[] {
+    if (filter?.status) {
+      const rows = this.db.prepare(
+        'SELECT * FROM pending_llm_decisions WHERE status = ? ORDER BY queued_at DESC'
+      ).all(filter.status) as unknown as PendingLlmDecisionRow[]
+      return rows.map(llmDecisionRowToRecord)
+    }
+    const rows = this.db.prepare(
+      'SELECT * FROM pending_llm_decisions ORDER BY queued_at DESC'
+    ).all() as unknown as PendingLlmDecisionRow[]
+    return rows.map(llmDecisionRowToRecord)
+  }
+
+  /** Resolve a pending decision (approve, deny, escalate). */
+  resolveLlmDecision(id: string, decision: LlmDecisionStatus): void {
+    this.db.prepare(`
+      UPDATE pending_llm_decisions
+      SET status = ?, decision = ?, resolved_at = ?
+      WHERE id = ?
+    `).run(decision, decision, Date.now(), id)
+  }
+
+  /**
+   * Find and mark timed-out pending decisions.
+   * Returns the count of decisions that were escalated.
+   */
+  escalateTimedOutDecisions(): number {
+    const now = Date.now()
+    const result = this.db.prepare(`
+      UPDATE pending_llm_decisions
+      SET status = 'timed_out', resolved_at = ?
+      WHERE status = 'pending' AND (queued_at + timeout_ms) < ?
+    `).run(now, now)
+    return (result as { changes: number }).changes ?? 0
+  }
+
   close(): void {
     this.db.close()
   }
@@ -767,5 +1027,36 @@ function messagingRouteRowToRecord(row: MessagingRouteRow): MessagingRouteRecord
     agentSessionId: row.agent_session_id,
     createdAt: new Date(row.created_at),
     lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : undefined,
+  }
+}
+
+// =============================================================================
+// Row → record converters for orchestrator tables (PRLT-1265)
+// =============================================================================
+
+function threadRowToRecord(row: OrchestratorThreadRow): OrchestratorThreadRecord {
+  return {
+    name: row.name,
+    address: row.address,
+    routes: row.routes ? row.routes.split(',').map(r => r.trim()).filter(Boolean) : null,
+    status: row.status as OrchestratorThreadStatus,
+    registeredAt: new Date(row.registered_at),
+    lastSeen: new Date(row.last_seen),
+  }
+}
+
+function llmDecisionRowToRecord(row: PendingLlmDecisionRow): PendingLlmDecisionRecord {
+  return {
+    id: row.id,
+    eventName: row.event_name,
+    hookName: row.hook_name,
+    action: row.action,
+    contextJson: row.context_json,
+    status: row.status as LlmDecisionStatus,
+    orchestratorName: row.orchestrator_name,
+    queuedAt: new Date(row.queued_at),
+    timeoutMs: row.timeout_ms,
+    resolvedAt: row.resolved_at ? new Date(row.resolved_at) : null,
+    decision: row.decision,
   }
 }

--- a/apps/cli/src/lib/orchestrate/thread-router.ts
+++ b/apps/cli/src/lib/orchestrate/thread-router.ts
@@ -1,0 +1,173 @@
+/**
+ * Orchestrator Thread Router (PRLT-1265)
+ *
+ * Routes daemon events to the correct orchestrator thread via tmux send-keys.
+ * Messages are tagged with structured metadata so the orchestrator can
+ * distinguish daemon-routed messages from human input.
+ *
+ * Message format:
+ *   [daemon:event_name:ticket_id] Human-readable summary
+ *   [notify:event_name] FYI-only notification
+ *
+ * Response flow:
+ *   1. Daemon writes to pending_llm_decisions table
+ *   2. Router formats + sends message to orchestrator via tmux
+ *   3. Orchestrator reads context, generates response
+ *   4. Hook callback picks up the response and routes to action execution
+ *   5. Without orchestrator (timeout): escalates to human (tier 3)
+ */
+
+import { MachineDB, type OrchestratorThreadRecord, type PendingLlmDecisionRecord } from '../machine-db.js'
+import type { EscalationContext } from './escalation.js'
+
+// =============================================================================
+// Message metadata types
+// =============================================================================
+
+export type MessageType = 'daemon' | 'notify'
+
+export interface DaemonMessage {
+  type: MessageType
+  eventName: string
+  ticketId?: string
+  body: string
+}
+
+// =============================================================================
+// Message formatting
+// =============================================================================
+
+/**
+ * Format a daemon message with structured metadata prefix.
+ *
+ * Examples:
+ *   [daemon:on_pr_conflicting:PRLT-1259] PR #1094 has conflicts on main.
+ *   [notify:on_ci_failed] PR #1094 CI failed on e2e-tests.
+ */
+export function formatDaemonMessage(msg: DaemonMessage): string {
+  const tag = msg.ticketId
+    ? `[${msg.type}:${msg.eventName}:${msg.ticketId}]`
+    : `[${msg.type}:${msg.eventName}]`
+  return `${tag} ${msg.body}`
+}
+
+/**
+ * Parse a metadata-tagged message back into its components.
+ * Returns null if the message has no metadata tag (i.e. human input).
+ */
+export function parseDaemonMessage(raw: string): DaemonMessage | null {
+  const match = raw.match(/^\[(daemon|notify):([^:\]]+)(?::([^\]]+))?\]\s*(.*)$/s)
+  if (!match) return null
+  return {
+    type: match[1] as MessageType,
+    eventName: match[2],
+    ticketId: match[3] || undefined,
+    body: match[4],
+  }
+}
+
+// =============================================================================
+// Thread routing
+// =============================================================================
+
+/**
+ * Resolve which orchestrator thread should handle an event.
+ * Opens and closes machine.db internally.
+ *
+ * @returns The thread record, or null if no thread handles this event.
+ */
+export function resolveThreadForEvent(eventName: string, dbPath?: string): OrchestratorThreadRecord | null {
+  const machineDb = new MachineDB(dbPath)
+  try {
+    return machineDb.findThreadForEvent(eventName)
+  } finally {
+    machineDb.close()
+  }
+}
+
+/**
+ * Parse a thread address into its components.
+ *
+ * Address formats:
+ *   "host:tmux:session-name"
+ *   "container:abc123/tmux:session-name"
+ */
+export function parseThreadAddress(address: string): {
+  environment: 'host' | 'container'
+  containerId?: string
+  sessionId: string
+} {
+  if (address.startsWith('container:')) {
+    const rest = address.slice('container:'.length)
+    const slashIdx = rest.indexOf('/tmux:')
+    if (slashIdx === -1) {
+      return { environment: 'container', containerId: rest, sessionId: rest }
+    }
+    return {
+      environment: 'container',
+      containerId: rest.substring(0, slashIdx),
+      sessionId: rest.substring(slashIdx + '/tmux:'.length),
+    }
+  }
+  // host:tmux:session-name
+  const sessionId = address.replace(/^host:tmux:/, '')
+  return { environment: 'host', sessionId }
+}
+
+/**
+ * Build an escalation context into a formatted daemon message for the orchestrator.
+ */
+export function escalationToMessage(ctx: EscalationContext, decisionId?: string): DaemonMessage {
+  const ticketId = (ctx.ctx?.ticketId as string) || undefined
+  const parts = [`Hook "${ctx.hookName}" triggered by ${ctx.event}.`]
+  parts.push(`Action: ${ctx.action}`)
+  if (decisionId) {
+    parts.push(`Decision ID: ${decisionId}`)
+  }
+  parts.push('Decision needed: approve, deny, or escalate?')
+
+  return {
+    type: 'daemon',
+    eventName: ctx.event,
+    ticketId,
+    body: parts.join(' '),
+  }
+}
+
+/**
+ * Queue an escalation context as a pending LLM decision and return
+ * the formatted message to send to the orchestrator.
+ *
+ * This is the main integration point between the hook manager's
+ * LLM tier and the orchestrator thread system.
+ */
+export function queueAndFormatDecision(
+  ctx: EscalationContext,
+  dbPath?: string,
+): { message: string; decision: PendingLlmDecisionRecord; thread: OrchestratorThreadRecord } | null {
+  const machineDb = new MachineDB(dbPath)
+  try {
+    const thread = machineDb.findThreadForEvent(ctx.event)
+    if (!thread) return null
+
+    const decision = machineDb.createPendingLlmDecision({
+      eventName: ctx.event,
+      hookName: ctx.hookName,
+      action: ctx.action,
+      contextJson: JSON.stringify(ctx.ctx),
+      orchestratorName: thread.name,
+    })
+
+    // Touch the thread to update last_seen
+    machineDb.touchThread(thread.name)
+
+    const msg = escalationToMessage(ctx, decision.id)
+    return {
+      message: formatDaemonMessage(msg),
+      decision,
+      thread,
+    }
+  } finally {
+    machineDb.close()
+  }
+}

--- a/apps/cli/test/unit/db-repair-hq-scope.test.ts
+++ b/apps/cli/test/unit/db-repair-hq-scope.test.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+/**
+ * PRLT-1340: db repair must scope to current HQ, not scan all HQs.
+ *
+ * The resolveWorkspacePath logic was extracted into a pure function here
+ * so we can test it without spinning up the full oclif command.
+ */
+
+/**
+ * Replicate the fixed resolveWorkspacePath logic from repair.ts.
+ * This mirrors the private method for testability.
+ */
+function resolveWorkspacePath(
+  explicit: string | undefined,
+  findHQRootFn: () => string | null,
+): string | null {
+  if (explicit) {
+    return fs.existsSync(explicit) ? explicit : null
+  }
+
+  const hqPath = findHQRootFn()
+  if (hqPath && fs.existsSync(hqPath)) {
+    return hqPath
+  }
+
+  return null
+}
+
+describe('PRLT-1340: db repair HQ scoping', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-db-repair-scope-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('resolveWorkspacePath', () => {
+    it('should use explicit --workspace path when provided', () => {
+      const hqPath = path.join(tmpDir, 'my-hq')
+      fs.mkdirSync(hqPath, { recursive: true })
+
+      const result = resolveWorkspacePath(hqPath, () => '/other/hq')
+      expect(result).to.equal(hqPath)
+    })
+
+    it('should return null for explicit path that does not exist', () => {
+      const result = resolveWorkspacePath('/nonexistent/path', () => '/other/hq')
+      expect(result).to.be.null
+    })
+
+    it('should use findHQRoot result (current HQ from cwd) when no explicit path', () => {
+      const hqPath = path.join(tmpDir, 'current-hq')
+      fs.mkdirSync(hqPath, { recursive: true })
+
+      const result = resolveWorkspacePath(undefined, () => hqPath)
+      expect(result).to.equal(hqPath)
+    })
+
+    it('should return null when outside any HQ (findHQRoot returns null)', () => {
+      // This is the key regression test — previously the code would fall back
+      // to iterating ALL registered HQs and return a random one.
+      const result = resolveWorkspacePath(undefined, () => null)
+      expect(result).to.be.null
+    })
+
+    it('should NOT fall back to other registered HQs (PRLT-1340 regression)', () => {
+      // Create two fake HQ directories to simulate the multi-HQ environment
+      const inflowHq = path.join(tmpDir, 'inflow-hq')
+      const photobohemiaHq = path.join(tmpDir, 'photobohemia-hq')
+      fs.mkdirSync(inflowHq, { recursive: true })
+      fs.mkdirSync(photobohemiaHq, { recursive: true })
+
+      // Simulate running from outside any HQ — findHQRoot returns null
+      // The old code would fall back to getRegisteredHeadquarters() and
+      // return photobohemia-hq's path. The fix ensures it returns null.
+      const result = resolveWorkspacePath(undefined, () => null)
+      expect(result).to.be.null
+    })
+
+    it('should scope to the enclosing HQ, not the globally active one', () => {
+      // Simulate: user is inside inflow-hq, but global active is photobohemia-hq
+      const inflowHq = path.join(tmpDir, 'inflow-hq')
+      fs.mkdirSync(inflowHq, { recursive: true })
+
+      // findHQRoot walks up from cwd and finds inflow-hq
+      const result = resolveWorkspacePath(undefined, () => inflowHq)
+      expect(result).to.equal(inflowHq)
+    })
+  })
+
+  describe('--all flag behavior', () => {
+    it('should collect all valid registered HQ paths', () => {
+      // Simulate getRegisteredHeadquarters returning multiple HQs
+      const hq1 = path.join(tmpDir, 'hq1')
+      const hq2 = path.join(tmpDir, 'hq2')
+      const hq3Missing = path.join(tmpDir, 'hq3-missing')
+      fs.mkdirSync(hq1, { recursive: true })
+      fs.mkdirSync(hq2, { recursive: true })
+      // hq3 is intentionally not created (simulates stale registration)
+
+      const registeredHQs = [
+        { name: 'hq1', path: hq1, registeredAt: new Date().toISOString() },
+        { name: 'hq2', path: hq2, registeredAt: new Date().toISOString() },
+        { name: 'hq3-missing', path: hq3Missing, registeredAt: new Date().toISOString() },
+      ]
+
+      // Filter to valid HQs (same logic as repairAllHQs)
+      const validHQs = registeredHQs.filter(hq => fs.existsSync(hq.path))
+      expect(validHQs).to.have.length(2)
+      expect(validHQs.map(h => h.name)).to.deep.equal(['hq1', 'hq2'])
+    })
+  })
+
+  describe('output shows HQ identity', () => {
+    it('should derive HQ name from path basename', () => {
+      const workspacePath = '/Users/someone/Projects/inflow-hq'
+      const hqName = path.basename(workspacePath)
+      expect(hqName).to.equal('inflow-hq')
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrator-threads.test.ts
+++ b/apps/cli/test/unit/orchestrator-threads.test.ts
@@ -1,0 +1,210 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { MachineDB } from '../../src/lib/machine-db.js'
+
+describe('MachineDB — orchestrator threads (PRLT-1265)', () => {
+  let db: MachineDB
+  let dbPath: string
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-orch-threads-test-')))
+    dbPath = path.join(tmpDir, 'machine.db')
+    db = new MachineDB(dbPath)
+  })
+
+  afterEach(() => {
+    db.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('registerThread()', () => {
+    it('registers a thread with all fields', () => {
+      const thread = db.registerThread({
+        name: 'main',
+        address: 'host:tmux:prlt-orchestrator-hq-main',
+      })
+      expect(thread.name).to.equal('main')
+      expect(thread.address).to.equal('host:tmux:prlt-orchestrator-hq-main')
+      expect(thread.routes).to.be.null
+      expect(thread.status).to.equal('active')
+      expect(thread.registeredAt).to.be.instanceOf(Date)
+      expect(thread.lastSeen).to.be.instanceOf(Date)
+    })
+
+    it('registers a thread with explicit routes', () => {
+      const thread = db.registerThread({
+        name: 'reviewer',
+        address: 'host:tmux:prlt-orchestrator-hq-reviewer',
+        routes: ['on_pr_opened', 'on_review_requested'],
+      })
+      expect(thread.routes).to.deep.equal(['on_pr_opened', 'on_review_requested'])
+    })
+
+    it('upserts on name conflict', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:old-session', routes: ['on_ci_failed'] })
+      const updated = db.registerThread({ name: 'main', address: 'host:tmux:new-session', routes: ['on_pr_opened'] })
+      expect(updated.address).to.equal('host:tmux:new-session')
+      expect(updated.routes).to.deep.equal(['on_pr_opened'])
+    })
+  })
+
+  describe('getThread()', () => {
+    it('returns null for non-existent thread', () => {
+      expect(db.getThread('nonexistent')).to.be.null
+    })
+
+    it('returns the registered thread', () => {
+      db.registerThread({ name: 'ops', address: 'host:tmux:ops-session' })
+      const thread = db.getThread('ops')
+      expect(thread).to.not.be.null
+      expect(thread!.name).to.equal('ops')
+    })
+  })
+
+  describe('listThreads()', () => {
+    it('returns empty array when no threads registered', () => {
+      expect(db.listThreads()).to.have.lengthOf(0)
+    })
+
+    it('returns all threads', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      db.registerThread({ name: 'ops', address: 'host:tmux:ops' })
+      expect(db.listThreads()).to.have.lengthOf(2)
+    })
+
+    it('filters by status', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      db.registerThread({ name: 'ops', address: 'host:tmux:ops' })
+      db.updateThreadStatus('ops', 'inactive')
+      expect(db.listThreads({ status: 'active' })).to.have.lengthOf(1)
+      expect(db.listThreads({ status: 'inactive' })).to.have.lengthOf(1)
+    })
+  })
+
+  describe('updateThreadStatus()', () => {
+    it('marks a thread inactive', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      db.updateThreadStatus('main', 'inactive')
+      expect(db.getThread('main')!.status).to.equal('inactive')
+    })
+  })
+
+  describe('removeThread()', () => {
+    it('deletes a registered thread', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      db.removeThread('main')
+      expect(db.getThread('main')).to.be.null
+    })
+  })
+
+  describe('findThreadForEvent()', () => {
+    it('returns null when no threads are registered', () => {
+      expect(db.findThreadForEvent('on_ci_failed')).to.be.null
+    })
+
+    it('returns catch-all thread when no specific route matches', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      const match = db.findThreadForEvent('on_ci_failed')
+      expect(match).to.not.be.null
+      expect(match!.name).to.equal('main')
+    })
+
+    it('returns specific thread over catch-all', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      db.registerThread({ name: 'reviewer', address: 'host:tmux:reviewer', routes: ['on_pr_opened', 'on_review_requested'] })
+      expect(db.findThreadForEvent('on_pr_opened')!.name).to.equal('reviewer')
+      expect(db.findThreadForEvent('on_ci_failed')!.name).to.equal('main')
+    })
+
+    it('skips inactive threads', () => {
+      db.registerThread({ name: 'main', address: 'host:tmux:main' })
+      db.updateThreadStatus('main', 'inactive')
+      expect(db.findThreadForEvent('on_ci_failed')).to.be.null
+    })
+  })
+})
+
+describe('MachineDB — pending LLM decisions (PRLT-1265)', () => {
+  let db: MachineDB
+  let dbPath: string
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-llm-decisions-test-')))
+    dbPath = path.join(tmpDir, 'machine.db')
+    db = new MachineDB(dbPath)
+  })
+
+  afterEach(() => {
+    db.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('createPendingLlmDecision()', () => {
+    it('creates a decision with LLMD- prefix ID', () => {
+      const decision = db.createPendingLlmDecision({ eventName: 'on_pr_opened', hookName: 'auto-merge', action: 'merge_pr' })
+      expect(decision.id).to.match(/^LLMD-[A-Z0-9]{8}$/)
+      expect(decision.status).to.equal('pending')
+      expect(decision.eventName).to.equal('on_pr_opened')
+      expect(decision.timeoutMs).to.equal(300000)
+    })
+
+    it('stores orchestrator name and context JSON', () => {
+      const ctx = { ticketId: 'PRLT-100', prNumber: 42 }
+      const decision = db.createPendingLlmDecision({
+        eventName: 'on_ci_green', hookName: 'ship-it', action: 'merge',
+        contextJson: JSON.stringify(ctx), orchestratorName: 'main', timeoutMs: 60000,
+      })
+      expect(decision.orchestratorName).to.equal('main')
+      expect(JSON.parse(decision.contextJson)).to.deep.equal(ctx)
+      expect(decision.timeoutMs).to.equal(60000)
+    })
+  })
+
+  describe('listPendingLlmDecisions()', () => {
+    it('returns empty array when none exist', () => {
+      expect(db.listPendingLlmDecisions()).to.have.lengthOf(0)
+    })
+
+    it('filters by status', () => {
+      const d = db.createPendingLlmDecision({ eventName: 'e1', hookName: 'h1', action: 'a1' })
+      db.createPendingLlmDecision({ eventName: 'e2', hookName: 'h2', action: 'a2' })
+      db.resolveLlmDecision(d.id, 'approved')
+      expect(db.listPendingLlmDecisions({ status: 'pending' })).to.have.lengthOf(1)
+      expect(db.listPendingLlmDecisions({ status: 'approved' })).to.have.lengthOf(1)
+    })
+  })
+
+  describe('resolveLlmDecision()', () => {
+    it('marks decision as approved with resolvedAt', () => {
+      const d = db.createPendingLlmDecision({ eventName: 'e', hookName: 'h', action: 'a' })
+      db.resolveLlmDecision(d.id, 'approved')
+      const resolved = db.getPendingLlmDecision(d.id)
+      expect(resolved!.status).to.equal('approved')
+      expect(resolved!.decision).to.equal('approved')
+      expect(resolved!.resolvedAt).to.not.be.null
+    })
+  })
+
+  describe('escalateTimedOutDecisions()', () => {
+    it('escalates decisions past their timeout', () => {
+      // Create a decision with a normal timeout, then backdate queued_at
+      // so it appears to have expired (avoids same-ms race condition)
+      const d = db.createPendingLlmDecision({ eventName: 'e', hookName: 'h', action: 'a', timeoutMs: 1000 })
+      // Backdate by 2 seconds so it's past the 1-second timeout
+      const backdated = Date.now() - 2000
+      ;(db as any).db.prepare('UPDATE pending_llm_decisions SET queued_at = ? WHERE id = ?').run(backdated, d.id)
+      const count = db.escalateTimedOutDecisions()
+      expect(count).to.equal(1)
+      expect(db.listPendingLlmDecisions({ status: 'timed_out' })).to.have.lengthOf(1)
+    })
+
+    it('does not escalate decisions within timeout', () => {
+      db.createPendingLlmDecision({ eventName: 'e', hookName: 'h', action: 'a', timeoutMs: 300000 })
+      expect(db.escalateTimedOutDecisions()).to.equal(0)
+    })
+  })
+})

--- a/apps/cli/test/unit/thread-router.test.ts
+++ b/apps/cli/test/unit/thread-router.test.ts
@@ -1,0 +1,149 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  formatDaemonMessage,
+  parseDaemonMessage,
+  parseThreadAddress,
+  escalationToMessage,
+  queueAndFormatDecision,
+} from '../../src/lib/orchestrate/thread-router.js'
+import { MachineDB } from '../../src/lib/machine-db.js'
+import type { EscalationContext } from '../../src/lib/orchestrate/escalation.js'
+
+describe('thread-router — message formatting (PRLT-1265)', () => {
+  describe('formatDaemonMessage()', () => {
+    it('formats a daemon message with ticket ID', () => {
+      const result = formatDaemonMessage({
+        type: 'daemon', eventName: 'on_pr_conflicting', ticketId: 'PRLT-1259',
+        body: 'PR #1094 has conflicts on main.',
+      })
+      expect(result).to.equal('[daemon:on_pr_conflicting:PRLT-1259] PR #1094 has conflicts on main.')
+    })
+
+    it('formats a notify message without ticket ID', () => {
+      const result = formatDaemonMessage({
+        type: 'notify', eventName: 'on_ci_failed',
+        body: 'CI failed on e2e-tests.',
+      })
+      expect(result).to.equal('[notify:on_ci_failed] CI failed on e2e-tests.')
+    })
+  })
+
+  describe('parseDaemonMessage()', () => {
+    it('parses a daemon message with ticket ID', () => {
+      const parsed = parseDaemonMessage('[daemon:on_pr_conflicting:PRLT-1259] PR #1094 has conflicts.')
+      expect(parsed).to.not.be.null
+      expect(parsed!.type).to.equal('daemon')
+      expect(parsed!.eventName).to.equal('on_pr_conflicting')
+      expect(parsed!.ticketId).to.equal('PRLT-1259')
+      expect(parsed!.body).to.equal('PR #1094 has conflicts.')
+    })
+
+    it('parses a notify message without ticket ID', () => {
+      const parsed = parseDaemonMessage('[notify:on_ci_failed] CI failed.')
+      expect(parsed!.type).to.equal('notify')
+      expect(parsed!.eventName).to.equal('on_ci_failed')
+      expect(parsed!.ticketId).to.be.undefined
+    })
+
+    it('returns null for plain human input', () => {
+      expect(parseDaemonMessage('hey what is the status on PRLT-1259')).to.be.null
+    })
+
+    it('roundtrips through format and parse', () => {
+      const original = {
+        type: 'daemon' as const, eventName: 'on_review_approved',
+        ticketId: 'TKT-100', body: 'Review approved by alice.',
+      }
+      const formatted = formatDaemonMessage(original)
+      const parsed = parseDaemonMessage(formatted)
+      expect(parsed).to.deep.equal(original)
+    })
+  })
+})
+
+describe('thread-router — address parsing (PRLT-1265)', () => {
+  describe('parseThreadAddress()', () => {
+    it('parses host tmux address', () => {
+      const result = parseThreadAddress('host:tmux:prlt-orchestrator-hq-main')
+      expect(result.environment).to.equal('host')
+      expect(result.sessionId).to.equal('prlt-orchestrator-hq-main')
+      expect(result.containerId).to.be.undefined
+    })
+
+    it('parses container tmux address', () => {
+      const result = parseThreadAddress('container:abc123def/tmux:prlt-orchestrator-hq-reviewer')
+      expect(result.environment).to.equal('container')
+      expect(result.containerId).to.equal('abc123def')
+      expect(result.sessionId).to.equal('prlt-orchestrator-hq-reviewer')
+    })
+  })
+})
+
+describe('thread-router — escalation formatting (PRLT-1265)', () => {
+  it('builds a daemon message from escalation context', () => {
+    const ctx: EscalationContext = {
+      hookName: 'auto-merge', event: 'on_ci_green', action: 'merge_pr',
+      ctx: { ticketId: 'PRLT-100', prNumber: 42 },
+    }
+    const msg = escalationToMessage(ctx, 'LLMD-ABC12345')
+    expect(msg.type).to.equal('daemon')
+    expect(msg.eventName).to.equal('on_ci_green')
+    expect(msg.ticketId).to.equal('PRLT-100')
+    expect(msg.body).to.include('auto-merge')
+    expect(msg.body).to.include('LLMD-ABC12345')
+  })
+})
+
+describe('thread-router — queueAndFormatDecision (PRLT-1265)', () => {
+  let dbPath: string
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-router-test-')))
+    dbPath = path.join(tmpDir, 'machine.db')
+    const db = new MachineDB(dbPath)
+    db.registerThread({ name: 'main', address: 'host:tmux:prlt-orchestrator-hq-main' })
+    db.registerThread({ name: 'reviewer', address: 'host:tmux:prlt-orchestrator-hq-reviewer', routes: ['on_pr_opened', 'on_review_requested'] })
+    db.close()
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('queues a decision and returns formatted message for matching event', () => {
+    const ctx: EscalationContext = {
+      hookName: 'review-check', event: 'on_pr_opened', action: 'auto_review',
+      ctx: { ticketId: 'PRLT-200' },
+    }
+    const result = queueAndFormatDecision(ctx, dbPath)
+    expect(result).to.not.be.null
+    expect(result!.thread.name).to.equal('reviewer')
+    expect(result!.decision.status).to.equal('pending')
+    expect(result!.decision.id).to.match(/^LLMD-/)
+    expect(result!.message).to.include('[daemon:on_pr_opened:PRLT-200]')
+  })
+
+  it('routes unmatched events to catch-all', () => {
+    const ctx: EscalationContext = {
+      hookName: 'ci-check', event: 'on_ci_failed', action: 'notify_team', ctx: {},
+    }
+    const result = queueAndFormatDecision(ctx, dbPath)
+    expect(result!.thread.name).to.equal('main')
+  })
+
+  it('returns null when no thread handles the event', () => {
+    const db = new MachineDB(dbPath)
+    db.removeThread('main')
+    db.removeThread('reviewer')
+    db.close()
+
+    const ctx: EscalationContext = {
+      hookName: 'test', event: 'on_ci_failed', action: 'test', ctx: {},
+    }
+    expect(queueAndFormatDecision(ctx, dbPath)).to.be.null
+  })
+})


### PR DESCRIPTION
## Summary

Implements orchestrator thread registration (PRLT-1265) — the system for registering Claude/Codex tmux sessions as LLM tier endpoints with metadata-tagged messaging and event routing.

- **Machine.db schema**: Added `orchestrator_threads` and `pending_llm_decisions` tables with full DAL methods (register, get, list, update, remove, findForEvent, queue/resolve decisions, timeout escalation)
- **Thread registration**: `prlt orchestrator start` now registers the session in `orchestrator_threads` with its tmux address. `prlt orchestrator stop` deregisters it
- **`--routes` flag**: New flag on `prlt orchestrator start` for event routing (e.g. `--routes "on_pr_opened,on_review_requested"`). Omit for catch-all
- **`prlt orchestrator list`**: Shows all registered orchestrator threads with status, address, and routes
- **`prlt orchestrator routes`**: Shows the event routing table (which events go to which orchestrator). Supports `--event` flag to check a specific event
- **Thread router library**: `thread-router.ts` provides message formatting (`[daemon:event:ticket]` prefix), parsing, address resolution, and decision queuing — the integration point between the hook manager's LLM tier and orchestrator threads
- **33 unit tests**: Full coverage of DAL methods, message formatting/parsing, address parsing, event routing, and decision queuing

## Architecture

```
Daemon event → findThreadForEvent() → format with [daemon:event:ticket] prefix
                                     → queue in pending_llm_decisions
                                     → send to orchestrator via tmux send-keys
Orchestrator response → hook callback picks up response → action execution
```

## Test plan
- [x] 33 unit tests pass (orchestrator-threads.test.ts + thread-router.test.ts)
- [x] Build passes (pnpm build)
- [ ] Manual: `prlt orchestrator start --name reviewer --routes "on_pr_opened"`
- [ ] Manual: `prlt orchestrator list` shows registered threads
- [ ] Manual: `prlt orchestrator routes` shows routing table
- [ ] Manual: `prlt orchestrator stop reviewer` deregisters thread

Closes: PRLT-1265
Epic: PRLT-1250 (HQ Orchestration)