### PR TITLE
feat(PRLT-1285): onboarding wizard — auto-map board columns to intents

### DIFF
--- a/apps/cli/src/commands/linear/connect.ts
+++ b/apps/cli/src/commands/linear/connect.ts
@@ -21,8 +21,8 @@ import {
   getLinearApiKey,
 } from '../../lib/linear/index.js'
 import { upsertProviderSource, removeProviderSourcesByProvider } from '../../lib/work-source/provider-sources.js'
-import { autoMapIntents, formatMappingTable} from '../../lib/providers/auto-mapper.js'
-import { TransitionMapStore, validateTransitionMap } from '../../lib/providers/transition-map.js'
+import { validateTransitionMap } from '../../lib/providers/transition-map.js'
+import { runColumnWizard } from '../../lib/onboarding/column-wizard.js'
 
 export default class LinearConnect extends PMOCommand {
   static description = 'Connect to Linear workspace and configure authentication'
@@ -444,8 +444,8 @@ export default class LinearConnect extends PMOCommand {
   }
 
   /**
-   * Pull board states from Linear, auto-guess intent mappings,
-   * show to user for confirmation, and store in pmo_transition_map.
+   * Pull board states from Linear, run the column mapping wizard,
+   * and store confirmed mappings in pmo_transition_map.
    */
   private async autoMapBoardStates(
     client: LinearClient,
@@ -460,74 +460,15 @@ export default class LinearConnect extends PMOCommand {
       // Sort by position for display
       const sortedStates = [...states].sort((a, b) => a.position - b.position)
 
-      // Auto-guess mappings using state types + name heuristics
-      const mappings = autoMapIntents(
-        sortedStates.map(s => ({ id: s.id, name: s.name, type: s.type, position: s.position })),
-        'linear',
-      )
-
-      if (mappings.length === 0) return
-
-      // Display the mapping table
-      if (!jsonMode) {
-        this.log('')
-        this.log(colors.primary('Board State Mapping'))
-        this.log('')
-        const lines = formatMappingTable(
-          mappings,
-          sortedStates.map(s => ({ id: s.id, name: s.name, type: s.type, position: s.position })),
-        )
-        for (const line of lines) {
-          this.log(colors.textMuted(`  ${line}`))
-        }
-        this.log('')
-      }
-
-      // In JSON mode, output the mappings for agent confirmation
-      if (jsonMode) {
-        // Store mappings automatically in JSON mode (agents can't confirm interactively)
-        const store = new TransitionMapStore(db)
-        for (const m of mappings) {
-          store.upsertMapping({
-            provider: 'linear',
-            intent: m.intent,
-            providerStateName: m.stateName,
-            providerStateId: m.stateId,
-          })
-        }
-        // Validate transition_map against actual provider states (PRLT-1299)
-        this.validateTransitionMapAgainstProvider(db, sortedStates.map(s => s.name), jsonMode)
-        return
-      }
-
-      // Interactive: ask user to confirm or edit mappings
-      const choices = [
-        { name: 'Yes, save these mappings', value: 'accept' },
-        { name: 'No, skip mapping for now', value: 'skip' },
-      ]
-      const message = 'Save these state mappings?'
-
-      const { action } = await inquirer.prompt([{
-        type: 'list',
-        name: 'action',
-        message,
-        choices,
-      }])
-
-      if (action === 'accept') {
-        const store = new TransitionMapStore(db)
-        for (const m of mappings) {
-          store.upsertMapping({
-            provider: 'linear',
-            intent: m.intent,
-            providerStateName: m.stateName,
-            providerStateId: m.stateId,
-          })
-        }
-        this.log(colors.textMuted(`  Saved ${mappings.length} state mappings`))
-      } else {
-        this.log(colors.textMuted('  Skipped state mapping. You can configure later with "prlt config set state-map.<intent> <state-name>"'))
-      }
+      // Run the column mapping wizard
+      await runColumnWizard({
+        states: sortedStates.map(s => ({ id: s.id, name: s.name, type: s.type, position: s.position })),
+        provider: 'linear',
+        providerType: 'linear',
+        db,
+        jsonMode,
+        log: (msg: string) => this.log(msg),
+      })
 
       // Validate transition_map against actual provider states (PRLT-1299)
       this.validateTransitionMapAgainstProvider(db, sortedStates.map(s => s.name), jsonMode)

--- a/apps/cli/src/lib/database/migrations/0025_transition_map_many_to_one.ts
+++ b/apps/cli/src/lib/database/migrations/0025_transition_map_many_to_one.ts
@@ -1,0 +1,37 @@
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const transitionMapManyToOne: Migration = {
+  id: '0025',
+  name: 'transition_map_many_to_one',
+  up: (db: Database.Database) => {
+    // Allow multiple board columns to map to the same intent.
+    // e.g., "New Issues" + "New Functionality Requests" → backlog
+    //       "Canceled" + "Duplicate" → dropped
+    //
+    // SQLite doesn't support ALTER TABLE ... DROP CONSTRAINT, so we
+    // recreate the table with the new unique constraint.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS pmo_transition_map_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL,
+        intent TEXT NOT NULL,
+        provider_state_name TEXT NOT NULL,
+        provider_state_id TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(provider, intent, provider_state_name)
+      )
+    `)
+
+    db.exec(`
+      INSERT OR IGNORE INTO pmo_transition_map_new
+        (provider, intent, provider_state_name, provider_state_id, created_at, updated_at)
+      SELECT provider, intent, provider_state_name, provider_state_id, created_at, updated_at
+      FROM pmo_transition_map
+    `)
+
+    db.exec(`DROP TABLE IF EXISTS pmo_transition_map`)
+    db.exec(`ALTER TABLE pmo_transition_map_new RENAME TO pmo_transition_map`)
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -30,6 +30,7 @@ import { notificationSystem } from './0021_notification_system.js'
 import { hookModeTiers } from './0022_hook_mode_tiers.js'
 import { intentBasedActions } from './0023_intent_based_actions.js'
 import { dropDeadPmoTables } from './0024_drop_dead_pmo_tables.js'
+import { transitionMapManyToOne } from './0025_transition_map_many_to_one.js'
 
 /**
  * Ordered list of all migrations.
@@ -60,4 +61,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   hookModeTiers,
   intentBasedActions,
   dropDeadPmoTables,
+  transitionMapManyToOne,
 ]

--- a/apps/cli/src/lib/onboarding/column-wizard.ts
+++ b/apps/cli/src/lib/onboarding/column-wizard.ts
@@ -24,12 +24,6 @@ import {
 } from '../providers/auto-mapper.js'
 import { TRANSITION_INTENTS, type TransitionIntent } from '../providers/state-intents.js'
 import { TransitionMapStore } from '../providers/transition-map.js'
-import {
-  outputPromptAsJson,
-  outputSuccessAsJson,
-  buildPromptConfig,
-  createMetadata,
-} from '../prompt-json.js'
 
 export type ProviderType = 'linear' | 'jira' | 'trello' | 'asana' | 'shortcut' | 'clickup' | 'github' | 'pmo'
 
@@ -71,7 +65,7 @@ export async function runColumnWizard(opts: ColumnWizardOptions): Promise<Wizard
 
   // Step 2: Handle JSON mode — auto-save and return
   if (jsonMode) {
-    return handleJsonMode(mappings, ambiguous, unmapped, provider, db, states)
+    return handleJsonMode(mappings, ambiguous, unmapped, provider, db)
   }
 
   // Step 3: Show mapping table
@@ -123,10 +117,9 @@ export async function runColumnWizard(opts: ColumnWizardOptions): Promise<Wizard
 function handleJsonMode(
   mappings: IntentMapping[],
   ambiguous: Array<{ state: BoardState; candidateIntents: Array<{ intent: string; reason: string }> }>,
-  unmapped: BoardState[],
+  _unmapped: BoardState[],
   provider: string,
   db: Database.Database,
-  allStates: BoardState[],
 ): WizardResult {
   // In JSON mode, resolve ambiguous states with first candidate
   for (const amb of ambiguous) {

--- a/apps/cli/src/lib/onboarding/column-wizard.ts
+++ b/apps/cli/src/lib/onboarding/column-wizard.ts
@@ -1,0 +1,296 @@
+/**
+ * Column Mapping Wizard
+ *
+ * Interactive wizard that auto-maps board columns to prlt's abstract intents
+ * during onboarding (prlt init, prlt connect). Handles:
+ *
+ * 1. Auto-matching obvious columns via fuzzy string matching
+ * 2. Asking about ambiguous columns (e.g., "Closed" → completed or dropped?)
+ * 3. Asking about unmapped columns (map to intent, create custom, or skip)
+ * 4. Many-to-one mapping (multiple columns → same intent)
+ * 5. Suggesting custom actions for non-standard columns
+ * 6. JSON mode for AI agent interaction
+ */
+
+import inquirer from 'inquirer'
+import type Database from 'better-sqlite3'
+import { colors } from '../colors.js'
+import {
+  type BoardState,
+  type IntentMapping,
+  autoMapWithDisambiguation,
+  formatMappingTable,
+  suggestCustomActions,
+} from '../providers/auto-mapper.js'
+import { TRANSITION_INTENTS, type TransitionIntent } from '../providers/state-intents.js'
+import { TransitionMapStore } from '../providers/transition-map.js'
+import {
+  outputPromptAsJson,
+  outputSuccessAsJson,
+  buildPromptConfig,
+  createMetadata,
+} from '../prompt-json.js'
+
+export type ProviderType = 'linear' | 'jira' | 'trello' | 'asana' | 'shortcut' | 'clickup' | 'github' | 'pmo'
+
+export interface ColumnWizardOptions {
+  states: BoardState[]
+  provider: string
+  providerType: ProviderType
+  db: Database.Database
+  jsonMode: boolean
+  log: (msg: string) => void
+}
+
+export interface WizardResult {
+  mappings: IntentMapping[]
+  saved: boolean
+  suggestions: string[]
+}
+
+/**
+ * Run the column mapping wizard.
+ *
+ * Flow:
+ * 1. Auto-map columns using heuristics
+ * 2. Show mapping table for user confirmation
+ * 3. Disambiguate ambiguous states
+ * 4. Handle unmapped states
+ * 5. Save to transition map
+ * 6. Suggest custom actions
+ */
+export async function runColumnWizard(opts: ColumnWizardOptions): Promise<WizardResult> {
+  const { states, provider, providerType, db, jsonMode, log } = opts
+
+  if (states.length === 0) {
+    return { mappings: [], saved: false, suggestions: [] }
+  }
+
+  // Step 1: Auto-map with disambiguation
+  const { mappings, ambiguous, unmapped } = autoMapWithDisambiguation(states, providerType)
+
+  // Step 2: Handle JSON mode — auto-save and return
+  if (jsonMode) {
+    return handleJsonMode(mappings, ambiguous, unmapped, provider, db, states)
+  }
+
+  // Step 3: Show mapping table
+  log('')
+  log(colors.primary('Board Column Mapping'))
+  log('')
+
+  if (mappings.length > 0) {
+    const lines = formatMappingTable(mappings, states)
+    for (const line of lines) {
+      log(colors.textMuted(`  ${line}`))
+    }
+    log('')
+  }
+
+  // Step 4: Handle few-column boards
+  if (states.length <= 3) {
+    log(colors.textMuted(`  Your board has ${states.length} columns. Multiple intents will share columns.`))
+    log('')
+  }
+
+  // Step 5: Disambiguate ambiguous states
+  const resolvedAmbiguous = await disambiguateStates(ambiguous, log)
+  mappings.push(...resolvedAmbiguous)
+
+  // Step 6: Handle unmapped states
+  const resolvedUnmapped = await handleUnmappedStates(unmapped, mappings, log)
+  mappings.push(...resolvedUnmapped)
+
+  // Step 7: Confirm and save
+  const saved = await confirmAndSave(mappings, provider, db, log)
+
+  // Step 8: Suggest custom actions
+  const suggestions = suggestCustomActions(mappings)
+  if (suggestions.length > 0) {
+    log('')
+    log(colors.primary('Suggested Actions'))
+    for (const suggestion of suggestions) {
+      log(colors.textMuted(`  ${suggestion}`))
+    }
+  }
+
+  return { mappings, saved, suggestions }
+}
+
+/**
+ * Handle JSON mode: auto-save mappings and return structured result.
+ */
+function handleJsonMode(
+  mappings: IntentMapping[],
+  ambiguous: Array<{ state: BoardState; candidateIntents: Array<{ intent: string; reason: string }> }>,
+  unmapped: BoardState[],
+  provider: string,
+  db: Database.Database,
+  allStates: BoardState[],
+): WizardResult {
+  // In JSON mode, resolve ambiguous states with first candidate
+  for (const amb of ambiguous) {
+    if (amb.candidateIntents.length > 0) {
+      mappings.push({
+        intent: amb.candidateIntents[0].intent as TransitionIntent,
+        stateName: amb.state.name,
+        stateId: amb.state.id,
+        confidence: 'none',
+      })
+    }
+  }
+
+  // Save all mappings
+  const store = new TransitionMapStore(db)
+  store.clearMappings(provider)
+  for (const m of mappings) {
+    store.upsertMapping({
+      provider,
+      intent: m.intent as TransitionIntent,
+      providerStateName: m.stateName,
+      providerStateId: m.stateId,
+    })
+  }
+
+  const suggestions = suggestCustomActions(mappings)
+  return { mappings, saved: true, suggestions }
+}
+
+/**
+ * Ask the user to disambiguate ambiguous states.
+ */
+async function disambiguateStates(
+  ambiguous: Array<{ state: BoardState; candidateIntents: Array<{ intent: string; reason: string }> }>,
+  log: (msg: string) => void,
+): Promise<IntentMapping[]> {
+  const resolved: IntentMapping[] = []
+
+  for (const { state, candidateIntents } of ambiguous) {
+    log(colors.warning(`  "${state.name}" is ambiguous — what does it mean for your team?`))
+
+    const choices = [
+      ...candidateIntents.map(c => ({
+        name: `${c.intent} — ${c.reason}`,
+        value: c.intent,
+      })),
+      { name: 'Skip — don\'t map this column', value: '__skip__' },
+    ]
+    const message = `What does "${state.name}" mean?`
+
+    const { selectedIntent } = await inquirer.prompt([{
+      type: 'list',
+      name: 'selectedIntent',
+      message,
+      choices,
+    }])
+
+    if (selectedIntent !== '__skip__') {
+      resolved.push({
+        intent: selectedIntent as TransitionIntent,
+        stateName: state.name,
+        stateId: state.id,
+        confidence: 'none',
+      })
+    }
+  }
+
+  return resolved
+}
+
+/**
+ * Ask the user what to do with unmapped states.
+ */
+async function handleUnmappedStates(
+  unmapped: BoardState[],
+  existingMappings: IntentMapping[],
+  log: (msg: string) => void,
+): Promise<IntentMapping[]> {
+  const resolved: IntentMapping[] = []
+
+  if (unmapped.length === 0) return resolved
+
+  log(colors.textMuted(`  ${unmapped.length} column(s) not auto-mapped:`))
+  for (const state of unmapped) {
+    log(colors.textMuted(`    - ${state.name}`))
+  }
+  log('')
+
+  for (const state of unmapped) {
+    // Build choices: existing intents + custom + skip
+    const mappedIntents = new Set(existingMappings.map(m => m.intent))
+    const allIntents = [...TRANSITION_INTENTS, 'testing', 'rework', 'blocked']
+
+    const choices = [
+      ...allIntents.map(intent => ({
+        name: `${intent}${mappedIntents.has(intent) ? ' (already mapped)' : ''}`,
+        value: intent,
+      })),
+      { name: 'Skip — don\'t map this column', value: '__skip__' },
+    ]
+    const message = `Map "${state.name}" to which intent?`
+
+    const { selectedIntent } = await inquirer.prompt([{
+      type: 'list',
+      name: 'selectedIntent',
+      message,
+      choices,
+    }])
+
+    if (selectedIntent !== '__skip__') {
+      resolved.push({
+        intent: selectedIntent as TransitionIntent,
+        stateName: state.name,
+        stateId: state.id,
+        confidence: 'none',
+      })
+    }
+  }
+
+  return resolved
+}
+
+/**
+ * Ask the user to confirm the mapping and save it.
+ */
+async function confirmAndSave(
+  mappings: IntentMapping[],
+  provider: string,
+  db: Database.Database,
+  log: (msg: string) => void,
+): Promise<boolean> {
+  if (mappings.length === 0) {
+    log(colors.textMuted('  No mappings to save.'))
+    return false
+  }
+
+  const choices = [
+    { name: 'Yes, save these mappings', value: true },
+    { name: 'No, skip mapping for now', value: false },
+  ]
+  const message = `Save ${mappings.length} state mapping(s)?`
+
+  const { confirmed } = await inquirer.prompt([{
+    type: 'list',
+    name: 'confirmed',
+    message,
+    choices,
+  }])
+
+  if (confirmed) {
+    const store = new TransitionMapStore(db)
+    store.clearMappings(provider)
+    for (const m of mappings) {
+      store.upsertMapping({
+        provider,
+        intent: m.intent as TransitionIntent,
+        providerStateName: m.stateName,
+        providerStateId: m.stateId,
+      })
+    }
+    log(colors.success(`  Saved ${mappings.length} state mapping(s)`))
+    return true
+  }
+
+  log(colors.textMuted('  Skipped state mapping. Configure later with "prlt config set state-map.<intent> <state-name>"'))
+  return false
+}

--- a/apps/cli/src/lib/onboarding/index.ts
+++ b/apps/cli/src/lib/onboarding/index.ts
@@ -5,3 +5,9 @@ export {
   isFirstTimeUser,
   type OnboardingResult,
 } from './wizard.js';
+export {
+  runColumnWizard,
+  type ColumnWizardOptions,
+  type WizardResult,
+  type ProviderType,
+} from './column-wizard.js';

--- a/apps/cli/src/lib/providers/auto-mapper.ts
+++ b/apps/cli/src/lib/providers/auto-mapper.ts
@@ -58,7 +58,7 @@ const LINEAR_TYPE_TO_INTENT: Record<string, TransitionIntent> = {
   completed: 'completed',
   canceled: 'dropped',
   cancelled: 'dropped',
-  backlog: 'paused',
+  backlog: 'backlog',
   unstarted: 'ready',
 }
 
@@ -75,12 +75,17 @@ const JIRA_CATEGORY_TO_INTENT: Record<string, TransitionIntent> = {
 
 /**
  * Custom intent patterns for non-standard board columns.
- * These extend beyond the base 7 canonical intents.
+ * These extend beyond the base 7 canonical intents, and also include
+ * intake/backlog patterns that standard alias matching misses.
+ *
+ * Checked BEFORE standard alias matching to avoid false positives
+ * (e.g., "Awaiting Client Feedback" matching "Waiting" for paused).
  */
 const CUSTOM_INTENT_PATTERNS: Array<{ intent: string; patterns: string[] }> = [
   { intent: 'testing', patterns: ['test', 'qa', 'quality'] },
   { intent: 'blocked', patterns: ['block', 'wait', 'feedback', 'impediment'] },
   { intent: 'rework', patterns: ['return', 'rework', 'revision', 'changes requested'] },
+  { intent: 'backlog', patterns: ['new issue', 'new request', 'new functionality', 'intake', 'incoming'] },
 ]
 
 /**
@@ -131,6 +136,7 @@ export function autoMapIntents(
     'started',
     'needs_review',
     'completed',
+    'backlog',
     'paused',
     'ready',
     'dropped',
@@ -199,46 +205,62 @@ export function autoMapIntents(
  * - Ambiguous states needing user disambiguation
  * - Unmapped states that could be custom intents
  * - Many-to-one opportunities (multiple columns → same intent)
+ *
+ * Strategy:
+ * 1. Pre-filter: identify ambiguous states and custom intent matches FIRST
+ *    (these take priority over standard alias matching to avoid false positives
+ *    like "Awaiting Client Feedback" matching the "Waiting" alias for `paused`)
+ * 2. Run standard auto-mapping on remaining states
+ * 3. Check leftovers for many-to-one opportunities
  */
 export function autoMapWithDisambiguation(
   states: BoardState[],
   providerType: 'linear' | 'jira' | 'trello' | 'asana' | 'shortcut' | 'clickup' | 'github' | 'pmo' = 'pmo',
 ): AutoMapResult {
-  // First pass: standard auto-mapping
-  const mappings = autoMapIntents(states, providerType)
-  const mappedStateIds = new Set(mappings.map(m => m.stateId))
-
   const ambiguous: AmbiguousState[] = []
-  const unmapped: BoardState[] = []
+  const customMappings: IntentMapping[] = []
+  const excludedIds = new Set<string>()
 
-  // Second pass: check remaining states
+  // Pre-filter pass: identify ambiguous and custom intent states
   for (const state of states) {
-    if (mappedStateIds.has(state.id)) continue
-
-    // Check if this is an ambiguous state
+    // Check if this is an ambiguous state FIRST
     const ambiguousMatch = AMBIGUOUS_PATTERNS.find(p => p.pattern.test(state.name))
     if (ambiguousMatch) {
       ambiguous.push({
         state,
         candidateIntents: ambiguousMatch.intents,
       })
+      excludedIds.add(state.id)
       continue
     }
 
-    // Check if it matches a custom intent pattern
+    // Check if it matches a custom intent pattern (higher priority than standard aliases)
     const customMatch = matchCustomIntent(state.name)
     if (customMatch) {
-      mappings.push({
+      customMappings.push({
         intent: customMatch as TransitionIntent,
         stateName: state.name,
         stateId: state.id,
         confidence: 'name',
       })
-      mappedStateIds.add(state.id)
-      continue
+      excludedIds.add(state.id)
     }
+  }
 
-    // Check if this state could be many-to-one with an existing mapping
+  // Standard auto-mapping on remaining states
+  const availableStates = states.filter(s => !excludedIds.has(s.id))
+  const mappings = autoMapIntents(availableStates, providerType)
+
+  // Add custom intent mappings
+  mappings.push(...customMappings)
+  const mappedStateIds = new Set(mappings.map(m => m.stateId))
+
+  const unmapped: BoardState[] = []
+
+  // Check remaining states for many-to-one opportunities
+  for (const state of availableStates) {
+    if (mappedStateIds.has(state.id)) continue
+
     const manyToOneMatch = findManyToOneMatch(state, mappings)
     if (manyToOneMatch) {
       mappings.push({
@@ -251,7 +273,6 @@ export function autoMapWithDisambiguation(
       continue
     }
 
-    // Truly unmapped
     unmapped.push(state)
   }
 

--- a/apps/cli/src/lib/providers/auto-mapper.ts
+++ b/apps/cli/src/lib/providers/auto-mapper.ts
@@ -4,6 +4,11 @@
  * Auto-guesses intent-to-state mappings when connecting a board.
  * Uses provider state types first, then name heuristics.
  *
+ * Supports:
+ * - Many-to-one: multiple board columns can map to the same intent
+ * - Custom intents: testing, blocked, rework beyond the base 7
+ * - Ambiguous state detection: flags states that need user input
+ *
  * Each provider can have different state type vocabularies:
  * - Linear: triage, backlog, unstarted, started, completed, canceled
  * - Jira: new, indeterminate, done, category-based
@@ -21,10 +26,27 @@ export interface BoardState {
 }
 
 export interface IntentMapping {
-  intent: TransitionIntent
+  intent: TransitionIntent | string
   stateName: string
   stateId: string
   confidence: 'type' | 'name' | 'none'
+}
+
+/**
+ * A state flagged as ambiguous — needs user disambiguation.
+ */
+export interface AmbiguousState {
+  state: BoardState
+  candidateIntents: Array<{ intent: string; reason: string }>
+}
+
+/**
+ * Result of auto-mapping with disambiguation info.
+ */
+export interface AutoMapResult {
+  mappings: IntentMapping[]
+  ambiguous: AmbiguousState[]
+  unmapped: BoardState[]
 }
 
 /**
@@ -50,6 +72,40 @@ const JIRA_CATEGORY_TO_INTENT: Record<string, TransitionIntent> = {
   indeterminate: 'started',
   done: 'completed',
 }
+
+/**
+ * Custom intent patterns for non-standard board columns.
+ * These extend beyond the base 7 canonical intents.
+ */
+const CUSTOM_INTENT_PATTERNS: Array<{ intent: string; patterns: string[] }> = [
+  { intent: 'testing', patterns: ['test', 'qa', 'quality'] },
+  { intent: 'blocked', patterns: ['block', 'wait', 'feedback', 'impediment'] },
+  { intent: 'rework', patterns: ['return', 'rework', 'revision', 'changes requested'] },
+]
+
+/**
+ * States that are ambiguous and need user disambiguation.
+ * Maps state name patterns to their possible intents.
+ */
+const AMBIGUOUS_PATTERNS: Array<{
+  pattern: RegExp
+  intents: Array<{ intent: string; reason: string }>
+}> = [
+  {
+    pattern: /^closed$/i,
+    intents: [
+      { intent: 'completed', reason: 'Work is finished' },
+      { intent: 'dropped', reason: 'Canceled or won\'t do' },
+    ],
+  },
+  {
+    pattern: /^not working on$/i,
+    intents: [
+      { intent: 'dropped', reason: 'Permanently removed' },
+      { intent: 'paused', reason: 'Temporarily deprioritized' },
+    ],
+  },
+]
 
 /**
  * Auto-guess transition intent mappings from a list of board states.
@@ -139,6 +195,142 @@ export function autoMapIntents(
 }
 
 /**
+ * Extended auto-mapping that also detects:
+ * - Ambiguous states needing user disambiguation
+ * - Unmapped states that could be custom intents
+ * - Many-to-one opportunities (multiple columns → same intent)
+ */
+export function autoMapWithDisambiguation(
+  states: BoardState[],
+  providerType: 'linear' | 'jira' | 'trello' | 'asana' | 'shortcut' | 'clickup' | 'github' | 'pmo' = 'pmo',
+): AutoMapResult {
+  // First pass: standard auto-mapping
+  const mappings = autoMapIntents(states, providerType)
+  const mappedStateIds = new Set(mappings.map(m => m.stateId))
+
+  const ambiguous: AmbiguousState[] = []
+  const unmapped: BoardState[] = []
+
+  // Second pass: check remaining states
+  for (const state of states) {
+    if (mappedStateIds.has(state.id)) continue
+
+    // Check if this is an ambiguous state
+    const ambiguousMatch = AMBIGUOUS_PATTERNS.find(p => p.pattern.test(state.name))
+    if (ambiguousMatch) {
+      ambiguous.push({
+        state,
+        candidateIntents: ambiguousMatch.intents,
+      })
+      continue
+    }
+
+    // Check if it matches a custom intent pattern
+    const customMatch = matchCustomIntent(state.name)
+    if (customMatch) {
+      mappings.push({
+        intent: customMatch as TransitionIntent,
+        stateName: state.name,
+        stateId: state.id,
+        confidence: 'name',
+      })
+      mappedStateIds.add(state.id)
+      continue
+    }
+
+    // Check if this state could be many-to-one with an existing mapping
+    const manyToOneMatch = findManyToOneMatch(state, mappings)
+    if (manyToOneMatch) {
+      mappings.push({
+        intent: manyToOneMatch,
+        stateName: state.name,
+        stateId: state.id,
+        confidence: 'name',
+      })
+      mappedStateIds.add(state.id)
+      continue
+    }
+
+    // Truly unmapped
+    unmapped.push(state)
+  }
+
+  return { mappings, ambiguous, unmapped }
+}
+
+/**
+ * Check if a state name matches a custom intent pattern.
+ */
+function matchCustomIntent(stateName: string): string | null {
+  const lower = stateName.toLowerCase()
+  for (const { intent, patterns } of CUSTOM_INTENT_PATTERNS) {
+    if (patterns.some(p => lower.includes(p))) {
+      return intent
+    }
+  }
+  return null
+}
+
+/**
+ * Check if an unmapped state is similar enough to an already-mapped state
+ * to be a many-to-one candidate (same intent, different column name).
+ *
+ * Heuristics:
+ * - "Duplicate" alongside "Canceled" → both map to `dropped`
+ * - States with the same provider type as an existing mapping
+ */
+function findManyToOneMatch(state: BoardState, existingMappings: IntentMapping[]): string | null {
+  const lower = state.name.toLowerCase()
+
+  // Check if the state name matches known patterns for existing mapped intents
+  const droppedPatterns = ['duplicate', 'won\'t fix', 'won\'t do', 'wontfix', 'obsolete']
+  if (droppedPatterns.some(p => lower.includes(p))) {
+    if (existingMappings.some(m => m.intent === 'dropped')) {
+      return 'dropped'
+    }
+  }
+
+  const backlogPatterns = ['new issue', 'new request', 'new functionality', 'intake', 'incoming']
+  if (backlogPatterns.some(p => lower.includes(p))) {
+    if (existingMappings.some(m => m.intent === 'backlog')) {
+      return 'backlog'
+    }
+  }
+
+  return null
+}
+
+/**
+ * Detect custom action suggestions based on non-standard columns.
+ * Returns suggestions like "You have Testing columns — want a QA action?"
+ */
+export function suggestCustomActions(
+  mappings: IntentMapping[],
+): string[] {
+  const suggestions: string[] = []
+
+  const testingMappings = mappings.filter(m => m.intent === 'testing')
+  if (testingMappings.length > 0) {
+    const names = testingMappings.map(m => m.stateName).join(' and ')
+    suggestions.push(`You have ${names} — want to create a test action that moves tickets through QA?`)
+  }
+
+  const reworkMappings = mappings.filter(m => m.intent === 'rework')
+  if (reworkMappings.length > 0) {
+    const names = reworkMappings.map(m => m.stateName).join(' and ')
+    suggestions.push(`You have ${names} — want to create a rework action that sends tickets back to development?`)
+  }
+
+  const blockedMappings = mappings.filter(m => m.intent === 'blocked')
+  if (blockedMappings.length > 0) {
+    const names = blockedMappings.map(m => m.stateName).join(' and ')
+    suggestions.push(`You have ${names} — want to create a block action for dependency tracking?`)
+  }
+
+  return suggestions
+}
+
+/**
  * Format intent mappings for display to the user.
  *
  * @param mappings - The auto-guessed mappings
@@ -164,6 +356,9 @@ export function formatMappingTable(
     paused: 'work stop',
     ready: 'work groom',
     dropped: 'work drop',
+    testing: '(custom)',
+    rework: '(custom)',
+    blocked: '(custom)',
   }
 
   // Map states to their intents

--- a/apps/cli/src/lib/providers/transition-map.ts
+++ b/apps/cli/src/lib/providers/transition-map.ts
@@ -6,6 +6,9 @@
  * canonical intent, and this store resolves that intent to whatever state
  * name exists on the connected board.
  *
+ * Supports many-to-one mapping: multiple board columns can map to the same
+ * intent (e.g., "New Issues" + "New Functionality Requests" → backlog).
+ *
  * Resolution order (in state-resolution.ts):
  * 1. pmo_transition_map (this store) — explicit user-confirmed mappings
  * 2. state-map.{intent} config override
@@ -31,8 +34,10 @@ export class TransitionMapStore {
   constructor(private db: Database.Database) {}
 
   /**
-   * Get the provider state name mapped to a transition intent.
+   * Get the first provider state name mapped to a transition intent.
    * Returns null if no mapping exists.
+   *
+   * For many-to-one mappings, use getMappingsForIntent() instead.
    */
   getMapping(provider: string, intent: string): TransitionMapping | null {
     try {
@@ -40,6 +45,7 @@ export class TransitionMapStore {
         SELECT provider, intent, provider_state_name, provider_state_id
         FROM pmo_transition_map
         WHERE provider = ? AND intent = ?
+        LIMIT 1
       `).get(provider, intent) as {
         provider: string
         intent: string
@@ -61,14 +67,42 @@ export class TransitionMapStore {
   }
 
   /**
+   * Get all provider state names mapped to a transition intent.
+   * Supports many-to-one: multiple columns can map to the same intent.
+   */
+  getMappingsForIntent(provider: string, intent: string): TransitionMapping[] {
+    try {
+      const rows = this.db.prepare(`
+        SELECT provider, intent, provider_state_name, provider_state_id
+        FROM pmo_transition_map
+        WHERE provider = ? AND intent = ?
+      `).all(provider, intent) as Array<{
+        provider: string
+        intent: string
+        provider_state_name: string
+        provider_state_id: string | null
+      }>
+
+      return rows.map(row => ({
+        provider: row.provider,
+        intent: row.intent as TransitionIntent,
+        providerStateName: row.provider_state_name,
+        providerStateId: row.provider_state_id,
+      }))
+    } catch {
+      return []
+    }
+  }
+
+  /**
    * Add or update a transition mapping.
+   * With many-to-one support, conflict is on (provider, intent, provider_state_name).
    */
   upsertMapping(mapping: TransitionMapping): void {
     this.db.prepare(`
       INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id, updated_at)
       VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
-      ON CONFLICT(provider, intent) DO UPDATE SET
-        provider_state_name = excluded.provider_state_name,
+      ON CONFLICT(provider, intent, provider_state_name) DO UPDATE SET
         provider_state_id = excluded.provider_state_id,
         updated_at = CURRENT_TIMESTAMP
     `).run(
@@ -88,7 +122,7 @@ export class TransitionMapStore {
         SELECT provider, intent, provider_state_name, provider_state_id
         FROM pmo_transition_map
         WHERE provider = ?
-        ORDER BY intent
+        ORDER BY intent, provider_state_name
       `).all(provider) as Array<{
         provider: string
         intent: string
@@ -108,13 +142,24 @@ export class TransitionMapStore {
   }
 
   /**
-   * Remove a specific transition mapping.
+   * Remove a specific transition mapping by intent.
+   * Removes ALL state names mapped to this intent.
    */
   removeMapping(provider: string, intent: string): void {
     this.db.prepare(`
       DELETE FROM pmo_transition_map
       WHERE provider = ? AND intent = ?
     `).run(provider, intent)
+  }
+
+  /**
+   * Remove a specific state name mapping.
+   */
+  removeMappingByState(provider: string, intent: string, stateName: string): void {
+    this.db.prepare(`
+      DELETE FROM pmo_transition_map
+      WHERE provider = ? AND intent = ? AND provider_state_name = ?
+    `).run(provider, intent, stateName)
   }
 
   /**
@@ -129,7 +174,7 @@ export class TransitionMapStore {
 
   /**
    * Resolve a transition intent to a provider state name.
-   * Returns the mapped state name, or null if no mapping exists.
+   * Returns the first mapped state name, or null if no mapping exists.
    *
    * This is the primary resolution method called by work commands.
    * If this returns null, the caller should fall through to alias/LLM resolution.

--- a/apps/cli/test/unit/column-wizard.test.ts
+++ b/apps/cli/test/unit/column-wizard.test.ts
@@ -1,0 +1,660 @@
+/**
+ * Tests for PRLT-1285: Onboarding wizard — auto-map board columns to intents.
+ *
+ * Tests cover:
+ * - Auto-matching columns to intents with fuzzy string matching
+ * - Many-to-one mapping (multiple columns → same intent)
+ * - Ambiguous state detection (e.g., "Closed" → completed or dropped?)
+ * - Custom intent detection (testing, rework, blocked)
+ * - All 5 board examples from docs/concepts/board-types.md
+ * - 3-column board produces valid mapping
+ * - Migration 0025 (many-to-one unique constraint)
+ * - TransitionMapStore many-to-one support
+ */
+
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import Database from 'better-sqlite3'
+import {
+  autoMapIntents,
+  autoMapWithDisambiguation,
+  formatMappingTable,
+  suggestCustomActions,
+  type BoardState,
+  type IntentMapping,
+} from '../../src/lib/providers/auto-mapper.js'
+import { TransitionMapStore } from '../../src/lib/providers/transition-map.js'
+import type { TransitionIntent } from '../../src/lib/providers/state-intents.js'
+import { transitionMapManyToOne } from '../../src/lib/database/migrations/0025_transition_map_many_to_one.js'
+import { transitionMap } from '../../src/lib/database/migrations/0020_transition_map.js'
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+  // Apply migration 0020 first (creates table with old constraint)
+  transitionMap.up(db)
+  // Then apply migration 0025 (changes unique constraint)
+  transitionMapManyToOne.up(db)
+  return db
+}
+
+function byIntent(mappings: IntentMapping[]): Map<string, IntentMapping[]> {
+  const map = new Map<string, IntentMapping[]>()
+  for (const m of mappings) {
+    const existing = map.get(m.intent) || []
+    existing.push(m)
+    map.set(m.intent, existing)
+  }
+  return map
+}
+
+// =============================================================================
+// Board Examples from docs/concepts/board-types.md
+// =============================================================================
+
+/** Board 1 — Trello (feature-focused team) */
+const BOARD_1_TRELLO_FEATURE: BoardState[] = [
+  { id: '1', name: 'New Functionality Requests', position: 0 },
+  { id: '2', name: 'New Issues', position: 1 },
+  { id: '3', name: 'Working On', position: 2 },
+  { id: '4', name: 'Needs Review', position: 3 },
+  { id: '5', name: 'Done', position: 4 },
+  { id: '6', name: 'Not Working On', position: 5 },
+]
+
+/** Board 2 — Trello (dev-focused team) */
+const BOARD_2_TRELLO_DEV: BoardState[] = [
+  { id: '1', name: 'Backlog', position: 0 },
+  { id: '2', name: 'Development Ready', position: 1 },
+  { id: '3', name: 'In Progress', position: 2 },
+  { id: '4', name: 'In Review', position: 3 },
+  { id: '5', name: 'Done', position: 4 },
+]
+
+/** Board 3 — ClickUp (client services) */
+const BOARD_3_CLICKUP: BoardState[] = [
+  { id: '1', name: 'BACKLOG', position: 0 },
+  { id: '2', name: 'TO DO', position: 1 },
+  { id: '3', name: 'IN PROGRESS', position: 2 },
+  { id: '4', name: 'AWAITING CLIENT FEEDBACK', position: 3 },
+  { id: '5', name: 'PAUSED', position: 4 },
+  { id: '6', name: 'COMPLETE', position: 5 },
+]
+
+/** Board 4 — Enterprise QA-heavy workflow */
+const BOARD_4_QA_HEAVY: BoardState[] = [
+  { id: '1', name: 'To Do', position: 0 },
+  { id: '2', name: 'Returned', position: 1 },
+  { id: '3', name: 'In Progress', position: 2 },
+  { id: '4', name: 'In Review', position: 3 },
+  { id: '5', name: 'To Test', position: 4 },
+  { id: '6', name: 'Testing', position: 5 },
+  { id: '7', name: 'Done', position: 6 },
+  { id: '8', name: 'Closed', position: 7 },
+]
+
+/** Board 5 — Linear (proletariat) */
+const BOARD_5_LINEAR: BoardState[] = [
+  { id: '1', name: 'Triage', type: 'triage', position: 0 },
+  { id: '2', name: 'Backlog', type: 'backlog', position: 1 },
+  { id: '3', name: 'Ready', type: 'unstarted', position: 2 },
+  { id: '4', name: 'In Progress', type: 'started', position: 3 },
+  { id: '5', name: 'Review', type: 'started', position: 4 },
+  { id: '6', name: 'Done', type: 'completed', position: 5 },
+  { id: '7', name: 'Canceled', type: 'canceled', position: 6 },
+  { id: '8', name: 'Duplicate', type: 'canceled', position: 7 },
+]
+
+/** 3-column minimal board */
+const BOARD_MINIMAL: BoardState[] = [
+  { id: '1', name: 'To Do', position: 0 },
+  { id: '2', name: 'In Progress', position: 1 },
+  { id: '3', name: 'Done', position: 2 },
+]
+
+// =============================================================================
+// Auto-Mapper with Disambiguation Tests
+// =============================================================================
+
+describe('PRLT-1285: Column Wizard Auto-Mapping', () => {
+  describe('autoMapWithDisambiguation()', () => {
+    it('Board 1 (Trello feature-focused): maps correctly with disambiguation', () => {
+      const result = autoMapWithDisambiguation(BOARD_1_TRELLO_FEATURE, 'trello')
+
+      const mapped = byIntent(result.mappings)
+
+      // Working On → started
+      expect(mapped.get('started')?.[0].stateName).to.equal('Working On')
+      // Needs Review → needs_review
+      expect(mapped.get('needs_review')?.[0].stateName).to.equal('Needs Review')
+      // Done → completed
+      expect(mapped.get('completed')?.[0].stateName).to.equal('Done')
+
+      // "Not Working On" should be flagged as ambiguous
+      const notWorkingOn = result.ambiguous.find(a => a.state.name === 'Not Working On')
+      expect(notWorkingOn, '"Not Working On" should be ambiguous').to.not.be.undefined
+      expect(notWorkingOn!.candidateIntents.length).to.be.greaterThanOrEqual(2)
+    })
+
+    it('Board 2 (Trello dev-focused): maps 1:1 with base intents', () => {
+      const result = autoMapWithDisambiguation(BOARD_2_TRELLO_DEV, 'trello')
+
+      const mapped = byIntent(result.mappings)
+
+      expect(mapped.get('started')?.[0].stateName).to.equal('In Progress')
+      expect(mapped.get('needs_review')?.[0].stateName).to.equal('In Review')
+      expect(mapped.get('completed')?.[0].stateName).to.equal('Done')
+      expect(mapped.get('ready')?.[0].stateName).to.equal('Development Ready')
+
+      // All states should be mapped, none ambiguous or unmapped
+      expect(result.ambiguous).to.have.length(0)
+      expect(result.unmapped).to.have.length(0)
+    })
+
+    it('Board 3 (ClickUp): maps with custom intents for feedback and paused', () => {
+      const result = autoMapWithDisambiguation(BOARD_3_CLICKUP, 'clickup')
+
+      const mapped = byIntent(result.mappings)
+
+      expect(mapped.get('started')?.[0].stateName).to.equal('IN PROGRESS')
+      expect(mapped.get('completed')?.[0].stateName).to.equal('COMPLETE')
+
+      // AWAITING CLIENT FEEDBACK → blocked (custom intent, contains "feedback")
+      expect(mapped.get('blocked')?.[0].stateName).to.equal('AWAITING CLIENT FEEDBACK')
+
+      // PAUSED → paused
+      expect(mapped.get('paused')?.[0].stateName).to.equal('PAUSED')
+
+      // No ambiguous states
+      expect(result.ambiguous).to.have.length(0)
+    })
+
+    it('Board 4 (Enterprise QA): maps with custom testing and rework intents', () => {
+      const result = autoMapWithDisambiguation(BOARD_4_QA_HEAVY, 'pmo')
+
+      const mapped = byIntent(result.mappings)
+
+      expect(mapped.get('started')?.[0].stateName).to.equal('In Progress')
+      expect(mapped.get('needs_review')?.[0].stateName).to.equal('In Review')
+      expect(mapped.get('completed')?.[0].stateName).to.equal('Done')
+      expect(mapped.get('ready')?.[0].stateName).to.equal('To Do')
+
+      // Returned → rework (custom intent, contains "return")
+      expect(mapped.get('rework')?.[0].stateName).to.equal('Returned')
+
+      // To Test and/or Testing → testing (custom intent, contains "test")
+      const testingMappings = mapped.get('testing') || []
+      expect(testingMappings.length).to.be.greaterThanOrEqual(1)
+
+      // "Closed" should be flagged as ambiguous
+      const closedAmbiguous = result.ambiguous.find(a => a.state.name === 'Closed')
+      expect(closedAmbiguous, '"Closed" should be ambiguous').to.not.be.undefined
+    })
+
+    it('Board 5 (Linear): maps using type-based matching with many-to-one', () => {
+      const result = autoMapWithDisambiguation(BOARD_5_LINEAR, 'linear')
+
+      const mapped = byIntent(result.mappings)
+
+      // Type-based mappings
+      expect(mapped.get('started')?.[0].stateName).to.equal('In Progress')
+      expect(mapped.get('completed')?.[0].stateName).to.equal('Done')
+      expect(mapped.get('dropped')?.[0].stateName).to.equal('Canceled')
+      expect(mapped.get('ready')?.[0].stateName).to.equal('Ready')
+
+      // Review → needs_review (name heuristic, since Linear has no review type)
+      expect(mapped.get('needs_review')?.[0].stateName).to.equal('Review')
+
+      // Duplicate should be mapped to dropped (many-to-one via findManyToOneMatch)
+      const droppedMappings = mapped.get('dropped') || []
+      const hasDuplicate = droppedMappings.some(m => m.stateName === 'Duplicate')
+      expect(hasDuplicate, 'Duplicate should map to dropped').to.be.true
+    })
+
+    it('3-column board: produces valid mapping where multiple intents share columns', () => {
+      const result = autoMapWithDisambiguation(BOARD_MINIMAL, 'pmo')
+
+      const mapped = byIntent(result.mappings)
+
+      // Core intents should be mapped
+      expect(mapped.get('started')?.[0].stateName).to.equal('In Progress')
+      expect(mapped.get('completed')?.[0].stateName).to.equal('Done')
+      expect(mapped.get('ready')?.[0].stateName).to.equal('To Do')
+
+      // Should have no ambiguous states
+      expect(result.ambiguous).to.have.length(0)
+
+      // All 3 states should be accounted for
+      const totalMapped = result.mappings.length
+      const totalAmbiguous = result.ambiguous.length
+      const totalUnmapped = result.unmapped.length
+      expect(totalMapped + totalAmbiguous + totalUnmapped).to.equal(3)
+    })
+  })
+
+  describe('Custom intent detection', () => {
+    it('detects testing intent from "To Test" and "Testing" columns', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'To Test', position: 1 },
+        { id: '3', name: 'Testing', position: 2 },
+        { id: '4', name: 'Done', position: 3 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'pmo')
+      const mapped = byIntent(result.mappings)
+      const testingMappings = mapped.get('testing') || []
+      expect(testingMappings.length).to.be.greaterThanOrEqual(1)
+    })
+
+    it('detects blocked intent from "Awaiting Client Feedback"', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'Awaiting Client Feedback', position: 1 },
+        { id: '3', name: 'Done', position: 2 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'pmo')
+      const mapped = byIntent(result.mappings)
+      expect(mapped.get('blocked')?.[0].stateName).to.equal('Awaiting Client Feedback')
+    })
+
+    it('detects rework intent from "Returned" column', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'Returned', position: 1 },
+        { id: '3', name: 'Done', position: 2 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'pmo')
+      const mapped = byIntent(result.mappings)
+      expect(mapped.get('rework')?.[0].stateName).to.equal('Returned')
+    })
+  })
+
+  describe('Ambiguous state detection', () => {
+    it('flags "Closed" as ambiguous (completed or dropped)', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'Done', position: 1 },
+        { id: '3', name: 'Closed', position: 2 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'pmo')
+      const closedAmb = result.ambiguous.find(a => a.state.name === 'Closed')
+      expect(closedAmb, '"Closed" should be ambiguous').to.not.be.undefined
+      expect(closedAmb!.candidateIntents.some(c => c.intent === 'completed')).to.be.true
+      expect(closedAmb!.candidateIntents.some(c => c.intent === 'dropped')).to.be.true
+    })
+
+    it('flags "Not Working On" as ambiguous (dropped or paused)', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'Done', position: 1 },
+        { id: '3', name: 'Not Working On', position: 2 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'pmo')
+      const amb = result.ambiguous.find(a => a.state.name === 'Not Working On')
+      expect(amb, '"Not Working On" should be ambiguous').to.not.be.undefined
+      expect(amb!.candidateIntents.some(c => c.intent === 'dropped')).to.be.true
+      expect(amb!.candidateIntents.some(c => c.intent === 'paused')).to.be.true
+    })
+  })
+
+  describe('Many-to-one mapping', () => {
+    it('"Duplicate" alongside "Canceled" both map to dropped', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'Done', position: 1 },
+        { id: '3', name: 'Canceled', position: 2 },
+        { id: '4', name: 'Duplicate', position: 3 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'pmo')
+      const mapped = byIntent(result.mappings)
+      const droppedMappings = mapped.get('dropped') || []
+      expect(droppedMappings.length).to.equal(2)
+      const names = droppedMappings.map(m => m.stateName).sort()
+      expect(names).to.deep.equal(['Canceled', 'Duplicate'])
+    })
+
+    it('multiple intake columns map to backlog', () => {
+      const states: BoardState[] = [
+        { id: '1', name: 'New Functionality Requests', position: 0 },
+        { id: '2', name: 'New Issues', position: 1 },
+        { id: '3', name: 'In Progress', position: 2 },
+        { id: '4', name: 'Done', position: 3 },
+      ]
+
+      const result = autoMapWithDisambiguation(states, 'trello')
+      const mapped = byIntent(result.mappings)
+
+      // Both intake columns should map to backlog (via many-to-one heuristics)
+      // At least the "New Issues" pattern should match via "new issue" in backlog patterns
+      // "New Functionality Requests" matches via "new request"
+      const backlogMappings = mapped.get('backlog') || []
+      // At minimum, the standard mapping should have picked up one
+      expect(backlogMappings.length).to.be.greaterThanOrEqual(1)
+    })
+  })
+
+  describe('suggestCustomActions()', () => {
+    it('suggests QA action for testing mappings', () => {
+      const mappings: IntentMapping[] = [
+        { intent: 'testing', stateName: 'To Test', stateId: '1', confidence: 'name' },
+      ]
+      const suggestions = suggestCustomActions(mappings)
+      expect(suggestions.length).to.be.greaterThanOrEqual(1)
+      expect(suggestions[0]).to.include('test')
+    })
+
+    it('suggests rework action for rework mappings', () => {
+      const mappings: IntentMapping[] = [
+        { intent: 'rework', stateName: 'Returned', stateId: '1', confidence: 'name' },
+      ]
+      const suggestions = suggestCustomActions(mappings)
+      expect(suggestions.length).to.be.greaterThanOrEqual(1)
+      expect(suggestions[0]).to.include('rework')
+    })
+
+    it('suggests block action for blocked mappings', () => {
+      const mappings: IntentMapping[] = [
+        { intent: 'blocked', stateName: 'Awaiting Feedback', stateId: '1', confidence: 'name' },
+      ]
+      const suggestions = suggestCustomActions(mappings)
+      expect(suggestions.length).to.be.greaterThanOrEqual(1)
+      expect(suggestions[0]).to.include('block')
+    })
+
+    it('returns empty for standard intents only', () => {
+      const mappings: IntentMapping[] = [
+        { intent: 'started', stateName: 'In Progress', stateId: '1', confidence: 'name' },
+        { intent: 'completed', stateName: 'Done', stateId: '2', confidence: 'name' },
+      ]
+      const suggestions = suggestCustomActions(mappings)
+      expect(suggestions).to.have.length(0)
+    })
+  })
+
+  describe('formatMappingTable()', () => {
+    it('includes custom intents in the table', () => {
+      const mappings: IntentMapping[] = [
+        { intent: 'started', stateName: 'In Progress', stateId: '1', confidence: 'name' },
+        { intent: 'testing', stateName: 'To Test', stateId: '2', confidence: 'name' },
+      ]
+      const states: BoardState[] = [
+        { id: '1', name: 'In Progress', position: 0 },
+        { id: '2', name: 'To Test', position: 1 },
+      ]
+      const lines = formatMappingTable(mappings, states)
+      const testingLine = lines.find(l => l.includes('testing'))
+      expect(testingLine).to.not.be.undefined
+      expect(testingLine).to.include('(custom)')
+    })
+  })
+})
+
+// =============================================================================
+// Migration 0025 Tests
+// =============================================================================
+
+describe('PRLT-1285: Migration 0025 — many-to-one transition map', () => {
+  it('allows multiple columns to map to the same intent', () => {
+    const db = createTestDb()
+
+    // Insert two mappings for the same intent — should succeed
+    db.prepare(`
+      INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id)
+      VALUES (?, ?, ?, ?)
+    `).run('linear', 'dropped', 'Canceled', 'id-1')
+
+    db.prepare(`
+      INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id)
+      VALUES (?, ?, ?, ?)
+    `).run('linear', 'dropped', 'Duplicate', 'id-2')
+
+    const rows = db.prepare(`
+      SELECT * FROM pmo_transition_map WHERE provider = 'linear' AND intent = 'dropped'
+    `).all() as Array<{ provider_state_name: string }>
+
+    expect(rows).to.have.length(2)
+    const names = rows.map(r => r.provider_state_name).sort()
+    expect(names).to.deep.equal(['Canceled', 'Duplicate'])
+
+    db.close()
+  })
+
+  it('still enforces uniqueness on (provider, intent, provider_state_name)', () => {
+    const db = createTestDb()
+
+    db.prepare(`
+      INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id)
+      VALUES (?, ?, ?, ?)
+    `).run('linear', 'dropped', 'Canceled', 'id-1')
+
+    // Inserting same (provider, intent, provider_state_name) should fail
+    expect(() => {
+      db.prepare(`
+        INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id)
+        VALUES (?, ?, ?, ?)
+      `).run('linear', 'dropped', 'Canceled', 'id-1-duplicate')
+    }).to.throw()
+
+    db.close()
+  })
+
+  it('preserves existing data during migration', () => {
+    // Create a fresh DB with just the old migration
+    const db = new Database(':memory:')
+    transitionMap.up(db)
+
+    // Insert some data with old schema
+    db.prepare(`
+      INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id)
+      VALUES (?, ?, ?, ?)
+    `).run('linear', 'started', 'In Progress', 'id-1')
+
+    db.prepare(`
+      INSERT INTO pmo_transition_map (provider, intent, provider_state_name, provider_state_id)
+      VALUES (?, ?, ?, ?)
+    `).run('linear', 'completed', 'Done', 'id-2')
+
+    // Apply migration 0025
+    transitionMapManyToOne.up(db)
+
+    // Verify data is preserved
+    const rows = db.prepare(`
+      SELECT * FROM pmo_transition_map ORDER BY intent
+    `).all() as Array<{ intent: string; provider_state_name: string }>
+
+    expect(rows).to.have.length(2)
+    expect(rows[0].intent).to.equal('completed')
+    expect(rows[0].provider_state_name).to.equal('Done')
+    expect(rows[1].intent).to.equal('started')
+    expect(rows[1].provider_state_name).to.equal('In Progress')
+
+    db.close()
+  })
+})
+
+// =============================================================================
+// TransitionMapStore Many-to-One Tests
+// =============================================================================
+
+describe('PRLT-1285: TransitionMapStore many-to-one support', () => {
+  let db: Database.Database
+  let store: TransitionMapStore
+
+  beforeEach(() => {
+    db = createTestDb()
+    store = new TransitionMapStore(db)
+  })
+
+  afterEach(() => {
+    db.close()
+  })
+
+  it('upsertMapping stores multiple states for same intent', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Canceled',
+      providerStateId: 'id-1',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Duplicate',
+      providerStateId: 'id-2',
+    })
+
+    const mappings = store.getMappingsForIntent('linear', 'dropped')
+    expect(mappings).to.have.length(2)
+    const names = mappings.map(m => m.providerStateName).sort()
+    expect(names).to.deep.equal(['Canceled', 'Duplicate'])
+  })
+
+  it('getMappingsForIntent returns all mappings for an intent', () => {
+    store.upsertMapping({
+      provider: 'trello',
+      intent: 'backlog',
+      providerStateName: 'New Issues',
+      providerStateId: 'id-1',
+    })
+    store.upsertMapping({
+      provider: 'trello',
+      intent: 'backlog',
+      providerStateName: 'New Functionality Requests',
+      providerStateId: 'id-2',
+    })
+
+    const mappings = store.getMappingsForIntent('trello', 'backlog')
+    expect(mappings).to.have.length(2)
+  })
+
+  it('getMapping returns first match (backward compatible)', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Canceled',
+      providerStateId: 'id-1',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Duplicate',
+      providerStateId: 'id-2',
+    })
+
+    const mapping = store.getMapping('linear', 'dropped')
+    expect(mapping).to.not.be.null
+    // Should return one of them (first in DB order)
+    expect(['Canceled', 'Duplicate']).to.include(mapping!.providerStateName)
+  })
+
+  it('resolveIntent returns first state name (backward compatible)', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'started',
+      providerStateName: 'In Progress',
+      providerStateId: 'id-1',
+    })
+
+    const result = store.resolveIntent('linear', 'started')
+    expect(result).to.equal('In Progress')
+  })
+
+  it('removeMappingByState removes only the specific state mapping', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Canceled',
+      providerStateId: 'id-1',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Duplicate',
+      providerStateId: 'id-2',
+    })
+
+    store.removeMappingByState('linear', 'dropped', 'Duplicate')
+
+    const mappings = store.getMappingsForIntent('linear', 'dropped')
+    expect(mappings).to.have.length(1)
+    expect(mappings[0].providerStateName).to.equal('Canceled')
+  })
+
+  it('removeMapping removes all states for an intent', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Canceled',
+      providerStateId: 'id-1',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Duplicate',
+      providerStateId: 'id-2',
+    })
+
+    store.removeMapping('linear', 'dropped')
+
+    const mappings = store.getMappingsForIntent('linear', 'dropped')
+    expect(mappings).to.have.length(0)
+  })
+
+  it('clearMappings removes all mappings for a provider', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'started',
+      providerStateName: 'In Progress',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'completed',
+      providerStateName: 'Done',
+    })
+
+    store.clearMappings('linear')
+
+    const mappings = store.listMappings('linear')
+    expect(mappings).to.have.length(0)
+  })
+
+  it('listMappings returns all mappings ordered by intent and state name', () => {
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Duplicate',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'dropped',
+      providerStateName: 'Canceled',
+    })
+    store.upsertMapping({
+      provider: 'linear',
+      intent: 'started',
+      providerStateName: 'In Progress',
+    })
+
+    const mappings = store.listMappings('linear')
+    expect(mappings).to.have.length(3)
+    // Should be ordered: dropped-Canceled, dropped-Duplicate, started-In Progress
+    expect(mappings[0].intent).to.equal('dropped')
+    expect(mappings[0].providerStateName).to.equal('Canceled')
+    expect(mappings[1].intent).to.equal('dropped')
+    expect(mappings[1].providerStateName).to.equal('Duplicate')
+    expect(mappings[2].intent).to.equal('started')
+  })
+})

--- a/apps/cli/test/unit/transition-intents.test.ts
+++ b/apps/cli/test/unit/transition-intents.test.ts
@@ -165,8 +165,8 @@ describe('Auto-Mapper', () => {
       // dropped → Canceled (type: canceled)
       expect(byIntent.get('dropped')?.stateName).to.equal('Canceled')
 
-      // paused → Backlog (type: backlog)
-      expect(byIntent.get('paused')?.stateName).to.equal('Backlog')
+      // backlog → Backlog (type: backlog)
+      expect(byIntent.get('backlog')?.stateName).to.equal('Backlog')
 
       // ready → Ready (type: unstarted)
       expect(byIntent.get('ready')?.stateName).to.equal('Ready')


### PR DESCRIPTION
## Summary

- Add onboarding column wizard that auto-maps board columns to prlt's abstract intents during `prlt connect`
- Support many-to-one mapping: multiple board columns can map to the same intent (migration 0025 changes UNIQUE constraint)
- Detect ambiguous states (e.g., "Closed" → completed or dropped?) and prompt user for disambiguation
- Detect custom intents (testing, rework, blocked) from non-standard column names
- Suggest custom actions for non-standard columns (QA action, rework action, block action)
- Works across all provider types: Linear, Trello, ClickUp, Jira, Asana, Shortcut, GitHub Projects

## Test plan

- [x] 29 new unit tests covering all 5 board examples from board-types.md
- [x] Many-to-one mapping (Canceled + Duplicate → dropped)
- [x] Multiple intake columns → backlog
- [x] 3-column board produces valid mapping
- [x] Ambiguous state detection (Closed, Not Working On)
- [x] Custom intent detection (testing, rework, blocked)
- [x] Migration 0025 data preservation and constraint change
- [x] TransitionMapStore CRUD with many-to-one support
- [x] All 4270 existing tests still pass (no regressions)