### PR TITLE
refactor(PRLT-1263): unify session lookup in poke command with session list

### DIFF
--- a/apps/cli/src/commands/poke.ts
+++ b/apps/cli/src/commands/poke.ts
@@ -1,25 +1,16 @@
 /**
  * prlt poke <agent> <message> — send message to agent
  *
- * Sends keystrokes to the agent's tmux pane.
- * Works without HQ / PMO.
+ * PRLT-1263: Delegates to `session poke` so all poke entry-points
+ * share the same unified session resolution path.
  */
 
 import { Args } from '@oclif/core'
 import { PromptCommand } from '../lib/prompt-command.js'
 import { machineOutputFlags } from '../lib/pmo/index.js'
-import {
-  shouldOutputJson,
-  outputSuccessAsJson,
-  outputErrorAsJson,
-  createMetadata,
-} from '../lib/prompt-json.js'
-import { styles } from '../lib/styles.js'
-import { SessionStore } from '../lib/session-store.js'
-import { getRunner } from '../lib/runners/index.js'
 
 export default class Poke extends PromptCommand {
-  static description = 'Send a message to a running agent'
+  static description = 'Send a message to a running agent (delegates to session poke)'
 
   static examples = [
     '<%= config.bin %> poke bold-fox "focus on the login bug"',
@@ -44,63 +35,15 @@ export default class Poke extends PromptCommand {
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(Poke)
-    const jsonMode = shouldOutputJson(flags)
 
-    const store = new SessionStore()
-    try {
-      store.reconcile()
-      const session = store.resolve(args.agent)
-
-      if (!session) {
-        if (jsonMode) {
-          outputErrorAsJson('SESSION_NOT_FOUND', `No session found for "${args.agent}". Run "prlt ps" to see agents.`, createMetadata('poke', flags))
-          return
-        }
-        this.error(`No session found for "${args.agent}". Run "prlt ps" to see agents.`)
-      }
-
-      if (session.status !== 'running') {
-        if (jsonMode) {
-          outputErrorAsJson('SESSION_NOT_RUNNING', `Session "${session.agentName}" is not running (status: ${session.status}).`, createMetadata('poke', flags))
-          return
-        }
-        this.error(`Session "${session.agentName}" is not running (status: ${session.status}).`)
-      }
-
-      const runner = getRunner(session.runner)
-      if (!runner) {
-        if (jsonMode) {
-          outputErrorAsJson('RUNNER_NOT_FOUND', `Runner "${session.runner}" not available.`, createMetadata('poke', flags))
-          return
-        }
-        this.error(`Runner "${session.runner}" not available.`)
-      }
-
-      const agentSession = {
-        id: session.id,
-        runner: session.runner,
-        sessionName: session.sessionName,
-        task: session.task,
-        workdir: session.workdir,
-        startedAt: session.startedAt,
-        status: 'running' as const,
-      }
-
-      await runner.poke(agentSession, args.message)
-
-      if (jsonMode) {
-        outputSuccessAsJson({
-          id: session.id,
-          agentName: session.agentName,
-          message: args.message,
-          delivered: true,
-        }, createMetadata('poke', flags))
-        return
-      }
-
-      this.log(styles.success(`✓ Message sent to ${session.agentName}`))
-    } finally {
-      store.close()
+    const pokeArgs: string[] = [args.agent]
+    if (args.message) {
+      pokeArgs.push(args.message)
     }
+    if (flags.json) {
+      pokeArgs.push('--json')
+    }
+
+    await this.config.runCommand('session:poke', pokeArgs)
   }
 }

--- a/apps/cli/src/commands/session/poke.ts
+++ b/apps/cli/src/commands/session/poke.ts
@@ -6,10 +6,7 @@ import {
   captureTmuxPane,
   sendTmuxMessage,
 } from '../../lib/execution/session-utils.js'
-import {
-  collectAllSessions,
-  findSessionByIdentifier,
-} from '../../lib/session/renderer.js'
+import { SessionService } from '../../services/session-service.js'
 import { PromptCommand } from '../../lib/prompt-command.js'
 import { machineOutputFlags } from '../../lib/pmo/index.js'
 import {
@@ -268,23 +265,17 @@ export default class SessionPoke extends PromptCommand {
    * Resolve an agent identifier (name, ticket ID, or tmux session name) to a
    * running session.
    *
-   * PRLT-1323: Uses the unified machine-wide session collection so this works
-   * for workers, orchestrators, AND daemons — any running tmux pane with a
-   * tracked record (workspace.db, machine.db, or tmux/Docker discovery) is
-   * reachable by identifier. No "active execution" row is required.
+   * PRLT-1263: Delegates to SessionService.resolveSession() — the same
+   * machine-wide collection path that `session list` uses — so poke and
+   * list always see an identical set of sessions.
    */
   private resolveAgentSession(
     identifier: string,
     jsonMode: boolean,
     flags: Record<string, unknown>,
   ): ResolvedSession | null {
-    // Collect every known session on the machine — across all registered HQs,
-    // machine.db, and discovered tmux/Docker sessions (orchestrators, daemons).
-    // includeAll: true so stale DB records are still considered; the helper
-    // prefers alive sessions and only falls back to stale rows when no live
-    // match exists (so tmux-level failures surface clearly to the caller).
-    const sessions = collectAllSessions({ includeAll: true })
-    const result = findSessionByIdentifier(sessions, identifier)
+    const sessionService = new SessionService()
+    const result = sessionService.resolveSession(identifier)
 
     if (result.kind === 'none') {
       if (jsonMode) {

--- a/apps/cli/src/services/index.ts
+++ b/apps/cli/src/services/index.ts
@@ -44,6 +44,7 @@ export type {
   GetTicketResult,
   ListSessionsOptions,
   ListSessionsResult,
+  ResolveSessionResult,
   RunReconcileOptions,
   WatchReconcileOptions,
   CreatePROptions,

--- a/apps/cli/src/services/session-service.ts
+++ b/apps/cli/src/services/session-service.ts
@@ -13,6 +13,7 @@ import {
   collectAllSessions,
   groupSessionsByHQ,
   bucketElsewhereByHq,
+  findSessionByIdentifier,
 } from '../lib/session/renderer.js'
 import type {
   UnifiedSession,
@@ -20,7 +21,7 @@ import type {
   SessionRole,
 } from '../lib/session/renderer.js'
 import { ServiceError } from './types.js'
-import type { ListSessionsOptions, ListSessionsResult } from './types.js'
+import type { ListSessionsOptions, ListSessionsResult, ResolveSessionResult } from './types.js'
 
 export class SessionService {
   /**
@@ -47,6 +48,32 @@ export class SessionService {
       throw new ServiceError(
         'INTERNAL',
         `Failed to collect sessions: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      )
+    }
+  }
+
+
+  /**
+   * Resolve a user-supplied identifier (agent name, ticket ID, tmux session
+   * name, or role shorthand) to a single session.
+   *
+   * Uses the same machine-wide collection path as listSessions() followed
+   * by findSessionByIdentifier(), ensuring poke and list always see
+   * the same set of sessions (PRLT-1263).
+   */
+  resolveSession(identifier: string, options: CollectOptions = {}): ResolveSessionResult {
+    try {
+      const sessions = collectAllSessions({
+        includeAll: options.includeAll ?? true,
+        hqPathFilter: options.hqPathFilter,
+        roleFilter: options.roleFilter,
+      })
+      return findSessionByIdentifier(sessions, identifier)
+    } catch (error) {
+      throw new ServiceError(
+        'INTERNAL',
+        `Failed to resolve session "${identifier}": ${error instanceof Error ? error.message : String(error)}`,
         { cause: error },
       )
     }

--- a/apps/cli/src/services/types.ts
+++ b/apps/cli/src/services/types.ts
@@ -295,6 +295,15 @@ export interface ListSessionsResult {
   grouped: GroupedSessions
 }
 
+
+/**
+ * Result of resolving a session by identifier.
+ */
+export type ResolveSessionResult =
+  | { kind: 'match'; session: UnifiedSession }
+  | { kind: 'multiple'; candidates: UnifiedSession[] }
+  | { kind: 'none' }
+
 // =============================================================================
 // Reconcile Service Types
 // =============================================================================

--- a/apps/cli/test/unit/session-poke-unified.test.ts
+++ b/apps/cli/test/unit/session-poke-unified.test.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai'
+import { SessionService } from '../../src/services/session-service.js'
+import {
+  findSessionByIdentifier,
+  type UnifiedSession,
+} from '../../src/lib/session/renderer.js'
+import type { ResolveSessionResult } from '../../src/services/types.js'
+
+/**
+ * PRLT-1263 — Unify session lookup in poke command with session list.
+ *
+ * Verifies that SessionService.resolveSession() delegates to the same
+ * collectAllSessions + findSessionByIdentifier path that listSessions()
+ * uses, so `session poke` and `session list` always see an identical
+ * set of sessions.
+ */
+
+describe('SessionService.resolveSession (PRLT-1263)', () => {
+  let service: SessionService
+
+  beforeEach(() => {
+    service = new SessionService()
+  })
+
+  it('returns none for a non-existent session identifier', () => {
+    const result = service.resolveSession('nonexistent-agent-xyz-12345')
+    expect(result.kind).to.equal('none')
+  })
+
+  it('returns a ResolveSessionResult type with valid kind', () => {
+    const result = service.resolveSession('nonexistent-agent-xyz-12345')
+    expect(result).to.have.property('kind')
+    expect(['match', 'multiple', 'none']).to.include(result.kind)
+  })
+
+  it('accepts CollectOptions to pass through to collectAllSessions', () => {
+    const result = service.resolveSession('nonexistent-agent-xyz-12345', {
+      roleFilter: 'worker',
+    })
+    expect(result.kind).to.equal('none')
+  })
+
+  it('accepts hqPathFilter option', () => {
+    const result = service.resolveSession('nonexistent-agent-xyz-12345', {
+      hqPathFilter: '/tmp/nonexistent-hq',
+    })
+    expect(result.kind).to.equal('none')
+  })
+
+  it('uses the same session pool as listSessions', () => {
+    const listResult = service.listSessions({ includeAll: true })
+    const sessions = listResult.sessions
+
+    for (const s of sessions) {
+      const resolveResult = service.resolveSession(s.agentName, { includeAll: true })
+      expect(resolveResult.kind).to.not.equal('none',
+        `resolveSession should find session "${s.agentName}" that listSessions returned`)
+    }
+  })
+})
+
+describe('findSessionByIdentifier — unified resolution contract (PRLT-1263)', () => {
+  const makeSession = (overrides: Partial<UnifiedSession> = {}): UnifiedSession => ({
+    id: 'WORK-1',
+    sessionId: 'PRLT-100-Implement-fair-knight',
+    ticketId: 'PRLT-100',
+    agentName: 'fair-knight',
+    status: 'running',
+    role: 'worker',
+    environment: 'host',
+    exists: true,
+    source: 'db',
+    ...overrides,
+  })
+
+  it('returns the same result type as ResolveSessionResult', () => {
+    const sessions = [makeSession()]
+    const result: ResolveSessionResult = findSessionByIdentifier(sessions, 'fair-knight')
+    expect(result.kind).to.equal('match')
+  })
+
+  it('resolution is deterministic — same input always yields same output', () => {
+    const sessions = [
+      makeSession(),
+      makeSession({
+        id: 'WORK-2',
+        sessionId: 'prlt-orchestrator-main',
+        ticketId: 'ORCH',
+        agentName: 'orchestrator-main',
+        role: 'orchestrator',
+      }),
+    ]
+
+    const r1 = findSessionByIdentifier(sessions, 'fair-knight')
+    const r2 = findSessionByIdentifier(sessions, 'fair-knight')
+    expect(r1.kind).to.equal(r2.kind)
+    if (r1.kind === 'match' && r2.kind === 'match') {
+      expect(r1.session.id).to.equal(r2.session.id)
+    }
+  })
+
+  it('poke resolution matches what list would show — sessions from all sources are fair game', () => {
+    const sessions = [
+      makeSession({ source: 'db', hqPath: '/home/user/hq1' }),
+      makeSession({
+        id: 'MACHINE-1',
+        sessionId: 'headless-run-1',
+        ticketId: 'headless',
+        agentName: 'headless-runner',
+        source: 'db',
+        role: 'headless',
+        hqPath: undefined,
+      }),
+      makeSession({
+        id: 'prlt-orchestrator-proletariat-main',
+        sessionId: 'prlt-orchestrator-proletariat-main',
+        ticketId: 'ORCH',
+        agentName: 'orchestrator-main',
+        source: 'discovered',
+        role: 'orchestrator',
+      }),
+    ]
+
+    expect(findSessionByIdentifier(sessions, 'fair-knight').kind).to.equal('match')
+    expect(findSessionByIdentifier(sessions, 'headless-runner').kind).to.equal('match')
+    expect(findSessionByIdentifier(sessions, 'orchestrator-main').kind).to.equal('match')
+  })
+})


### PR DESCRIPTION
## Summary

- Added `SessionService.resolveSession()` method that wraps `collectAllSessions()` + `findSessionByIdentifier()`, ensuring poke and list use the same machine-wide session collection path
- Updated `session/poke.ts` to use `SessionService.resolveSession()` instead of calling renderer functions directly
- Replaced old `poke.ts` `SessionStore`-based lookup with delegation to `session:poke` (matching `work/poke.ts` pattern)
- Added `ResolveSessionResult` type to the service layer and exported it
- Added 8 unit tests for the unified resolution path

## Problem

`prlt poke` used `SessionStore.resolve()` which only queried `~/.proletariat/sessions.db` with partial string matching — a completely different lookup path from `session list` which uses `SessionService` → `collectAllSessions()`. This caused inconsistencies where poke could not find sessions that list displayed.

## Solution

Unified all poke entry-points through `SessionService.resolveSession()`:
- `prlt poke` → delegates to `session:poke`
- `prlt session poke` → uses `SessionService.resolveSession()`
- `prlt work poke` → already delegates to `session:poke`
- `prlt session list` → uses `SessionService.listSessions()`

Both `resolveSession()` and `listSessions()` call `collectAllSessions()` internally, guaranteeing they always see the same set of sessions.

## Test plan

- [x] 8 new unit tests in `session-poke-unified.test.ts`
- [x] All 18 existing `session-poke-lookup.test.ts` tests pass
- [x] Build passes cleanly
- [x] No regressions in services.test.ts

Closes PRLT-1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)