### PR TITLE
fix(PRLT-1350): watch daemon uses category-based query for ready tickets

### DIFF
--- a/apps/cli/src/lib/orchestrate/simple-poller.ts
+++ b/apps/cli/src/lib/orchestrate/simple-poller.ts
@@ -15,7 +15,6 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import type Database from 'better-sqlite3'
 import { isGHInstalled, isGHAuthenticated, listOpenPRs, getPRChecks } from '../pr/index.js'
-import { getWorkflowConfig } from '../work-lifecycle/settings.js'
 import {
   type AgentHealthState,
   detectState,
@@ -361,38 +360,21 @@ export class SimplePoller {
     const items: StateItem[] = []
 
     try {
-      // Resolve configured ready status name
-      let readyStatusName: string | null = null
-      try {
-        const config = getWorkflowConfig(this.db)
-        readyStatusName = config.planned
-      } catch {
-        // pmo_settings may not exist yet
-      }
-
-      const readyTickets = readyStatusName
-        ? this.db.prepare(`
-            SELECT t.id, t.title
-            FROM pmo_tickets t
-            JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-            WHERE LOWER(ws.name) = LOWER(?)
-              AND t.assignee IS NULL
-              AND t.id NOT IN (
-                SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-              )
-            LIMIT 20
-          `).all(readyStatusName) as Array<{ id: string; title: string }>
-        : this.db.prepare(`
-            SELECT t.id, t.title
-            FROM pmo_tickets t
-            JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-            WHERE ws.category = 'unstarted'
-              AND t.assignee IS NULL
-              AND t.id NOT IN (
-                SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-              )
-            LIMIT 20
-          `).all() as Array<{ id: string; title: string }>
+      // Query by category ('unstarted') rather than a single status name.
+      // The 'unstarted' category covers all ready-to-work statuses regardless
+      // of name — "Ready", "Planned", "To Do", etc. — fixing the mismatch
+      // where config.planned defaults to "Planned" but the board uses "Ready".
+      const readyTickets = this.db.prepare(`
+        SELECT t.id, t.title
+        FROM pmo_tickets t
+        JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
+        WHERE ws.category = 'unstarted'
+          AND t.assignee IS NULL
+          AND t.id NOT IN (
+            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
+          )
+        LIMIT 20
+      `).all() as Array<{ id: string; title: string }>
 
       for (const ticket of readyTickets) {
         items.push({ category: 'board', summary: `${ticket.id} "${ticket.title}": ready, unassigned` })

--- a/apps/cli/test/unit/simple-poller.test.ts
+++ b/apps/cli/test/unit/simple-poller.test.ts
@@ -208,6 +208,45 @@ describe('SimplePoller', () => {
       const result = await poller.poll()
       expect(result.items).to.have.length(0)
     })
+
+    it('should use category-based query, not status name match (PRLT-1350)', async () => {
+      // Regression: gatherReadyTicketState() used config.planned (defaults to "Planned")
+      // but the board status is named "Ready". The fix uses ws.category = 'unstarted'
+      // which matches any ready-like status regardless of name.
+      const queriesExecuted: string[] = []
+      const db = {
+        _data: { readyTickets: [{ id: 'TKT-R1', title: 'Ready ticket' }], agents: [] },
+        prepare: (sql: string) => {
+          queriesExecuted.push(sql)
+          return {
+            all: (..._args: unknown[]) => {
+              if (sql.includes('pmo_tickets') && sql.includes('unstarted')) {
+                return [{ id: 'TKT-R1', title: 'Ready ticket' }]
+              }
+              if (sql.includes('agent_work')) return []
+              return []
+            },
+            get: () => undefined,
+          }
+        },
+        close: () => {},
+      }
+      const poller = createPoller(db as any)
+
+      const result = await poller.poll()
+
+      // Must find the ticket via category-based query
+      const boardItems = result.items.filter(i => i.category === 'board')
+      expect(boardItems).to.have.length(1)
+      expect(boardItems[0].summary).to.include('TKT-R1')
+
+      // The ticket query must NOT use ws.name matching (the old broken approach)
+      const ticketQuery = queriesExecuted.find(q => q.includes('pmo_tickets') && q.includes('unstarted'))
+      expect(ticketQuery).to.exist
+      // Should not have a ws.name = ? clause in the ticket query
+      const nameMatchQuery = queriesExecuted.find(q => q.includes('pmo_tickets') && q.includes('ws.name'))
+      expect(nameMatchQuery).to.be.undefined
+    })
   })
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

- `gatherReadyTicketState()` used `config.planned` (defaults to "Planned") to match ticket status names, but boards using the built-in template have the status named "Ready" — causing a name mismatch that returned 0 results
- Fixed by switching to category-based filtering (`ws.category = 'unstarted'`), which matches any ready-to-work status regardless of name ("Ready", "Planned", "To Do", etc.)
- This matches the approach already used by the MCP diet tools

## Test plan
- [x] Added regression test verifying category-based query is used (not status name match)
- [x] All existing SimplePoller tests pass