### PR TITLE
feat(PRLT-1344): safe brew upgrade — tap refresh, binary verification, and recovery

### DIFF
--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -10,6 +10,7 @@ import {
   getStandaloneInstallDir,
   isNewerVersion,
   runNpmInstallWithRetry,
+  runBrewUpgradeWithSafety,
   type PackageManager,
 } from '../lib/update-check.js'
 
@@ -133,7 +134,10 @@ export default class Update extends Command {
     }
 
     try {
-      if (pm === 'npm') {
+      if (pm === 'brew') {
+        // PRLT-1344: safe brew upgrade — refreshes tap, verifies binary, recovers if missing
+        runBrewUpgradeWithSafety()
+      } else if (pm === 'npm') {
         runNpmInstallWithRetry(command)
       } else {
         execSync(command, {

--- a/apps/cli/src/lib/update-check.ts
+++ b/apps/cli/src/lib/update-check.ts
@@ -309,6 +309,125 @@ export function getStaleTapCommands(): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Brew upgrade safety (PRLT-1344)
+// ---------------------------------------------------------------------------
+
+/**
+ * Refresh the local Homebrew tap so the latest formula is available
+ * before attempting `brew upgrade`. Runs:
+ *   brew tap --force chrismcdermut/proletariat
+ *
+ * Returns true on success, false on failure (caller should still attempt
+ * the upgrade — brew may have a local cache that works).
+ */
+export function refreshBrewTap(): boolean {
+  try {
+    execSync('brew tap --force chrismcdermut/proletariat', {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 60_000,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check whether the prlt binary exists and is callable.
+ * Uses `which` to verify it is on PATH and resolves to a real file.
+ */
+export function verifyBrewBinaryExists(): boolean {
+  try {
+    const result = execSync('which prlt', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }).trim()
+    // `which` found something — verify the file actually exists
+    // (handles dangling symlinks from partial uninstall)
+    return result.length > 0 && fs.existsSync(result)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Run `brew upgrade` with safety measures so the user never ends up
+ * without a working prlt binary (PRLT-1344).
+ *
+ * Steps:
+ * 1. Refresh the Homebrew tap to ensure the target formula version exists
+ * 2. Run `brew upgrade chrismcdermut/proletariat/prlt`
+ * 3. Verify the binary still exists after upgrade
+ * 4. If the binary is gone, attempt `brew reinstall` as recovery
+ * 5. If recovery fails, throw with clear manual instructions
+ *
+ * Throws on unrecoverable failure.
+ */
+export function runBrewUpgradeWithSafety(): void {
+  const upgradeCmd = 'brew upgrade chrismcdermut/proletariat/prlt'
+  const reinstallCmd = 'brew reinstall chrismcdermut/proletariat/prlt'
+
+  // Step 1: Refresh the tap
+  console.log('Refreshing Homebrew tap…')
+  const tapRefreshed = refreshBrewTap()
+  if (!tapRefreshed) {
+    console.log('Warning: could not refresh tap. Attempting upgrade anyway…')
+  }
+
+  // Step 2: Run the upgrade
+  let upgradeSucceeded = true
+  try {
+    execSync(upgradeCmd, {
+      stdio: 'inherit',
+      timeout: 120_000,
+    })
+  } catch {
+    upgradeSucceeded = false
+  }
+
+  // Step 3: Verify binary still exists
+  if (verifyBrewBinaryExists()) {
+    // Binary is present — whether or not the upgrade command itself exited
+    // cleanly (brew sometimes exits non-zero for "already installed")
+    if (!upgradeSucceeded) {
+      // Upgrade exited non-zero but binary is fine — likely "already installed"
+      throw new Error('brew upgrade exited with an error. prlt is still installed.')
+    }
+    return
+  }
+
+  // Step 4: Binary is gone — attempt recovery
+  console.error('')
+  console.error('brew upgrade removed prlt without installing the new version.')
+  console.error('Attempting to reinstall…')
+
+  try {
+    execSync(reinstallCmd, {
+      stdio: 'inherit',
+      timeout: 120_000,
+    })
+  } catch {
+    // reinstall also failed
+  }
+
+  // Step 5: Final verification
+  if (verifyBrewBinaryExists()) {
+    console.log('')
+    console.log('Recovery succeeded — prlt has been reinstalled.')
+    return
+  }
+
+  // Unrecoverable — give the user clear instructions
+  throw new Error(
+    'brew upgrade left prlt uninstalled and automatic recovery failed.\n' +
+    'Reinstall manually:\n' +
+    '  brew tap --force chrismcdermut/proletariat\n' +
+    '  brew install chrismcdermut/proletariat/prlt',
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Version fetching
 // ---------------------------------------------------------------------------
 

--- a/apps/cli/src/lib/update-prompt.ts
+++ b/apps/cli/src/lib/update-prompt.ts
@@ -13,7 +13,7 @@
 
 import { execSync } from 'node:child_process'
 import type { UpdateInfo } from './update-check.js'
-import { dismissVersion, getStaleTapCommands, getStandaloneInstallDir, runNpmInstallWithRetry } from './update-check.js'
+import { dismissVersion, getStaleTapCommands, getStandaloneInstallDir, runNpmInstallWithRetry, runBrewUpgradeWithSafety } from './update-check.js'
 
 // ---------------------------------------------------------------------------
 // Environment guards
@@ -174,7 +174,11 @@ async function executeUpdate(info: UpdateInfo): Promise<'updated' | 'failed'> {
   console.log('')
 
   try {
-    if (info.packageManager === 'npm') {
+    if (info.packageManager === 'brew') {
+      // PRLT-1344: safe brew upgrade — refreshes tap first, verifies binary
+      // after upgrade, and attempts recovery if binary is missing.
+      runBrewUpgradeWithSafety()
+    } else if (info.packageManager === 'npm') {
       runNpmInstallWithRetry(command)
     } else {
       execSync(command, {
@@ -191,7 +195,7 @@ async function executeUpdate(info: UpdateInfo): Promise<'updated' | 'failed'> {
     console.error(`  ${command}`)
 
     // If brew upgrade failed and the tap is stale, show remediation
-    if (info.packageManager === 'brew' && info.staleTap?.isStale) {
+    if (info.packageManager === 'brew') {
       await printStaleTapGuidance()
     }
 

--- a/apps/cli/test/unit/brew-upgrade-safety.test.ts
+++ b/apps/cli/test/unit/brew-upgrade-safety.test.ts
@@ -1,0 +1,349 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { execSync } from 'node:child_process'
+import {
+  refreshBrewTap,
+  verifyBrewBinaryExists,
+  runBrewUpgradeWithSafety,
+} from '../../src/lib/update-check.js'
+
+// ---------------------------------------------------------------------------
+// PRLT-1344: brew upgrade safety
+//
+// These tests verify that:
+// 1. refreshBrewTap() refreshes the tap before upgrade (AC #1)
+// 2. verifyBrewBinaryExists() detects missing binary after upgrade (AC #2, #4)
+// 3. runBrewUpgradeWithSafety() orchestrates tap refresh, upgrade, and recovery (AC #1, #2, #4)
+// 4. detectPackageManager + getUpdateCommand already handles AC #3 (tested in update-check.test.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal system PATH that includes basic system commands (which, bash, rm, etc.)
+ * but NOT real brew or prlt installations.
+ */
+const SYSTEM_ONLY_PATH = '/usr/bin:/bin'
+
+describe('Brew upgrade safety (PRLT-1344)', () => {
+  let originalLog: typeof console.log
+  let originalError: typeof console.error
+  let logs: string[]
+  let errors: string[]
+
+  beforeEach(() => {
+    logs = []
+    errors = []
+    originalLog = console.log
+    originalError = console.error
+    console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')) }
+    console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')) }
+  })
+
+  afterEach(() => {
+    console.log = originalLog
+    console.error = originalError
+  })
+
+  // =========================================================================
+  // refreshBrewTap
+  // =========================================================================
+  describe('refreshBrewTap', () => {
+    it('returns a boolean and does not throw', () => {
+      // In CI or environments without brew, this returns false gracefully.
+      // On developer machines with brew, this returns true.
+      const result = refreshBrewTap()
+      expect(result).to.be.a('boolean')
+    })
+
+    it('returns false when brew is not available', () => {
+      // Save original PATH
+      const originalPath = process.env.PATH
+      try {
+        // Set PATH to empty so brew can't be found
+        process.env.PATH = ''
+        const result = refreshBrewTap()
+        expect(result).to.be.false
+      } finally {
+        process.env.PATH = originalPath
+      }
+    })
+  })
+
+  // =========================================================================
+  // verifyBrewBinaryExists
+  // =========================================================================
+  describe('verifyBrewBinaryExists', () => {
+    it('returns a boolean and does not throw', () => {
+      const result = verifyBrewBinaryExists()
+      expect(result).to.be.a('boolean')
+    })
+
+    it('returns false when PATH is empty (no binary found)', () => {
+      const originalPath = process.env.PATH
+      try {
+        process.env.PATH = '/nonexistent-path-that-has-no-binaries'
+        const result = verifyBrewBinaryExists()
+        expect(result).to.be.false
+      } finally {
+        process.env.PATH = originalPath
+      }
+    })
+
+    it('returns true when a real prlt binary exists on PATH', () => {
+      // Create a temp dir with a fake "prlt" binary and put it on PATH
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-verify-'))
+      const fakeBin = path.join(tmpDir, 'prlt')
+      fs.writeFileSync(fakeBin, '#!/bin/bash\necho "fake prlt"')
+      fs.chmodSync(fakeBin, '755')
+
+      const originalPath = process.env.PATH
+      try {
+        process.env.PATH = `${tmpDir}:${originalPath}`
+        const result = verifyBrewBinaryExists()
+        expect(result).to.be.true
+      } finally {
+        process.env.PATH = originalPath
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('returns false when which finds a path but file does not exist (dangling symlink)', () => {
+      // Create a temp dir with a dangling symlink named "prlt"
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-verify-dangle-'))
+      const fakeBin = path.join(tmpDir, 'prlt')
+      fs.symlinkSync('/nonexistent-target-for-prlt-test', fakeBin)
+
+      const originalPath = process.env.PATH
+      try {
+        // Use only the temp dir + system commands — no real prlt on PATH
+        process.env.PATH = `${tmpDir}:${SYSTEM_ONLY_PATH}`
+        const result = verifyBrewBinaryExists()
+        expect(result).to.be.false
+      } finally {
+        process.env.PATH = originalPath
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  // =========================================================================
+  // runBrewUpgradeWithSafety
+  // =========================================================================
+  describe('runBrewUpgradeWithSafety', () => {
+    it('logs tap refresh message before attempting upgrade', () => {
+      const originalPath = process.env.PATH
+      try {
+        // Ensure no real brew runs — use system-only PATH
+        process.env.PATH = SYSTEM_ONLY_PATH
+        try {
+          runBrewUpgradeWithSafety()
+        } catch {
+          // Expected to fail without brew
+        }
+
+        const output = logs.join('\n')
+        expect(output).to.include('Refreshing Homebrew tap')
+      } finally {
+        process.env.PATH = originalPath
+      }
+    })
+
+    it('throws with clear reinstall instructions when brew is unavailable', () => {
+      const originalPath = process.env.PATH
+      try {
+        // Remove brew from PATH
+        process.env.PATH = '/nonexistent-path-only'
+        let thrownError: Error | null = null
+        try {
+          runBrewUpgradeWithSafety()
+        } catch (err) {
+          thrownError = err as Error
+        }
+        expect(thrownError).to.not.be.null
+        // The error message should contain reinstall instructions
+        const errorMsg = thrownError!.message
+        expect(errorMsg).to.include('brew')
+      } finally {
+        process.env.PATH = originalPath
+      }
+    })
+
+    it('attempts recovery when binary is missing after upgrade failure', () => {
+      // Set PATH so no brew is available — this simulates the worst case
+      // where upgrade fails and binary is not found
+      const originalPath = process.env.PATH
+      try {
+        process.env.PATH = '/nonexistent-path-only'
+        try {
+          runBrewUpgradeWithSafety()
+        } catch {
+          // Expected
+        }
+        // Should have attempted recovery (logged error about missing binary)
+        const errorOutput = errors.join('\n')
+        expect(errorOutput).to.include('removed prlt without installing')
+      } finally {
+        process.env.PATH = originalPath
+      }
+    })
+
+    it('does not throw when upgrade exits non-zero but binary is still present', () => {
+      // Create a fake "prlt" on PATH so verifyBrewBinaryExists returns true
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-brew-safe-'))
+      const fakeBin = path.join(tmpDir, 'prlt')
+      fs.writeFileSync(fakeBin, '#!/bin/bash\necho "fake prlt"')
+      fs.chmodSync(fakeBin, '755')
+
+      // Also create a fake "brew" that fails on upgrade but succeeds on tap
+      const fakeBrew = path.join(tmpDir, 'brew')
+      fs.writeFileSync(fakeBrew, [
+        '#!/bin/bash',
+        'if [[ "$1" == "tap" ]]; then exit 0; fi',
+        'if [[ "$1" == "upgrade" ]]; then',
+        '  echo "Error: already installed" >&2',
+        '  exit 1',
+        'fi',
+        'exit 1',
+      ].join('\n'))
+      fs.chmodSync(fakeBrew, '755')
+
+      const originalPath = process.env.PATH
+      try {
+        // Use only tmpDir + system commands to avoid real brew
+        process.env.PATH = `${tmpDir}:${SYSTEM_ONLY_PATH}`
+
+        // Should throw because brew upgrade failed, but prlt is still there
+        let thrownError: Error | null = null
+        try {
+          runBrewUpgradeWithSafety()
+        } catch (err) {
+          thrownError = err as Error
+        }
+        // It should throw with a message about the error, but binary is fine
+        expect(thrownError).to.not.be.null
+        expect(thrownError!.message).to.include('brew upgrade exited with an error')
+        expect(thrownError!.message).to.include('prlt is still installed')
+      } finally {
+        process.env.PATH = originalPath
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('succeeds when brew tap and upgrade both succeed and binary exists', () => {
+      // Create a temp dir with fake brew and prlt
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-brew-ok-'))
+      const fakeBin = path.join(tmpDir, 'prlt')
+      fs.writeFileSync(fakeBin, '#!/bin/bash\necho "fake prlt"')
+      fs.chmodSync(fakeBin, '755')
+
+      const fakeBrew = path.join(tmpDir, 'brew')
+      fs.writeFileSync(fakeBrew, [
+        '#!/bin/bash',
+        '# Fake brew that succeeds for both tap and upgrade',
+        'exit 0',
+      ].join('\n'))
+      fs.chmodSync(fakeBrew, '755')
+
+      const originalPath = process.env.PATH
+      try {
+        // Use only tmpDir + system commands to avoid real brew
+        process.env.PATH = `${tmpDir}:${SYSTEM_ONLY_PATH}`
+        expect(() => runBrewUpgradeWithSafety()).to.not.throw()
+      } finally {
+        process.env.PATH = originalPath
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('attempts brew reinstall when upgrade removes binary', () => {
+      // Create a temp dir with fake brew and prlt
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-brew-reinstall-'))
+      const fakeBin = path.join(tmpDir, 'prlt')
+      fs.writeFileSync(fakeBin, '#!/bin/bash\necho "fake prlt"')
+      fs.chmodSync(fakeBin, '755')
+
+      // Fake brew: tap succeeds, upgrade removes prlt, reinstall puts it back
+      const fakeBrew = path.join(tmpDir, 'brew')
+      fs.writeFileSync(fakeBrew, [
+        '#!/bin/bash',
+        `if [[ "$1" == "tap" ]]; then exit 0; fi`,
+        `if [[ "$1" == "upgrade" ]]; then`,
+        `  rm -f "${fakeBin}"`,
+        `  exit 0`,
+        `fi`,
+        `if [[ "$1" == "reinstall" ]]; then`,
+        `  echo '#!/bin/bash' > "${fakeBin}"`,
+        `  echo 'echo reinstalled' >> "${fakeBin}"`,
+        `  chmod 755 "${fakeBin}"`,
+        `  exit 0`,
+        `fi`,
+        `exit 1`,
+      ].join('\n'))
+      fs.chmodSync(fakeBrew, '755')
+
+      const originalPath = process.env.PATH
+      try {
+        // Use only tmpDir + system commands so no real prlt interferes
+        process.env.PATH = `${tmpDir}:${SYSTEM_ONLY_PATH}`
+        // Should not throw because reinstall recovers the binary
+        expect(() => runBrewUpgradeWithSafety()).to.not.throw()
+
+        // Verify recovery messages were logged
+        const errorOutput = errors.join('\n')
+        expect(errorOutput).to.include('removed prlt without installing')
+        expect(errorOutput).to.include('Attempting to reinstall')
+
+        // Verify recovery success message
+        const logOutput = logs.join('\n')
+        expect(logOutput).to.include('Recovery succeeded')
+      } finally {
+        process.env.PATH = originalPath
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    it('throws with instructions when both upgrade and reinstall fail to provide binary', () => {
+      // Create a temp dir with fake brew that always removes prlt
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-brew-fatal-'))
+      const fakeBin = path.join(tmpDir, 'prlt')
+      fs.writeFileSync(fakeBin, '#!/bin/bash\necho "fake prlt"')
+      fs.chmodSync(fakeBin, '755')
+
+      // Fake brew: tap succeeds, upgrade removes prlt, reinstall also fails
+      const fakeBrew = path.join(tmpDir, 'brew')
+      fs.writeFileSync(fakeBrew, [
+        '#!/bin/bash',
+        `if [[ "$1" == "tap" ]]; then exit 0; fi`,
+        `if [[ "$1" == "upgrade" ]]; then`,
+        `  rm -f "${fakeBin}"`,
+        `  exit 0`,
+        `fi`,
+        `if [[ "$1" == "reinstall" ]]; then`,
+        `  exit 1`,
+        `fi`,
+        `exit 1`,
+      ].join('\n'))
+      fs.chmodSync(fakeBrew, '755')
+
+      const originalPath = process.env.PATH
+      try {
+        // Use only tmpDir + system commands so no real prlt interferes
+        process.env.PATH = `${tmpDir}:${SYSTEM_ONLY_PATH}`
+        let thrownError: Error | null = null
+        try {
+          runBrewUpgradeWithSafety()
+        } catch (err) {
+          thrownError = err as Error
+        }
+        expect(thrownError).to.not.be.null
+        expect(thrownError!.message).to.include('automatic recovery failed')
+        expect(thrownError!.message).to.include('brew tap --force')
+        expect(thrownError!.message).to.include('brew install chrismcdermut/proletariat/prlt')
+      } finally {
+        process.env.PATH = originalPath
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `refreshBrewTap()` to refresh the Homebrew tap before `brew upgrade`, preventing stale-tap failures
- Adds `runBrewUpgradeWithSafety()` which orchestrates tap refresh → upgrade → binary verification → recovery
- Verifies the prlt binary exists after upgrade; attempts `brew reinstall` if binary is missing
- Updates both the interactive update prompt and `prlt update` command to use the safe brew path
- Detects install method (npm vs brew vs standalone) and offers the correct upgrade command (already existed, now verified)

## Test plan

- [x] `refreshBrewTap()` returns boolean, doesn't throw
- [x] `refreshBrewTap()` returns false when brew unavailable
- [x] `verifyBrewBinaryExists()` detects real binary on PATH
- [x] `verifyBrewBinaryExists()` returns false for dangling symlinks
- [x] `runBrewUpgradeWithSafety()` logs tap refresh before upgrade
- [x] Recovery attempted when upgrade removes binary
- [x] Throws with clear instructions when recovery fails
- [x] Succeeds when brew tap and upgrade both succeed
- [x] 13 new unit tests, all passing

Fixes: PRLT-1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)