### PR TITLE
feat(PRLT-1347): remove baseline/diff from watch command

### DIFF
--- a/apps/cli/src/commands/watch/index.ts
+++ b/apps/cli/src/commands/watch/index.ts
@@ -118,7 +118,7 @@ export default class Watch extends PromptCommand {
         cwd: workspaceInfo.path,
       })
 
-      // One-shot mode
+      // One-shot mode: single poll, always output full state
       if (flags.once) {
         const result = await poller.poll()
 
@@ -130,11 +130,7 @@ export default class Watch extends PromptCommand {
           return
         }
 
-        if (result.message) {
-          this.log(result.message)
-        } else {
-          this.log(styles.muted('No state to report.'))
-        }
+        this.log(result.message)
         return
       }
 
@@ -161,15 +157,6 @@ export default class Watch extends PromptCommand {
         this.log('')
       }
 
-      // Log initial state for debugging
-      this.log(styles.muted('  Capturing initial state...'))
-      const initial = await poller.poll()
-      if (initial.message && verbose) {
-        this.log(styles.muted(initial.message))
-      }
-      this.log(styles.muted(`  Initial state: ${initial.items.length} item(s). Polling every ${flags['poll-interval']}s...`))
-      this.log('')
-
       if (jsonMode) {
         // In daemon mode, output JSON status without throwing ExitError.
         // outputSuccessAsJson throws oclif ExitError which would kill the daemon loop.
@@ -182,27 +169,32 @@ export default class Watch extends PromptCommand {
         }, null, 2))
       }
 
-      // Poll loop
+      // Immediate first poll+poke — no baseline, no diff. The poller is a
+      // dumb pipe that pushes full state every cycle (PRLT-1347).
+      const pollAndPoke = async () => {
+        const result = await poller.poll()
+        if (verbose) {
+          this.log('')
+          this.log(styles.info(`[watch] State report (${result.items.length} items):`))
+          this.log(result.message)
+          this.log('')
+        }
+        this.pokeTarget(flags.target, result.message, verbose)
+      }
+
+      try {
+        await pollAndPoke()
+        this.log(styles.muted(`  First poke sent. Polling every ${flags['poll-interval']}s...`))
+        this.log('')
+      } catch (err) {
+        this.log(styles.error(`[watch] Initial poll error: ${err instanceof Error ? err.message : String(err)}`))
+      }
+
+      // Poll loop — every cycle polls and pokes, unconditionally
       const pollTimer = setInterval(async () => {
         try {
           if (verbose) this.log(styles.muted(`[watch] Polling at ${new Date().toISOString()}...`))
-
-          const result = await poller.poll()
-
-          if (result.message) {
-            // Always push full state — the orchestrator LLM determines what changed
-            if (verbose) {
-              this.log('')
-              this.log(styles.info(`[watch] State report (${result.items.length} items):`))
-              this.log(result.message)
-              this.log('')
-            }
-
-            // Poke the orchestrator with full state
-            this.pokeTarget(flags.target, result.message, verbose)
-          } else if (verbose) {
-            this.log(styles.muted('[watch] No state to report.'))
-          }
+          await pollAndPoke()
         } catch (err) {
           this.log(styles.error(`[watch] Poll error: ${err instanceof Error ? err.message : String(err)}`))
         }

--- a/apps/cli/src/lib/orchestrate/simple-poller.ts
+++ b/apps/cli/src/lib/orchestrate/simple-poller.ts
@@ -34,10 +34,10 @@ export interface StateItem {
   summary: string
 }
 
-/** Result of a poll cycle. */
+/** Result of a poll cycle. Message is always a formatted state report. */
 export interface PollResult {
   items: StateItem[]
-  message: string | null
+  message: string
 }
 
 // Keep old name as alias for backward compatibility in re-exports
@@ -128,7 +128,7 @@ export class SimplePoller {
     items.push(...this.gatherAgentState())
     items.push(...this.gatherReadyTicketState())
 
-    const message = items.length > 0 ? this.formatStateMessage(items) : null
+    const message = this.formatStateMessage(items)
     return { items, message }
   }
 

--- a/apps/cli/test/e2e/watch-orchestrate-ship.test.ts
+++ b/apps/cli/test/e2e/watch-orchestrate-ship.test.ts
@@ -728,7 +728,9 @@ describe('E2E: Watch -> Orchestrate -> Ship (PRLT-1333)', () => {
       const result = await poller.poll()
 
       expect(result.items).to.have.length(0)
-      expect(result.message).to.be.null
+      // Always returns a formatted state report, even when empty (PRLT-1347)
+      expect(result.message).to.be.a('string')
+      expect(result.message).to.include('none')
     })
   })
 

--- a/apps/cli/test/unit/simple-poller.test.ts
+++ b/apps/cli/test/unit/simple-poller.test.ts
@@ -125,14 +125,18 @@ describe('SimplePoller', () => {
       expect(r2.message).to.equal(r1.message)
     })
 
-    it('should return null message when there is no state at all', async () => {
+    it('should return a formatted message even when there is no state', async () => {
       const db = createMockDb()
       const poller = createPoller(db)
 
       const result = await poller.poll()
 
       expect(result.items).to.have.length(0)
-      expect(result.message).to.be.null
+      // Always returns a full state report — no null messages (PRLT-1347)
+      expect(result.message).to.be.a('string')
+      expect(result.message).to.include('GitHub PRs: none')
+      expect(result.message).to.include('Ready tickets: none')
+      expect(result.message).to.include('Active agents: none')
     })
 
     it('should reflect state changes immediately without needing a prior baseline', async () => {

--- a/apps/cli/test/unit/watch-orchestrate-loop.test.ts
+++ b/apps/cli/test/unit/watch-orchestrate-loop.test.ts
@@ -416,7 +416,93 @@ describe('Watch -> Orchestrate Loop -- Unit Tests (PRLT-1333)', () => {
       // Should not throw
       const result = await poller.poll()
       expect(result.items).to.have.length(0)
-      expect(result.message).to.be.null
+      // Always returns a formatted message, even when empty (PRLT-1347)
+      expect(result.message).to.be.a('string')
+      expect(result.message).to.include('none')
+    })
+  })
+
+  // ===========================================================================
+  // PRLT-1347: No baseline/diff — poke sent on first cycle
+  // ===========================================================================
+
+  describe('PRLT-1347: no baseline/diff, poke on first cycle', () => {
+    it('should produce a pokeable message on the very first poll — no baseline needed', async () => {
+      // Simulates 1 open PR reported by the poller. In production the PR comes
+      // from GitHub; here we use an agent entry as a proxy for "state exists."
+      const db = createMockDb({
+        agents: [{
+          id: 'exec-pr', ticket_id: 'PRLT-500', agent_name: 'pr-agent',
+          status: 'running', lifecycle_state: null, container_id: null,
+        }],
+      })
+      const poller = createTestPoller(db)
+
+      // First poll — previously this was swallowed as a "baseline" and the
+      // second poll (with identical state) produced an empty diff = no poke.
+      const result = await poller.poll()
+
+      // message must be non-null so the watch command pokes immediately
+      expect(result.message).to.be.a('string')
+      expect(result.message!.length).to.be.greaterThan(0)
+      expect(result.items).to.have.length(1)
+      expect(result.items[0].summary).to.include('PRLT-500')
+    })
+
+    it('should always produce a non-null message, even with zero items', async () => {
+      const db = createMockDb()
+      const poller = createTestPoller(db)
+
+      const result = await poller.poll()
+
+      // The watch command now pokes unconditionally — message must never be null
+      expect(result.message).to.be.a('string')
+      expect(result.message).to.include('GitHub PRs: none')
+      expect(result.message).to.include('Ready tickets: none')
+      expect(result.message).to.include('Active agents: none')
+    })
+
+    it('should produce identical messages on consecutive polls — stateless, no diff', async () => {
+      const db = createMockDb({
+        readyTickets: [{ id: 'TKT-700', title: 'Stable ticket' }],
+        agents: [{
+          id: 'exec-1', ticket_id: 'TKT-700', agent_name: 'stable-agent',
+          status: 'running', lifecycle_state: null, container_id: null,
+        }],
+      })
+      const poller = createTestPoller(db)
+
+      const r1 = await poller.poll()
+      const r2 = await poller.poll()
+      const r3 = await poller.poll()
+
+      // All three polls should produce the exact same message — the poller
+      // is a stateless pipe, no baseline or diff subtracted
+      expect(r1.message).to.equal(r2.message)
+      expect(r2.message).to.equal(r3.message)
+      expect(r1.items).to.deep.equal(r2.items)
+    })
+
+    it('message should be compact — under 31 lines for mobile scrollback', async () => {
+      // Simulate a moderately busy workspace: 3 agents + 3 ready tickets
+      const db = createMockDb({
+        readyTickets: [
+          { id: 'TKT-A', title: 'Feature A' },
+          { id: 'TKT-B', title: 'Feature B' },
+          { id: 'TKT-C', title: 'Feature C' },
+        ],
+        agents: [
+          { id: 'e1', ticket_id: 'TKT-A', agent_name: 'ag-1', status: 'running', lifecycle_state: null, container_id: null },
+          { id: 'e2', ticket_id: 'TKT-B', agent_name: 'ag-2', status: 'completed', lifecycle_state: 'completed', container_id: null },
+          { id: 'e3', ticket_id: 'TKT-C', agent_name: 'ag-3', status: 'starting', lifecycle_state: null, container_id: null },
+        ],
+      })
+      const poller = createTestPoller(db)
+
+      const result = await poller.poll()
+      const lineCount = result.message!.split('\n').length
+
+      expect(lineCount).to.be.at.most(31, `Message has ${lineCount} lines, exceeds 31-line mobile scrollback limit`)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Remove baseline/diff logic from watch command — the poller is a stateless pipe after PRLT-1346
- `--once` mode: single poll, always outputs full state report
- Daemon mode: immediate first poke, then every cycle pokes unconditionally
- SimplePoller.poll() now always returns a formatted message (never null)
- Message stays compact (under 31 lines for mobile scrollback)

## Test plan
- [x] Unit tests: SimplePoller always returns non-null message
- [x] Unit tests: consecutive polls produce identical output (no diff)
- [x] Unit tests: message is compact (under 31 lines)
- [x] E2e tests: full watch→orchestrate→ship loop passes
- [x] Build passes