### PR TITLE
feat(PRLT-1341): devcontainer image — install prlt via npm, auto-update on boot, rebuild on publish

### DIFF
--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,0 +1,53 @@
+name: build devcontainer image
+
+on:
+  workflow_run:
+    workflows: ["publish"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Wait for npm CDN propagation so the Dockerfile's
+      # `npm install -g @proletariat/cli@latest` picks up the new version.
+      - name: Wait for npm CDN propagation
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: sleep 90
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          VERSION=$(jq -r .version apps/cli/package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push catch-all devcontainer image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/catchall
+          push: true
+          tags: |
+            ghcr.io/chrismcdermut/proletariat-claude:latest
+            ghcr.io/chrismcdermut/proletariat-claude:${{ steps.version.outputs.version }}
+
+      - name: Summary
+        run: |
+          echo "### Devcontainer Image Build" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image:** \`ghcr.io/chrismcdermut/proletariat-claude:${{ steps.version.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Latest:** \`ghcr.io/chrismcdermut/proletariat-claude:latest\`" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/cli/src/commands/claude/index.ts
+++ b/apps/cli/src/commands/claude/index.ts
@@ -979,6 +979,8 @@ export default class Claude extends PromptCommand {
       containerEnv: {
         ANTHROPIC_API_KEY: '${localEnv:ANTHROPIC_API_KEY}',
       },
+      // PRLT-1341: Update prlt to latest on every container boot to avoid stale versions
+      postStartCommand: 'npm install -g @proletariat/cli@latest 2>/dev/null || true',
     }
 
     fs.writeFileSync(

--- a/apps/cli/src/commands/qa/index.ts
+++ b/apps/cli/src/commands/qa/index.ts
@@ -824,6 +824,8 @@ Clean up your tmux session when done.`,
       containerEnv: {
         ANTHROPIC_API_KEY: '${localEnv:ANTHROPIC_API_KEY}',
       },
+      // PRLT-1341: Update prlt to latest on every container boot to avoid stale versions
+      postStartCommand: 'npm install -g @proletariat/cli@latest 2>/dev/null || true',
     }
 
     fs.writeFileSync(

--- a/apps/cli/test/unit/catchall-devcontainer.test.ts
+++ b/apps/cli/test/unit/catchall-devcontainer.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+/**
+ * PRLT-1341: Catch-all devcontainer image installs prlt via npm and auto-updates on boot.
+ *
+ * Validates that:
+ * - The static Dockerfile uses npm (not Homebrew) to install prlt
+ * - The catch-all devcontainer configs include a postStartCommand for boot updates
+ * - The CI workflow rebuilds the image on every npm publish
+ */
+describe('Catch-all devcontainer image (PRLT-1341)', () => {
+  const repoRoot = path.resolve(__dirname, '../../../..')
+
+  describe('docker/catchall/Dockerfile', () => {
+    let dockerfile: string
+
+    before(() => {
+      const dockerfilePath = path.join(repoRoot, 'docker/catchall/Dockerfile')
+      dockerfile = fs.readFileSync(dockerfilePath, 'utf-8')
+    })
+
+    it('should install prlt via npm', () => {
+      expect(dockerfile).to.include('npm install -g @proletariat/cli@latest')
+    })
+
+    it('should NOT use Homebrew to install packages', () => {
+      expect(dockerfile).to.not.include('brew install')
+      expect(dockerfile).to.not.include('brew tap')
+    })
+
+    it('should use node:22 base image', () => {
+      expect(dockerfile).to.include('FROM node:22')
+    })
+
+    it('should install Claude Code', () => {
+      expect(dockerfile).to.include('@anthropic-ai/claude-code')
+    })
+
+    it('should install system dependencies (git, tmux, etc.)', () => {
+      expect(dockerfile).to.include('git')
+      expect(dockerfile).to.include('tmux')
+    })
+
+    it('should configure npm global directory for node user', () => {
+      expect(dockerfile).to.include('NPM_CONFIG_PREFIX=/home/node/.npm-global')
+    })
+  })
+
+  describe('catch-all devcontainer config (claude command)', () => {
+    let claudeCommandSource: string
+
+    before(() => {
+      const claudePath = path.join(repoRoot, 'apps/cli/src/commands/claude/index.ts')
+      claudeCommandSource = fs.readFileSync(claudePath, 'utf-8')
+    })
+
+    it('should reference the GHCR catch-all image', () => {
+      expect(claudeCommandSource).to.include('ghcr.io/chrismcdermut/proletariat-claude:latest')
+    })
+
+    it('should include postStartCommand to update prlt on boot', () => {
+      expect(claudeCommandSource).to.include('postStartCommand')
+      expect(claudeCommandSource).to.include('npm install -g @proletariat/cli@latest')
+    })
+  })
+
+  describe('catch-all devcontainer config (qa command)', () => {
+    let qaCommandSource: string
+
+    before(() => {
+      const qaPath = path.join(repoRoot, 'apps/cli/src/commands/qa/index.ts')
+      qaCommandSource = fs.readFileSync(qaPath, 'utf-8')
+    })
+
+    it('should reference the GHCR catch-all image', () => {
+      expect(qaCommandSource).to.include('ghcr.io/chrismcdermut/proletariat-claude:latest')
+    })
+
+    it('should include postStartCommand to update prlt on boot', () => {
+      expect(qaCommandSource).to.include('postStartCommand')
+      expect(qaCommandSource).to.include('npm install -g @proletariat/cli@latest')
+    })
+  })
+
+  describe('CI workflow (.github/workflows/build-devcontainer.yml)', () => {
+    let workflow: string
+
+    before(() => {
+      const workflowPath = path.join(repoRoot, '.github/workflows/build-devcontainer.yml')
+      workflow = fs.readFileSync(workflowPath, 'utf-8')
+    })
+
+    it('should trigger on publish workflow completion', () => {
+      expect(workflow).to.include('workflows: ["publish"]')
+      expect(workflow).to.include('types: [completed]')
+    })
+
+    it('should support manual dispatch', () => {
+      expect(workflow).to.include('workflow_dispatch')
+    })
+
+    it('should build from docker/catchall context', () => {
+      expect(workflow).to.include('context: docker/catchall')
+    })
+
+    it('should push to ghcr.io/chrismcdermut/proletariat-claude', () => {
+      expect(workflow).to.include('ghcr.io/chrismcdermut/proletariat-claude:latest')
+    })
+
+    it('should tag with both latest and version number', () => {
+      expect(workflow).to.include('proletariat-claude:latest')
+      expect(workflow).to.include('proletariat-claude:${{ steps.version.outputs.version }}')
+    })
+
+    it('should wait for npm CDN propagation', () => {
+      expect(workflow).to.include('Wait for npm CDN propagation')
+      expect(workflow).to.include('sleep 90')
+    })
+
+    it('should only run when publish workflow succeeds', () => {
+      expect(workflow).to.include('github.event.workflow_run.conclusion == \'success\'')
+    })
+  })
+})

--- a/docker/catchall/Dockerfile
+++ b/docker/catchall/Dockerfile
@@ -1,0 +1,57 @@
+# Catch-all devcontainer image for ad-hoc prlt claude / prlt qa sessions.
+#
+# Used when the target directory has no .devcontainer/ of its own.
+# Rebuilt automatically on every npm publish via build-devcontainer.yml.
+#
+# Image: ghcr.io/chrismcdermut/proletariat-claude:latest
+
+FROM node:22
+
+USER root
+
+ARG TZ=America/Los_Angeles
+ENV TZ=${TZ}
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    less git git-lfs procps sudo fzf zsh man-db unzip gnupg2 gh tmux \
+    jq nano vim \
+    && rm -rf /var/lib/apt/lists/* \
+    && git lfs install
+
+# Create workspace and home directories
+RUN mkdir -p /workspace /home/node/.claude \
+    && chown -R node:node /workspace /home/node/.claude
+
+# Set up persistent bash history
+RUN mkdir -p /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R node:node /commandhistory
+
+# Install git-delta for better diffs (architecture-aware)
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -L "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" -o /tmp/delta.deb && \
+    dpkg -i /tmp/delta.deb && \
+    rm /tmp/delta.deb
+
+# Configure npm global directory
+RUN mkdir -p /home/node/.npm-global/bin /home/node/.npm-global/lib \
+    && chown -R node:node /home/node/.npm-global
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=/home/node/.npm-global/bin:$PATH
+
+# Install pnpm, Claude Code, and prlt CLI via npm (not Homebrew)
+USER node
+RUN npm install -g pnpm \
+    && npm install -g @anthropic-ai/claude-code \
+    && npm install -g @proletariat/cli@latest
+USER root
+
+# Set default editor
+ENV EDITOR=nano
+
+# Configure shell history
+ENV HISTFILE=/commandhistory/.bash_history
+
+USER node
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

- **Dockerfile**: Created `docker/catchall/Dockerfile` that installs prlt via npm instead of Homebrew, eliminating the stale 0.3.55 version
- **Boot update**: Added `postStartCommand` to catch-all devcontainer configs (`prlt claude` and `prlt qa`) that runs `npm install -g @proletariat/cli@latest` on every container start
- **CI**: Added `build-devcontainer.yml` workflow that rebuilds and pushes the `ghcr.io/chrismcdermut/proletariat-claude` image to GHCR after every npm publish

## Test plan

- [x] 17 unit tests validate Dockerfile uses npm (not brew), postStartCommand present in both commands, CI workflow triggers correctly
- [x] Build passes
- [ ] Verify CI passes on PR

Closes PRLT-1341