### PR TITLE
chore: bump version to 0.3.123

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@proletariat/cli",
   "description": "Agent orchestration platform for AI labor - Spin up workers on demand for multi-agent development",
-  "version": "0.3.122",
+  "version": "0.3.123",
   "author": "Chris McDermut",
   "mcpName": "io.github.chrismcdermut/proletariat-cli",
   "publishConfig": {


### PR DESCRIPTION
## Summary
Version bump to 0.3.123 — 9 PRs merged since v0.3.122.

Quality hardening + orchestration features:
- Hard-remove ESLint rule (no more soft stubs)
- DB migration upgrade tests in PR CI
- CLI self-test smoke tests
- Devcontainer auto-update
- Non-interactive flags for agent automation
- Orchestrator HQ scoping
- Reconciler LLM escalation
- Onboarding wizard
- Cross-HQ fallback fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)