### PR TITLE
chore: bump version to 0.3.122

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.121",
+  "version": "0.3.122",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Version bump to 0.3.122. 14 PRs merged since v0.3.121:

**Bug fixes (8):**
- fix: `work ship` PR lookup from HQ directory (PRLT-1334)
- fix: branch picker bypasses `-y` flag and `--display background` (PRLT-1335)
- fix: `work propose`/`pr create` SQLiteStorage stub removal (PRLT-1336)
- fix: execution lifecycle — status transitions, completed_at, exit_code (PRLT-1337)
- fix: machine.db schema initialization during HQ setup (PRLT-1338)
- fix: `db repair` adds missing columns via ALTER TABLE (PRLT-1339)
- fix: `db repair` scoped to current HQ only (PRLT-1340)
- fix: Homebrew ABI mismatch auto-rebuild (PRLT-1330)

**Features (3):**
- feat: `prlt action` command namespace (PRLT-1315)
- feat: orchestrator thread registration (PRLT-1265)
- feat: e2e watch→orchestrate→ship test suite (PRLT-1333)

**Refactors (3):**
- refactor: unified session lookup in poke command (PRLT-1263)
- refactor: code quality audit — 158 lint fixes, CI lint enforcement (PRLT-1298)
- fix: docker agent worktree creation error propagation (PRLT-1331)

🤖 Generated with [Claude Code](https://claude.com/claude-code)