### PR TITLE
feat(PRLT-1295): clean up hook/action data model — action types, event payloads, action aliases, poke-orchestrator

### DIFF
--- a/apps/cli/src/commands/hook/list.ts
+++ b/apps/cli/src/commands/hook/list.ts
@@ -47,8 +47,8 @@ export default class HookList extends PromptCommand {
       description: 'Filter by event name',
     }),
     mode: Flags.string({
-      description: 'Filter by mode (auto, confirm, notify, off)',
-      options: ['auto', 'confirm', 'notify', 'off'],
+      description: 'Filter by mode (auto, confirm, notify, llm, human, off)',
+      options: ['auto', 'confirm', 'notify', 'llm', 'human', 'off'],
     }),
     source: Flags.string({
       description: 'Filter by source (yaml, cli, preset)',
@@ -157,9 +157,16 @@ export default class HookList extends PromptCommand {
                 ? styles.warning('confirm')
                 : mode === 'notify'
                   ? styles.info('notify')
-                  : styles.muted('off')
+                  : mode === 'llm'
+                    ? styles.warning('llm')
+                    : mode === 'human'
+                      ? styles.warning('human')
+                      : styles.muted('off')
 
-          this.log(`    ${status} ${styles.code(hook.action_value)} ${styles.muted(`[${source}]`)}`)
+          const typeLabel = hook.action_type !== 'shell' && hook.action_type !== 'action'
+            ? ` ${styles.muted(`(${hook.action_type})`)}`
+            : ''
+          this.log(`    ${status} ${styles.code(hook.action_value)}${typeLabel} ${styles.muted(`[${source}]`)}`)
           if (hook.description) {
             this.log(`         ${styles.muted(hook.description)}`)
           }

--- a/apps/cli/src/commands/work/hooks/add.ts
+++ b/apps/cli/src/commands/work/hooks/add.ts
@@ -36,8 +36,8 @@ export default class WorkHooksAdd extends PromptCommand {
       options: HOOKABLE_EVENTS,
     }),
     'action-type': Flags.string({
-      description: 'Action type (shell, webhook, log, or action)',
-      options: ['shell', 'webhook', 'log', 'action'],
+      description: 'Action type (shell, webhook, log, action, poke, or llm)',
+      options: ['shell', 'webhook', 'log', 'action', 'poke', 'llm'],
     }),
     'action-value': Flags.string({
       description: 'Action payload (command, URL, or message template)',
@@ -135,6 +135,8 @@ export default class WorkHooksAdd extends PromptCommand {
           { name: 'webhook — POST event data to a URL', value: 'webhook' },
           { name: 'log — Print a message to stdout', value: 'log' },
           { name: 'action — Call a built-in action directly (no shell)', value: 'action' },
+          { name: 'poke — Send a message to a named session', value: 'poke' },
+          { name: 'llm — Send to LLM for judgment/triage', value: 'llm' },
         ]
         const message = 'Action type:'
 
@@ -165,6 +167,8 @@ export default class WorkHooksAdd extends PromptCommand {
           webhook: 'Webhook URL:',
           log: 'Log message template (use {{workItemId}}, {{event}}, etc.):',
           action: 'Built-in action name (e.g. move-ticket, notify, merge-pr):',
+          poke: 'Session target name (e.g. orchestrator-main):',
+          llm: 'LLM prompt template (use {ticket_id}, {event}, etc.):',
         }
         const message = prompts[actionType!]
 

--- a/apps/cli/src/lib/database/migrations/0027_hook_action_types_expand.ts
+++ b/apps/cli/src/lib/database/migrations/0027_hook_action_types_expand.ts
@@ -1,0 +1,69 @@
+/**
+ * Migration 0027 — Expand Hook Action Types
+ *
+ * Adds 'poke' and 'llm' to the action_type CHECK constraint on pmo_work_hooks.
+ * Adds 'action_ref' column for shared action definitions (multiple events
+ * can reference the same action definition without duplicating config).
+ *
+ * - poke: Send a message to a named session via tmux (in-process, no shell)
+ * - llm: Send payload to LLM for judgment/triage
+ * - action_ref: Points to a shared action definition by name
+ */
+
+import type Database from 'better-sqlite3'
+import type { Migration } from '../migrator.js'
+
+export const hookActionTypesExpand: Migration = {
+  id: '0027',
+  name: 'hook_action_types_expand',
+  up: (db: Database.Database) => {
+    const tableExists = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get()
+    if (!tableExists) return
+
+    // Check if 'poke' is already in the constraint — skip if already migrated
+    const createSql = db.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='pmo_work_hooks'"
+    ).get() as { sql: string } | undefined
+    if (createSql?.sql?.includes("'poke'")) return
+
+    // SQLite doesn't allow modifying CHECK constraints via ALTER TABLE.
+    // Recreate the table with the expanded constraint + action_ref column.
+    db.exec(`
+      CREATE TABLE pmo_work_hooks_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        event TEXT NOT NULL,
+        action_type TEXT NOT NULL DEFAULT 'shell' CHECK (action_type IN ('shell', 'webhook', 'log', 'action', 'poke', 'llm')),
+        action_value TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        description TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off')),
+        priority INTEGER NOT NULL DEFAULT 0,
+        project_id TEXT,
+        source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset')),
+        config TEXT,
+        action_ref TEXT
+      )
+    `)
+
+    // Copy all existing data (action_ref defaults to NULL for existing rows)
+    db.exec(`
+      INSERT INTO pmo_work_hooks_new (id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, project_id, source, config)
+      SELECT id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, project_id, source, config
+      FROM pmo_work_hooks
+    `)
+
+    // Swap tables
+    db.exec('DROP TABLE pmo_work_hooks')
+    db.exec('ALTER TABLE pmo_work_hooks_new RENAME TO pmo_work_hooks')
+
+    // Recreate indexes
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_event ON pmo_work_hooks(event)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_enabled ON pmo_work_hooks(enabled)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+    db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_action_ref ON pmo_work_hooks(action_ref)')
+  },
+}

--- a/apps/cli/src/lib/database/migrations/index.ts
+++ b/apps/cli/src/lib/database/migrations/index.ts
@@ -32,6 +32,7 @@ import { intentBasedActions } from './0023_intent_based_actions.js'
 import { dropDeadPmoTables } from './0024_drop_dead_pmo_tables.js'
 import { transitionMapManyToOne } from './0025_transition_map_many_to_one.js'
 import { hookActionType } from './0026_hook_action_type.js'
+import { hookActionTypesExpand } from './0027_hook_action_types_expand.js'
 
 /**
  * Ordered list of all migrations.
@@ -64,4 +65,5 @@ export const ALL_MIGRATIONS: Migration[] = [
   dropDeadPmoTables,
   transitionMapManyToOne,
   hookActionType,
+  hookActionTypesExpand,
 ]

--- a/apps/cli/src/lib/orchestrate/presets.ts
+++ b/apps/cli/src/lib/orchestrate/presets.ts
@@ -52,6 +52,12 @@ const SHARED_HOOKS: Array<{ event: OrchestrateEvent; action: string; config?: Re
   { event: 'on_ci_failed', action: 'spawn-fix-agent' },
   // Periodic cleanup
   { event: 'on_agent_completed', action: 'gc-sweep' },
+  // Poke orchestrator — single action definition, multiple event triggers
+  { event: 'on_pr_opened', action: 'poke-orchestrator', config: { target: 'orchestrator-main', template: '{event}: {ticket_id} PR#{pr_number} by {author} — {branch}' } },
+  { event: 'on_ci_green', action: 'poke-orchestrator', config: { target: 'orchestrator-main', template: '{event}: {ticket_id} PR#{pr_number} — CI passed' } },
+  { event: 'on_ci_failed', action: 'poke-orchestrator', config: { target: 'orchestrator-main', template: '{event}: {ticket_id} PR#{pr_number} — CI failed' } },
+  { event: 'on_agent_completed', action: 'poke-orchestrator', config: { target: 'orchestrator-main', template: '{event}: {ticket_id} agent={agent_name} — {summary}' } },
+  { event: 'on_agent_died', action: 'poke-orchestrator', config: { target: 'orchestrator-main', template: '{event}: {ticket_id} agent={agent_name} exit={exit_code} — {error}' } },
 ]
 
 /**
@@ -72,6 +78,7 @@ const SAFE_ACTIONS = new Set([
   'rebase-conflicting-prs',
   'spawn-review-agent',
   'gc-sweep',
+  'poke-orchestrator',
 ])
 
 export const PRESETS: Record<PresetName, PresetDefinition> = {

--- a/apps/cli/src/lib/orchestrate/service-actions.ts
+++ b/apps/cli/src/lib/orchestrate/service-actions.ts
@@ -15,6 +15,7 @@ import type Database from 'better-sqlite3'
 import type { OrchestrateEventContext, OrchestrateActionResult } from './types.js'
 import { resolveWorkflowTarget } from '../work-lifecycle/settings.js'
 import type { ProviderStorage } from '../providers/types.js'
+import { interpolateTemplate } from '../work-lifecycle/hooks/types.js'
 
 type ServiceActionHandler = (
   ctx: OrchestrateEventContext,
@@ -56,6 +57,7 @@ function createMinimalStorage(db: Database.Database): ProviderStorage {
 export const SERVICE_BACKED_ACTIONS = new Set([
   'move-ticket',
   'notify',
+  'poke-orchestrator',
 ])
 
 /**
@@ -72,6 +74,7 @@ export function createServiceActionHandlers(
   return {
     'move-ticket': createMoveTicketHandler(db),
     'notify': createNotifyHandler(),
+    'poke-orchestrator': createPokeHandler(),
   }
 }
 
@@ -146,5 +149,91 @@ function createNotifyHandler(): ServiceActionHandler {
     console.log(`[orchestrate:notify] ${parts.join(' ')}`)
 
     return { action: 'notify', success: true, durationMs: Date.now() - start }
+  }
+}
+
+/**
+ * Service-backed poke handler (poke-orchestrator action).
+ *
+ * Sends a templated message to a named session via tmux. The target session
+ * and message template come from the hook's config JSON:
+ *
+ *   config: { target: 'orchestrator-main', template: '{event}: {ticket_id} — {summary}' }
+ *
+ * If no template is provided, generates a default message with event name,
+ * ticket ID, PR number, and a suggested next command.
+ */
+function createPokeHandler(): ServiceActionHandler {
+  return async (ctx, config) => {
+    const start = Date.now()
+    const target = (config?.target as string) || 'orchestrator-main'
+    const template = config?.template as string | undefined
+
+    // Build the message from template or default
+    let message: string
+    if (template) {
+      message = interpolateTemplate(template, ctx)
+    } else {
+      // Default message with event name, ticket, PR, and suggested next command
+      const parts: string[] = [`[${ctx.event || 'unknown'}]`]
+      if (ctx.ticket) parts.push(`ticket=${ctx.ticket}`)
+      if (ctx.pr) parts.push(`PR=#${ctx.pr}`)
+      if (ctx.agent) parts.push(`agent=${ctx.agent}`)
+
+      // Suggest a next command based on the event
+      const suggested = suggestNextCommand(ctx.event as string, ctx)
+      if (suggested) parts.push(`→ ${suggested}`)
+
+      message = parts.join(' ')
+    }
+
+    try {
+      // Import session resolution and tmux utilities lazily to avoid circular deps
+      const { SessionService } = await import('../../services/session-service.js')
+      const { sendTmuxMessage } = await import('../execution/session-utils.js')
+
+      const sessionService = new SessionService()
+      const resolved = sessionService.resolveSession(target)
+
+      if (resolved.kind === 'none') {
+        // Session not found — log the message instead of failing
+        console.log(`[poke-orchestrator] Session "${target}" not found. Message: ${message}`)
+        return { action: 'poke-orchestrator', success: true, durationMs: Date.now() - start }
+      }
+
+      if (resolved.kind === 'multiple') {
+        console.log(`[poke-orchestrator] Multiple sessions match "${target}". Message: ${message}`)
+        return { action: 'poke-orchestrator', success: true, durationMs: Date.now() - start }
+      }
+
+      const session = resolved.session
+      sendTmuxMessage(session.sessionId, message, session.containerId)
+
+      return { action: 'poke-orchestrator', success: true, durationMs: Date.now() - start }
+    } catch (err) {
+      // Poke failures are non-fatal — the orchestrator may not be running
+      console.log(`[poke-orchestrator] Failed to poke "${target}": ${err instanceof Error ? err.message : String(err)}. Message: ${message}`)
+      return { action: 'poke-orchestrator', success: true, durationMs: Date.now() - start }
+    }
+  }
+}
+
+/**
+ * Suggest a next prlt command based on the event type.
+ */
+function suggestNextCommand(event: string, ctx: Record<string, unknown>): string | undefined {
+  switch (event) {
+    case 'on_pr_opened':
+      return ctx.pr ? `prlt work ship ${ctx.ticket || ''}` : undefined
+    case 'on_ci_green':
+      return ctx.pr ? `prlt work ship ${ctx.ticket || ''}` : undefined
+    case 'on_ci_failed':
+      return ctx.ticket ? `prlt work start ${ctx.ticket} --action fix` : undefined
+    case 'on_agent_completed':
+      return ctx.ticket ? `prlt work propose ${ctx.ticket}` : undefined
+    case 'on_agent_died':
+      return ctx.ticket ? `prlt work start ${ctx.ticket}` : undefined
+    default:
+      return undefined
   }
 }

--- a/apps/cli/src/lib/orchestrate/types.ts
+++ b/apps/cli/src/lib/orchestrate/types.ts
@@ -94,6 +94,7 @@ export type BuiltinAction =
   | 'health-check'
   | 'resolve-conflict'
   | 'gc-sweep'
+  | 'poke-orchestrator'
 
 /** All valid built-in action names. */
 export const BUILTIN_ACTIONS: BuiltinAction[] = [
@@ -109,6 +110,7 @@ export const BUILTIN_ACTIONS: BuiltinAction[] = [
   'health-check',
   'resolve-conflict',
   'gc-sweep',
+  'poke-orchestrator',
 ]
 
 // =============================================================================

--- a/apps/cli/src/lib/work-lifecycle/hooks/executor.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/executor.ts
@@ -150,6 +150,32 @@ export function executeHook(
           durationMs: Date.now() - start,
         }
       }
+
+      case 'poke': {
+        // Poke-type hooks are handled by HookManager via service action handlers.
+        // They should not reach the executor directly.
+        return {
+          hookId: hook.id,
+          hookName: hook.name,
+          action: hook.actionValue,
+          success: false,
+          error: 'poke-type hooks must be routed through built-in action handlers, not the executor',
+          durationMs: Date.now() - start,
+        }
+      }
+
+      case 'llm': {
+        // LLM-type hooks are handled by HookManager via service action handlers.
+        // They should not reach the executor directly.
+        return {
+          hookId: hook.id,
+          hookName: hook.name,
+          action: hook.actionValue,
+          success: false,
+          error: 'llm-type hooks must be routed through built-in action handlers, not the executor',
+          durationMs: Date.now() - start,
+        }
+      }
     }
 
     return {

--- a/apps/cli/src/lib/work-lifecycle/hooks/index.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/index.ts
@@ -16,9 +16,26 @@ export type {
   HookExecutionResult,
   HookActionHandler,
   AsyncHookActionHandler,
+  EventPayloadMap,
+  PrOpenedPayload,
+  PrMergedPayload,
+  CiGreenPayload,
+  CiFailedPayload,
+  AgentCompletedPayload,
+  AgentDiedPayload,
+  PrCommentPayload,
+  TicketReadyPayload,
+  AgentSpawnedPayload,
+  ReviewApprovedPayload,
+  ChangesRequestedPayload,
 } from './types.js'
 
-export { HOOKABLE_EVENTS, HOOK_MODES } from './types.js'
+export {
+  HOOKABLE_EVENTS,
+  HOOK_MODES,
+  EVENT_PAYLOAD_FIELDS,
+  interpolateTemplate,
+} from './types.js'
 
 export {
   WorkHookStorage,

--- a/apps/cli/src/lib/work-lifecycle/hooks/manager.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/manager.ts
@@ -351,6 +351,8 @@ export class HookManager {
   /**
    * Resolve the action name from a hook config and a set of known action handlers.
    *
+   * - If action_ref is set, use it (shared action definition)
+   * - If the action_type is action/poke/llm, the action_value IS the action name
    * - If the action_value contains `--action <name>`, extracts the name
    * - If the action_value is a known built-in action, uses it directly
    * - Otherwise uses the raw action_value (shell command)
@@ -358,8 +360,11 @@ export class HookManager {
    * Public so it can be tested in isolation.
    */
   static resolveActionName(hook: WorkHookConfig, knownActions: Record<string, unknown> = {}): string {
-    // For action-type hooks, the action_value IS the action name
-    if (hook.actionType === 'action') return hook.actionValue
+    // If action_ref is set, use it — shared action definition
+    if (hook.actionRef) return hook.actionRef
+
+    // For action/poke/llm-type hooks, the action_value IS the action name
+    if (hook.actionType === 'action' || hook.actionType === 'poke' || hook.actionType === 'llm') return hook.actionValue
 
     // If the action_value contains --action, extract the action name
     const actionMatch = hook.actionValue.match(/--action\s+(\S+)/)
@@ -653,8 +658,8 @@ export class HookManager {
   ): Promise<HookExecutionResult> {
     const actionName = HookManager.resolveActionName(hook, this.actionHandlers)
 
-    // For action-type hooks, use service handlers first (async, in-process)
-    if (hook.actionType === 'action') {
+    // For action/poke/llm-type hooks, use service handlers first (async, in-process)
+    if (hook.actionType === 'action' || hook.actionType === 'poke' || hook.actionType === 'llm') {
       if (this.serviceActionHandlers[actionName]) {
         const handlerResult = await this.serviceActionHandlers[actionName](ctx, hook.config ?? undefined)
         return {
@@ -668,7 +673,7 @@ export class HookManager {
         }
       }
 
-      // Fall back to sync action handlers for action-type hooks
+      // Fall back to sync action handlers
       if (this.actionHandlers[actionName]) {
         const handlerResult = this.actionHandlers[actionName](ctx, hook.config ?? undefined)
         return {
@@ -682,7 +687,7 @@ export class HookManager {
         }
       }
 
-      // action-type but no matching handler — this is a configuration error
+      // No matching handler — this is a configuration error
       return {
         hookId: hook.id,
         hookName: hook.name,

--- a/apps/cli/src/lib/work-lifecycle/hooks/storage.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/storage.ts
@@ -18,7 +18,7 @@ export const HOOKS_TABLE_SCHEMA = `
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     event TEXT NOT NULL,
-    action_type TEXT NOT NULL CHECK (action_type IN ('shell', 'webhook', 'log', 'action')),
+    action_type TEXT NOT NULL CHECK (action_type IN ('shell', 'webhook', 'log', 'action', 'poke', 'llm')),
     action_value TEXT NOT NULL,
     enabled INTEGER NOT NULL DEFAULT 1,
     description TEXT,
@@ -65,6 +65,7 @@ function rowToConfig(row: WorkHookRow): WorkHookConfig {
     mode: (row.mode as HookMode) || 'auto',
     priority: row.priority ?? 0,
     config,
+    actionRef: row.action_ref ?? null,
   }
 }
 
@@ -93,16 +94,23 @@ export class WorkHookStorage {
       params.push(options.enabled ? 1 : 0)
     }
 
-    // Try extended query with mode/priority/config columns first
+    // Try extended query with mode/priority/config/action_ref columns first
     try {
-      const sql = `SELECT id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, config FROM ${HOOKS_TABLE}${where} ORDER BY priority ASC, created_at ASC`
+      const sql = `SELECT id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, config, action_ref FROM ${HOOKS_TABLE}${where} ORDER BY priority ASC, created_at ASC`
       const rows = this.db.prepare(sql).all(...params) as WorkHookRow[]
       return rows.map(rowToConfig)
     } catch {
-      // Fallback without mode/priority/config (pre-migration)
-      const sql = `SELECT id, name, event, action_type, action_value, enabled, description, created_at FROM ${HOOKS_TABLE}${where} ORDER BY created_at ASC`
-      const rows = this.db.prepare(sql).all(...params) as WorkHookRow[]
-      return rows.map(rowToConfig)
+      // Fallback without action_ref column
+      try {
+        const sql = `SELECT id, name, event, action_type, action_value, enabled, description, created_at, mode, priority, config FROM ${HOOKS_TABLE}${where} ORDER BY priority ASC, created_at ASC`
+        const rows = this.db.prepare(sql).all(...params) as WorkHookRow[]
+        return rows.map(rowToConfig)
+      } catch {
+        // Fallback without mode/priority/config (pre-migration)
+        const sql = `SELECT id, name, event, action_type, action_value, enabled, description, created_at FROM ${HOOKS_TABLE}${where} ORDER BY created_at ASC`
+        const rows = this.db.prepare(sql).all(...params) as WorkHookRow[]
+        return rows.map(rowToConfig)
+      }
     }
   }
 

--- a/apps/cli/src/lib/work-lifecycle/hooks/types.ts
+++ b/apps/cli/src/lib/work-lifecycle/hooks/types.ts
@@ -68,8 +68,10 @@ export const HOOKABLE_EVENTS: HookableEvent[] = [
  * - webhook: POST event data to a URL
  * - log: Write a message to stdout (useful for notifications/debugging)
  * - action: Call a built-in action handler directly in-process (no shell)
+ * - poke: Send a message to a named session via tmux (in-process, no shell)
+ * - llm: Send payload to LLM for judgment/triage (Tier 2 execution)
  */
-export type HookActionType = 'shell' | 'webhook' | 'log' | 'action'
+export type HookActionType = 'shell' | 'webhook' | 'log' | 'action' | 'poke' | 'llm'
 
 /**
  * Automation mode for a hook — determines the decision tier.
@@ -137,6 +139,8 @@ export interface WorkHookConfig {
   priority: number
   /** Optional JSON config for built-in actions */
   config: Record<string, unknown> | null
+  /** Optional reference to a shared action definition by name. Multiple hooks can point to the same action_ref to avoid duplicating config. */
+  actionRef: string | null
 }
 
 /**
@@ -154,6 +158,7 @@ export interface WorkHookRow {
   mode: string | null
   priority: number | null
   config: string | null
+  action_ref: string | null
 }
 
 /**
@@ -197,4 +202,148 @@ export interface HookExecutionResult {
   escalatedToHuman?: boolean
   /** The decision tier that handled this hook */
   tier?: DecisionTier
+}
+
+// =============================================================================
+// Event Payload Schemas
+// =============================================================================
+
+/**
+ * Typed event payloads. Each event carries a known set of fields
+ * that actions can reference in templates via {field_name} syntax.
+ */
+
+export interface PrOpenedPayload {
+  pr_number: number
+  ticket_id: string
+  branch: string
+  author: string
+  repo: string
+}
+
+export interface PrMergedPayload {
+  pr_number: number
+  ticket_id: string
+  branch: string
+  merge_sha: string
+}
+
+export interface CiGreenPayload {
+  pr_number: number
+  ticket_id: string
+  check_suite_url?: string
+}
+
+export interface CiFailedPayload {
+  pr_number: number
+  ticket_id: string
+  failed_checks: string[]
+}
+
+export interface AgentCompletedPayload {
+  agent_name: string
+  ticket_id: string
+  execution_id?: string
+  summary?: string
+}
+
+export interface AgentDiedPayload {
+  agent_name: string
+  ticket_id: string
+  execution_id?: string
+  exit_code?: number
+  error?: string
+}
+
+export interface PrCommentPayload {
+  pr_number: number
+  ticket_id: string
+  comment_id: string
+  author: string
+  body: string
+  file?: string
+  line?: number
+}
+
+export interface TicketReadyPayload {
+  ticket_id: string
+  project_id?: string
+}
+
+export interface AgentSpawnedPayload {
+  agent_name: string
+  ticket_id: string
+  execution_id?: string
+  environment?: string
+}
+
+export interface ReviewApprovedPayload {
+  pr_number: number
+  ticket_id: string
+  reviewer?: string
+}
+
+export interface ChangesRequestedPayload {
+  pr_number: number
+  ticket_id: string
+  reviewer?: string
+  body?: string
+}
+
+/**
+ * Map from event name to its payload type.
+ */
+export interface EventPayloadMap {
+  on_pr_opened: PrOpenedPayload
+  on_pr_merged: PrMergedPayload
+  on_ci_green: CiGreenPayload
+  on_ci_failed: CiFailedPayload
+  on_agent_completed: AgentCompletedPayload
+  on_agent_died: AgentDiedPayload
+  on_pr_comment: PrCommentPayload
+  on_ticket_ready: TicketReadyPayload
+  on_agent_spawned: AgentSpawnedPayload
+  on_review_approved: ReviewApprovedPayload
+  on_changes_requested: ChangesRequestedPayload
+}
+
+/**
+ * All event payload field names for documentation/validation.
+ */
+export const EVENT_PAYLOAD_FIELDS: Record<string, string[]> = {
+  on_pr_opened: ['pr_number', 'ticket_id', 'branch', 'author', 'repo'],
+  on_pr_merged: ['pr_number', 'ticket_id', 'branch', 'merge_sha'],
+  on_ci_green: ['pr_number', 'ticket_id', 'check_suite_url'],
+  on_ci_failed: ['pr_number', 'ticket_id', 'failed_checks'],
+  on_agent_completed: ['agent_name', 'ticket_id', 'execution_id', 'summary'],
+  on_agent_died: ['agent_name', 'ticket_id', 'execution_id', 'exit_code', 'error'],
+  on_pr_comment: ['pr_number', 'ticket_id', 'comment_id', 'author', 'body', 'file', 'line'],
+  on_ticket_ready: ['ticket_id', 'project_id'],
+  on_agent_spawned: ['agent_name', 'ticket_id', 'execution_id', 'environment'],
+  on_review_approved: ['pr_number', 'ticket_id', 'reviewer'],
+  on_changes_requested: ['pr_number', 'ticket_id', 'reviewer', 'body'],
+}
+
+/**
+ * Interpolate {field} placeholders in a template string with payload data.
+ * Uses single-brace syntax: '{ticket_id}', '{pr_number}', '{author}'.
+ *
+ * Falls back to the context object (normalized field names) if the payload
+ * doesn't contain the field, enabling both raw payload fields and normalized
+ * context fields in templates.
+ */
+export function interpolateTemplate(
+  template: string,
+  payload: Record<string, unknown>,
+  ctx?: Record<string, unknown>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (_match, field: string) => {
+    const value = payload[field] ?? ctx?.[field]
+    if (value === null || value === undefined) return `{${field}}`
+    if (value instanceof Date) return value.toISOString()
+    if (typeof value === 'object') {
+      try { return JSON.stringify(value) } catch { return String(value) }
+    }
+    return String(value)
+  })
 }

--- a/apps/cli/test/unit/hook-action-model-cleanup.test.ts
+++ b/apps/cli/test/unit/hook-action-model-cleanup.test.ts
@@ -1,0 +1,916 @@
+import { expect } from 'chai'
+import Database from 'better-sqlite3'
+import { ensureHooksTable, WorkHookStorage } from '../../src/lib/work-lifecycle/hooks/storage.js'
+import { HookManager } from '../../src/lib/work-lifecycle/hooks/manager.js'
+import { executeHook } from '../../src/lib/work-lifecycle/hooks/executor.js'
+import {
+  interpolateTemplate,
+  EVENT_PAYLOAD_FIELDS,
+} from '../../src/lib/work-lifecycle/hooks/types.js'
+import type {
+  WorkHookConfig,
+  HookActionHandler,
+  AsyncHookActionHandler,
+} from '../../src/lib/work-lifecycle/hooks/types.js'
+import { applyPreset } from '../../src/lib/orchestrate/config-loader.js'
+import { PRESETS } from '../../src/lib/orchestrate/presets.js'
+import { createServiceActionHandlers, SERVICE_BACKED_ACTIONS } from '../../src/lib/orchestrate/service-actions.js'
+import { hookActionTypesExpand } from '../../src/lib/database/migrations/0027_hook_action_types_expand.js'
+import { resetEventBus } from '../../src/lib/events/event-bus.js'
+
+/**
+ * Tests for PRLT-1295: Clean up hook/action data model.
+ *
+ * Covers:
+ * - New action types: poke, llm (alongside existing shell, webhook, log, action)
+ * - Event payload schemas and template interpolation
+ * - action_ref for shared action definitions
+ * - poke-orchestrator wired to multiple events
+ * - Migration 0027: CHECK constraint expansion + action_ref column
+ * - Backward compatibility with existing hooks
+ */
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:')
+  // Create the table with the expanded CHECK constraint directly
+  db.exec(`
+    CREATE TABLE pmo_work_hooks (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      event TEXT NOT NULL,
+      action_type TEXT NOT NULL DEFAULT 'shell' CHECK (action_type IN ('shell', 'webhook', 'log', 'action', 'poke', 'llm')),
+      action_value TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off')),
+      priority INTEGER NOT NULL DEFAULT 0,
+      project_id TEXT,
+      source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset')),
+      config TEXT,
+      action_ref TEXT
+    )
+  `)
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_event ON pmo_work_hooks(event)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_enabled ON pmo_work_hooks(enabled)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_action_ref ON pmo_work_hooks(action_ref)')
+  return db
+}
+
+/**
+ * Create a pre-migration DB (has 'action' in CHECK but NOT 'poke'/'llm', no action_ref).
+ */
+function createPreMigrationDb(): Database.Database {
+  const db = new Database(':memory:')
+  db.exec(`
+    CREATE TABLE pmo_work_hooks (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      event TEXT NOT NULL,
+      action_type TEXT NOT NULL DEFAULT 'shell' CHECK (action_type IN ('shell', 'webhook', 'log', 'action')),
+      action_value TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      mode TEXT NOT NULL DEFAULT 'auto' CHECK (mode IN ('auto', 'confirm', 'notify', 'llm', 'human', 'off')),
+      priority INTEGER NOT NULL DEFAULT 0,
+      project_id TEXT,
+      source TEXT NOT NULL DEFAULT 'cli' CHECK (source IN ('yaml', 'cli', 'preset')),
+      config TEXT
+    )
+  `)
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_event ON pmo_work_hooks(event)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_enabled ON pmo_work_hooks(enabled)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pmo_work_hooks_priority ON pmo_work_hooks(event, priority)')
+  return db
+}
+
+function insertHook(db: Database.Database, opts: {
+  name: string
+  event: string
+  actionType?: string
+  actionValue: string
+  mode?: string
+  priority?: number
+  config?: string
+  source?: string
+  enabled?: number
+  actionRef?: string
+}): string {
+  const id = `hook-${Math.random().toString(36).slice(2, 8)}`
+  db.prepare(`
+    INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, mode, priority, source, config, action_ref)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    opts.name,
+    opts.event,
+    opts.actionType ?? 'shell',
+    opts.actionValue,
+    opts.enabled ?? 1,
+    opts.mode ?? 'auto',
+    opts.priority ?? 0,
+    opts.source ?? 'cli',
+    opts.config ?? null,
+    opts.actionRef ?? null,
+  )
+  return id
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Hook/Action Data Model Cleanup (PRLT-1295)', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = createTestDb()
+    resetEventBus()
+  })
+
+  afterEach(() => {
+    resetEventBus()
+    db.close()
+  })
+
+  // ===========================================================================
+  // 1. Expanded action_type support
+  // ===========================================================================
+
+  describe('action_type supports shell, poke, action, webhook, llm', () => {
+    it('should insert and read hooks with action_type="poke"', () => {
+      insertHook(db, {
+        name: 'poke-hook',
+        event: 'on_pr_opened',
+        actionType: 'poke',
+        actionValue: 'poke-orchestrator',
+        config: JSON.stringify({ target: 'orchestrator-main', template: '{event}: {ticket_id}' }),
+      })
+
+      const row = db.prepare('SELECT action_type, action_value FROM pmo_work_hooks WHERE name = ?').get('poke-hook') as { action_type: string; action_value: string }
+      expect(row.action_type).to.equal('poke')
+      expect(row.action_value).to.equal('poke-orchestrator')
+    })
+
+    it('should insert and read hooks with action_type="llm"', () => {
+      insertHook(db, {
+        name: 'llm-hook',
+        event: 'on_changes_requested',
+        actionType: 'llm',
+        actionValue: 'triage-comment',
+        config: JSON.stringify({ prompt: 'Triage this event: {body}' }),
+      })
+
+      const row = db.prepare('SELECT action_type, action_value FROM pmo_work_hooks WHERE name = ?').get('llm-hook') as { action_type: string; action_value: string }
+      expect(row.action_type).to.equal('llm')
+      expect(row.action_value).to.equal('triage-comment')
+    })
+
+    it('should still allow all existing action types', () => {
+      for (const actionType of ['shell', 'webhook', 'log', 'action']) {
+        insertHook(db, {
+          name: `test-${actionType}`,
+          event: 'on_ci_green',
+          actionType,
+          actionValue: `test-${actionType}`,
+        })
+      }
+      const count = db.prepare('SELECT COUNT(*) as cnt FROM pmo_work_hooks').get() as { cnt: number }
+      expect(count.cnt).to.equal(4)
+    })
+  })
+
+  // ===========================================================================
+  // 2. Poke type sends message without shelling out
+  // ===========================================================================
+
+  describe('poke type routes through service action handlers', () => {
+    it('should route poke-type hooks to service action handlers', async () => {
+      let handlerCalled = false
+      let receivedCtx: Record<string, unknown> | null = null
+      let receivedConfig: Record<string, unknown> | undefined
+
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'poke-orchestrator': async (ctx, config) => {
+          handlerCalled = true
+          receivedCtx = ctx
+          receivedConfig = config
+          return { action: 'poke-orchestrator', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'poke-test',
+        event: 'on_pr_opened',
+        actionType: 'poke',
+        actionValue: 'poke-orchestrator',
+        config: JSON.stringify({ target: 'orchestrator-main', template: '{event}: {ticket_id}' }),
+      })
+
+      const manager = new HookManager({
+        db,
+        serviceActionHandlers: serviceHandlers,
+      })
+      const results = await manager.fireEvent('on_pr_opened', { ticketId: 'TKT-1', prNumber: 42 })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(results[0].action).to.equal('poke-orchestrator')
+      expect(handlerCalled).to.be.true
+      expect(receivedConfig).to.deep.equal({ target: 'orchestrator-main', template: '{event}: {ticket_id}' })
+    })
+
+    it('executor should reject poke-type hooks (must go through handlers)', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-1',
+        name: 'poke-hook',
+        event: 'on_pr_opened',
+        actionType: 'poke',
+        actionValue: 'poke-orchestrator',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+        actionRef: null,
+      }
+      const result = executeHook(hook, 'on_pr_opened', {})
+      expect(result.success).to.be.false
+      expect(result.error).to.include('poke-type hooks must be routed through built-in action handlers')
+    })
+  })
+
+  // ===========================================================================
+  // 3. Action type resolves named pmo_action directly
+  // ===========================================================================
+
+  describe('action type direct dispatch', () => {
+    it('should resolve action name from actionValue for action-type hooks', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-1',
+        name: 'action-hook',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+        actionRef: null,
+      }
+      const result = HookManager.resolveActionName(hook, {})
+      expect(result).to.equal('merge-pr')
+    })
+
+    it('should route action-type hooks to service handlers (no shell)', async () => {
+      let handlerCalled = false
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'move-ticket': async () => {
+          handlerCalled = true
+          return { action: 'move-ticket', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'action-move',
+        event: 'on_pr_merged',
+        actionType: 'action',
+        actionValue: 'move-ticket',
+        config: JSON.stringify({ target: 'done' }),
+      })
+
+      const manager = new HookManager({ db, serviceActionHandlers: serviceHandlers })
+      const results = await manager.fireEvent('on_pr_merged', { ticketId: 'TKT-1' })
+      expect(handlerCalled).to.be.true
+      expect(results[0].success).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // 4. Event payloads are typed and documented
+  // ===========================================================================
+
+  describe('event payload schemas', () => {
+    it('should have payload fields defined for all key events', () => {
+      const expectedEvents = [
+        'on_pr_opened', 'on_pr_merged', 'on_ci_green', 'on_ci_failed',
+        'on_agent_completed', 'on_agent_died', 'on_pr_comment',
+        'on_ticket_ready', 'on_agent_spawned', 'on_review_approved',
+        'on_changes_requested',
+      ]
+      for (const event of expectedEvents) {
+        expect(EVENT_PAYLOAD_FIELDS[event]).to.be.an('array').with.length.greaterThan(0)
+      }
+    })
+
+    it('on_pr_opened should have pr_number, ticket_id, branch, author, repo', () => {
+      expect(EVENT_PAYLOAD_FIELDS['on_pr_opened']).to.include.members([
+        'pr_number', 'ticket_id', 'branch', 'author', 'repo',
+      ])
+    })
+
+    it('on_agent_completed should have agent_name, ticket_id, execution_id, summary', () => {
+      expect(EVENT_PAYLOAD_FIELDS['on_agent_completed']).to.include.members([
+        'agent_name', 'ticket_id', 'execution_id', 'summary',
+      ])
+    })
+
+    it('on_agent_died should have agent_name, ticket_id, exit_code, error', () => {
+      expect(EVENT_PAYLOAD_FIELDS['on_agent_died']).to.include.members([
+        'agent_name', 'ticket_id', 'exit_code', 'error',
+      ])
+    })
+  })
+
+  // ===========================================================================
+  // 5. Action templates can reference payload fields
+  // ===========================================================================
+
+  describe('template interpolation', () => {
+    it('should interpolate {ticket_id}, {pr_number}, {author}', () => {
+      const template = 'PR #{pr_number} opened for {ticket_id} by {author}'
+      const payload = { pr_number: 42, ticket_id: 'TKT-123', author: 'alice' }
+      const result = interpolateTemplate(template, payload)
+      expect(result).to.equal('PR #42 opened for TKT-123 by alice')
+    })
+
+    it('should leave unresolved fields as-is', () => {
+      const template = '{event}: {ticket_id} — {unknown_field}'
+      const payload = { event: 'on_ci_green', ticket_id: 'TKT-1' }
+      const result = interpolateTemplate(template, payload)
+      expect(result).to.equal('on_ci_green: TKT-1 — {unknown_field}')
+    })
+
+    it('should handle missing payload values', () => {
+      const template = '{event}: {ticket_id}'
+      const payload = { event: 'on_ci_green' }
+      const result = interpolateTemplate(template, payload)
+      expect(result).to.equal('on_ci_green: {ticket_id}')
+    })
+
+    it('should fall back to context for field resolution', () => {
+      const template = '{event}: ticket={ticket}'
+      const payload = { event: 'on_ci_green' }
+      const ctx = { ticket: 'TKT-99' }
+      const result = interpolateTemplate(template, payload, ctx)
+      expect(result).to.equal('on_ci_green: ticket=TKT-99')
+    })
+
+    it('should handle Date objects in payload', () => {
+      const template = 'Created at {created_at}'
+      const date = new Date('2026-01-15T10:00:00Z')
+      const payload = { created_at: date }
+      const result = interpolateTemplate(template, payload)
+      expect(result).to.equal('Created at 2026-01-15T10:00:00.000Z')
+    })
+
+    it('should handle array/object values as JSON', () => {
+      const template = 'Failed: {failed_checks}'
+      const payload = { failed_checks: ['lint', 'test'] }
+      const result = interpolateTemplate(template, payload)
+      expect(result).to.equal('Failed: ["lint","test"]')
+    })
+  })
+
+  // ===========================================================================
+  // 6. Multiple events reference same action definition (action_ref)
+  // ===========================================================================
+
+  describe('action_ref for shared action definitions', () => {
+    it('should use action_ref to resolve action name when set', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-ref',
+        name: 'poke-on-pr',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: '',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+        actionRef: 'poke-orchestrator',
+      }
+      const result = HookManager.resolveActionName(hook, {})
+      expect(result).to.equal('poke-orchestrator')
+    })
+
+    it('should prioritize action_ref over action_value', () => {
+      const hook: WorkHookConfig = {
+        id: 'test-ref',
+        name: 'ref-vs-value',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+        actionRef: 'custom-action',
+      }
+      const result = HookManager.resolveActionName(hook, {})
+      expect(result).to.equal('custom-action')
+    })
+
+    it('should store and retrieve action_ref from database', () => {
+      insertHook(db, {
+        name: 'ref-hook-1',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        actionRef: 'poke-orchestrator',
+      })
+      insertHook(db, {
+        name: 'ref-hook-2',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        actionRef: 'poke-orchestrator',
+      })
+
+      const storage = new WorkHookStorage(db)
+      const hooks = storage.list()
+      expect(hooks).to.have.length(2)
+      expect(hooks[0].actionRef).to.equal('poke-orchestrator')
+      expect(hooks[1].actionRef).to.equal('poke-orchestrator')
+    })
+
+    it('should fire same handler for different events via action_ref', async () => {
+      let callCount = 0
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'poke-orchestrator': async () => {
+          callCount++
+          return { action: 'poke-orchestrator', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'ref-pr',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        actionRef: 'poke-orchestrator',
+      })
+      insertHook(db, {
+        name: 'ref-ci',
+        event: 'on_ci_green',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        actionRef: 'poke-orchestrator',
+      })
+
+      const manager = new HookManager({ db, serviceActionHandlers: serviceHandlers })
+
+      await manager.fireEvent('on_pr_opened', { ticketId: 'TKT-1' })
+      expect(callCount).to.equal(1)
+
+      await manager.fireEvent('on_ci_green', { ticketId: 'TKT-1' })
+      expect(callCount).to.equal(2)
+    })
+  })
+
+  // ===========================================================================
+  // 7. poke-orchestrator wired to 5 events
+  // ===========================================================================
+
+  describe('poke-orchestrator in presets', () => {
+    it('aggressive preset should include poke-orchestrator hooks', () => {
+      const preset = PRESETS.aggressive
+      const pokeHooks = preset.hooks.filter(h => h.action === 'poke-orchestrator')
+      expect(pokeHooks).to.have.length(5)
+
+      const pokeEvents = pokeHooks.map(h => h.event)
+      expect(pokeEvents).to.include('on_pr_opened')
+      expect(pokeEvents).to.include('on_ci_green')
+      expect(pokeEvents).to.include('on_ci_failed')
+      expect(pokeEvents).to.include('on_agent_completed')
+      expect(pokeEvents).to.include('on_agent_died')
+    })
+
+    it('poke-orchestrator hooks should all have config with target and template', () => {
+      const preset = PRESETS.aggressive
+      const pokeHooks = preset.hooks.filter(h => h.action === 'poke-orchestrator')
+      for (const hook of pokeHooks) {
+        expect(hook.config).to.exist
+        expect(hook.config!.target).to.equal('orchestrator-main')
+        expect(hook.config!.template).to.be.a('string')
+      }
+    })
+
+    it('poke-orchestrator should be a safe action (auto mode in all presets)', () => {
+      for (const presetName of ['aggressive', 'conservative', 'supervised'] as const) {
+        const preset = PRESETS[presetName]
+        const pokeHooks = preset.hooks.filter(h => h.action === 'poke-orchestrator')
+        for (const hook of pokeHooks) {
+          expect(hook.mode).to.equal('auto', `poke-orchestrator should be auto in ${presetName} preset`)
+        }
+      }
+    })
+
+    it('applyPreset should create poke-orchestrator hooks in DB', () => {
+      applyPreset(db, 'aggressive')
+
+      const pokeHooks = db.prepare(
+        "SELECT * FROM pmo_work_hooks WHERE action_value = 'poke-orchestrator' AND source = 'preset'"
+      ).all() as Array<{ event: string; action_type: string; config: string }>
+
+      expect(pokeHooks).to.have.length(5)
+
+      for (const hook of pokeHooks) {
+        expect(hook.action_type).to.equal('action')
+        const config = JSON.parse(hook.config)
+        expect(config.target).to.equal('orchestrator-main')
+      }
+    })
+  })
+
+  // ===========================================================================
+  // 8. Backward compatibility: existing shell-type hooks work
+  // ===========================================================================
+
+  describe('backward compatibility', () => {
+    it('should execute shell-type hooks unchanged', async () => {
+      insertHook(db, {
+        name: 'shell-hook',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'true',
+      })
+
+      const manager = new HookManager({ db })
+      const results = await manager.fireEvent('on_ci_green', {})
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+    })
+
+    it('should still resolve --action flag from shell hooks', () => {
+      const hook: WorkHookConfig = {
+        id: 'compat-1',
+        name: 'old-shell',
+        event: 'on_ci_green',
+        actionType: 'shell',
+        actionValue: 'prlt hook fire on_ci_green --action merge-pr',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+        actionRef: null,
+      }
+      const result = HookManager.resolveActionName(hook, {})
+      expect(result).to.equal('merge-pr')
+    })
+
+    it('should execute log-type hooks unchanged', () => {
+      const hook: WorkHookConfig = {
+        id: 'log-1',
+        name: 'log-hook',
+        event: 'on_ci_green',
+        actionType: 'log',
+        actionValue: 'CI passed for {{event}}',
+        enabled: true,
+        description: null,
+        createdAt: new Date().toISOString(),
+        mode: 'auto',
+        priority: 0,
+        config: null,
+        actionRef: null,
+      }
+      const result = executeHook(hook, 'on_ci_green', {})
+      expect(result.success).to.be.true
+    })
+  })
+
+  // ===========================================================================
+  // 9. hook list displays new action types correctly
+  // ===========================================================================
+
+  describe('hook list JSON output', () => {
+    it('should list hooks with poke and llm action types', () => {
+      insertHook(db, { name: 'poke-hook', event: 'on_pr_opened', actionType: 'poke', actionValue: 'poke-orchestrator' })
+      insertHook(db, { name: 'llm-hook', event: 'on_changes_requested', actionType: 'llm', actionValue: 'triage-comment' })
+      insertHook(db, { name: 'shell-hook', event: 'on_ci_green', actionType: 'shell', actionValue: 'echo test' })
+
+      const storage = new WorkHookStorage(db)
+      const hooks = storage.list()
+      expect(hooks).to.have.length(3)
+
+      const pokeHook = hooks.find(h => h.actionType === 'poke')
+      expect(pokeHook).to.exist
+      expect(pokeHook!.actionValue).to.equal('poke-orchestrator')
+
+      const llmHook = hooks.find(h => h.actionType === 'llm')
+      expect(llmHook).to.exist
+      expect(llmHook!.actionValue).to.equal('triage-comment')
+    })
+  })
+
+  // ===========================================================================
+  // 10. hook add supports new action types
+  // ===========================================================================
+
+  describe('hook add with new action types', () => {
+    it('should create hooks with action_type="poke" via WorkHookStorage', () => {
+      const storage = new WorkHookStorage(db)
+      const hook = storage.create({
+        name: 'poke-add-test',
+        event: 'on_pr_opened',
+        actionType: 'poke',
+        actionValue: 'poke-orchestrator',
+      })
+      expect(hook.actionType).to.equal('poke')
+    })
+
+    it('should create hooks with action_type="llm" via WorkHookStorage', () => {
+      const storage = new WorkHookStorage(db)
+      const hook = storage.create({
+        name: 'llm-add-test',
+        event: 'on_changes_requested',
+        actionType: 'llm',
+        actionValue: 'triage-comment',
+      })
+      expect(hook.actionType).to.equal('llm')
+    })
+  })
+
+  // ===========================================================================
+  // 11. Fire on_pr_opened → poke lands with correct payload fields
+  // ===========================================================================
+
+  describe('fire on_pr_opened → poke-orchestrator with payload', () => {
+    it('should fire poke-orchestrator with correct payload fields', async () => {
+      let receivedCtx: Record<string, unknown> | null = null
+      let receivedConfig: Record<string, unknown> | undefined
+
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'poke-orchestrator': async (ctx, config) => {
+          receivedCtx = ctx
+          receivedConfig = config
+          return { action: 'poke-orchestrator', success: true, durationMs: 1 }
+        },
+      }
+
+      insertHook(db, {
+        name: 'poke-pr',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        config: JSON.stringify({ target: 'orchestrator-main', template: '{event}: {ticket_id} PR#{pr_number} by {author}' }),
+      })
+
+      const manager = new HookManager({ db, serviceActionHandlers: serviceHandlers })
+      const results = await manager.fireEvent('on_pr_opened', {
+        ticketId: 'TKT-42',
+        prNumber: 123,
+        branch: 'feat/my-feature',
+        author: 'alice',
+        repo: 'proletariat',
+      })
+
+      expect(results).to.have.length(1)
+      expect(results[0].success).to.be.true
+      expect(receivedCtx).to.exist
+      // The context should include the normalized fields
+      expect(receivedCtx!.ticket).to.equal('TKT-42')
+      expect(receivedCtx!.pr).to.equal(123)
+      expect(receivedCtx!.event).to.equal('on_pr_opened')
+      // Config with template should be passed through
+      expect(receivedConfig!.template).to.equal('{event}: {ticket_id} PR#{pr_number} by {author}')
+    })
+  })
+
+  // ===========================================================================
+  // 12. Fire on_agent_completed → same poke-orchestrator fires (shared def)
+  // ===========================================================================
+
+  describe('fire on_agent_completed → shared poke-orchestrator', () => {
+    it('should fire the same poke-orchestrator action for on_agent_completed', async () => {
+      const firedEvents: string[] = []
+
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'poke-orchestrator': async (ctx) => {
+          firedEvents.push(ctx.event as string)
+          return { action: 'poke-orchestrator', success: true, durationMs: 1 }
+        },
+      }
+
+      // Wire same action to two events (simulating shared definition)
+      insertHook(db, {
+        name: 'poke-pr-opened',
+        event: 'on_pr_opened',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        config: JSON.stringify({ target: 'orchestrator-main' }),
+      })
+      insertHook(db, {
+        name: 'poke-agent-completed',
+        event: 'on_agent_completed',
+        actionType: 'action',
+        actionValue: 'poke-orchestrator',
+        config: JSON.stringify({ target: 'orchestrator-main' }),
+      })
+
+      const manager = new HookManager({ db, serviceActionHandlers: serviceHandlers })
+
+      await manager.fireEvent('on_pr_opened', { ticketId: 'TKT-1' })
+      await manager.fireEvent('on_agent_completed', { ticketId: 'TKT-1', agentName: 'bold-turing' })
+
+      expect(firedEvents).to.have.length(2)
+      expect(firedEvents[0]).to.equal('on_pr_opened')
+      expect(firedEvents[1]).to.equal('on_agent_completed')
+    })
+  })
+
+  // ===========================================================================
+  // 13. Existing aggressive preset hooks still work after migration
+  // ===========================================================================
+
+  describe('aggressive preset backward compatibility', () => {
+    it('should create all preset hooks including poke-orchestrator', () => {
+      const count = applyPreset(db, 'aggressive')
+      expect(count).to.equal(PRESETS.aggressive.hooks.length)
+
+      // Verify existing hooks are still present
+      const mergeHook = db.prepare(
+        "SELECT * FROM pmo_work_hooks WHERE action_value = 'merge-pr' AND source = 'preset'"
+      ).get()
+      expect(mergeHook).to.exist
+
+      const moveHooks = db.prepare(
+        "SELECT * FROM pmo_work_hooks WHERE action_value = 'move-ticket' AND source = 'preset'"
+      ).all()
+      expect(moveHooks.length).to.be.greaterThan(0)
+
+      // Verify poke-orchestrator hooks are present
+      const pokeHooks = db.prepare(
+        "SELECT * FROM pmo_work_hooks WHERE action_value = 'poke-orchestrator' AND source = 'preset'"
+      ).all()
+      expect(pokeHooks).to.have.length(5)
+    })
+
+    it('should execute preset hooks via action handlers', async () => {
+      const executed: string[] = []
+      const actionHandlers: Record<string, HookActionHandler> = {
+        'merge-pr': () => { executed.push('merge-pr'); return { action: 'merge-pr', success: true, durationMs: 1 } },
+        'notify': () => { executed.push('notify'); return { action: 'notify', success: true, durationMs: 1 } },
+      }
+      const serviceHandlers: Record<string, AsyncHookActionHandler> = {
+        'poke-orchestrator': async () => { executed.push('poke-orchestrator'); return { action: 'poke-orchestrator', success: true, durationMs: 1 } },
+      }
+
+      applyPreset(db, 'aggressive')
+
+      const manager = new HookManager({ db, actionHandlers, serviceActionHandlers: serviceHandlers })
+      await manager.fireEvent('on_ci_green', { ticketId: 'TKT-1', prNumber: 42 })
+
+      // on_ci_green should trigger merge-pr and poke-orchestrator
+      expect(executed).to.include('merge-pr')
+      expect(executed).to.include('poke-orchestrator')
+    })
+  })
+
+  // ===========================================================================
+  // Migration 0027 Tests
+  // ===========================================================================
+
+  describe('Migration 0027 (hookActionTypesExpand)', () => {
+    it('should add poke and llm to CHECK constraint', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        hookActionTypesExpand.up(preMigDb)
+
+        // Should be able to insert poke-type hooks
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value)
+          VALUES ('test-poke', 'test-poke', 'on_pr_opened', 'poke', 'poke-orchestrator')
+        `).run()
+
+        // Should be able to insert llm-type hooks
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value)
+          VALUES ('test-llm', 'test-llm', 'on_changes_requested', 'llm', 'triage-comment')
+        `).run()
+
+        const rows = preMigDb.prepare('SELECT action_type FROM pmo_work_hooks').all() as Array<{ action_type: string }>
+        const types = rows.map(r => r.action_type)
+        expect(types).to.include('poke')
+        expect(types).to.include('llm')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should add action_ref column', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        hookActionTypesExpand.up(preMigDb)
+
+        // Should be able to insert with action_ref
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, action_ref)
+          VALUES ('test-ref', 'test-ref', 'on_ci_green', 'action', 'poke-orchestrator', 'poke-orchestrator')
+        `).run()
+
+        const row = preMigDb.prepare('SELECT action_ref FROM pmo_work_hooks WHERE id = ?').get('test-ref') as { action_ref: string }
+        expect(row.action_ref).to.equal('poke-orchestrator')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should preserve all existing data during migration', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        // Insert hook with all columns populated
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value, enabled, description, mode, priority, project_id, source, config)
+          VALUES ('full-1', 'full-hook', 'on_ci_green', 'action', 'merge-pr', 1, 'Test desc', 'llm', 5, 'PRLT', 'preset', '{"key":"val"}')
+        `).run()
+
+        hookActionTypesExpand.up(preMigDb)
+
+        const row = preMigDb.prepare('SELECT * FROM pmo_work_hooks WHERE id = ?').get('full-1') as Record<string, unknown>
+        expect(row.name).to.equal('full-hook')
+        expect(row.action_type).to.equal('action')
+        expect(row.action_value).to.equal('merge-pr')
+        expect(row.mode).to.equal('llm')
+        expect(row.priority).to.equal(5)
+        expect(row.source).to.equal('preset')
+        expect(row.config).to.equal('{"key":"val"}')
+        expect(row.action_ref).to.be.null
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should be idempotent', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        hookActionTypesExpand.up(preMigDb)
+        hookActionTypesExpand.up(preMigDb) // Should not throw
+
+        // Verify functionality still works
+        preMigDb.prepare(`
+          INSERT INTO pmo_work_hooks (id, name, event, action_type, action_value)
+          VALUES ('idem-1', 'idem-test', 'on_ci_green', 'poke', 'test')
+        `).run()
+
+        const row = preMigDb.prepare('SELECT action_type FROM pmo_work_hooks WHERE id = ?').get('idem-1') as { action_type: string }
+        expect(row.action_type).to.equal('poke')
+      } finally {
+        preMigDb.close()
+      }
+    })
+
+    it('should skip when table does not exist', () => {
+      const emptyDb = new Database(':memory:')
+      try {
+        hookActionTypesExpand.up(emptyDb) // Should not throw
+      } finally {
+        emptyDb.close()
+      }
+    })
+
+    it('should create action_ref index', () => {
+      const preMigDb = createPreMigrationDb()
+      try {
+        hookActionTypesExpand.up(preMigDb)
+
+        const idx = preMigDb.prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_pmo_work_hooks_action_ref'"
+        ).get()
+        expect(idx).to.exist
+      } finally {
+        preMigDb.close()
+      }
+    })
+  })
+
+  // ===========================================================================
+  // Service action handlers
+  // ===========================================================================
+
+  describe('service action handlers', () => {
+    it('should include poke-orchestrator in SERVICE_BACKED_ACTIONS', () => {
+      expect(SERVICE_BACKED_ACTIONS.has('poke-orchestrator')).to.be.true
+    })
+
+    it('should return poke-orchestrator handler from createServiceActionHandlers', () => {
+      const handlers = createServiceActionHandlers(db)
+      expect(handlers['poke-orchestrator']).to.be.a('function')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Expands `action_type` to support `poke` and `llm` alongside existing `shell`, `webhook`, `log`, `action`
- Adds typed event payload schemas with `{field}` template interpolation for all key events
- Adds `action_ref` column for shared action definitions — multiple events reference one action without row duplication
- Wires `poke-orchestrator` built-in action to 5 events (on_pr_opened, on_ci_green, on_ci_failed, on_agent_completed, on_agent_died) across all presets
- Migration 0027 expands CHECK constraint and adds `action_ref` column
- 43 new tests covering all acceptance criteria

## Test plan

- [x] `action_type` supports: shell, poke, action, webhook, llm
- [x] `poke` type routes through service action handlers (no shell)
- [x] `action` type resolves named pmo_action directly
- [x] Event payloads typed and documented per event
- [x] Template interpolation with `{ticket_id}`, `{pr_number}`, `{author}`
- [x] `action_ref` enables shared definitions across events
- [x] `poke-orchestrator` wired to 5 events in all presets
- [x] Backward compatible — existing shell/action hooks unchanged
- [x] Migration 0027 idempotent, preserves data
- [x] Existing hook tests (52) still pass

Linear: https://linear.app/integrated-ventures/issue/PRLT-1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)