### PR TITLE
feat(PRLT-1349): suppress-if-identical poke and increase default poll interval to 300s

### DIFF
--- a/apps/cli/src/commands/watch/index.ts
+++ b/apps/cli/src/commands/watch/index.ts
@@ -14,6 +14,7 @@
  */
 
 import { Flags } from '@oclif/core'
+import { createHash } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
 import { openWorkspaceDatabase } from '../../lib/database/index.js'
 import { PromptCommand } from '../../lib/prompt-command.js'
@@ -53,7 +54,7 @@ export default class Watch extends PromptCommand {
     }),
     'poll-interval': Flags.integer({
       description: 'Poll interval in seconds',
-      default: 60,
+      default: 300,
     }),
     verbose: Flags.boolean({
       description: 'Show detailed output including poll results',
@@ -169,10 +170,22 @@ export default class Watch extends PromptCommand {
         }, null, 2))
       }
 
-      // Immediate first poll+poke — no baseline, no diff. The poller is a
-      // dumb pipe that pushes full state every cycle (PRLT-1347).
+      // PRLT-1349: Track the hash of the last poked state. If the next poll
+      // produces identical state, suppress the poke to avoid interrupting the
+      // orchestrator with redundant messages.
+      let lastPokeHash: string | null = null
+
       const pollAndPoke = async () => {
         const result = await poller.poll()
+        const hash = createHash('sha256').update(result.message).digest('hex')
+
+        if (hash === lastPokeHash) {
+          if (verbose) {
+            this.log(styles.muted(`[watch] State unchanged — poke suppressed`))
+          }
+          return
+        }
+
         if (verbose) {
           this.log('')
           this.log(styles.info(`[watch] State report (${result.items.length} items):`))
@@ -180,6 +193,7 @@ export default class Watch extends PromptCommand {
           this.log('')
         }
         this.pokeTarget(flags.target, result.message, verbose)
+        lastPokeHash = hash
       }
 
       try {

--- a/apps/cli/src/lib/session/daemon-manager.ts
+++ b/apps/cli/src/lib/session/daemon-manager.ts
@@ -220,7 +220,7 @@ export function reconcilerDaemonSpec(intervalSeconds: number = 300): DaemonSpec 
  */
 export function watchDaemonSpec(
   target: string,
-  pollIntervalSeconds: number = 60,
+  pollIntervalSeconds: number = 300,
 ): DaemonSpec {
   // Shell-escape the target name to survive the tmux new-session `sh -c`
   // wrapper. Target names are agent/session identifiers so this is a light

--- a/apps/cli/test/unit/watch-daemon.test.ts
+++ b/apps/cli/test/unit/watch-daemon.test.ts
@@ -32,7 +32,7 @@ describe('Watch Daemon (PRLT-1321)', () => {
       expect(spec.command).to.contain('--foreground')
       expect(spec.command).to.contain('--verbose')
       expect(spec.command).to.contain('--target orchestrator-main')
-      expect(spec.command).to.contain('--poll-interval 60')
+      expect(spec.command).to.contain('--poll-interval 300')
     })
 
     it('honors a custom poll interval', () => {

--- a/apps/cli/test/unit/watch-suppress-identical.test.ts
+++ b/apps/cli/test/unit/watch-suppress-identical.test.ts
@@ -1,0 +1,157 @@
+import { expect } from 'chai'
+import { createHash } from 'node:crypto'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const WATCH_SOURCE = fs.readFileSync(
+  path.resolve(__dirname, '../../src/commands/watch/index.ts'),
+  'utf-8',
+)
+
+/**
+ * Tests for PRLT-1349: Watch daemon suppress-if-identical and default interval.
+ *
+ * Two fixes:
+ * 1) Suppress poke if state is identical to last poke (no changes = no poke)
+ * 2) Default poll interval is 300s (5 min), not 60s
+ */
+
+describe('Watch suppress-if-identical (PRLT-1349)', () => {
+  // ===========================================================================
+  // Default poll interval
+  // ===========================================================================
+
+  describe('default poll interval', () => {
+    it('watch command defaults to 300s (5 minutes)', () => {
+      // The flag definition should have default: 300
+      expect(WATCH_SOURCE).to.match(
+        /['"]poll-interval['"].*default:\s*300/s,
+        'default poll interval should be 300s',
+      )
+    })
+
+    it('watchDaemonSpec defaults to 300s', async () => {
+      const { watchDaemonSpec } = await import('../../src/lib/session/daemon-manager.js')
+      const spec = watchDaemonSpec('test-target')
+      expect(spec.command).to.contain('--poll-interval 300')
+    })
+
+    it('watch command no longer defaults to 60s', () => {
+      expect(WATCH_SOURCE).to.not.match(
+        /['"]poll-interval['"].*default:\s*60\b/s,
+        'default poll interval should NOT be 60s',
+      )
+    })
+  })
+
+  // ===========================================================================
+  // Suppress-if-identical source guards
+  // ===========================================================================
+
+  describe('suppress-if-identical implementation', () => {
+    it('imports createHash from node:crypto', () => {
+      expect(WATCH_SOURCE).to.match(
+        /import\s*\{[^}]*createHash[^}]*\}\s*from\s*['"]node:crypto['"]/,
+        'watch command must import createHash for state hashing',
+      )
+    })
+
+    it('tracks lastPokeHash for deduplication', () => {
+      expect(WATCH_SOURCE).to.include('lastPokeHash')
+    })
+
+    it('computes hash of poll result message', () => {
+      expect(WATCH_SOURCE).to.match(
+        /createHash\s*\(\s*['"]sha256['"]\s*\)/,
+        'must use sha256 hash for state comparison',
+      )
+    })
+
+    it('suppresses poke when hash matches last poke', () => {
+      // The pattern: if (hash === lastPokeHash) { ... return }
+      expect(WATCH_SOURCE).to.include('hash === lastPokeHash')
+    })
+
+    it('updates lastPokeHash after a successful poke', () => {
+      expect(WATCH_SOURCE).to.include('lastPokeHash = hash')
+    })
+
+    it('logs suppression in verbose mode', () => {
+      expect(WATCH_SOURCE).to.match(
+        /poke suppressed/i,
+        'should log when a poke is suppressed',
+      )
+    })
+  })
+
+  // ===========================================================================
+  // Hash deduplication logic
+  // ===========================================================================
+
+  describe('hash deduplication logic', () => {
+    it('identical messages produce the same hash', () => {
+      const msg = 'GitHub PRs: none\n\nReady tickets: none\n\nActive agents: none'
+      const h1 = createHash('sha256').update(msg).digest('hex')
+      const h2 = createHash('sha256').update(msg).digest('hex')
+      expect(h1).to.equal(h2)
+    })
+
+    it('different messages produce different hashes', () => {
+      const msg1 = 'GitHub PRs: none\n\nReady tickets: none\n\nActive agents: none'
+      const msg2 = 'GitHub PRs: none\n\nReady tickets (1 unassigned):\n- TKT-001 "Feature": ready, unassigned\n\nActive agents: none'
+      const h1 = createHash('sha256').update(msg1).digest('hex')
+      const h2 = createHash('sha256').update(msg2).digest('hex')
+      expect(h1).to.not.equal(h2)
+    })
+
+    it('first poll always sends a poke (lastPokeHash starts null)', () => {
+      // Verify the initial value is null — any hash will differ from null
+      const hash = createHash('sha256').update('any message').digest('hex')
+      const lastPokeHash: string | null = null
+      expect(hash === lastPokeHash).to.be.false
+    })
+
+    it('simulates suppress-then-poke cycle', () => {
+      // Simulate the deduplication flow
+      let lastHash: string | null = null
+      const pokes: string[] = []
+
+      const pollAndPoke = (message: string) => {
+        const hash = createHash('sha256').update(message).digest('hex')
+        if (hash === lastHash) return // suppressed
+        pokes.push(message)
+        lastHash = hash
+      }
+
+      const stateA = 'GitHub PRs: none\nReady tickets: none\nActive agents: none'
+      const stateB = 'GitHub PRs (1 open):\n- #42: "Fix bug"\nReady tickets: none\nActive agents: none'
+
+      // Cycle 1: first poll — always pokes
+      pollAndPoke(stateA)
+      expect(pokes).to.have.length(1)
+
+      // Cycle 2: same state — suppressed
+      pollAndPoke(stateA)
+      expect(pokes).to.have.length(1)
+
+      // Cycle 3: still same — suppressed
+      pollAndPoke(stateA)
+      expect(pokes).to.have.length(1)
+
+      // Cycle 4: state changed — pokes
+      pollAndPoke(stateB)
+      expect(pokes).to.have.length(2)
+      expect(pokes[1]).to.equal(stateB)
+
+      // Cycle 5: back to original state — pokes (different from last)
+      pollAndPoke(stateA)
+      expect(pokes).to.have.length(3)
+
+      // Cycle 6: same as last — suppressed again
+      pollAndPoke(stateA)
+      expect(pokes).to.have.length(3)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Suppress redundant pokes**: Hash the poll result message with SHA-256 and compare to the last poke's hash. If identical (state unchanged), suppress the poke to avoid interrupting orchestrator tool calls with redundant messages.
- **Increase default poll interval to 300s (5 min)**: Changed from 60s to reduce orchestrator interruptions. The old 60s interval was too aggressive for the orchestrator use case where pokes arrive as user messages that cancel in-flight commands.

## Changes

- `apps/cli/src/commands/watch/index.ts`: Added `createHash` import, `lastPokeHash` tracking, and deduplication logic in `pollAndPoke`. Changed default poll-interval from 60 to 300.
- `apps/cli/src/lib/session/daemon-manager.ts`: Changed `watchDaemonSpec` default from 60 to 300.
- `apps/cli/test/unit/watch-daemon.test.ts`: Updated expected default from 60 to 300.
- `apps/cli/test/unit/watch-suppress-identical.test.ts`: New test file with 13 tests covering default interval, source guards for dedup implementation, and hash deduplication logic simulation.

## Test plan

- [x] All 13 new suppress-if-identical tests pass
- [x] All 31 existing watch-daemon tests pass (updated default assertion)
- [x] All SimplePoller tests pass
- [x] Build passes (`pnpm build`)

Closes PRLT-1349