### PR TITLE
feat(PRLT-1304): wire hooks to service layer — eliminate shell indirection

### DIFF
--- a/apps/cli/src/commands/work/hooks/add.ts
+++ b/apps/cli/src/commands/work/hooks/add.ts
@@ -163,6 +163,7 @@ export default class WorkHooksAdd extends PromptCommand {
           shell: 'Shell command to run:',
           webhook: 'Webhook URL:',
           log: 'Log message template (use {{workItemId}}, {{event}}, etc.):',
+          action: 'Built-in action name (e.g., move-ticket, merge-pr):',
         }
         const message = prompts[actionType!]
 

--- a/apps/cli/src/lib/database/migrations/0025_hook_action_type.ts
+++ b/apps/cli/src/lib/database/migrations/0025_hook_action_type.ts
@@ -1,0 +1,85 @@
+/**
+ * Migration 0025 — Hook Action Type
+ *
+ * Adds 'action' to the action_type CHECK constraint on pmo_work_hooks.
+ * The 'action' type allows hooks to call built-in action handlers
+ * directly in-process instead of shelling out to prlt CLI commands.
+ *
+ * Also migrates existing preset hooks from shell-based indirection
+ * (action_type='shell', action_value='prlt hook fire ... --action <name>')
+ * to direct action invocation (action_type='action', action_value='<name>').
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const hookActionType: Migration = {
+  id: '0025',
+  name: 'hook_action_type',
+  up: (db: Database.Database) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get()
+    if (!tableExists) return
+
+    // Check if the constraint already includes 'action' — skip if already migrated
+    const createSql = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get() as { sql: string } | undefined
+    if (createSql?.sql?.includes("'action'")) return
+
+    // SQLite doesn't allow modifying CHECK constraints via ALTER TABLE.
+    // Recreate the table with the expanded constraint.
+    db.exec(`
+      CREATE TABLE pmo_work_hooks_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        event TEXT NOT NULL,
+        action_type TEXT NOT NULL DEFAULT 'shell' CHECK (action_type IN ('shell', 'webhook', 'log', 'action')),
+        action_value TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        description TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off')),
+        priority INTEGER NOT NULL DEFAULT 0,
+        project_id TEXT,
+        source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset')),
+        config TEXT
+      )
+    `)
+
+    // Copy all existing data
+    db.exec(`
+      INSERT INTO pmo_work_hooks_new (id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, project_id, source, config)
+      SELECT id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, project_id, source, config
+      FROM pmo_work_hooks
+    `)
+
+    // Swap tables
+    db.exec('DROP TABLE pmo_work_hooks')
+    db.exec('ALTER TABLE pmo_work_hooks_new RENAME TO pmo_work_hooks')
+
+    // Recreate indexes
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_event ON pmo_work_hooks(event)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_enabled ON pmo_work_hooks(enabled)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+
+    // Migrate existing preset hooks from shell indirection to direct action type.
+    // Pattern: action_value = 'prlt hook fire <event> --action <action-name>'
+    // → action_type = 'action', action_value = '<action-name>'
+    const presetHooks = db.prepare(
+      "SELECT id, action_value FROM pmo_work_hooks WHERE source = 'preset' AND action_type = 'shell'"
+    ).all() as Array<{ id: string; action_value: string }>
+
+    const updateStmt = db.prepare(
+      "UPDATE pmo_work_hooks SET action_type = 'action', action_value = ? WHERE id = ?"
+    )
+
+    for (const hook of presetHooks) {
+      const match = hook.action_value.match(/--action\s+(\S+)/)
+      if (match) {
+        updateStmt.run(match[1], hook.id)
+      }
+    }
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -30,6 +30,7 @@ import { notificationSystem } from './0021_notification_system.js'
 import { hookModeTiers } from './0022_hook_mode_tiers.js'
 import { intentBasedActions } from './0023_intent_based_actions.js'
 import { dropDeadPmoTables } from './0024_drop_dead_pmo_tables.js'
+import { hookActionType } from './0025_hook_action_type.js'
 
 /**
  * Ordered list of all migrations.
@@ -60,4 +61,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   hookModeTiers,
   intentBasedActions,
   dropDeadPmoTables,
+  hookActionType,
 ]

--- a/apps/cli/src/lib/orchestrate/config-loader.ts
+++ b/apps/cli/src/lib/orchestrate/config-loader.ts
@@ -18,8 +18,11 @@ import type {
   HookMode,
   PresetName,
 } from './types.js'
-import { HOOK_MODES } from './types.js'
+import { HOOK_MODES, BUILTIN_ACTIONS } from './types.js'
 import { getPreset } from './presets.js'
+
+/** Set of built-in action names for quick lookup. */
+const BUILTIN_ACTION_SET = new Set<string>(BUILTIN_ACTIONS)
 
 // =============================================================================
 // YAML File Loading
@@ -83,11 +86,14 @@ export function syncHooksFromYaml(db: Database.Database, hooksYaml: HooksYaml): 
 
       const hookName = `yaml:${eventName}:${entry.action}:${i}`
 
+      // Use 'action' type for known built-in actions, 'shell' for custom commands
+      const isBuiltinAction = BUILTIN_ACTION_SET.has(entry.action)
+
       try {
         const hook = storage.create({
           name: hookName,
           event: (eventName as HookableEvent) || 'work:status_changed',
-          actionType: 'shell',
+          actionType: isBuiltinAction ? 'action' : 'shell',
           actionValue: entry.action,
           description: `From hooks.yml: ${eventName} → ${entry.action} (${mode})`,
         })
@@ -134,8 +140,8 @@ export function applyPreset(db: Database.Database, presetName: PresetName): numb
       const created = storage.create({
         name: hookName,
         event: mapOrchestrateToHookable(hook.event),
-        actionType: 'shell',
-        actionValue: `prlt hook fire ${hook.event} --action ${hook.action}`,
+        actionType: 'action',
+        actionValue: hook.action,
         description: `Preset ${presetName}: ${hook.event} → ${hook.action} (${hook.mode})`,
       })
 

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -16,6 +16,7 @@ import type Database from 'better-sqlite3'
 import { HookManager } from '../work-lifecycle/hooks/manager.js'
 import type { HookExecutionResult, HookActionHandler, LlmDecision } from '../work-lifecycle/hooks/types.js'
 import { ACTION_HANDLERS } from './actions.js'
+import { createServiceActionHandlers } from './service-actions.js'
 import {
   NotificationManager,
   initNotificationManager,
@@ -75,6 +76,16 @@ export class OrchestrateEngine {
         }
       : undefined
 
+    // Service-backed handlers override shell-based ACTION_HANDLERS for actions
+    // where a direct service/provider call exists (e.g., move-ticket).
+    // Shell-based handlers remain as fallback for actions that inherently need
+    // child processes (spawn-agent, cleanup-container, etc.).
+    const serviceHandlers = createServiceActionHandlers(options.db)
+    const allHandlers: Record<string, HookActionHandler> = {
+      ...(ACTION_HANDLERS as Record<string, HookActionHandler>),
+      ...(serviceHandlers as Record<string, HookActionHandler>),
+    }
+
     this.manager = new HookManager({
       db: options.db,
       log: options.log,
@@ -83,7 +94,7 @@ export class OrchestrateEngine {
       onLlmDecision: options.onLlmDecision,
       onHumanEscalation: options.onHumanEscalation,
       llmTimeoutMs: options.llmTimeoutMs,
-      actionHandlers: ACTION_HANDLERS as Record<string, HookActionHandler>,
+      actionHandlers: allHandlers,
     })
 
     // Initialize the notification manager so it subscribes to events

--- a/apps/cli/src/lib/orchestrate/index.ts
+++ b/apps/cli/src/lib/orchestrate/index.ts
@@ -44,6 +44,10 @@ export {
 } from './actions.js'
 
 export {
+  createServiceActionHandlers,
+} from './service-actions.js'
+
+export {
   OrchestrateEngine,
   initOrchestrateEngine,
   getOrchestrateEngine,

--- a/apps/cli/src/lib/orchestrate/service-actions.ts
+++ b/apps/cli/src/lib/orchestrate/service-actions.ts
@@ -1,0 +1,109 @@
+/**
+ * Service-Backed Action Handlers
+ *
+ * Action handlers that call the service/provider layer directly instead of
+ * shelling out to prlt CLI commands. These replace the shell-based handlers
+ * in actions.ts for actions where a service equivalent exists.
+ *
+ * The key change: hook → service → DB (in-process, no child process spawn).
+ *
+ * Handlers that inherently need external processes (spawn-agent, health-check,
+ * cleanup-container, etc.) are NOT replaced here — they remain in actions.ts.
+ */
+
+import type Database from 'better-sqlite3'
+import type { OrchestrateEventContext, OrchestrateActionResult } from './types.js'
+import { resolveWorkflowTarget } from '../work-lifecycle/settings.js'
+import type { ProviderStorage } from '../providers/types.js'
+
+type AsyncActionHandler = (
+  ctx: OrchestrateEventContext,
+  config?: Record<string, unknown>,
+) => Promise<OrchestrateActionResult>
+
+/**
+ * Create a minimal ProviderStorage stub for use with resolveProjectProvider.
+ *
+ * External providers (Linear, Jira, etc.) don't use storage methods — they go
+ * directly to the external API. The local PMO provider does use storage, but
+ * it's rarely the active provider when the orchestrate daemon runs (you need
+ * an external tracker to have tickets to automate).
+ *
+ * If a storage method IS called on this stub, it throws so we can diagnose
+ * rather than silently misbehave.
+ */
+function createMinimalStorage(db: Database.Database): ProviderStorage {
+  const notImplemented = (method: string) => () => {
+    throw new Error(`ProviderStorage.${method}() not available in service-action context`)
+  }
+
+  return {
+    getTicket: notImplemented('getTicket') as any,
+    getProjectBoard: notImplemented('getProjectBoard') as any,
+    moveTicket: notImplemented('moveTicket') as any,
+    deleteTicket: notImplemented('deleteTicket') as any,
+    listTickets: notImplemented('listTickets') as any,
+    createTicket: notImplemented('createTicket') as any,
+    updateTicket: notImplemented('updateTicket') as any,
+    getDatabase: () => db,
+  }
+}
+
+/**
+ * Create service-backed action handlers that use the database and provider
+ * layer directly, eliminating shell indirection.
+ *
+ * Returns a map of action names to async handlers. These override the
+ * shell-based equivalents in ACTION_HANDLERS when used by the engine.
+ */
+export function createServiceActionHandlers(
+  db: Database.Database,
+): Record<string, AsyncActionHandler> {
+  return {
+    'move-ticket': createMoveTicketHandler(db),
+  }
+}
+
+/**
+ * Service-backed move-ticket handler.
+ *
+ * Before: walkPromptChain('prlt ticket move TKT-123 "Done"') — spawns prlt process
+ * After:  provider.moveTicket('TKT-123', 'Done') — in-process call to provider API
+ */
+function createMoveTicketHandler(db: Database.Database): AsyncActionHandler {
+  return async (ctx, config) => {
+    const start = Date.now()
+    if (!ctx.ticket) {
+      return { action: 'move-ticket', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    const requestedTarget = (config?.target as string) || 'done'
+
+    try {
+      // Resolve intent-like targets (e.g., 'done' → 'Done', 'review' → 'In Review')
+      // through the workflow configuration
+      const resolvedTarget = resolveWorkflowTarget(db, requestedTarget)
+
+      // Use the provider layer directly — no shell
+      const { resolveProjectProvider } = await import('../providers/resolver.js')
+      const storage = createMinimalStorage(db)
+      const provider = resolveProjectProvider(db, storage, ctx.projectId || '')
+
+      const result = await provider.moveTicket(ctx.ticket, resolvedTarget)
+
+      return {
+        action: 'move-ticket',
+        success: result.success,
+        error: result.error,
+        durationMs: Date.now() - start,
+      }
+    } catch (err) {
+      return {
+        action: 'move-ticket',
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+}

--- a/apps/cli/src/lib/work-lifecycle/hooks/executor.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/executor.ts
@@ -1,8 +1,14 @@
 /**
  * Hook Executor
  *
- * Executes hook actions (shell commands, webhooks, log messages) when
- * work lifecycle events fire. Each action type has its own execution logic.
+ * Executes hook actions (shell commands, webhooks, log messages, built-in actions)
+ * when work lifecycle events fire. Each action type has its own execution logic.
+ *
+ * Action types:
+ * - shell: Run a shell command with event data as PRLT_HOOK_* env vars
+ * - webhook: POST event data as JSON to a URL
+ * - log: Print interpolated message to stdout
+ * - action: Call a built-in action handler directly (in-process, no shell)
  *
  * Shell commands receive event data as environment variables prefixed with
  * PRLT_HOOK_. A PRLT_HOOK_JSON variable carries the full payload as valid
@@ -135,6 +141,20 @@ export function executeHook(
         const message = interpolate(hook.actionValue, eventName, eventData)
         console.log(`[hook:${hook.name}] ${message}`)
         break
+      }
+
+      case 'action': {
+        // action-type hooks are handled by the manager's action handler registry,
+        // not by the executor. If we reach here, it means no action handler was
+        // registered for this action — return a clear error.
+        return {
+          hookId: hook.id,
+          hookName: hook.name,
+          action: hook.actionValue,
+          success: false,
+          error: `No action handler registered for built-in action: ${hook.actionValue}`,
+          durationMs: Date.now() - start,
+        }
       }
     }
 

--- a/apps/cli/src/lib/work-lifecycle/hooks/manager.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/manager.ts
@@ -177,7 +177,7 @@ export class HookManager {
     if (index < 0 || index >= this._pendingConfirmations.length) return null
 
     const pending = this._pendingConfirmations.splice(index, 1)[0]
-    const result = this.executeActionByName(pending.action, pending.ctx, pending.config)
+    const result = await this.executeActionByName(pending.action, pending.ctx, pending.config)
 
     this.log(`[hooks] Approved: ${pending.hookName} → ${pending.action} (${result.success ? 'success' : 'failed'})`)
     return result
@@ -212,7 +212,7 @@ export class HookManager {
     if (index < 0 || index >= this._pendingLlmDecisions.length) return null
 
     const pending = this._pendingLlmDecisions.splice(index, 1)[0]
-    const result = this.executeActionByName(pending.action, pending.ctx, pending.config)
+    const result = await this.executeActionByName(pending.action, pending.ctx, pending.config)
 
     this.log(`[hooks] LLM approved: ${pending.hookName} → ${pending.action} (${result.success ? 'success' : 'failed'})`)
     return { ...result, tier: 'llm' }
@@ -296,7 +296,7 @@ export class HookManager {
     if (index < 0 || index >= this._pendingHumanEscalations.length) return null
 
     const pending = this._pendingHumanEscalations.splice(index, 1)[0]
-    const result = this.executeActionByName(pending.action, pending.ctx, pending.config)
+    const result = await this.executeActionByName(pending.action, pending.ctx, pending.config)
 
     this.log(`[hooks] Human approved: ${pending.hookName} → ${pending.action} (${result.success ? 'success' : 'failed'})`)
     return { ...result, tier: 'human' }
@@ -341,6 +341,7 @@ export class HookManager {
   /**
    * Resolve the action name from a hook config and a set of known action handlers.
    *
+   * - If action_type is 'action', the action_value IS the action name
    * - If the action_value contains `--action <name>`, extracts the name
    * - If the action_value is a known built-in action, uses it directly
    * - Otherwise uses the raw action_value (shell command)
@@ -348,6 +349,9 @@ export class HookManager {
    * Public so it can be tested in isolation.
    */
   static resolveActionName(hook: WorkHookConfig, knownActions: Record<string, unknown> = {}): string {
+    // action-type hooks: the value IS the action name (no parsing needed)
+    if (hook.actionType === 'action') return hook.actionValue
+
     // If the action_value contains --action, extract the action name
     const actionMatch = hook.actionValue.match(/--action\s+(\S+)/)
     if (actionMatch) return actionMatch[1]
@@ -441,7 +445,7 @@ export class HookManager {
                   continue
                 }
                 // Human approved — fall through to execution
-                const result = this.executeHookAction(hook, eventName, eventData, ctx)
+                const result = await this.executeHookAction(hook, eventName, eventData, ctx)
                 results.push({ ...result, escalatedToHuman: true, tier: 'human' })
                 this.log(`[hooks] ${hook.name} → ${actionName}: ${result.success ? 'success' : `failed: ${result.error}`} (${result.durationMs}ms) [escalated to human]`)
                 continue
@@ -601,7 +605,7 @@ export class HookManager {
         }
 
         // --- auto / notify / confirmed / llm-approved / human-approved: execute ---
-        const result = this.executeHookAction(hook, eventName, eventData, ctx)
+        const result = await this.executeHookAction(hook, eventName, eventData, ctx)
         results.push(result)
 
         this.log(
@@ -622,18 +626,19 @@ export class HookManager {
 
   /**
    * Execute a hook action — either via a built-in handler or the standard executor.
+   * Handlers may be sync or async (service-backed handlers are async).
    */
-  private executeHookAction(
+  private async executeHookAction(
     hook: WorkHookConfig,
     eventName: string,
     eventData: Record<string, unknown>,
     ctx: Record<string, unknown>,
-  ): HookExecutionResult {
+  ): Promise<HookExecutionResult> {
     const actionName = HookManager.resolveActionName(hook, this.actionHandlers)
 
     // Try built-in action handler first
     if (this.actionHandlers[actionName]) {
-      const handlerResult = this.actionHandlers[actionName](ctx, hook.config ?? undefined)
+      const handlerResult = await this.actionHandlers[actionName](ctx, hook.config ?? undefined)
       return {
         hookId: hook.id,
         hookName: hook.name,
@@ -655,15 +660,16 @@ export class HookManager {
 
   /**
    * Execute an action by name (used for approved confirmations).
+   * Handlers may be sync or async (service-backed handlers are async).
    */
-  private executeActionByName(
+  private async executeActionByName(
     actionName: string,
     ctx: Record<string, unknown>,
     config?: Record<string, unknown>,
-  ): HookExecutionResult {
+  ): Promise<HookExecutionResult> {
     // Try built-in action handler first
     if (this.actionHandlers[actionName]) {
-      const handlerResult = this.actionHandlers[actionName](ctx, config)
+      const handlerResult = await this.actionHandlers[actionName](ctx, config)
       return {
         hookId: '',
         hookName: '',

--- a/apps/cli/src/lib/work-lifecycle/hooks/storage.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/storage.ts
@@ -18,7 +18,7 @@ export const HOOKS_TABLE_SCHEMA = `
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     event TEXT NOT NULL,
-    action_type TEXT NOT NULL CHECK (action_type IN ('shell', 'webhook', 'log')),
+    action_type TEXT NOT NULL CHECK (action_type IN ('shell', 'webhook', 'log', 'action')),
     action_value TEXT NOT NULL,
     enabled INTEGER NOT NULL DEFAULT 1,
     description TEXT,

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -67,8 +67,9 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
  * - shell: Run a shell command (with event data as env vars)
  * - webhook: POST event data to a URL
  * - log: Write a message to stdout (useful for notifications/debugging)
+ * - action: Call a built-in action handler directly (no shell, in-process)
  */
-export type HookActionType = 'shell' | 'webhook' | 'log'
+export type HookActionType = 'shell' | 'webhook' | 'log' | 'action'
 
 /**
  * Automation mode for a hook — determines the decision tier.
@@ -156,13 +157,25 @@ export interface WorkHookRow {
 }
 
 /**
+ * Result shape for built-in action handlers.
+ */
+export interface HookActionHandlerResult {
+  action: string
+  success: boolean
+  error?: string
+  durationMs: number
+  skipped?: boolean
+}
+
+/**
  * Handler function for built-in actions injected into HookManager.
  * Receives event context and optional per-hook config, returns an execution result.
+ * Handlers may be sync or async — callers always await the result.
  */
 export type HookActionHandler = (
   ctx: Record<string, unknown>,
   config?: Record<string, unknown>,
-) => { action: string; success: boolean; error?: string; durationMs: number; skipped?: boolean }
+) => HookActionHandlerResult | Promise<HookActionHandlerResult>
 
 /**
  * Result of executing a single hook.

--- a/apps/cli/test/unit/hook-action-type.test.ts
+++ b/apps/cli/test/unit/hook-action-type.test.ts
@@ -1,0 +1,721 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import { HookManager } from '../../src/lib/work-lifecycle/hooks/manager.js'
+import { WorkHookStorage, ensureHooksTable } from '../../src/lib/work-lifecycle/hooks/storage.js'
+import { executeHook } from '../../src/lib/work-lifecycle/hooks/executor.js'
+import { applyPreset } from '../../src/lib/orchestrate/config-loader.js'
+import { PRESETS } from '../../src/lib/orchestrate/presets.js'
+import { OrchestrateEngine } from '../../src/lib/orchestrate/engine.js'
+import { createServiceActionHandlers } from '../../src/lib/orchestrate/service-actions.js'
+import { BUILTIN_ACTIONS, PRESET_NAMES } from '../../src/lib/orchestrate/types.js'
+import { resetEventBus } from '../../src/lib/events/event-bus.js'
+import type { WorkHookConfig, HookActionHandler, HookActionHandlerResult } from '../../src/lib/work-lifecycle/hooks/types.js'
+import { hookActionType } from '../../src/lib/database/migrations/0025_hook_action_type.js'
+
+/**
+ * Unit tests for PRLT-1304: Wire hooks to service layer.
+ *
+ * Tests cover:
+ * - action_type='action' in the data model (types, storage, migration)
+ * - Preset hooks stored as action type (no shell indirection)
+ * - Action handlers called directly (in-process, no prlt spawn)
+ * - Backward compatibility for shell-type hooks
+ * - resolveActionName for action-type hooks
+ * - Service-backed action handlers
+ * - Latency improvement (action vs shell)
+ */
+
+// ===========================================================================
+// Test DB setup
+// ===========================================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  ensureHooksTable(db)
+  try {
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT")
+    db.exec("CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)")
+  } catch {
+    // Columns may already exist
+  }
+  return db
+}
+
+/**
+ * Create a test DB that already has the 0025 migration applied
+ * (action_type CHECK constraint includes 'action').
+ */
+function createMigratedTestDb(): Database.Database {
+  const db = createTestDb()
+  hookActionType.up(db)
+  return db
+}
+
+function insertHook(db: Database.Database, opts: {
+  name: string
+  event: string
+  actionType?: string
+  actionValue: string
+  mode?: string
+  priority?: number
+  config?: string
+  enabled?: number
+  source?: string
+}): string {
+  const id = `hook-${Math.random().toString(36).slice(2, 8)}`
+  db.prepare(`
+    INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, mode, priority, source, config)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    opts.name,
+    opts.event,
+    opts.actionType ?? 'action',
+    opts.actionValue,
+    opts.enabled ?? 1,
+    opts.mode ?? 'auto',
+    opts.priority ?? 0,
+    opts.source ?? 'cli',
+    opts.config ?? null,
+  )
+  return id
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe('PRLT-1304: Hook Action Type', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createMigratedTestDb()
+    resetEventBus()
+  })
+
+  afterEach(() => {
+    resetEventBus()
+    db.close()
+  })
+
+  // =========================================================================
+  // Data Model
+  // =========================================================================
+
+  describe('data model', () => {
+    it('should accept action_type=action in the database', () => {
+      expect(() => insertHook(db, {
+        name: 'test-action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+      })).to.not.throw()
+
+      const row = db.prepare("SELECT action_type, action_value FROM pmo_work_hooks WHERE name = ?")
+        .get('test-action-hook') as { action_type: string; action_value: string }
+      expect(row.action_type).to.equal('action')
+      expect(row.action_value).to.equal('merge-pr')
+    })
+
+    it('should still accept shell/webhook/log types', () => {
+      expect(() => insertHook(db, {
+        name: 'shell-hook',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'echo hello',
+      })).to.not.throw()
+
+      expect(() => insertHook(db, {
+        name: 'log-hook',
+        event: 'on_ci_green',
+        actionType: 'log',
+        actionValue: 'Event: {{event}}',
+      })).to.not.throw()
+    })
+
+    it('WorkHookStorage should list action-type hooks', () => {
+      insertHook(db, {
+        name: 'action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+      })
+
+      const storage = new WorkHookStorage(db)
+      const hooks = storage.list({ event: 'on_ci_green' as any })
+      expect(hooks).to.have.length(1)
+      expect(hooks[0].actionType).to.equal('action')
+      expect(hooks[0].actionValue).to.equal('merge-pr')
+    })
+  })
+
+  // =========================================================================
+  // Migration
+  // =========================================================================
+
+  describe('migration 0025', () => {
+    it('should be idempotent — safe to run twice', () => {
+      const freshDb = createTestDb()
+      hookActionType.up(freshDb)
+      expect(() => hookActionType.up(freshDb)).to.not.throw()
+      freshDb.close()
+    })
+
+    it('should migrate preset hooks from shell to action type', () => {
+      // Start with a fresh DB that does NOT have the 'action' CHECK constraint yet
+      // (simulating pre-migration state). We need a DB without CHECK constraint
+      // restrictions so we can verify the migration adds support.
+      const freshDb = new Database(':memory:')
+      // Create table WITHOUT action CHECK constraint (simulating old schema)
+      freshDb.exec(`
+        CREATE TABLE pmo_work_hooks (
+          id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          event TEXT NOT NULL,
+          action_type TEXT NOT NULL DEFAULT 'shell',
+          action_value TEXT NOT NULL,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          description TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          mode TEXT NOT NULL DEFAULT 'auto',
+          priority INTEGER NOT NULL DEFAULT 0,
+          project_id TEXT,
+          source TEXT NOT NULL DEFAULT 'cli',
+          config TEXT
+        )
+      `)
+
+      // Insert a shell-type preset hook (old format)
+      freshDb.prepare(`
+        INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, mode, priority, source, config)
+        VALUES (?, ?, ?, 'shell', ?, 1, 'auto', 0, 'preset', NULL)
+      `).run('test-1', 'preset:aggressive:on_ci_green:merge-pr:0', 'on_ci_green', 'prlt hook fire on_ci_green --action merge-pr')
+
+      // Run migration
+      hookActionType.up(freshDb)
+
+      // Should now be action type
+      const row = freshDb.prepare("SELECT action_type, action_value FROM pmo_work_hooks WHERE id = ?")
+        .get('test-1') as { action_type: string; action_value: string }
+      expect(row.action_type).to.equal('action')
+      expect(row.action_value).to.equal('merge-pr')
+
+      freshDb.close()
+    })
+
+    it('should NOT migrate non-preset shell hooks', () => {
+      const freshDb = createTestDb()
+
+      // Insert a user-defined shell hook (should NOT be migrated)
+      freshDb.prepare(`
+        INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, mode, priority, source, config)
+        VALUES (?, ?, ?, 'shell', ?, 1, 'auto', 0, 'cli', NULL)
+      `).run('user-1', 'my-custom-hook', 'on_ci_green', 'echo "CI passed!"')
+
+      // Run migration
+      hookActionType.up(freshDb)
+
+      // Should still be shell type
+      const row = freshDb.prepare("SELECT action_type, action_value FROM pmo_work_hooks WHERE id = ?")
+        .get('user-1') as { action_type: string; action_value: string }
+      expect(row.action_type).to.equal('shell')
+      expect(row.action_value).to.equal('echo "CI passed!"')
+
+      freshDb.close()
+    })
+  })
+
+  // =========================================================================
+  // Preset Application
+  // =========================================================================
+
+  describe('preset application', () => {
+    it('should store preset hooks with action_type=action', () => {
+      applyPreset(db, 'aggressive')
+
+      const hooks = db.prepare("SELECT action_type, action_value FROM pmo_work_hooks WHERE source = 'preset'")
+        .all() as Array<{ action_type: string; action_value: string }>
+
+      expect(hooks.length).to.be.greaterThan(0)
+
+      for (const hook of hooks) {
+        expect(hook.action_type).to.equal('action',
+          `Hook with action_value "${hook.action_value}" should be action type, not shell`)
+      }
+    })
+
+    it('should store action names directly (not prlt hook fire commands)', () => {
+      applyPreset(db, 'aggressive')
+
+      const hooks = db.prepare("SELECT action_value FROM pmo_work_hooks WHERE source = 'preset'")
+        .all() as Array<{ action_value: string }>
+
+      for (const hook of hooks) {
+        // Should be a clean action name, not a prlt command
+        expect(hook.action_value).to.not.include('prlt hook fire')
+        expect(hook.action_value).to.not.include('--action')
+        // Should be a known built-in action name
+        expect(BUILTIN_ACTIONS).to.include(hook.action_value as any)
+      }
+    })
+
+    it('all 22 preset hooks should use action type (not shell)', () => {
+      applyPreset(db, 'aggressive')
+
+      const count = db.prepare(
+        "SELECT COUNT(*) as c FROM pmo_work_hooks WHERE source = 'preset' AND action_type = 'action'"
+      ).get() as { c: number }
+
+      expect(count.c).to.equal(PRESETS.aggressive.hooks.length)
+    })
+
+    it('should work for all preset names', () => {
+      for (const presetName of PRESET_NAMES) {
+        try { db.exec("DELETE FROM pmo_work_hooks WHERE source = 'preset'") } catch { /* */ }
+
+        applyPreset(db, presetName)
+
+        const shellCount = db.prepare(
+          "SELECT COUNT(*) as c FROM pmo_work_hooks WHERE source = 'preset' AND action_type = 'shell'"
+        ).get() as { c: number }
+
+        expect(shellCount.c).to.equal(0,
+          `Preset "${presetName}" should have no shell-type hooks`)
+      }
+    })
+  })
+
+  // =========================================================================
+  // resolveActionName
+  // =========================================================================
+
+  describe('resolveActionName', () => {
+    it('should return action_value directly for action-type hooks', () => {
+      const hook: WorkHookConfig = {
+        id: 'test',
+        name: 'test',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: '',
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+
+      const result = HookManager.resolveActionName(hook)
+      expect(result).to.equal('merge-pr')
+    })
+
+    it('should still extract --action from shell-type hooks (backward compat)', () => {
+      const hook: WorkHookConfig = {
+        id: 'test',
+        name: 'test',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'prlt hook fire on_ci_green --action merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: '',
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+
+      const result = HookManager.resolveActionName(hook)
+      expect(result).to.equal('merge-pr')
+    })
+
+    it('should return raw command for shell-type hooks without --action', () => {
+      const hook: WorkHookConfig = {
+        id: 'test',
+        name: 'test',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'echo hello',
+        enabled: true,
+        description: null,
+        createdAt: '',
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+
+      const result = HookManager.resolveActionName(hook)
+      expect(result).to.equal('echo hello')
+    })
+  })
+
+  // =========================================================================
+  // Direct Execution (no shell)
+  // =========================================================================
+
+  describe('direct execution via action handlers', () => {
+    it('should call action handler in-process for action-type hooks', async () => {
+      let handlerCalled = false
+      let receivedCtx: Record<string, unknown> | null = null
+
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'move-ticket': (ctx, config) => {
+          handlerCalled = true
+          receivedCtx = ctx
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-move',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        config: JSON.stringify({ target: 'review' }),
+      })
+
+      const manager = new HookManager({ db, actionHandlers })
+      const results = await manager.fireEvent('on_pr_opened', { ticket: 'TKT-100', pr: 42 })
+
+      expect(handlerCalled).to.be.true
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(results[0].action).to.equal('move-ticket')
+      expect(receivedCtx).to.not.be.null
+      expect(receivedCtx!.ticket).to.equal('TKT-100')
+    })
+
+    it('should return error when action-type hook has no registered handler', async () => {
+      insertHook(db, {
+        name: 'unknown-action',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'nonexistent-action',
+      })
+
+      const manager = new HookManager({ db, actionHandlers: {} })
+      const results = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.false
+      expect(results[0].error).to.include('No action handler registered')
+    })
+
+    it('should NOT spawn shell for action-type hooks', async () => {
+      // If action-type hooks were executed as shell, "merge-pr" would fail because
+      // it's not a valid shell command. The handler intercepts it.
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'merge-pr': () => ({ action: 'merge-pr', success: true, durationMs: 0 }),
+      }
+
+      insertHook(db, {
+        name: 'no-shell',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+      })
+
+      const manager = new HookManager({ db, actionHandlers })
+      const results = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+    })
+
+    it('should support async action handlers', async () => {
+      const asyncHandler: HookActionHandler = async (ctx, config) => {
+        // Simulate async work (e.g., service call)
+        await new Promise(resolve => setTimeout(resolve, 1))
+        return { action: 'move-ticket', success: true, durationMs: 1 }
+      }
+
+      insertHook(db, {
+        name: 'async-action',
+        event: 'on_pr_merged',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+      })
+
+      const manager = new HookManager({ db, actionHandlers: { 'move-ticket': asyncHandler } })
+      const results = await manager.fireEvent('on_pr_merged', { ticket: 'TKT-100' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+    })
+  })
+
+  // =========================================================================
+  // Backward Compatibility
+  // =========================================================================
+
+  describe('backward compatibility', () => {
+    it('should still execute shell-type hooks as shell commands', async () => {
+      insertHook(db, {
+        name: 'shell-hook',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'echo hello',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+    })
+
+    it('should still execute log-type hooks', async () => {
+      insertHook(db, {
+        name: 'log-hook',
+        event: 'on_ci_green',
+        actionType: 'log',
+        actionValue: 'Event fired: {{event}}',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+    })
+
+    it('should handle mixed action-type and shell-type hooks for same event', async () => {
+      const handlerCalled = { action: false, shell: false }
+
+      insertHook(db, {
+        name: 'action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'notify',
+        priority: 1,
+      })
+      insertHook(db, {
+        name: 'shell-hook',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'echo "shell fired"',
+        priority: 2,
+      })
+
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'notify': () => {
+          handlerCalled.action = true
+          return { action: 'notify', success: true, durationMs: 0 }
+        },
+      }
+
+      const manager = new HookManager({ db, actionHandlers })
+      const results = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+
+      expect(results).to.have.length(2)
+      expect(handlerCalled.action).to.be.true
+      expect(results[0].success).to.be.true
+      expect(results[1].success).to.be.true
+    })
+  })
+
+  // =========================================================================
+  // Executor: action type fallback
+  // =========================================================================
+
+  describe('executor fallback', () => {
+    it('should return error for action-type hooks in executor (no handler registered)', () => {
+      const hook: WorkHookConfig = {
+        id: 'test',
+        name: 'test-action',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: '',
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+
+      const result = executeHook(hook, 'on_ci_green', { ticket: 'TKT-100' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No action handler registered')
+    })
+  })
+
+  // =========================================================================
+  // OrchestrateEngine integration
+  // =========================================================================
+
+  describe('OrchestrateEngine integration', () => {
+    it('should execute action-type preset hooks via engine', async () => {
+      applyPreset(db, 'aggressive')
+
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_ci_green', { event: 'on_ci_green', ticket: 'TKT-100', pr: 42 })
+
+      // on_ci_green fires merge-pr — with no real repo this will fail at the action
+      // level, but the important thing is that it went through the action handler
+      // (not through a shell prlt process)
+      expect(results).to.have.length(1)
+      expect(results[0].action).to.equal('merge-pr')
+    })
+
+    it('should execute move-ticket action-type hooks via engine without shell', async () => {
+      // Insert an action-type hook for move-ticket (simulating preset)
+      insertHook(db, {
+        name: 'move-to-review',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        config: JSON.stringify({ target: 'review' }),
+        source: 'preset',
+      })
+
+      // The service-backed handler will try to resolve the provider, which will
+      // fail in test (no workspace). But it should NOT spawn a prlt process.
+      const engine = new OrchestrateEngine({ db })
+      const results = await engine.fireEvent('on_pr_opened', {
+        event: 'on_pr_opened',
+        ticket: 'TKT-100',
+        pr: 42,
+      })
+
+      expect(results.length).to.be.greaterThan(0)
+      const moveResult = results.find(r => r.action === 'move-ticket')
+      expect(moveResult).to.exist
+      // It may fail (no real provider), but should have an error, not hang
+      expect(moveResult!.durationMs).to.be.a('number')
+    })
+  })
+
+  // =========================================================================
+  // Service-backed handlers
+  // =========================================================================
+
+  describe('service-backed action handlers', () => {
+    it('createServiceActionHandlers returns handlers for move-ticket', () => {
+      const handlers = createServiceActionHandlers(db)
+      expect(handlers).to.have.property('move-ticket')
+      expect(handlers['move-ticket']).to.be.a('function')
+    })
+
+    it('move-ticket handler returns result without spawning shell', async () => {
+      const handlers = createServiceActionHandlers(db)
+      const handler = handlers['move-ticket']
+
+      const result = await handler(
+        { event: 'on_pr_opened', ticket: 'TKT-100', projectId: 'PROJ-1' },
+        { target: 'review' },
+      )
+
+      expect(result.action).to.equal('move-ticket')
+      expect(result.durationMs).to.be.a('number')
+      // Will fail (no real provider configured in test DB) but should not throw
+      // and should NOT spawn a shell process
+    })
+
+    it('move-ticket handler returns error when no ticket in context', async () => {
+      const handlers = createServiceActionHandlers(db)
+      const result = await handlers['move-ticket'](
+        { event: 'on_pr_opened' },
+        { target: 'review' },
+      )
+
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket in context')
+    })
+  })
+
+  // =========================================================================
+  // Latency measurement
+  // =========================================================================
+
+  describe('latency: action vs shell', () => {
+    it('action-type hooks should be faster than shell-type hooks', async () => {
+      // action-type hook — calls handler directly
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'notify': () => ({ action: 'notify', success: true, durationMs: 0 }),
+      }
+
+      insertHook(db, {
+        name: 'fast-action',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'notify',
+        priority: 1,
+      })
+
+      const manager = new HookManager({ db, actionHandlers })
+
+      // Measure action-type execution
+      const actionStart = Date.now()
+      const actionResults = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+      const actionDuration = Date.now() - actionStart
+
+      // Remove action hook, add shell hook
+      db.exec("DELETE FROM pmo_work_hooks")
+      insertHook(db, {
+        name: 'slow-shell',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'echo hello',
+        priority: 1,
+      })
+
+      // Measure shell-type execution
+      const shellStart = Date.now()
+      const shellResults = await manager.fireEvent('on_ci_green', { ticket: 'TKT-100' })
+      const shellDuration = Date.now() - shellStart
+
+      // Action should succeed
+      expect(actionResults[0].success).to.be.true
+      expect(shellResults[0].success).to.be.true
+
+      // Action type should be faster (in-process vs fork+exec)
+      // Note: this is a statistical test — on very fast machines the difference
+      // may be small, so we just verify action is not slower
+      expect(actionDuration).to.be.at.most(shellDuration + 10,
+        `Action hook (${actionDuration}ms) should be faster than shell hook (${shellDuration}ms)`)
+    })
+  })
+
+  // =========================================================================
+  // No process spawning
+  // =========================================================================
+
+  describe('no prlt process spawning', () => {
+    it('preset hooks should not contain prlt commands in action_value', () => {
+      applyPreset(db, 'aggressive')
+
+      const hooks = db.prepare("SELECT action_value FROM pmo_work_hooks WHERE source = 'preset'")
+        .all() as Array<{ action_value: string }>
+
+      for (const hook of hooks) {
+        expect(hook.action_value).to.not.match(/^prlt\b/,
+          `Preset hook should not shell out to prlt: "${hook.action_value}"`)
+      }
+    })
+
+    it('PRLT-1257 regression: event names preserved with action type', () => {
+      applyPreset(db, 'aggressive')
+
+      const hooks = db.prepare("SELECT event, action_value FROM pmo_work_hooks WHERE source = 'preset'")
+        .all() as Array<{ event: string; action_value: string }>
+
+      // Since action_value is now just the action name, verify events are correct
+      const presetEvents = new Set(PRESETS.aggressive.hooks.map(h => h.event))
+      const storedEvents = new Set(hooks.map(h => h.event))
+
+      expect(storedEvents.has('on_ci_green')).to.be.true
+      expect(storedEvents.has('on_pr_opened')).to.be.true
+      expect(storedEvents.has('on_ticket_ready')).to.be.true
+      expect(storedEvents.has('on_agent_died')).to.be.true
+
+      // No hook should be misrouted to work:status_changed
+      if (!presetEvents.has('work:status_changed')) {
+        expect(storedEvents.has('work:status_changed')).to.be.false
+      }
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-config-loader.test.ts
+++ b/apps/cli/test/unit/orchestrate-config-loader.test.ts
@@ -195,14 +195,13 @@ review:
       const count = applyPreset(db, 'conservative')
       expect(count).to.be.greaterThan(0)
 
-      const hooks = db.prepare("SELECT * FROM pmo_work_hooks WHERE source = 'preset'").all() as Array<{ mode: string; action_value: string }>
+      const hooks = db.prepare("SELECT * FROM pmo_work_hooks WHERE source = 'preset'").all() as Array<{ mode: string; action_type: string; action_value: string }>
       for (const hook of hooks) {
         // Conservative preset: safe actions are auto (Tier 1), destructive actions are human (Tier 3)
-        // action_value is like "prlt hook fire on_ci_green --action merge-pr", extract the action name
+        // action_type is 'action' and action_value is the action name directly (PRLT-1304)
         const SAFE_ACTIONS = new Set(['move-ticket', 'notify', 'cleanup-container', 'health-check', 'rebase-conflicting-prs', 'spawn-review-agent', 'gc-sweep'])
-        const actionMatch = hook.action_value.match(/--action\s+(\S+)/)
-        const actionName = actionMatch ? actionMatch[1] : hook.action_value
-        const expectedMode = SAFE_ACTIONS.has(actionName) ? 'auto' : 'human'
+        expect(hook.action_type).to.equal('action')
+        const expectedMode = SAFE_ACTIONS.has(hook.action_value) ? 'auto' : 'human'
         expect(hook.mode).to.equal(expectedMode)
       }
     })
@@ -236,23 +235,24 @@ review:
     it('should store each preset hook with its correct event name, never work:status_changed fallback', () => {
       applyPreset(db, 'aggressive')
 
-      const hooks = db.prepare("SELECT event, action_value FROM pmo_work_hooks WHERE source = 'preset'")
-        .all() as Array<{ event: string; action_value: string }>
+      const hooks = db.prepare("SELECT event, action_type, action_value FROM pmo_work_hooks WHERE source = 'preset'")
+        .all() as Array<{ event: string; action_type: string; action_value: string }>
 
       // No hook should have been silently misrouted to work:status_changed
       // unless the preset actually defines a work:status_changed hook
       const presetEvents = new Set(PRESETS.aggressive.hooks.map(h => h.event))
       const hasWorkStatusChanged = presetEvents.has('work:status_changed')
 
-      for (const hook of hooks) {
-        // Extract the original event from the action_value: "prlt hook fire <event> --action ..."
-        const match = hook.action_value.match(/prlt hook fire (\S+) --action/)
-        expect(match, `Could not parse event from action_value: ${hook.action_value}`).to.not.be.null
-        const originalEvent = match![1]
-
-        // The stored event MUST match the original event from the preset
-        expect(hook.event).to.equal(originalEvent,
-          `Hook for event "${originalEvent}" was stored as "${hook.event}" — misrouted!`)
+      // Since PRLT-1304 changed preset hooks to action_type='action' with
+      // action_value=<action-name> (not a prlt command), verify event correctness
+      // by checking the stored event matches the preset definition
+      const presetHooksByIndex = PRESETS.aggressive.hooks
+      for (let i = 0; i < hooks.length; i++) {
+        const hook = hooks[i]
+        // action_type should be 'action' (PRLT-1304)
+        expect(hook.action_type).to.equal('action')
+        // The stored event should be a valid preset event
+        expect(presetEvents.has(hook.event as any)).to.be.true
       }
 
       // Verify we actually have hooks for orchestrate events (not just work:* events)
@@ -286,14 +286,18 @@ review:
         try { db.exec("DELETE FROM pmo_work_hooks WHERE source = 'preset'") } catch { /* */ }
         applyPreset(db, presetName)
 
-        const hooks = db.prepare("SELECT event, action_value FROM pmo_work_hooks WHERE source = 'preset'")
-          .all() as Array<{ event: string; action_value: string }>
+        const hooks = db.prepare("SELECT event, action_type, action_value FROM pmo_work_hooks WHERE source = 'preset'")
+          .all() as Array<{ event: string; action_type: string; action_value: string }>
+
+        // PRLT-1304: action_type is now 'action', action_value is the action name directly.
+        // Verify events match by checking against preset definition.
+        const presetDef = PRESETS[presetName]
+        const presetEvents = new Set(presetDef.hooks.map(h => h.event))
 
         for (const hook of hooks) {
-          const match = hook.action_value.match(/prlt hook fire (\S+) --action/)
-          expect(match).to.not.be.null
-          expect(hook.event).to.equal(match![1],
-            `${presetName} preset: event "${match![1]}" misrouted to "${hook.event}"`)
+          expect(hook.action_type).to.equal('action')
+          expect(presetEvents.has(hook.event as any)).to.be.true,
+            `${presetName} preset: event "${hook.event}" not found in preset definition`
         }
       }
     })


### PR DESCRIPTION
## Summary
- Adds action_type=action to hook data model for direct in-process handler calls
- Migrates all 22 preset hooks from shell to action type (no prlt process spawn)
- Service-backed move-ticket handler calls provider directly
- Migration 0025 auto-converts existing preset hooks
- Backward compatible: shell/webhook/log hooks unchanged

## Test plan
- 29 new unit tests
- All 295 hook-related tests pass
- Build passes