### PR TITLE
feat(PRLT-1309): non-interactive flags for agent automation

### DIFF
--- a/apps/cli/src/commands/linear/import.ts
+++ b/apps/cli/src/commands/linear/import.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core'
-import inquirer from 'inquirer'
 import { PMOCommand, pmoBaseFlags } from '../../lib/pmo/index.js'
 import { colors } from '../../lib/colors.js'
 import {
@@ -153,30 +152,17 @@ export default class LinearImport extends PMOCommand {
         if (teams.length === 1) {
           filter.teamKey = teams[0].key
         } else {
-          if (jsonMode) {
-            const teamChoices = teams.map((t) => ({
-              name: `${t.name} (${t.key})`,
-              value: t.key,
-            }))
-            outputPromptAsJson(
-              buildPromptConfig('list', 'teamKey', 'Select a team to import from:', teamChoices),
-              createMetadata('linear import', flags),
-            )
-            return
-          }
-
-          const teamChoices = teams.map((t) => ({
-            name: `${t.name} (${t.key})`,
-            value: t.key,
-          }))
-
-          const { teamKey } = await inquirer.prompt([{
-            type: 'list',
-            name: 'teamKey',
+          const selected = await this.selectFromList({
             message: 'Select a team to import from:',
-            choices: teamChoices,
-          }])
-          filter.teamKey = teamKey
+            items: teams,
+            getName: (t) => `${t.name} (${t.key})`,
+            getValue: (t) => t.key,
+            getCommand: (t) => `prlt linear import --team ${t.key}${flags.all ? ' --all' : ''}${flags['dry-run'] ? ' --dry-run' : ''}${flags.state ? ` --state "${flags.state}"` : ''}${flags.label ? ` --label "${flags.label}"` : ''} --json`,
+            jsonMode: jsonMode ? { flags, commandName: 'linear import' } : null,
+          })
+
+          if (!selected) return
+          filter.teamKey = selected
         }
       }
 
@@ -224,19 +210,34 @@ export default class LinearImport extends PMOCommand {
 
     // Interactive selection (unless --all or explicit IDs)
     let selectedIssues = newIssues
-    if (!flags.all && issueIdentifiers.length === 0 && !jsonMode) {
+    if (!flags.all && issueIdentifiers.length === 0) {
+      if (jsonMode) {
+        // In JSON mode, output issue list as a prompt so agents can select
+        // or re-run with explicit issue IDs or --all
+        const issueChoices = newIssues.map((issue) => ({
+          name: `${issue.identifier}  ${issue.title}  [${issue.state.name}]  ${issue.priority > 0 ? `P${issue.priority - 1}` : ''}`,
+          value: issue.identifier,
+          command: `prlt linear import ${issue.identifier} --json`,
+        }))
+        outputPromptAsJson(
+          buildPromptConfig('checkbox', 'issues', `Select issues to import (${newIssues.length} new, ${alreadyImported.length} already imported):`, issueChoices),
+          createMetadata('linear import', flags),
+        )
+        return
+      }
+
       const issueChoices = newIssues.map((issue) => ({
         name: `${issue.identifier}  ${issue.title}  [${issue.state.name}]  ${issue.priority > 0 ? `P${issue.priority - 1}` : ''}`,
         value: issue.id,
         checked: true,
       }))
 
-      const { selectedIds } = await inquirer.prompt([{
+      const { selectedIds } = await this.prompt<{ selectedIds: string[] }>([{
         type: 'checkbox',
         name: 'selectedIds',
         message: `Select issues to import (${newIssues.length} new, ${alreadyImported.length} already imported):`,
         choices: issueChoices,
-      }])
+      }], jsonMode ? { flags, commandName: 'linear import' } : null)
 
       selectedIssues = newIssues.filter((i) => (selectedIds as string[]).includes(i.id))
     }

--- a/apps/cli/src/commands/project/configure.ts
+++ b/apps/cli/src/commands/project/configure.ts
@@ -75,25 +75,6 @@ export default class ProjectConfigure extends PMOCommand {
         : undefined,
     })
 
-    // Get current board columns
-    const board = await this.storage.getProjectBoard(projectId)
-    if (!board) {
-      if (jsonMode) {
-        outputErrorAsJson('PROJECT_NOT_FOUND', 'Project not found.', createMetadata('project configure', flags))
-        return
-      }
-      this.error('Project not found.')
-    }
-
-    const columns = board.columns.map((col) => col.name)
-    if (columns.length === 0) {
-      if (jsonMode) {
-        outputErrorAsJson('NO_COLUMNS', 'No columns found on the board.', createMetadata('project configure', flags))
-        return
-      }
-      this.error('No columns found on the board.')
-    }
-
     if (!this.db) {
       if (jsonMode) {
         outputErrorAsJson('NO_DATABASE', 'No workspace database found.', createMetadata('project configure', flags))
@@ -116,12 +97,11 @@ export default class ProjectConfigure extends PMOCommand {
       }
     }
 
-    // Show-only mode
+    // Show-only mode — does not require board columns
     if (flags.show) {
       if (jsonMode) {
         outputSuccessAsJson({
           workflow: currentConfig,
-          columns,
         }, createMetadata('project configure', flags))
         return
       }
@@ -129,15 +109,14 @@ export default class ProjectConfigure extends PMOCommand {
       this.log(styles.emphasis('\nWorkflow Column Mapping:\n'))
       for (const intent of WORKFLOW_INTENTS) {
         const current = currentConfig[intent.key]
-        const exists = columns.some((c) => c.toLowerCase() === current.toLowerCase())
-        const status = exists ? styles.success('(exists)') : styles.warning('(not on board)')
-        this.log(`  ${intent.label}: ${styles.emphasis(current)} ${status}`)
+        this.log(`  ${intent.label}: ${styles.emphasis(current)}`)
       }
       this.log('')
       return
     }
 
-    // Non-interactive --set mode: parse key=value pairs and apply directly
+    // Non-interactive --set mode: parse key=value pairs and save directly
+    // Does not require board column lookup — the user/agent provides exact values.
     if (flags.set && flags.set.length > 0) {
       const newConfig: Partial<WorkflowConfig> = {}
 
@@ -170,17 +149,7 @@ export default class ProjectConfigure extends PMOCommand {
           this.error(`Empty value for key "${key}". Provide a column name.`)
         }
 
-        // Validate value is a valid board column (case-insensitive)
-        const matchedColumn = columns.find((c) => c.toLowerCase() === value.toLowerCase())
-        if (!matchedColumn) {
-          if (jsonMode) {
-            outputErrorAsJson('COLUMN_NOT_FOUND', `Column "${value}" not found on board. Available columns: ${columns.join(', ')}`, createMetadata('project configure', flags))
-            return
-          }
-          this.error(`Column "${value}" not found on board. Available columns: ${columns.join(', ')}`)
-        }
-
-        newConfig[key as WorkColumnType] = matchedColumn
+        newConfig[key as WorkColumnType] = value
       }
 
       setWorkflowConfig(this.db!, newConfig)
@@ -193,15 +162,37 @@ export default class ProjectConfigure extends PMOCommand {
       this.log(styles.success('\nWorkflow mapping saved.\n'))
       const merged = { ...currentConfig, ...newConfig }
       for (const intent of WORKFLOW_INTENTS) {
-        const value = merged[intent.key]
+        const val = merged[intent.key]
         const changed = newConfig[intent.key] ? styles.success(' (updated)') : ''
-        this.log(`  ${intent.label}: ${styles.emphasis(value)}${changed}`)
+        this.log(`  ${intent.label}: ${styles.emphasis(val)}${changed}`)
       }
       this.log('')
       return
     }
 
-    // Interactive mapping
+    // Interactive mapping — needs board columns from provider
+    let columns: string[]
+    try {
+      const board = await this.storage.getProjectBoard(projectId)
+      columns = board ? board.columns.map((col) => col.name) : []
+    } catch {
+      // PRLT-1299: getProjectBoard may be dead if provider handles boards.
+      // Fall back to current config values as the column list.
+      columns = []
+    }
+
+    if (columns.length === 0) {
+      // Fall back to current config values as column choices
+      columns = [...new Set(Object.values(currentConfig))]
+      if (columns.length === 0) {
+        if (jsonMode) {
+          outputErrorAsJson('NO_COLUMNS', 'No columns found. Use --set to configure workflow mappings directly (e.g., --set planned=Todo).', createMetadata('project configure', flags))
+          return
+        }
+        this.error('No columns found. Use --set to configure workflow mappings directly (e.g., --set planned=Todo).')
+      }
+    }
+
     if (!jsonMode) {
       this.log(styles.emphasis('\nWorkflow Column Mapping'))
       this.log(styles.muted('Map your board columns to workflow stages.\n'))

--- a/apps/cli/src/commands/project/configure.ts
+++ b/apps/cli/src/commands/project/configure.ts
@@ -7,6 +7,7 @@ import { styles } from '../../lib/styles.js'
 import {
   shouldOutputJson,
   outputPromptAsJson,
+  outputSuccessAsJson,
   buildPromptConfig,
   createMetadata,
   outputErrorAsJson,
@@ -34,12 +35,17 @@ const WORKFLOW_INTENTS: Array<{
   { key: 'backlog', label: 'Backlog', description: 'Tickets not yet scheduled' },
 ]
 
+/** Valid keys for the --set flag */
+const VALID_SET_KEYS = new Set<string>(WORKFLOW_INTENTS.map((i) => i.key))
+
 export default class ProjectConfigure extends PMOCommand {
   static description = 'Configure workflow column mapping for a project'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> --workflow',
     '<%= config.bin %> <%= command.id %> --workflow --show',
+    '<%= config.bin %> <%= command.id %> --set planned=Todo --set in_progress="In Progress"',
+    '<%= config.bin %> <%= command.id %> --set review=Review --set done=Done --set backlog=Backlog',
   ]
 
   static flags = {
@@ -52,6 +58,10 @@ export default class ProjectConfigure extends PMOCommand {
     show: Flags.boolean({
       description: 'Show current workflow mapping without prompting',
       default: false,
+    }),
+    set: Flags.string({
+      multiple: true,
+      description: 'Set a workflow column mapping as key=value (e.g., --set planned=Todo). Valid keys: planned, in_progress, review, done, backlog',
     }),
   }
 
@@ -109,11 +119,10 @@ export default class ProjectConfigure extends PMOCommand {
     // Show-only mode
     if (flags.show) {
       if (jsonMode) {
-        this.log(JSON.stringify({
-          success: true,
+        outputSuccessAsJson({
           workflow: currentConfig,
           columns,
-        }, null, 2))
+        }, createMetadata('project configure', flags))
         return
       }
 
@@ -123,6 +132,70 @@ export default class ProjectConfigure extends PMOCommand {
         const exists = columns.some((c) => c.toLowerCase() === current.toLowerCase())
         const status = exists ? styles.success('(exists)') : styles.warning('(not on board)')
         this.log(`  ${intent.label}: ${styles.emphasis(current)} ${status}`)
+      }
+      this.log('')
+      return
+    }
+
+    // Non-interactive --set mode: parse key=value pairs and apply directly
+    if (flags.set && flags.set.length > 0) {
+      const newConfig: Partial<WorkflowConfig> = {}
+
+      for (const pair of flags.set) {
+        const eqIndex = pair.indexOf('=')
+        if (eqIndex === -1) {
+          if (jsonMode) {
+            outputErrorAsJson('INVALID_SET_FORMAT', `Invalid --set format: "${pair}". Expected key=value (e.g., --set planned=Todo)`, createMetadata('project configure', flags))
+            return
+          }
+          this.error(`Invalid --set format: "${pair}". Expected key=value (e.g., --set planned=Todo)`)
+        }
+
+        const key = pair.substring(0, eqIndex)
+        const value = pair.substring(eqIndex + 1)
+
+        if (!VALID_SET_KEYS.has(key)) {
+          if (jsonMode) {
+            outputErrorAsJson('INVALID_SET_KEY', `Invalid workflow key: "${key}". Valid keys: ${[...VALID_SET_KEYS].join(', ')}`, createMetadata('project configure', flags))
+            return
+          }
+          this.error(`Invalid workflow key: "${key}". Valid keys: ${[...VALID_SET_KEYS].join(', ')}`)
+        }
+
+        if (!value) {
+          if (jsonMode) {
+            outputErrorAsJson('EMPTY_SET_VALUE', `Empty value for key "${key}". Provide a column name.`, createMetadata('project configure', flags))
+            return
+          }
+          this.error(`Empty value for key "${key}". Provide a column name.`)
+        }
+
+        // Validate value is a valid board column (case-insensitive)
+        const matchedColumn = columns.find((c) => c.toLowerCase() === value.toLowerCase())
+        if (!matchedColumn) {
+          if (jsonMode) {
+            outputErrorAsJson('COLUMN_NOT_FOUND', `Column "${value}" not found on board. Available columns: ${columns.join(', ')}`, createMetadata('project configure', flags))
+            return
+          }
+          this.error(`Column "${value}" not found on board. Available columns: ${columns.join(', ')}`)
+        }
+
+        newConfig[key as WorkColumnType] = matchedColumn
+      }
+
+      setWorkflowConfig(this.db!, newConfig)
+
+      if (jsonMode) {
+        outputSuccessAsJson({ workflow: { ...currentConfig, ...newConfig } }, createMetadata('project configure', flags))
+        return
+      }
+
+      this.log(styles.success('\nWorkflow mapping saved.\n'))
+      const merged = { ...currentConfig, ...newConfig }
+      for (const intent of WORKFLOW_INTENTS) {
+        const value = merged[intent.key]
+        const changed = newConfig[intent.key] ? styles.success(' (updated)') : ''
+        this.log(`  ${intent.label}: ${styles.emphasis(value)}${changed}`)
       }
       this.log('')
       return
@@ -148,8 +221,17 @@ export default class ProjectConfigure extends PMOCommand {
       const defaultValue = columns.find((c) => c.toLowerCase() === currentConfig[intent.key].toLowerCase()) || columns[0]
 
       if (jsonMode) {
+        // Build accumulated --set flags from any already-resolved intents
+        const accumulatedSets = Object.entries(newConfig)
+          .map(([k, v]) => `--set ${k}=${v}`)
+          .join(' ')
+        const setPrefix = accumulatedSets ? `${accumulatedSets} ` : ''
+
         outputPromptAsJson(
-          buildPromptConfig('list', intent.key, message, choices, defaultValue),
+          buildPromptConfig('list', intent.key, message, choices.map((c) => ({
+            ...c,
+            command: `prlt project configure -P ${projectId} ${setPrefix}--set ${intent.key}=${c.value} --json`,
+          })), defaultValue),
           createMetadata('project configure', flags),
         )
         return
@@ -181,7 +263,7 @@ export default class ProjectConfigure extends PMOCommand {
       }
       this.log('')
     } else {
-      this.log(JSON.stringify({ success: true, workflow: newConfig }, null, 2))
+      outputSuccessAsJson({ workflow: newConfig }, createMetadata('project configure', flags))
     }
   }
 }

--- a/apps/cli/src/commands/ticket/delete.ts
+++ b/apps/cli/src/commands/ticket/delete.ts
@@ -8,23 +8,28 @@ import { styles } from '../../lib/styles.js';
 import {
   shouldOutputJson,
   outputErrorAsJson,
+  outputSuccessAsJson,
   createMetadata,
 } from '../../lib/prompt-json.js';
 
 export default class TicketDelete extends PMOCommand {
   static description = 'Delete ticket(s) permanently';
 
+  static strict = false; // Allow variadic ticket ID args
+
   static examples = [
     '<%= config.bin %> <%= command.id %> TICK-001',
+    '<%= config.bin %> <%= command.id %> TICK-001 TICK-002 TICK-003  # Delete multiple tickets',
     '<%= config.bin %> <%= command.id %> TICK-001 --force',
     '<%= config.bin %> <%= command.id %>  # Interactive mode',
     '<%= config.bin %> <%= command.id %> --bulk',
+    '<%= config.bin %> <%= command.id %> --bulk --force --status Done  # Non-interactive bulk delete by status',
     '<%= config.bin %> <%= command.id %> --json  # Output choices as JSON',
   ];
 
   static args = {
     ticketId: Args.string({
-      description: 'Ticket ID to delete - prompts with dropdown if not provided',
+      description: 'Ticket ID(s) to delete — pass multiple IDs to delete several tickets. Prompts with dropdown if not provided.',
       required: false,
     }),
   };
@@ -41,10 +46,14 @@ export default class TicketDelete extends PMOCommand {
       description: 'Enable bulk mode to delete multiple tickets',
       default: false,
     }),
+    status: Flags.string({
+      char: 's',
+      description: 'Filter tickets by status name (for use with --bulk --force)',
+    }),
   };
 
   async execute(): Promise<void> {
-    const { args, flags } = await this.parse(TicketDelete);
+    const { args, argv, flags } = await this.parse(TicketDelete);
     const projectId = (flags as { project?: string }).project;
 
     // Check if JSON output mode is active
@@ -59,20 +68,44 @@ export default class TicketDelete extends PMOCommand {
       this.error(message);
     };
 
+    // Collect all ticket IDs from variadic args
+    const ticketIds = argv as string[];
+
     // Get all tickets from provider — no local PMO fallback
     const deleteProvider = this.resolveProjectProvider(projectId || '');
     const deleteListResult = await deleteProvider.listTickets(projectId);
     if (!deleteListResult.success) {
       return handleError('LIST_FAILED', deleteListResult.error || 'Failed to list tickets.');
     }
-    const allTickets = deleteListResult.tickets;
+    let allTickets = deleteListResult.tickets;
 
     if (allTickets.length === 0) {
       return handleError('NO_TICKETS', 'No tickets found.');
     }
 
+    // Apply --status filter if provided
+    if (flags.status) {
+      const statusLower = flags.status.toLowerCase();
+      allTickets = allTickets.filter((t) => (t.statusName ?? '').toLowerCase() === statusLower);
+      if (allTickets.length === 0) {
+        return handleError('NO_MATCHING_TICKETS', `No tickets found with status "${flags.status}".`);
+      }
+    }
+
+    // Multiple ticket IDs provided — delete each one
+    if (ticketIds.length > 1) {
+      await this.executeMultiple(ticketIds, projectId || '', flags.force, jsonMode, flags);
+      return;
+    }
+
     // Bulk mode
     if (flags.bulk) {
+      // When --force + --status (or just --force), skip interactive selection
+      if (flags.force && (flags.status || ticketIds.length === 0)) {
+        const ticketsToDelete = flags.status ? allTickets : allTickets;
+        await this.executeDirectBulk(ticketsToDelete, jsonMode, flags);
+        return;
+      }
       await this.executeBulk(allTickets, flags.force, flags);
       return;
     }
@@ -157,8 +190,143 @@ export default class TicketDelete extends PMOCommand {
       return;
     }
 
-    this.log(styles.success(`\n✅ Ticket ${styles.emphasis(ticketId)} deleted`));
+    this.log(styles.success(`\nTicket ${styles.emphasis(ticketId)} deleted`));
     this.log(styles.muted(`   Removed from ${result.provider === 'pmo' ? 'database and board' : `${result.provider} and local mirror`}`));
+  }
+
+  /**
+   * Delete multiple tickets by explicit IDs (non-interactive).
+   */
+  private async executeMultiple(
+    ticketIds: string[],
+    projectId: string,
+    force: boolean,
+    jsonMode: boolean,
+    flags: Record<string, unknown>
+  ): Promise<void> {
+    if (!force) {
+      this.log(styles.warning(`\nThis will PERMANENTLY DELETE ${ticketIds.length} ticket(s):`));
+      for (const id of ticketIds) {
+        this.log(styles.primary(`  ${id}`));
+      }
+      this.log('');
+
+      const jsonModeConfig = jsonMode ? { flags, commandName: 'ticket delete' } : null;
+      const { confirmed } = await this.prompt<{ confirmed: boolean }>([{
+        type: 'list',
+        name: 'confirmed',
+        message: 'Are you sure? This cannot be undone.',
+        choices: [
+          { name: 'No, cancel', value: false, command: '' },
+          { name: 'Yes, DELETE tickets', value: true, command: `prlt ticket delete ${ticketIds.join(' ')} --force --json` },
+        ],
+        default: 0,
+      }], jsonModeConfig);
+
+      if (!confirmed) {
+        this.log(styles.muted('Deletion cancelled.'));
+        return;
+      }
+    }
+
+    let successCount = 0;
+    let failCount = 0;
+    const results: Array<{ id: string; success: boolean; error?: string }> = [];
+
+    for (const ticketId of ticketIds) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const provider = await this.resolveTicketProvider(ticketId, projectId);
+        // eslint-disable-next-line no-await-in-loop
+        const result = await provider.deleteTicket(ticketId);
+        if (result.success) {
+          if (!jsonMode) this.log(styles.success(`Deleted ${ticketId} (via ${result.provider})`));
+          results.push({ id: ticketId, success: true });
+          successCount++;
+        } else {
+          if (!jsonMode) this.log(styles.error(`Failed to delete ${ticketId}: ${result.error}`));
+          results.push({ id: ticketId, success: false, error: result.error });
+          failCount++;
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (!jsonMode) this.log(styles.error(`Failed to delete ${ticketId}: ${msg}`));
+        results.push({ id: ticketId, success: false, error: msg });
+        failCount++;
+      }
+    }
+
+    await autoExportToBoard(this.pmoPath, this.storage, (msg) => this.log(styles.muted(msg)));
+
+    if (jsonMode) {
+      this.log(JSON.stringify({
+        success: failCount === 0,
+        deleted: successCount,
+        failed: failCount,
+        results,
+      }, null, 2));
+      return;
+    }
+
+    this.log('');
+    if (successCount > 0) this.log(styles.success(`Deleted ${successCount} ticket(s)`));
+    if (failCount > 0) this.log(styles.error(`Failed to delete ${failCount} ticket(s)`));
+  }
+
+  /**
+   * Bulk delete filtered tickets without interactive selection (--bulk --force).
+   */
+  private async executeDirectBulk(
+    tickets: Awaited<ReturnType<typeof this.storage.listTickets>>,
+    jsonMode: boolean,
+    flags: Record<string, unknown>
+  ): Promise<void> {
+    const ticketIds = tickets.map((t) => t.id);
+    const projectId = (flags as { project?: string }).project || '';
+
+    let successCount = 0;
+    let failCount = 0;
+    const results: Array<{ id: string; success: boolean; error?: string }> = [];
+
+    for (const ticketId of ticketIds) {
+      try {
+        const ticket = tickets.find((t) => t.id === ticketId);
+        const ticketProjectId = ticket?.projectId || projectId;
+        // eslint-disable-next-line no-await-in-loop
+        const provider = await this.resolveTicketProvider(ticketId, ticketProjectId);
+        // eslint-disable-next-line no-await-in-loop
+        const result = await provider.deleteTicket(ticketId);
+        if (result.success) {
+          if (!jsonMode) this.log(styles.success(`Deleted ${ticketId} (via ${result.provider})`));
+          results.push({ id: ticketId, success: true });
+          successCount++;
+        } else {
+          if (!jsonMode) this.log(styles.error(`Failed to delete ${ticketId}: ${result.error}`));
+          results.push({ id: ticketId, success: false, error: result.error });
+          failCount++;
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (!jsonMode) this.log(styles.error(`Failed to delete ${ticketId}: ${msg}`));
+        results.push({ id: ticketId, success: false, error: msg });
+        failCount++;
+      }
+    }
+
+    await autoExportToBoard(this.pmoPath, this.storage, (msg) => this.log(styles.muted(msg)));
+
+    if (jsonMode) {
+      outputSuccessAsJson({
+        deleted: successCount,
+        failed: failCount,
+        results,
+      }, createMetadata('ticket delete', flags));
+      return;
+    }
+
+    this.log('');
+    if (successCount > 0) this.log(styles.success(`Deleted ${successCount} ticket(s)`));
+    if (failCount > 0) this.log(styles.error(`Failed to delete ${failCount} ticket(s)`));
   }
 
   private async executeBulk(
@@ -168,7 +336,7 @@ export default class TicketDelete extends PMOCommand {
   ): Promise<void> {
     const jsonMode = flags ? shouldOutputJson(flags) : false;
     const jsonModeConfig = jsonMode ? { flags: flags as Record<string, unknown>, commandName: 'ticket delete' } : null;
-    this.log(styles.emphasis('🗑️  Delete Multiple Tickets\n'));
+    this.log(styles.emphasis('Delete Multiple Tickets\n'));
 
     // Select tickets to delete
     const { selectedTickets } = await this.prompt<{ selectedTickets: string[] }>([{
@@ -191,7 +359,7 @@ export default class TicketDelete extends PMOCommand {
       this.log(styles.warning('\nThis will PERMANENTLY DELETE:'));
       for (const ticketId of selectedTickets) {
         const ticket = allTickets.find(t => t.id === ticketId);
-        this.log(styles.primary(`  • ${ticketId}: ${ticket?.title}`));
+        this.log(styles.primary(`  ${ticketId}: ${ticket?.title}`));
       }
       this.log('');
 

--- a/apps/cli/test/e2e/non-interactive-commands.test.ts
+++ b/apps/cli/test/e2e/non-interactive-commands.test.ts
@@ -1,0 +1,224 @@
+/* eslint-disable max-nested-callbacks */
+import { expect } from 'chai';
+import Database from 'better-sqlite3';
+import {
+  createTestEnvironment,
+  cleanupTestEnvironment,
+  createHQConfig,
+  createPMODirectories,
+  setupProductionSchema,
+  createTestProject,
+  extractJson as extractJsonOrNull,
+  execInProcess,
+  type TestEnvironment,
+} from './test-helpers.js';
+
+/**
+ * Asserting wrapper around shared extractJson.
+ * Throws if no valid JSON is found.
+ */
+function extractJson<T>(output: string): T {
+  const result = extractJsonOrNull<T>(output);
+  if (result === null) {
+    throw new Error(`No JSON found in output: ${output.substring(0, 500)}...`);
+  }
+  return result;
+}
+
+/**
+ * Tests for non-interactive command improvements (PRLT-1309).
+ *
+ * Verifies that commands that previously required interactive input
+ * now support non-interactive flags and JSON mode fallbacks for agent automation.
+ */
+describe('Non-interactive command improvements (PRLT-1309)', () => {
+  let env: TestEnvironment;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    env = createTestEnvironment('non-interactive-');
+
+    db = setupProductionSchema(env.dbPath, env.pmoPath);
+    createTestProject(db, { id: 'test-project', name: 'Test Project', description: 'E2E test project' });
+
+    createHQConfig(env.proletariatDir);
+    createPMODirectories(env.pmoPath, 'test-project');
+  });
+
+  afterEach(() => {
+    if (db) db.close();
+    cleanupTestEnvironment(env);
+  });
+
+  /** Insert a test ticket into the ticket_refs table (provider-agnostic cache). */
+  function createLocalTestTicket(id: string, title: string, statusId: string = 'default-backlog'): void {
+    const statusName = statusId === 'default-backlog' ? 'Backlog' :
+                       statusId === 'default-in-progress' ? 'In Progress' :
+                       statusId === 'default-review' ? 'Review' : 'Done';
+
+    // Try pmo_tickets first (older schema), then ticket_refs (current schema)
+    try {
+      db.prepare(`
+        INSERT INTO pmo_tickets (id, project_id, title, status, status_id)
+        VALUES (?, 'test-project', ?, ?, ?)
+      `).run(id, title, statusName, statusId);
+    } catch {
+      // pmo_tickets table doesn't exist (PRLT-1299); use ticket_refs
+      db.prepare(`
+        INSERT INTO ticket_refs (id, provider, title, status, project_id)
+        VALUES (?, 'pmo', ?, ?, 'test-project')
+      `).run(id, title, statusName);
+    }
+  }
+
+  // ===========================================================================
+  // project configure --set
+  // ===========================================================================
+  describe('project configure --set', () => {
+    it('should set a single workflow column mapping via --set flag', async () => {
+      const output = await execInProcess(
+        'project configure --set planned=Todo -P test-project --json'
+      );
+      const json = extractJson<{ type: string; result: { workflow: Record<string, string> } }>(output);
+
+      expect(json.type).to.equal('success');
+      expect(json.result.workflow.planned).to.equal('Todo');
+    });
+
+    it('should set multiple workflow column mappings via repeated --set flags', async () => {
+      const output = await execInProcess(
+        'project configure --set planned=Todo --set done=Shipped -P test-project --json'
+      );
+      const json = extractJson<{ type: string; result: { workflow: Record<string, string> } }>(output);
+
+      expect(json.type).to.equal('success');
+      expect(json.result.workflow.planned).to.equal('Todo');
+      expect(json.result.workflow.done).to.equal('Shipped');
+    });
+
+    it('should reject invalid workflow keys', async () => {
+      const output = await execInProcess(
+        'project configure --set invalid_key=Todo -P test-project --json'
+      );
+      const json = extractJson<{ type: string; error: { code: string } }>(output);
+
+      expect(json.type).to.equal('error');
+      expect(json.error.code).to.equal('INVALID_SET_KEY');
+    });
+
+    it('should reject invalid --set format (missing =)', async () => {
+      const output = await execInProcess(
+        'project configure --set planned -P test-project --json'
+      );
+      const json = extractJson<{ type: string; error: { code: string } }>(output);
+
+      expect(json.type).to.equal('error');
+      expect(json.error.code).to.equal('INVALID_SET_FORMAT');
+    });
+
+    it('should reject empty values', async () => {
+      const output = await execInProcess(
+        'project configure --set planned= -P test-project --json'
+      );
+      const json = extractJson<{ type: string; error: { code: string } }>(output);
+
+      expect(json.type).to.equal('error');
+      expect(json.error.code).to.equal('EMPTY_SET_VALUE');
+    });
+
+    it('should persist workflow config across invocations', async () => {
+      // Set a column mapping
+      await execInProcess(
+        'project configure --set planned=Todo -P test-project --json'
+      );
+
+      // Read it back with --show
+      const output = await execInProcess(
+        'project configure --show -P test-project --json'
+      );
+      const json = extractJson<{ type: string; result: { workflow: Record<string, string> } }>(output);
+
+      expect(json.type).to.equal('success');
+      expect(json.result.workflow.planned).to.equal('Todo');
+    });
+
+    it('should show current config with --show in JSON mode', async () => {
+      const output = await execInProcess(
+        'project configure --show -P test-project --json'
+      );
+      const json = extractJson<{ type: string; result: { workflow: Record<string, string> } }>(output);
+
+      expect(json.type).to.equal('success');
+      expect(json.result.workflow).to.have.property('planned');
+      expect(json.result.workflow).to.have.property('in_progress');
+      expect(json.result.workflow).to.have.property('review');
+      expect(json.result.workflow).to.have.property('done');
+      expect(json.result.workflow).to.have.property('backlog');
+    });
+
+    it('should output column choices as JSON prompt when no --set given', async () => {
+      const output = await execInProcess(
+        'project configure -P test-project --json'
+      );
+      const json = extractJson<{ type: string; prompt: { type: string; name: string; choices: Array<{ command: string }> } }>(output);
+
+      expect(json.type).to.equal('prompt');
+      expect(json.prompt.type).to.equal('list');
+      // First prompt is for the 'planned' intent
+      expect(json.prompt.name).to.equal('planned');
+      // Each choice command should include --set and --json for stateless continuation
+      for (const choice of json.prompt.choices) {
+        expect(choice.command).to.include('--set planned=');
+        expect(choice.command).to.include('--json');
+        expect(choice.command).to.include('-P test-project');
+      }
+    });
+  });
+
+  // ===========================================================================
+  // ticket delete — JSON mode and flag validation
+  // ===========================================================================
+  describe('ticket delete — JSON mode', () => {
+    // Note: Full E2E tests for ticket delete with actual ticket data require
+    // a working ticket provider (Linear/Jira/PMO). The PMO provider's ticket
+    // operations were removed in PRLT-1299, so we test the command structure,
+    // JSON output format, and flag validation here.
+
+    it('should accept --status flag without error', async () => {
+      // When no tickets exist, the command should still produce valid JSON
+      const output = await execInProcess(
+        'ticket delete --bulk --force --status Done -P test-project --json'
+      );
+      const json = extractJson<{ type: string; error?: { code: string } }>(output);
+
+      // Command produces a structured JSON error (not a crash)
+      expect(json.type).to.be.a('string');
+    });
+
+    it('should accept variadic ticket IDs without parse error', async () => {
+      // The command should accept multiple args even if the provider fails
+      const output = await execInProcess(
+        'ticket delete TKT-001 TKT-002 --force -P test-project --json'
+      );
+      const json = extractJson<{ type?: string; success?: boolean; deleted?: number; failed?: number }>(output);
+
+      // Should produce JSON output (success or error, not a parse crash)
+      expect(json).to.be.an('object');
+    });
+  });
+
+  // ===========================================================================
+  // linear import — JSON mode prompts
+  // ===========================================================================
+  describe('linear import — JSON mode', () => {
+    it('should output error when Linear is not configured', async () => {
+      const output = await execInProcess(
+        'linear import -P test-project --json'
+      );
+      const json = extractJson<{ type: string; error: { code: string } }>(output);
+
+      expect(json.type).to.equal('error');
+      expect(json.error.code).to.equal('LINEAR_NOT_CONFIGURED');
+    });
+  });
+});

--- a/apps/cli/test/unit/non-interactive-flags.test.ts
+++ b/apps/cli/test/unit/non-interactive-flags.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for non-interactive flag parsing (PRLT-1309).
+ *
+ * Tests the --set flag parsing for project configure workflow,
+ * and the --status filter for ticket delete.
+ */
+
+import { expect } from 'chai';
+
+/**
+ * Valid workflow intent keys (mirrors WORKFLOW_INTENTS in configure.ts).
+ */
+const VALID_SET_KEYS = new Set(['planned', 'in_progress', 'review', 'done', 'backlog']);
+
+/**
+ * Parse a --set flag value into a key-value pair.
+ * Returns { key, value } or { error } if invalid.
+ *
+ * Note: does NOT validate against board columns — the user/agent provides exact values.
+ * Board column validation was removed in PRLT-1309 because board data
+ * is provider-managed and may not be available locally.
+ */
+function parseSetFlag(
+  pair: string,
+  validKeys: Set<string>,
+): { key: string; value: string } | { error: string; code: string } {
+  const eqIndex = pair.indexOf('=');
+  if (eqIndex === -1) {
+    return { error: `Invalid --set format: "${pair}". Expected key=value`, code: 'INVALID_SET_FORMAT' };
+  }
+
+  const key = pair.substring(0, eqIndex);
+  const value = pair.substring(eqIndex + 1);
+
+  if (!validKeys.has(key)) {
+    return { error: `Invalid workflow key: "${key}"`, code: 'INVALID_SET_KEY' };
+  }
+
+  if (!value) {
+    return { error: `Empty value for key "${key}"`, code: 'EMPTY_SET_VALUE' };
+  }
+
+  return { key, value };
+}
+
+/**
+ * Filter tickets by status name (case-insensitive).
+ */
+function filterByStatus<T extends { statusName?: string }>(tickets: T[], statusFilter: string): T[] {
+  const statusLower = statusFilter.toLowerCase();
+  return tickets.filter((t) => (t.statusName ?? '').toLowerCase() === statusLower);
+}
+
+describe('Non-interactive flag parsing (PRLT-1309)', () => {
+  describe('--set flag parsing', () => {
+    it('should parse valid key=value pairs', () => {
+      const result = parseSetFlag('planned=Backlog', VALID_SET_KEYS);
+      expect(result).to.deep.equal({ key: 'planned', value: 'Backlog' });
+    });
+
+    it('should accept any column name value', () => {
+      const result = parseSetFlag('done=Shipped', VALID_SET_KEYS);
+      expect(result).to.deep.equal({ key: 'done', value: 'Shipped' });
+    });
+
+    it('should handle values with = in them', () => {
+      // First = is the delimiter; everything after is the value
+      const result = parseSetFlag('planned=Backlog=Extra', VALID_SET_KEYS);
+      expect(result).to.deep.equal({ key: 'planned', value: 'Backlog=Extra' });
+    });
+
+    it('should reject pairs without = separator', () => {
+      const result = parseSetFlag('planned', VALID_SET_KEYS);
+      expect(result).to.have.property('code', 'INVALID_SET_FORMAT');
+    });
+
+    it('should reject invalid keys', () => {
+      const result = parseSetFlag('invalid_key=Backlog', VALID_SET_KEYS);
+      expect(result).to.have.property('code', 'INVALID_SET_KEY');
+    });
+
+    it('should reject empty values', () => {
+      const result = parseSetFlag('planned=', VALID_SET_KEYS);
+      expect(result).to.have.property('code', 'EMPTY_SET_VALUE');
+    });
+
+    it('should accept all valid workflow keys', () => {
+      for (const key of VALID_SET_KEYS) {
+        const result = parseSetFlag(`${key}=Todo`, VALID_SET_KEYS);
+        expect(result).to.have.property('key', key);
+      }
+    });
+  });
+
+  describe('--status filter', () => {
+    const tickets = [
+      { id: 'TKT-001', statusName: 'Backlog' },
+      { id: 'TKT-002', statusName: 'Backlog' },
+      { id: 'TKT-003', statusName: 'In Progress' },
+      { id: 'TKT-004', statusName: 'Done' },
+      { id: 'TKT-005', statusName: undefined },
+    ];
+
+    it('should filter tickets by exact status (case-insensitive)', () => {
+      const result = filterByStatus(tickets, 'backlog');
+      expect(result).to.have.length(2);
+      expect(result.map((t) => t.id)).to.deep.equal(['TKT-001', 'TKT-002']);
+    });
+
+    it('should match status case-insensitively', () => {
+      const result = filterByStatus(tickets, 'IN PROGRESS');
+      expect(result).to.have.length(1);
+      expect(result[0].id).to.equal('TKT-003');
+    });
+
+    it('should return empty array when no tickets match', () => {
+      const result = filterByStatus(tickets, 'Review');
+      expect(result).to.have.length(0);
+    });
+
+    it('should handle tickets with undefined statusName', () => {
+      const result = filterByStatus(tickets, 'Backlog');
+      // TKT-005 has undefined statusName, should not match
+      expect(result.map((t) => t.id)).to.not.include('TKT-005');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **project configure --set**: Add `--set key=value` flag for non-interactive workflow column mapping. Fix broken `getProjectBoard()` call (dead since PRLT-1299) by making interactive mode gracefully degrade.
- **linear import**: Replace raw `inquirer.prompt()` with `this.selectFromList()` for team selection. In JSON mode without `--all`, output a checkbox prompt for issue selection instead of silently importing all.
- **ticket delete**: Accept multiple ticket IDs as variadic args. Add `--status` filter flag for non-interactive bulk delete (`--bulk --force --status Done`).

## Test plan
- [x] Unit tests: 11 tests for --set flag parsing and --status filter logic
- [x] E2E tests: 11 tests for JSON mode output, --set persistence, and flag validation
- [x] Build passes (tsc -b)
