### PR TITLE
feat(PRLT-1304): wire hooks to service layer — eliminate shell indirection

### DIFF
--- a/apps/cli/src/commands/work/hooks/add.ts
+++ b/apps/cli/src/commands/work/hooks/add.ts
@@ -36,8 +36,8 @@ export default class WorkHooksAdd extends PromptCommand {
       options: HOOKABLE_EVENTS,
     }),
     'action-type': Flags.string({
-      description: 'Action type (shell, webhook, or log)',
-      options: ['shell', 'webhook', 'log'],
+      description: 'Action type (shell, webhook, log, or action)',
+      options: ['shell', 'webhook', 'log', 'action'],
     }),
     'action-value': Flags.string({
       description: 'Action payload (command, URL, or message template)',
@@ -134,6 +134,7 @@ export default class WorkHooksAdd extends PromptCommand {
           { name: 'shell — Run a shell command', value: 'shell' },
           { name: 'webhook — POST event data to a URL', value: 'webhook' },
           { name: 'log — Print a message to stdout', value: 'log' },
+          { name: 'action — Call a built-in action directly (no shell)', value: 'action' },
         ]
         const message = 'Action type:'
 
@@ -163,6 +164,7 @@ export default class WorkHooksAdd extends PromptCommand {
           shell: 'Shell command to run:',
           webhook: 'Webhook URL:',
           log: 'Log message template (use {{workItemId}}, {{event}}, etc.):',
+          action: 'Built-in action name (e.g. move-ticket, notify, merge-pr):',
         }
         const message = prompts[actionType!]
 

--- a/apps/cli/src/lib/database/migrations/0026_hook_action_type.ts
+++ b/apps/cli/src/lib/database/migrations/0026_hook_action_type.ts
@@ -1,0 +1,85 @@
+/**
+ * Migration 0026 — Hook Action Type
+ *
+ * Adds 'action' to the action_type CHECK constraint on pmo_work_hooks.
+ * The 'action' type allows hooks to call built-in action handlers
+ * directly in-process instead of shelling out to prlt CLI commands.
+ *
+ * Also migrates existing preset hooks from shell-based indirection
+ * (action_type='shell', action_value='prlt hook fire ... --action <name>')
+ * to direct action invocation (action_type='action', action_value='<name>').
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const hookActionType: Migration = {
+  id: '0026',
+  name: 'hook_action_type',
+  up: (db: Database.Database) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get()
+    if (!tableExists) return
+
+    // Check if the constraint already includes 'action' — skip if already migrated
+    const createSql = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get() as { sql: string } | undefined
+    if (createSql?.sql?.includes("'action'")) return
+
+    // SQLite doesn't allow modifying CHECK constraints via ALTER TABLE.
+    // Recreate the table with the expanded constraint.
+    db.exec(`
+      CREATE TABLE pmo_work_hooks_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        event TEXT NOT NULL,
+        action_type TEXT NOT NULL DEFAULT 'shell' CHECK (action_type IN ('shell', 'webhook', 'log', 'action')),
+        action_value TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        description TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off')),
+        priority INTEGER NOT NULL DEFAULT 0,
+        project_id TEXT,
+        source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset')),
+        config TEXT
+      )
+    `)
+
+    // Copy all existing data
+    db.exec(`
+      INSERT INTO pmo_work_hooks_new (id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, project_id, source, config)
+      SELECT id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, project_id, source, config
+      FROM pmo_work_hooks
+    `)
+
+    // Swap tables
+    db.exec('DROP TABLE pmo_work_hooks')
+    db.exec('ALTER TABLE pmo_work_hooks_new RENAME TO pmo_work_hooks')
+
+    // Recreate indexes
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_event ON pmo_work_hooks(event)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_enabled ON pmo_work_hooks(enabled)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+
+    // Migrate existing preset hooks from shell indirection to direct action type.
+    // Pattern: action_value = 'prlt hook fire <event> --action <action-name>'
+    // → action_type = 'action', action_value = '<action-name>'
+    const presetHooks = db.prepare(
+      "SELECT id, action_value FROM pmo_work_hooks WHERE source = 'preset' AND action_type = 'shell'"
+    ).all() as Array<{ id: string; action_value: string }>
+
+    const updateStmt = db.prepare(
+      "UPDATE pmo_work_hooks SET action_type = 'action', action_value = ? WHERE id = ?"
+    )
+
+    for (const hook of presetHooks) {
+      const match = hook.action_value.match(/--action\s+(\S+)/)
+      if (match) {
+        updateStmt.run(match[1], hook.id)
+      }
+    }
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -31,6 +31,7 @@ import { hookModeTiers } from './0022_hook_mode_tiers.js'
 import { intentBasedActions } from './0023_intent_based_actions.js'
 import { dropDeadPmoTables } from './0024_drop_dead_pmo_tables.js'
 import { transitionMapManyToOne } from './0025_transition_map_many_to_one.js'
+import { hookActionType } from './0026_hook_action_type.js'
 
 /**
  * Ordered list of all migrations.
@@ -62,4 +63,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   intentBasedActions,
   dropDeadPmoTables,
   transitionMapManyToOne,
+  hookActionType,
 ]

--- a/apps/cli/src/lib/orchestrate/config-loader.ts
+++ b/apps/cli/src/lib/orchestrate/config-loader.ts
@@ -134,8 +134,8 @@ export function applyPreset(db: Database.Database, presetName: PresetName): numb
       const created = storage.create({
         name: hookName,
         event: mapOrchestrateToHookable(hook.event),
-        actionType: 'shell',
-        actionValue: `prlt hook fire ${hook.event} --action ${hook.action}`,
+        actionType: 'action',
+        actionValue: hook.action,
         description: `Preset ${presetName}: ${hook.event} → ${hook.action} (${hook.mode})`,
       })
 

--- a/apps/cli/src/lib/orchestrate/engine.ts
+++ b/apps/cli/src/lib/orchestrate/engine.ts
@@ -14,8 +14,9 @@
 
 import type Database from 'better-sqlite3'
 import { HookManager } from '../work-lifecycle/hooks/manager.js'
-import type { HookExecutionResult, HookActionHandler, LlmDecision } from '../work-lifecycle/hooks/types.js'
+import type { HookExecutionResult, HookActionHandler, AsyncHookActionHandler, LlmDecision } from '../work-lifecycle/hooks/types.js'
 import { ACTION_HANDLERS } from './actions.js'
+import { createServiceActionHandlers } from './service-actions.js'
 import {
   NotificationManager,
   initNotificationManager,
@@ -75,6 +76,9 @@ export class OrchestrateEngine {
         }
       : undefined
 
+    // Create service-backed handlers for action-type hooks (in-process, no shell)
+    const serviceHandlers = createServiceActionHandlers(options.db)
+
     this.manager = new HookManager({
       db: options.db,
       log: options.log,
@@ -84,6 +88,7 @@ export class OrchestrateEngine {
       onHumanEscalation: options.onHumanEscalation,
       llmTimeoutMs: options.llmTimeoutMs,
       actionHandlers: ACTION_HANDLERS as Record<string, HookActionHandler>,
+      serviceActionHandlers: serviceHandlers as Record<string, AsyncHookActionHandler>,
     })
 
     // Initialize the notification manager so it subscribes to events

--- a/apps/cli/src/lib/orchestrate/index.ts
+++ b/apps/cli/src/lib/orchestrate/index.ts
@@ -44,6 +44,11 @@ export {
 } from './actions.js'
 
 export {
+  createServiceActionHandlers,
+  SERVICE_BACKED_ACTIONS,
+} from './service-actions.js'
+
+export {
   OrchestrateEngine,
   initOrchestrateEngine,
   getOrchestrateEngine,

--- a/apps/cli/src/lib/orchestrate/service-actions.ts
+++ b/apps/cli/src/lib/orchestrate/service-actions.ts
@@ -1,0 +1,150 @@
+/**
+ * Service-Backed Action Handlers
+ *
+ * Action handlers that call the service/provider layer directly instead of
+ * shelling out to prlt CLI commands. These replace the shell-based handlers
+ * in actions.ts for actions where a service equivalent exists.
+ *
+ * The key change: hook → service → DB (in-process, no child process spawn).
+ *
+ * Actions that inherently need external processes (spawn-agent, health-check,
+ * cleanup-container, etc.) are NOT replaced here — they remain in actions.ts.
+ */
+
+import type Database from 'better-sqlite3'
+import type { OrchestrateEventContext, OrchestrateActionResult } from './types.js'
+import { resolveWorkflowTarget } from '../work-lifecycle/settings.js'
+import type { ProviderStorage } from '../providers/types.js'
+
+type ServiceActionHandler = (
+  ctx: OrchestrateEventContext,
+  config?: Record<string, unknown>,
+) => Promise<OrchestrateActionResult>
+
+/**
+ * Create a minimal ProviderStorage for use with resolveProjectProvider.
+ *
+ * External providers (Linear, Jira, etc.) don't use storage methods — they go
+ * directly to the external API. The local PMO provider does use storage, but
+ * it's rarely the active provider when the orchestrate daemon runs (you need
+ * an external tracker to have tickets to automate).
+ *
+ * If a storage method IS called on this stub, it throws so we can diagnose
+ * rather than silently misbehave.
+ */
+function createMinimalStorage(db: Database.Database): ProviderStorage {
+  const notImplemented = (method: string) => () => {
+    throw new Error(`ProviderStorage.${method}() not available in service-action context`)
+  }
+
+  return {
+    getTicket: notImplemented('getTicket') as never,
+    getProjectBoard: notImplemented('getProjectBoard') as never,
+    moveTicket: notImplemented('moveTicket') as never,
+    deleteTicket: notImplemented('deleteTicket') as never,
+    listTickets: notImplemented('listTickets') as never,
+    createTicket: notImplemented('createTicket') as never,
+    updateTicket: notImplemented('updateTicket') as never,
+    getDatabase: () => db,
+  }
+}
+
+/**
+ * Actions that have service-backed replacements.
+ * Other actions (spawn-agent, health-check, etc.) still use shell execution.
+ */
+export const SERVICE_BACKED_ACTIONS = new Set([
+  'move-ticket',
+  'notify',
+])
+
+/**
+ * Create service-backed action handlers that use the database and provider
+ * layer directly, eliminating shell indirection.
+ *
+ * Returns a map of action names to async handlers. These override the
+ * shell-based equivalents in ACTION_HANDLERS when the hook's action_type
+ * is 'action'.
+ */
+export function createServiceActionHandlers(
+  db: Database.Database,
+): Record<string, ServiceActionHandler> {
+  return {
+    'move-ticket': createMoveTicketHandler(db),
+    'notify': createNotifyHandler(),
+  }
+}
+
+/**
+ * Service-backed move-ticket handler.
+ *
+ * Before: walkPromptChain('prlt ticket move TKT-123 "Done"') — spawns prlt process
+ * After:  provider.moveTicket('TKT-123', 'Done') — in-process call to provider API
+ */
+function createMoveTicketHandler(db: Database.Database): ServiceActionHandler {
+  return async (ctx, config) => {
+    const start = Date.now()
+    if (!ctx.ticket) {
+      return { action: 'move-ticket', success: false, error: 'No ticket in context', durationMs: Date.now() - start }
+    }
+
+    const requestedTarget = (config?.target as string) || 'done'
+
+    try {
+      const resolvedTarget = resolveWorkflowTarget(db, requestedTarget)
+
+      const { resolveProjectProvider } = await import('../providers/resolver.js')
+      const storage = createMinimalStorage(db)
+      const provider = resolveProjectProvider(db, storage, ctx.projectId || '')
+
+      const result = await provider.moveTicket(ctx.ticket, resolvedTarget)
+
+      return {
+        action: 'move-ticket',
+        success: result.success,
+        error: result.error,
+        durationMs: Date.now() - start,
+      }
+    } catch (err) {
+      return {
+        action: 'move-ticket',
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+}
+
+/**
+ * Service-backed notify handler.
+ *
+ * Before: shelling out to prlt or console.log via actions.ts
+ * After:  dispatches through NotificationManager in-process
+ */
+function createNotifyHandler(): ServiceActionHandler {
+  return async (ctx) => {
+    const start = Date.now()
+
+    try {
+      const { getNotificationManager } = await import('../notifications/index.js')
+      const manager = getNotificationManager()
+      if (manager) {
+        const notifCtx = { ...ctx, event: ctx.event || 'notify' }
+        await manager.fireEvent(notifCtx.event, notifCtx)
+        return { action: 'notify', success: true, durationMs: Date.now() - start }
+      }
+    } catch {
+      // Notification layer not available — fall through to terminal
+    }
+
+    const parts: string[] = []
+    if (ctx.event) parts.push(`[${ctx.event}]`)
+    if (ctx.ticket) parts.push(`ticket=${ctx.ticket}`)
+    if (ctx.pr) parts.push(`PR=#${ctx.pr}`)
+    if (ctx.agent) parts.push(`agent=${ctx.agent}`)
+    console.log(`[orchestrate:notify] ${parts.join(' ')}`)
+
+    return { action: 'notify', success: true, durationMs: Date.now() - start }
+  }
+}

--- a/apps/cli/src/lib/work-lifecycle/hooks/executor.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/executor.ts
@@ -136,6 +136,20 @@ export function executeHook(
         console.log(`[hook:${hook.name}] ${message}`)
         break
       }
+
+      case 'action': {
+        // Action-type hooks are handled directly by HookManager via
+        // built-in action handlers — they should not reach the executor.
+        // If they do, return an error so the misconfiguration is visible.
+        return {
+          hookId: hook.id,
+          hookName: hook.name,
+          action: hook.actionValue,
+          success: false,
+          error: 'action-type hooks must be routed through built-in action handlers, not the executor',
+          durationMs: Date.now() - start,
+        }
+      }
     }
 
     return {

--- a/apps/cli/src/lib/work-lifecycle/hooks/index.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/index.ts
@@ -15,6 +15,7 @@ export type {
   WorkHookRow,
   HookExecutionResult,
   HookActionHandler,
+  AsyncHookActionHandler,
 } from './types.js'
 
 export { HOOKABLE_EVENTS, HOOK_MODES } from './types.js'

--- a/apps/cli/src/lib/work-lifecycle/hooks/manager.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/manager.ts
@@ -24,6 +24,7 @@ import {
   type HookableEvent,
   type HookExecutionResult,
   type HookActionHandler,
+  type AsyncHookActionHandler,
   type WorkHookConfig,
   type LlmDecision,
 } from './types.js'
@@ -76,6 +77,13 @@ export interface HookManagerOptions {
    * is called instead of shell/webhook/log execution.
    */
   actionHandlers?: Record<string, HookActionHandler>
+  /**
+   * Service-backed async action handlers for action-type hooks.
+   * These call services directly in-process (no shell) and are used
+   * when hook.actionType === 'action'. They take priority over
+   * actionHandlers for action-type hooks.
+   */
+  serviceActionHandlers?: Record<string, AsyncHookActionHandler>
 }
 
 // =============================================================================
@@ -110,6 +118,7 @@ export class HookManager {
   private onHumanEscalation?: (context: EscalationContext, reason: EscalationReason) => Promise<boolean>
   private llmTimeoutMs: number
   private actionHandlers: Record<string, HookActionHandler>
+  private serviceActionHandlers: Record<string, AsyncHookActionHandler>
   private _pendingConfirmations: PendingConfirmation[] = []
   private _pendingLlmDecisions: PendingLlmDecision[] = []
   private _pendingHumanEscalations: PendingHumanEscalation[] = []
@@ -124,6 +133,7 @@ export class HookManager {
     this.onHumanEscalation = options.onHumanEscalation
     this.llmTimeoutMs = options.llmTimeoutMs ?? DEFAULT_LLM_TIMEOUT_MS
     this.actionHandlers = options.actionHandlers ?? {}
+    this.serviceActionHandlers = options.serviceActionHandlers ?? {}
   }
 
   /**
@@ -348,6 +358,9 @@ export class HookManager {
    * Public so it can be tested in isolation.
    */
   static resolveActionName(hook: WorkHookConfig, knownActions: Record<string, unknown> = {}): string {
+    // For action-type hooks, the action_value IS the action name
+    if (hook.actionType === 'action') return hook.actionValue
+
     // If the action_value contains --action, extract the action name
     const actionMatch = hook.actionValue.match(/--action\s+(\S+)/)
     if (actionMatch) return actionMatch[1]
@@ -441,7 +454,7 @@ export class HookManager {
                   continue
                 }
                 // Human approved — fall through to execution
-                const result = this.executeHookAction(hook, eventName, eventData, ctx)
+                const result = await this.executeHookAction(hook, eventName, eventData, ctx)
                 results.push({ ...result, escalatedToHuman: true, tier: 'human' })
                 this.log(`[hooks] ${hook.name} → ${actionName}: ${result.success ? 'success' : `failed: ${result.error}`} (${result.durationMs}ms) [escalated to human]`)
                 continue
@@ -601,7 +614,7 @@ export class HookManager {
         }
 
         // --- auto / notify / confirmed / llm-approved / human-approved: execute ---
-        const result = this.executeHookAction(hook, eventName, eventData, ctx)
+        const result = await this.executeHookAction(hook, eventName, eventData, ctx)
         results.push(result)
 
         this.log(
@@ -622,16 +635,65 @@ export class HookManager {
 
   /**
    * Execute a hook action — either via a built-in handler or the standard executor.
+   *
+   * For action-type hooks (action_type='action'), the action_value is the
+   * built-in action name (e.g. 'move-ticket'). These are routed to async
+   * service handlers first (in-process, no shell), then fall back to
+   * sync action handlers.
+   *
+   * For shell-type hooks, we first check if the action_value resolves to a
+   * known built-in action (via --action flag parsing), then fall back to
+   * the standard executor for raw shell commands.
    */
-  private executeHookAction(
+  private async executeHookAction(
     hook: WorkHookConfig,
     eventName: string,
     eventData: Record<string, unknown>,
     ctx: Record<string, unknown>,
-  ): HookExecutionResult {
+  ): Promise<HookExecutionResult> {
     const actionName = HookManager.resolveActionName(hook, this.actionHandlers)
 
-    // Try built-in action handler first
+    // For action-type hooks, use service handlers first (async, in-process)
+    if (hook.actionType === 'action') {
+      if (this.serviceActionHandlers[actionName]) {
+        const handlerResult = await this.serviceActionHandlers[actionName](ctx, hook.config ?? undefined)
+        return {
+          hookId: hook.id,
+          hookName: hook.name,
+          action: handlerResult.action,
+          success: handlerResult.success,
+          error: handlerResult.error,
+          durationMs: handlerResult.durationMs,
+          skipped: handlerResult.skipped,
+        }
+      }
+
+      // Fall back to sync action handlers for action-type hooks
+      if (this.actionHandlers[actionName]) {
+        const handlerResult = this.actionHandlers[actionName](ctx, hook.config ?? undefined)
+        return {
+          hookId: hook.id,
+          hookName: hook.name,
+          action: handlerResult.action,
+          success: handlerResult.success,
+          error: handlerResult.error,
+          durationMs: handlerResult.durationMs,
+          skipped: handlerResult.skipped,
+        }
+      }
+
+      // action-type but no matching handler — this is a configuration error
+      return {
+        hookId: hook.id,
+        hookName: hook.name,
+        action: actionName,
+        success: false,
+        error: `No built-in action handler for '${actionName}'`,
+        durationMs: 0,
+      }
+    }
+
+    // For shell-type hooks, try built-in action handler first (backward compat)
     if (this.actionHandlers[actionName]) {
       const handlerResult = this.actionHandlers[actionName](ctx, hook.config ?? undefined)
       return {

--- a/apps/cli/src/lib/work-lifecycle/hooks/storage.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/storage.ts
@@ -18,7 +18,7 @@ export const HOOKS_TABLE_SCHEMA = `
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     event TEXT NOT NULL,
-    action_type TEXT NOT NULL CHECK (action_type IN ('shell', 'webhook', 'log')),
+    action_type TEXT NOT NULL CHECK (action_type IN ('shell', 'webhook', 'log', 'action')),
     action_value TEXT NOT NULL,
     enabled INTEGER NOT NULL DEFAULT 1,
     description TEXT,

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -67,8 +67,9 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
  * - shell: Run a shell command (with event data as env vars)
  * - webhook: POST event data to a URL
  * - log: Write a message to stdout (useful for notifications/debugging)
+ * - action: Call a built-in action handler directly in-process (no shell)
  */
-export type HookActionType = 'shell' | 'webhook' | 'log'
+export type HookActionType = 'shell' | 'webhook' | 'log' | 'action'
 
 /**
  * Automation mode for a hook — determines the decision tier.
@@ -163,6 +164,16 @@ export type HookActionHandler = (
   ctx: Record<string, unknown>,
   config?: Record<string, unknown>,
 ) => { action: string; success: boolean; error?: string; durationMs: number; skipped?: boolean }
+
+/**
+ * Async handler function for service-backed actions (action_type='action').
+ * Same contract as HookActionHandler but returns a Promise — used for
+ * in-process service calls that replace shell execution.
+ */
+export type AsyncHookActionHandler = (
+  ctx: Record<string, unknown>,
+  config?: Record<string, unknown>,
+) => Promise<{ action: string; success: boolean; error?: string; durationMs: number; skipped?: boolean }>
 
 /**
  * Result of executing a single hook.

--- a/apps/cli/test/unit/hook-action-type.test.ts
+++ b/apps/cli/test/unit/hook-action-type.test.ts
@@ -1,0 +1,743 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import { ensureHooksTable, WorkHookStorage } from '../../src/lib/work-lifecycle/hooks/storage.js'
+import { HookManager } from '../../src/lib/work-lifecycle/hooks/manager.js'
+import { executeHook } from '../../src/lib/work-lifecycle/hooks/executor.js'
+import { applyPreset } from '../../src/lib/orchestrate/config-loader.js'
+import { PRESETS } from '../../src/lib/orchestrate/presets.js'
+import { createServiceActionHandlers, SERVICE_BACKED_ACTIONS } from '../../src/lib/orchestrate/service-actions.js'
+import { hookActionType } from '../../src/lib/database/migrations/0026_hook_action_type.js'
+import { resetEventBus } from '../../src/lib/events/event-bus.js'
+import type { WorkHookConfig, HookActionHandler, AsyncHookActionHandler } from '../../src/lib/work-lifecycle/hooks/types.js'
+
+/**
+ * Tests for PRLT-1304: Wire hooks to service layer.
+ *
+ * Covers:
+ * - action type in HookActionType (types, storage, executor)
+ * - Migration 0026: CHECK constraint expansion and preset migration
+ * - Service-backed action handlers (createServiceActionHandlers)
+ * - HookManager routing: action-type → service handlers, shell-type → ACTION_HANDLERS
+ * - Preset hooks use action_type='action' after applyPreset()
+ * - Backward compatibility: shell-type hooks still work
+ * - Latency: action-type handlers avoid spawning new processes
+ */
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  ensureHooksTable(db)
+  try {
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN project_id TEXT")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset'))")
+    db.exec("ALTER TABLE pmo_work_hooks ADD COLUMN config TEXT")
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+  } catch {
+    // Columns may already exist
+  }
+  return db
+}
+
+/**
+ * Create a test DB that mimics the pre-migration state (no 'action' in CHECK constraint).
+ * Used to test the migration itself.
+ */
+function createPreMigrationDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE pmo_work_hooks (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      event TEXT NOT NULL,
+      action_type TEXT NOT NULL DEFAULT 'shell' CHECK (action_type IN ('shell', 'webhook', 'log')),
+      action_value TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off')),
+      priority INTEGER NOT NULL DEFAULT 0,
+      project_id TEXT,
+      source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset')),
+      config TEXT
+    )
+  `)
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_event ON pmo_work_hooks(event)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_enabled ON pmo_work_hooks(enabled)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+  return db
+}
+
+function insertHook(db: Database.Database, opts: {
+  name: string
+  event: string
+  actionType?: string
+  actionValue: string
+  mode?: string
+  priority?: number
+  config?: string
+  source?: string
+  enabled?: number
+}): string {
+  const id = `hook-${Math.random().toString(36).slice(2, 8)}`
+  db.prepare(`
+    INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, mode, priority, source, config)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    opts.name,
+    opts.event,
+    opts.actionType ?? 'shell',
+    opts.actionValue,
+    opts.enabled ?? 1,
+    opts.mode ?? 'auto',
+    opts.priority ?? 0,
+    opts.source ?? 'cli',
+    opts.config ?? null,
+  )
+  return id
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Hook Action Type (PRLT-1304)', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+    resetEventBus()
+  })
+
+  afterEach(() => {
+    resetEventBus()
+    db.close()
+  })
+
+  // ===========================================================================
+  // Storage: action type support
+  // ===========================================================================
+
+  describe('WorkHookStorage', () => {
+    it('should create hooks with action_type="action"', () => {
+      const storage = new WorkHookStorage(db)
+      const hook = storage.create({
+        name: 'test-action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        description: 'Direct merge-pr action',
+      })
+      expect(hook.actionType).to.equal('action')
+      expect(hook.actionValue).to.equal('merge-pr')
+    })
+
+    it('should list hooks with action_type="action"', () => {
+      const storage = new WorkHookStorage(db)
+      storage.create({ name: 'action-hook', event: 'on_ci_green', actionType: 'action', actionValue: 'merge-pr' })
+      storage.create({ name: 'shell-hook', event: 'on_ci_green', actionType: 'shell', actionValue: 'echo hi' })
+      const hooks = storage.list({ event: 'on_ci_green' })
+      expect(hooks).to.have.length(2)
+      const actionHook = hooks.find(h => h.actionType === 'action')
+      expect(actionHook).to.exist
+      expect(actionHook!.actionValue).to.equal('merge-pr')
+    })
+
+    it('should still create shell-type hooks (backward compat)', () => {
+      const storage = new WorkHookStorage(db)
+      const hook = storage.create({
+        name: 'shell-hook',
+        event: 'work:started',
+        actionType: 'shell',
+        actionValue: 'echo "hello"',
+      })
+      expect(hook.actionType).to.equal('shell')
+    })
+  })
+
+  // ===========================================================================
+  // Executor: action type handling
+  // ===========================================================================
+
+  describe('executeHook (executor)', () => {
+    it('should return error for action-type hooks (they must use built-in handlers)', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-1',
+        name: 'action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+      const result = executeHook(hook, 'on_ci_green', {})
+      expect(result.success).to.be.false
+      expect(result.error).to.include('action-type hooks must be routed through built-in action handlers')
+    })
+  })
+
+  // ===========================================================================
+  // HookManager: action-type routing
+  // ===========================================================================
+
+  describe('HookManager', () => {
+    it('should resolve action name directly from actionValue for action-type hooks', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-1',
+        name: 'action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+      const result = HookManager.resolveActionName(hook, {})
+      expect(result).to.equal('move-ticket')
+    })
+
+    it('should extract --action name from shell-type hooks (backward compat)', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-2',
+        name: 'shell-hook',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'prlt hook fire on_ci_green --action merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+      }
+      const result = HookManager.resolveActionName(hook, {})
+      expect(result).to.equal('merge-pr')
+    })
+
+    it('should route action-type hooks to service action handlers', async () => {
+      let handlerCalled = false
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'move-ticket': async (ctx, config) => {
+          handlerCalled = true
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-move',
+        event: 'on_agent_spawned',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        config: JSON.stringify({ target: 'in-progress' }),
+      })
+
+      const manager = new HookManager({
+        db,
+        serviceActionHandlers: serviceHandlers,
+      })
+      const results = await manager.fireEvent('on_agent_spawned', { ticketId: 'TKT-1' })
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(results[0].action).to.equal('move-ticket')
+      expect(handlerCalled).to.be.true
+    })
+
+    it('should fall back to sync actionHandlers for action-type hooks when no service handler exists', async () => {
+      let syncCalled = false
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'gc-sweep': (_ctx) => {
+          syncCalled = true
+          return { action: 'gc-sweep', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-gc',
+        event: 'on_agent_completed',
+        actionType: 'action',
+        actionValue: 'gc-sweep',
+      })
+
+      const manager = new HookManager({
+        db,
+        actionHandlers,
+      })
+      const results = await manager.fireEvent('on_agent_completed', { ticketId: 'TKT-1' })
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(syncCalled).to.be.true
+    })
+
+    it('should return error for action-type hooks with no matching handler', async () => {
+      insertHook(db, {
+        name: 'action-unknown',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'nonexistent-action',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', {})
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.false
+      expect(results[0].error).to.include("No built-in action handler for 'nonexistent-action'")
+    })
+
+    it('should still execute shell-type hooks via ACTION_HANDLERS (backward compat)', async () => {
+      let handlerCalled = false
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'notify': (_ctx) => {
+          handlerCalled = true
+          return { action: 'notify', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'shell-notify',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'prlt hook fire on_ci_green --action notify',
+      })
+
+      const manager = new HookManager({
+        db,
+        actionHandlers,
+      })
+      const results = await manager.fireEvent('on_ci_green', {})
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(handlerCalled).to.be.true
+    })
+
+    it('should prefer service handlers over sync handlers for action-type hooks', async () => {
+      let serviceHandlerCalled = false
+      let syncHandlerCalled = false
+
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'move-ticket': async () => {
+          serviceHandlerCalled = true
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'move-ticket': () => {
+          syncHandlerCalled = true
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-move',
+        event: 'on_pr_merged',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        config: JSON.stringify({ target: 'done' }),
+      })
+
+      const manager = new HookManager({
+        db,
+        actionHandlers,
+        serviceActionHandlers: serviceHandlers,
+      })
+      const results = await manager.fireEvent('on_pr_merged', { ticketId: 'TKT-1' })
+      expect(results).to.have.length(1)
+      expect(serviceHandlerCalled).to.be.true
+      expect(syncHandlerCalled).to.be.false
+    })
+
+    it('should not use service handlers for shell-type hooks', async () => {
+      let serviceHandlerCalled = false
+      let syncHandlerCalled = false
+
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'move-ticket': async () => {
+          serviceHandlerCalled = true
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'move-ticket': () => {
+          syncHandlerCalled = true
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'shell-move',
+        event: 'on_pr_merged',
+        actionType: 'shell',
+        actionValue: 'prlt hook fire on_pr_merged --action move-ticket',
+      })
+
+      const manager = new HookManager({
+        db,
+        actionHandlers,
+        serviceActionHandlers: serviceHandlers,
+      })
+      const results = await manager.fireEvent('on_pr_merged', { ticketId: 'TKT-1' })
+      expect(results).to.have.length(1)
+      // Shell-type hooks go through the sync handler path, not service handlers
+      expect(syncHandlerCalled).to.be.true
+      expect(serviceHandlerCalled).to.be.false
+    })
+  })
+
+  // ===========================================================================
+  // Migration 0026: Hook Action Type
+  // ===========================================================================
+
+  describe('Migration 0026 (hookActionType)', () => {
+    it('should add action to CHECK constraint', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        hookActionType.up(preMigDb)
+
+        // Verify we can now insert action-type hooks
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value)
+          VALUES ('test-1', 'test-hook', 'on_ci_green', 'action', 'merge-pr')
+        `).run()
+
+        const row = preMigDb.prepare('SELECT action_type FROM pmo_work_hooks WHERE id = ?').get('test-1') as { action_type: string }
+        expect(row.action_type).to.equal('action')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should migrate preset shell hooks to action type', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        // Insert preset hooks with shell indirection (pre-migration pattern)
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, source)
+          VALUES ('p1', 'preset:agg:on_ci_green:merge-pr:0', 'on_ci_green', 'shell', 'prlt hook fire on_ci_green --action merge-pr', 'preset')
+        `).run()
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, source)
+          VALUES ('p2', 'preset:agg:on_pr_merged:move-ticket:1', 'on_pr_merged', 'shell', 'prlt hook fire on_pr_merged --action move-ticket', 'preset')
+        `).run()
+
+        // Insert a CLI hook that should NOT be migrated
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, source)
+          VALUES ('c1', 'custom-shell', 'on_ci_green', 'shell', 'echo "CI passed"', 'cli')
+        `).run()
+
+        hookActionType.up(preMigDb)
+
+        // Verify preset hooks were migrated
+        const p1 = preMigDb.prepare('SELECT action_type, action_value FROM pmo_work_hooks WHERE id = ?').get('p1') as { action_type: string; action_value: string }
+        expect(p1.action_type).to.equal('action')
+        expect(p1.action_value).to.equal('merge-pr')
+
+        const p2 = preMigDb.prepare('SELECT action_type, action_value FROM pmo_work_hooks WHERE id = ?').get('p2') as { action_type: string; action_value: string }
+        expect(p2.action_type).to.equal('action')
+        expect(p2.action_value).to.equal('move-ticket')
+
+        // Verify CLI hook was NOT migrated
+        const c1 = preMigDb.prepare('SELECT action_type, action_value FROM pmo_work_hooks WHERE id = ?').get('c1') as { action_type: string; action_value: string }
+        expect(c1.action_type).to.equal('shell')
+        expect(c1.action_value).to.equal('echo "CI passed"')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should be idempotent (skip if already migrated)', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        hookActionType.up(preMigDb)
+        // Running again should not throw
+        hookActionType.up(preMigDb)
+
+        // Verify we can still insert
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value)
+          VALUES ('idem-1', 'test', 'on_ci_green', 'action', 'notify')
+        `).run()
+
+        const row = preMigDb.prepare('SELECT action_type FROM pmo_work_hooks WHERE id = ?').get('idem-1') as { action_type: string }
+        expect(row.action_type).to.equal('action')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should preserve all existing data during table recreation', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        // Insert hook with all columns populated
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, description, mode, priority, project_id, source, config)
+          VALUES ('full-1', 'full-hook', 'on_ci_green', 'shell', 'echo test', 1, 'Test desc', 'llm', 5, 'PRLT', 'cli', '{"key":"val"}')
+        `).run()
+
+        hookActionType.up(preMigDb)
+
+        const row = preMigDb.prepare('SELECT * FROM pmo_work_hooks WHERE id = ?').get('full-1') as Record<string, unknown>
+        expect(row.name).to.equal('full-hook')
+        expect(row.event).to.equal('on_ci_green')
+        expect(row.action_type).to.equal('shell')
+        expect(row.action_value).to.equal('echo test')
+        expect(row.enabled).to.equal(1)
+        expect(row.description).to.equal('Test desc')
+        expect(row.mode).to.equal('llm')
+        expect(row.priority).to.equal(5)
+        expect(row.project_id).to.equal('PRLT')
+        expect(row.source).to.equal('cli')
+        expect(row.config).to.equal('{"key":"val"}')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should skip when table does not exist', () => {
+      const emptyDb = new Database(':memory:')
+      try {
+        // Should not throw
+        hookActionType.up(emptyDb)
+      } finally {
+        emptyDb.close()
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Service Action Handlers
+  // ===========================================================================
+
+  describe('createServiceActionHandlers', () => {
+    it('should return handlers for service-backed actions', () => {
+      const handlers = createServiceActionHandlers(db)
+      expect(handlers['move-ticket']).to.be.a('function')
+      expect(handlers['notify']).to.be.a('function')
+    })
+
+    it('should report SERVICE_BACKED_ACTIONS matching handler keys', () => {
+      expect(SERVICE_BACKED_ACTIONS.has('move-ticket')).to.be.true
+      expect(SERVICE_BACKED_ACTIONS.has('notify')).to.be.true
+    })
+
+    it('move-ticket handler should fail without ticket in context', async () => {
+      const handlers = createServiceActionHandlers(db)
+      const result = await handlers['move-ticket']({ event: 'on_pr_merged' })
+      expect(result.success).to.be.false
+      expect(result.error).to.include('No ticket in context')
+      expect(result.action).to.equal('move-ticket')
+    })
+
+    it('notify handler should succeed with fallback to console.log', async () => {
+      const handlers = createServiceActionHandlers(db)
+      const result = await handlers['notify']({ event: 'on_ci_green', ticket: 'TKT-1' })
+      expect(result.success).to.be.true
+      expect(result.action).to.equal('notify')
+      expect(result.durationMs).to.be.a('number')
+    })
+  })
+
+  // ===========================================================================
+  // Preset Application
+  // ===========================================================================
+
+  describe('applyPreset with action type', () => {
+    it('should create preset hooks with action_type="action"', () => {
+      const count = applyPreset(db, 'aggressive')
+      expect(count).to.be.greaterThan(0)
+
+      const hooks = db.prepare(
+        "SELECT action_type, action_value FROM pmo_work_hooks WHERE source = 'preset'"
+      ).all() as Array<{ action_type: string; action_value: string }>
+
+      // All preset hooks should be action type
+      for (const hook of hooks) {
+        expect(hook.action_type).to.equal('action')
+        // action_value should be the action name directly (e.g. 'merge-pr'), not a shell command
+        expect(hook.action_value).to.not.include('prlt hook fire')
+        expect(hook.action_value).to.not.include('--action')
+      }
+    })
+
+    it('should create all 21 preset hooks for aggressive preset', () => {
+      const count = applyPreset(db, 'aggressive')
+      expect(count).to.equal(PRESETS.aggressive.hooks.length)
+    })
+
+    it('should create hooks for conservative preset with correct modes', () => {
+      applyPreset(db, 'conservative')
+
+      const hooks = db.prepare(
+        "SELECT action_value, mode FROM pmo_work_hooks WHERE source = 'preset'"
+      ).all() as Array<{ action_value: string; mode: string }>
+
+      // move-ticket and notify should be auto, spawn-agent should be human
+      const moveHook = hooks.find(h => h.action_value === 'move-ticket')
+      expect(moveHook?.mode).to.equal('auto')
+
+      const spawnHook = hooks.find(h => h.action_value === 'spawn-agent')
+      expect(spawnHook?.mode).to.equal('human')
+    })
+
+    it('should create hooks for supervised preset with correct modes', () => {
+      applyPreset(db, 'supervised')
+
+      const hooks = db.prepare(
+        "SELECT action_value, mode FROM pmo_work_hooks WHERE source = 'preset'"
+      ).all() as Array<{ action_value: string; mode: string }>
+
+      const notifyHook = hooks.find(h => h.action_value === 'notify')
+      expect(notifyHook?.mode).to.equal('auto')
+
+      const spawnHook = hooks.find(h => h.action_value === 'spawn-agent')
+      expect(spawnHook?.mode).to.equal('llm')
+    })
+  })
+
+  // ===========================================================================
+  // No process spawning for action-type hooks
+  // ===========================================================================
+
+  describe('No process spawning', () => {
+    it('action-type hooks should not call execSync or child_process', async () => {
+      let handlerCtx: Record<string, unknown> | null = null
+      let handlerConfig: Record<string, unknown> | undefined
+
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'move-ticket': async (ctx, config) => {
+          handlerCtx = ctx
+          handlerConfig = config
+          return { action: 'move-ticket', success: true, durationMs: 0 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-move',
+        event: 'on_agent_spawned',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        config: JSON.stringify({ target: 'in-progress' }),
+      })
+
+      const manager = new HookManager({
+        db,
+        serviceActionHandlers: serviceHandlers,
+      })
+
+      const results = await manager.fireEvent('on_agent_spawned', { ticketId: 'TKT-99' })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      // Verify the handler received the correct context and config
+      expect(handlerCtx).to.include({ ticket: 'TKT-99' })
+      expect(handlerConfig).to.deep.equal({ target: 'in-progress' })
+    })
+  })
+
+  // ===========================================================================
+  // Latency measurement
+  // ===========================================================================
+
+  describe('Latency', () => {
+    it('action-type handler execution should be sub-millisecond (no process spawn)', async () => {
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'notify': async () => {
+          return { action: 'notify', success: true, durationMs: 0 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-notify',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'notify',
+      })
+
+      const manager = new HookManager({
+        db,
+        serviceActionHandlers: serviceHandlers,
+      })
+
+      const start = Date.now()
+      const results = await manager.fireEvent('on_ci_green', {})
+      const elapsed = Date.now() - start
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      // In-process action should complete well under 100ms (no process spawn overhead)
+      expect(elapsed).to.be.lessThan(100)
+    })
+  })
+
+  // ===========================================================================
+  // Mode-aware behavior with action-type hooks
+  // ===========================================================================
+
+  describe('Mode-aware behavior with action-type hooks', () => {
+    it('should skip action-type hooks when mode is off', async () => {
+      insertHook(db, {
+        name: 'action-off',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        mode: 'off',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', {})
+      expect(results).to.have.length(1)
+      expect(results[0].skipped).to.be.true
+    })
+
+    it('should queue action-type hooks for confirmation when mode is confirm', async () => {
+      insertHook(db, {
+        name: 'action-confirm',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        mode: 'confirm',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', {})
+      expect(results).to.have.length(1)
+      expect(results[0].awaitingConfirmation).to.be.true
+
+      const pending = manager.getPendingConfirmations()
+      expect(pending).to.have.length(1)
+      expect(pending[0].action).to.equal('merge-pr')
+    })
+
+    it('should queue action-type hooks for LLM when mode is llm', async () => {
+      insertHook(db, {
+        name: 'action-llm',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'spawn-agent',
+        mode: 'llm',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', { ticketId: 'TKT-1' })
+      expect(results).to.have.length(1)
+      expect(results[0].awaitingLlmDecision).to.be.true
+
+      const pending = manager.getPendingLlmDecisions()
+      expect(pending).to.have.length(1)
+      expect(pending[0].action).to.equal('spawn-agent')
+    })
+  })
+})

--- a/apps/cli/test/unit/orchestrate-config-loader.test.ts
+++ b/apps/cli/test/unit/orchestrate-config-loader.test.ts
@@ -236,8 +236,8 @@ review:
     it('should store each preset hook with its correct event name, never work:status_changed fallback', () => {
       applyPreset(db, 'aggressive')
 
-      const hooks = db.prepare("SELECT event, action_value FROM pmo_work_hooks WHERE source = 'preset'")
-        .all() as Array<{ event: string; action_value: string }>
+      const hooks = db.prepare("SELECT event, action_type, action_value, name FROM pmo_work_hooks WHERE source = 'preset'")
+        .all() as Array<{ event: string; action_type: string; action_value: string; name: string }>
 
       // No hook should have been silently misrouted to work:status_changed
       // unless the preset actually defines a work:status_changed hook
@@ -245,10 +245,12 @@ review:
       const hasWorkStatusChanged = presetEvents.has('work:status_changed')
 
       for (const hook of hooks) {
-        // Extract the original event from the action_value: "prlt hook fire <event> --action ..."
-        const match = hook.action_value.match(/prlt hook fire (\S+) --action/)
-        expect(match, `Could not parse event from action_value: ${hook.action_value}`).to.not.be.null
-        const originalEvent = match![1]
+        // Preset hooks now use action_type='action' with the action name as action_value.
+        // Extract the original event from the hook name: "preset:<preset>:<event>:<action>:<idx>"
+        expect(hook.action_type).to.equal('action',
+          `Preset hook "${hook.name}" should use action_type='action', not '${hook.action_type}'`)
+        const nameParts = hook.name.split(':')
+        const originalEvent = nameParts[2]
 
         // The stored event MUST match the original event from the preset
         expect(hook.event).to.equal(originalEvent,
@@ -286,14 +288,16 @@ review:
         try { db.exec("DELETE FROM pmo_work_hooks WHERE source = 'preset'") } catch { /* */ }
         applyPreset(db, presetName)
 
-        const hooks = db.prepare("SELECT event, action_value FROM pmo_work_hooks WHERE source = 'preset'")
-          .all() as Array<{ event: string; action_value: string }>
+        const hooks = db.prepare("SELECT event, action_type, action_value, name FROM pmo_work_hooks WHERE source = 'preset'")
+          .all() as Array<{ event: string; action_type: string; action_value: string; name: string }>
 
         for (const hook of hooks) {
-          const match = hook.action_value.match(/prlt hook fire (\S+) --action/)
-          expect(match).to.not.be.null
-          expect(hook.event).to.equal(match![1],
-            `${presetName} preset: event "${match![1]}" misrouted to "${hook.event}"`)
+          // Preset hooks use action_type='action'. Extract expected event from hook name.
+          expect(hook.action_type).to.equal('action')
+          const nameParts = hook.name.split(':')
+          const originalEvent = nameParts[2]
+          expect(hook.event).to.equal(originalEvent,
+            `${presetName} preset: event "${originalEvent}" misrouted to "${hook.event}"`)
         }
       }
     })


### PR DESCRIPTION
## Summary

- Adds `action` type to `HookActionType` — hooks can now call built-in action handlers directly in-process instead of shelling out to `prlt` CLI commands
- Creates service-backed async action handlers (`service-actions.ts`) for `move-ticket` and `notify` that use the provider/notification layer directly
- Migrates all 21 preset hooks from `action_type='shell'` (with `prlt hook fire ... --action <name>`) to `action_type='action'` (with just the action name)
- Adds migration 0026 to expand the CHECK constraint and migrate existing preset hooks in the database
- Updates `HookManager` to route `action`-type hooks to async service handlers, with fallback to sync action handlers
- Backward compatible — existing shell/webhook/log hooks continue working unchanged

## Flow change

```
Before: hook → shell → prlt CLI → oclif boot → service → DB
After:  hook → service → DB (in-process, no child process)
```

## Test plan

- [x] 30 new unit tests covering action type storage, executor, manager routing, migration, service handlers, presets, mode-aware behavior, and latency
- [x] Updated 2 existing PRLT-1257 regression tests for new preset format
- [x] All 412 hook/orchestrate tests pass
- [x] Build passes cleanly

Linear: PRLT-1304