### PR TITLE
feat(PRLT-1329): scope orchestrator attach to current HQ by default

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.121",
+  "version": "0.3.122",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {

--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -16,7 +16,6 @@ import {
 } from '../../lib/prompt-json.js'
 import { styles } from '../../lib/styles.js'
 import { getWorkspaceInfo } from '../../lib/agents/commands.js'
-import { findHQRoot } from '../../lib/workspace.js'
 import { loadExecutionConfig, shouldUseControlMode, buildTmuxAttachCommand } from '../../lib/execution/index.js'
 import {
   collectAllSessions,

--- a/apps/cli/src/commands/orchestrator/attach.ts
+++ b/apps/cli/src/commands/orchestrator/attach.ts
@@ -78,14 +78,19 @@ export default class OrchestratorAttach extends PromptCommand {
       char: 'n',
       description: 'Name of the orchestrator to attach to (matches agentName)',
     }),
+    scope: Flags.string({
+      char: 's',
+      description: 'Scope of orchestrator sessions to show (current HQ or all HQs)',
+      options: ['current', 'all'],
+      default: 'current',
+    }),
     here: Flags.boolean({
-      description: 'Filter to orchestrators in the current HQ only',
+      description: '[deprecated] Now the default behavior. Use --scope all to see all HQs.',
       default: false,
-      exclusive: ['hq'],
+      hidden: true,
     }),
     hq: Flags.string({
       description: 'Filter to orchestrators in a specific HQ path',
-      exclusive: ['here'],
     }),
     'new-tab': Flags.boolean({
       description: 'Open in a new terminal tab instead of attaching in the current terminal',
@@ -107,26 +112,27 @@ export default class OrchestratorAttach extends PromptCommand {
     const { flags } = await this.parse(OrchestratorAttach)
     const jsonMode = shouldOutputJson(flags)
 
-    // Resolve HQ filter
+    // Resolve scope: --hq overrides --scope, --here is deprecated (now the default)
+    const scopeAll = flags.scope === 'all'
+
+    // Resolve explicit HQ filter (--hq flag takes precedence over scope)
     let hqPathFilter: string | undefined
-    if (flags.here) {
-      const cwdHq = findHQRoot(process.cwd())
-      if (cwdHq) hqPathFilter = cwdHq
-    } else if (flags.hq) {
+    if (flags.hq) {
       hqPathFilter = flags.hq
     }
 
-    // Always query machine-wide for orchestrators.
-    let orchestrators = collectAllSessions({
+    // Collect ALL orchestrator sessions machine-wide first, then apply scoping
+    const allOrchestrators = collectAllSessions({
       hqPathFilter,
       roleFilter: 'orchestrator',
       includeAll: false,
     })
 
     // Optional --name filter
+    let filteredOrchestrators = allOrchestrators
     if (flags.name) {
       const needle = flags.name.toLowerCase()
-      orchestrators = orchestrators.filter(
+      filteredOrchestrators = filteredOrchestrators.filter(
         s =>
           s.agentName.toLowerCase() === needle ||
           s.agentName.toLowerCase().includes(needle) ||
@@ -134,7 +140,43 @@ export default class OrchestratorAttach extends PromptCommand {
       )
     }
 
+    // Group sessions by HQ for scope filtering
+    const grouped = groupSessionsByHQ(filteredOrchestrators)
+    const currentHqPath = grouped.currentHq
+
+    // Apply scope filtering: default is current-HQ only
+    let orchestrators: UnifiedSession[]
+    let hiddenElsewhereCount = 0
+
+    if (scopeAll || !currentHqPath) {
+      // --scope all or not in any HQ: show everything
+      orchestrators = filteredOrchestrators
+    } else {
+      // Default (--scope current): show only current-HQ sessions
+      orchestrators = grouped.here
+      hiddenElsewhereCount = grouped.elsewhere.length
+    }
+
+    // Handle empty results with scope awareness
     if (orchestrators.length === 0) {
+      // Check if there are sessions in other HQs that were filtered out
+      if (hiddenElsewhereCount > 0) {
+        if (jsonMode) {
+          outputErrorAsJson(
+            'NO_CURRENT_HQ_SESSION',
+            `No orchestrator running in current HQ. ${hiddenElsewhereCount} orchestrator${hiddenElsewhereCount === 1 ? '' : 's'} in other HQs. Use --scope all to see them, or start one with: prlt orchestrator start`,
+            createMetadata('orchestrator attach', flags),
+          )
+          return
+        }
+        this.log('')
+        this.log(styles.warning('No orchestrator running in current HQ.'))
+        this.log(styles.muted(`${hiddenElsewhereCount} orchestrator${hiddenElsewhereCount === 1 ? '' : 's'} in other HQs. Use --scope all to see ${hiddenElsewhereCount === 1 ? 'it' : 'them'}.`))
+        this.log(styles.muted('Start one here with: prlt orchestrator start'))
+        this.log('')
+        return
+      }
+
       if (jsonMode) {
         outputErrorAsJson(
           'NOT_RUNNING',
@@ -150,20 +192,23 @@ export default class OrchestratorAttach extends PromptCommand {
       return
     }
 
-    // Pick a single orchestrator. Prefer current-HQ sessions when multiple exist.
+    // Pick a single orchestrator
     let picked: UnifiedSession | undefined
     if (orchestrators.length === 1) {
+      // Show a note about hidden sessions even when auto-picking
+      if (hiddenElsewhereCount > 0 && !jsonMode) {
+        this.log('')
+        this.log(styles.muted(`${hiddenElsewhereCount} orchestrator${hiddenElsewhereCount === 1 ? '' : 's'} in other HQs. Use --scope all to see ${hiddenElsewhereCount === 1 ? 'it' : 'them'}.`))
+      }
       picked = orchestrators[0]
     } else {
-      const grouped = groupSessionsByHQ(orchestrators)
-      const ordered: UnifiedSession[] = [...grouped.here, ...grouped.elsewhere]
-
-      const selectMessage = 'Multiple orchestrator sessions found. Select one to attach:'
-      const sessionChoices = ordered.map(s => {
+      const selectMessage = 'Select orchestrator session:'
+      const sessionChoices = orchestrators.map(s => {
         const hqLabel = s.hqPath ? tildifyPath(s.hqPath) : '(no HQ)'
         const tag = s.environment === 'container' ? ' (Docker)' : ''
+        const hqTag = scopeAll && currentHqPath && s.hqPath === currentHqPath ? ' (current HQ)' : ''
         return {
-          name: `${s.agentName}${tag} — ${hqLabel}`,
+          name: `${s.agentName}${tag} — ${hqLabel}${hqTag}`,
           value: s.sessionId,
           command: `prlt orchestrator attach --name "${s.agentName}" --json`,
         }
@@ -177,21 +222,10 @@ export default class OrchestratorAttach extends PromptCommand {
         return
       }
 
-      // Print a grouped preview banner above the picker.
-      if (grouped.currentHq) {
+      this.log('')
+      if (hiddenElsewhereCount > 0) {
+        this.log(styles.muted(`${hiddenElsewhereCount} orchestrator${hiddenElsewhereCount === 1 ? '' : 's'} in other HQs. Use --scope all to see ${hiddenElsewhereCount === 1 ? 'it' : 'them'}.`))
         this.log('')
-        this.log(
-          styles.header(
-            `Current HQ: ${tildifyPath(grouped.currentHq)} (${grouped.here.length} orchestrator${grouped.here.length === 1 ? '' : 's'})`,
-          ),
-        )
-      }
-      if (grouped.elsewhere.length > 0) {
-        this.log(
-          styles.muted(
-            `Other locations: ${grouped.elsewhere.length} orchestrator${grouped.elsewhere.length === 1 ? '' : 's'}`,
-          ),
-        )
       }
 
       const { session } = await this.prompt<{ session: string }>([{
@@ -200,7 +234,7 @@ export default class OrchestratorAttach extends PromptCommand {
         message: selectMessage,
         choices: sessionChoices,
       }])
-      picked = ordered.find(s => s.sessionId === session)
+      picked = orchestrators.find(s => s.sessionId === session)
     }
 
     if (!picked) {

--- a/apps/cli/test/unit/orchestrator-attach-scope.test.ts
+++ b/apps/cli/test/unit/orchestrator-attach-scope.test.ts
@@ -1,0 +1,232 @@
+import { expect } from 'chai'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  groupSessionsByHQ,
+  type UnifiedSession,
+} from '../../src/lib/session/renderer.js'
+
+/**
+ * Tests for orchestrator attach --scope behavior (PRLT-1329).
+ *
+ * The attach command scopes sessions by HQ:
+ *   - Default (--scope current): only current-HQ sessions, with a count of hidden others
+ *   - --scope all: all sessions across HQs
+ *   - When no current-HQ sessions but others exist: surfaces the hidden count
+ *
+ * These tests exercise the grouping logic that backs the scoping behavior
+ * without touching tmux, Docker, or the actual oclif command runner.
+ */
+describe('Orchestrator Attach Scope (PRLT-1329)', () => {
+  const fakeOrchestrator = (overrides: Partial<UnifiedSession>): UnifiedSession => ({
+    id: overrides.id ?? 'orch-1',
+    sessionId: overrides.sessionId ?? 'prlt-orchestrator-hq-main',
+    ticketId: 'orchestrator',
+    agentName: overrides.agentName ?? 'main',
+    status: 'running',
+    role: 'orchestrator',
+    environment: overrides.environment ?? 'host',
+    exists: true,
+    source: overrides.source ?? 'discovered',
+    hqPath: overrides.hqPath,
+    hqName: overrides.hqName,
+    repoPath: overrides.repoPath,
+    startedAt: overrides.startedAt,
+    containerId: overrides.containerId,
+  })
+
+  /**
+   * Replicate the attach command's scoping logic as a pure function.
+   * This mirrors the logic in OrchestratorAttach.run() for testability.
+   */
+  function applyScope(
+    sessions: UnifiedSession[],
+    scopeAll: boolean,
+    currentHqOverride?: string | null,
+  ): { orchestrators: UnifiedSession[]; hiddenElsewhereCount: number } {
+    const grouped = groupSessionsByHQ(sessions, currentHqOverride)
+    const currentHqPath = grouped.currentHq
+
+    if (scopeAll || !currentHqPath) {
+      return { orchestrators: sessions, hiddenElsewhereCount: 0 }
+    }
+
+    return {
+      orchestrators: grouped.here,
+      hiddenElsewhereCount: grouped.elsewhere.length,
+    }
+  }
+
+  const currentHq = path.join(os.tmpdir(), 'inflow-hq')
+  const otherHq = path.join(os.tmpdir(), 'proletariat-hq')
+
+  // ===========================================================================
+  // Default scope (current HQ only)
+  // ===========================================================================
+  describe('--scope current (default)', () => {
+    it('shows only current-HQ sessions', () => {
+      const sessions = [
+        fakeOrchestrator({
+          id: 'a',
+          sessionId: 'prlt-orchestrator-inflow-main',
+          agentName: 'main',
+          hqPath: currentHq,
+          hqName: 'inflow-hq',
+        }),
+        fakeOrchestrator({
+          id: 'b',
+          sessionId: 'prlt-orchestrator-proletariat-main',
+          agentName: 'main',
+          hqPath: otherHq,
+          hqName: 'proletariat-hq',
+        }),
+      ]
+
+      const result = applyScope(sessions, false, currentHq)
+      expect(result.orchestrators).to.have.length(1)
+      expect(result.orchestrators[0].hqPath).to.equal(currentHq)
+      expect(result.hiddenElsewhereCount).to.equal(1)
+    })
+
+    it('reports correct hidden count with multiple other-HQ sessions', () => {
+      const thirdHq = path.join(os.tmpdir(), 'third-hq')
+      const sessions = [
+        fakeOrchestrator({
+          id: 'a',
+          sessionId: 'orch-a',
+          hqPath: currentHq,
+          hqName: 'inflow-hq',
+        }),
+        fakeOrchestrator({
+          id: 'b',
+          sessionId: 'orch-b',
+          hqPath: otherHq,
+          hqName: 'proletariat-hq',
+        }),
+        fakeOrchestrator({
+          id: 'c',
+          sessionId: 'orch-c',
+          hqPath: thirdHq,
+          hqName: 'third-hq',
+        }),
+      ]
+
+      const result = applyScope(sessions, false, currentHq)
+      expect(result.orchestrators).to.have.length(1)
+      expect(result.hiddenElsewhereCount).to.equal(2)
+    })
+
+    it('returns empty with hidden count when no current-HQ sessions but others exist', () => {
+      const sessions = [
+        fakeOrchestrator({
+          id: 'b',
+          sessionId: 'prlt-orchestrator-proletariat-main',
+          agentName: 'main',
+          hqPath: otherHq,
+          hqName: 'proletariat-hq',
+        }),
+      ]
+
+      const result = applyScope(sessions, false, currentHq)
+      expect(result.orchestrators).to.have.length(0)
+      expect(result.hiddenElsewhereCount).to.equal(1)
+    })
+
+    it('returns empty with zero hidden when no sessions at all', () => {
+      const result = applyScope([], false, currentHq)
+      expect(result.orchestrators).to.have.length(0)
+      expect(result.hiddenElsewhereCount).to.equal(0)
+    })
+
+    it('shows all sessions when only current-HQ sessions exist', () => {
+      const sessions = [
+        fakeOrchestrator({
+          id: 'a',
+          sessionId: 'orch-a',
+          hqPath: currentHq,
+          hqName: 'inflow-hq',
+          agentName: 'main',
+        }),
+        fakeOrchestrator({
+          id: 'b',
+          sessionId: 'orch-b',
+          hqPath: currentHq,
+          hqName: 'inflow-hq',
+          agentName: 'secondary',
+        }),
+      ]
+
+      const result = applyScope(sessions, false, currentHq)
+      expect(result.orchestrators).to.have.length(2)
+      expect(result.hiddenElsewhereCount).to.equal(0)
+    })
+  })
+
+  // ===========================================================================
+  // --scope all
+  // ===========================================================================
+  describe('--scope all', () => {
+    it('shows sessions from all HQs', () => {
+      const sessions = [
+        fakeOrchestrator({
+          id: 'a',
+          sessionId: 'orch-a',
+          hqPath: currentHq,
+          hqName: 'inflow-hq',
+        }),
+        fakeOrchestrator({
+          id: 'b',
+          sessionId: 'orch-b',
+          hqPath: otherHq,
+          hqName: 'proletariat-hq',
+        }),
+      ]
+
+      const result = applyScope(sessions, true, currentHq)
+      expect(result.orchestrators).to.have.length(2)
+      expect(result.hiddenElsewhereCount).to.equal(0)
+    })
+
+    it('shows all sessions even when not in any HQ', () => {
+      const sessions = [
+        fakeOrchestrator({
+          id: 'a',
+          sessionId: 'orch-a',
+          hqPath: otherHq,
+          hqName: 'proletariat-hq',
+        }),
+      ]
+
+      const result = applyScope(sessions, true, null)
+      expect(result.orchestrators).to.have.length(1)
+      expect(result.hiddenElsewhereCount).to.equal(0)
+    })
+  })
+
+  // ===========================================================================
+  // Not in any HQ (fallback)
+  // ===========================================================================
+  describe('not in any HQ', () => {
+    it('shows all sessions when currentHq is undefined', () => {
+      const sessions = [
+        fakeOrchestrator({
+          id: 'a',
+          sessionId: 'orch-a',
+          hqPath: otherHq,
+          hqName: 'proletariat-hq',
+        }),
+        fakeOrchestrator({
+          id: 'b',
+          sessionId: 'orch-b',
+          hqPath: currentHq,
+          hqName: 'inflow-hq',
+        }),
+      ]
+
+      // When not in any HQ, scope filtering can't apply — show everything
+      const result = applyScope(sessions, false, null)
+      expect(result.orchestrators).to.have.length(2)
+      expect(result.hiddenElsewhereCount).to.equal(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Default `prlt orchestrator attach` now only shows sessions from the current HQ
- Sessions from other HQs are hidden behind `--scope all` flag
- When no current-HQ sessions exist but other HQs have sessions, suggests creating one instead of silently attaching elsewhere
- Deprecated `--here` flag (now the default behavior)

## Test plan
- [x] Unit tests verify scoping logic for all scenarios (8 tests)
- [ ] Manual: run `prlt orchestrator attach` in one HQ with sessions in another — only current HQ shown
- [ ] Manual: run `prlt orchestrator attach --scope all` — all sessions visible
- [ ] Manual: no sessions in current HQ but exist elsewhere — shows helpful message