### PR TITLE
fix(PRLT-1350): query ticket_refs instead of dropped pmo_tickets in watch daemon pollers

### DIFF
--- a/apps/cli/src/lib/orchestrate/poller.ts
+++ b/apps/cli/src/lib/orchestrate/poller.ts
@@ -93,38 +93,32 @@ export class OrchestratePoller {
    */
   private async pollReadyTickets(): Promise<void> {
     try {
-      // Resolve configured ready status name
-      let readyStatusName: string | null = null
+      // Build list of status names that represent "ready" tickets.
+      // Include the configured planned column name and common synonyms
+      // that external providers use (e.g. Linear uses "Ready", "Todo").
+      const readyNames = new Set(['ready', 'planned', 'todo'])
       try {
         const config = getWorkflowConfig(this.db)
-        readyStatusName = config.planned
+        readyNames.add(config.planned.toLowerCase())
       } catch {
         // pmo_settings may not exist yet
       }
 
-      const readyTickets = readyStatusName
-        ? this.db.prepare(`
-            SELECT t.id, t.title
-            FROM pmo_tickets t
-            JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-            WHERE LOWER(ws.name) = LOWER(?)
-              AND t.assignee IS NULL
-              AND t.id NOT IN (
-                SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-              )
-            LIMIT 10
-          `).all(readyStatusName) as Array<{ id: string; title: string }>
-        : this.db.prepare(`
-            SELECT t.id, t.title
-            FROM pmo_tickets t
-            JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-            WHERE ws.category = 'unstarted'
-              AND t.assignee IS NULL
-              AND t.id NOT IN (
-                SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-              )
-            LIMIT 10
-          `).all() as Array<{ id: string; title: string }>
+      const nameList = [...readyNames]
+      const placeholders = nameList.map(() => '?').join(', ')
+
+      // Query ticket_refs (runtime ticket cache) instead of the dropped
+      // pmo_tickets / pmo_workflow_statuses tables (PRLT-1350).
+      const readyTickets = this.db.prepare(`
+        SELECT id, title
+        FROM ticket_refs
+        WHERE LOWER(status) IN (${placeholders})
+          AND (assignee IS NULL OR assignee = '')
+          AND id NOT IN (
+            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
+          )
+        LIMIT 10
+      `).all(...nameList) as Array<{ id: string; title: string }>
 
       for (const ticket of readyTickets) {
         if (this.firedReadyTickets.has(ticket.id)) continue

--- a/apps/cli/src/lib/orchestrate/simple-poller.ts
+++ b/apps/cli/src/lib/orchestrate/simple-poller.ts
@@ -361,38 +361,32 @@ export class SimplePoller {
     const items: StateItem[] = []
 
     try {
-      // Resolve configured ready status name
-      let readyStatusName: string | null = null
+      // Build list of status names that represent "ready" tickets.
+      // Include the configured planned column name and common synonyms
+      // that external providers use (e.g. Linear uses "Ready", "Todo").
+      const readyNames = new Set(['ready', 'planned', 'todo'])
       try {
         const config = getWorkflowConfig(this.db)
-        readyStatusName = config.planned
+        readyNames.add(config.planned.toLowerCase())
       } catch {
         // pmo_settings may not exist yet
       }
 
-      const readyTickets = readyStatusName
-        ? this.db.prepare(`
-            SELECT t.id, t.title
-            FROM pmo_tickets t
-            JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-            WHERE LOWER(ws.name) = LOWER(?)
-              AND t.assignee IS NULL
-              AND t.id NOT IN (
-                SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-              )
-            LIMIT 20
-          `).all(readyStatusName) as Array<{ id: string; title: string }>
-        : this.db.prepare(`
-            SELECT t.id, t.title
-            FROM pmo_tickets t
-            JOIN pmo_workflow_statuses ws ON t.status_id = ws.id
-            WHERE ws.category = 'unstarted'
-              AND t.assignee IS NULL
-              AND t.id NOT IN (
-                SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-              )
-            LIMIT 20
-          `).all() as Array<{ id: string; title: string }>
+      const nameList = [...readyNames]
+      const placeholders = nameList.map(() => '?').join(', ')
+
+      // Query ticket_refs (runtime ticket cache) instead of the dropped
+      // pmo_tickets / pmo_workflow_statuses tables (PRLT-1350).
+      const readyTickets = this.db.prepare(`
+        SELECT id, title
+        FROM ticket_refs
+        WHERE LOWER(status) IN (${placeholders})
+          AND (assignee IS NULL OR assignee = '')
+          AND id NOT IN (
+            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
+          )
+        LIMIT 20
+      `).all(...nameList) as Array<{ id: string; title: string }>
 
       for (const ticket of readyTickets) {
         items.push({ category: 'board', summary: `${ticket.id} "${ticket.title}": ready, unassigned` })

--- a/apps/cli/test/e2e/watch-orchestrate-ship.test.ts
+++ b/apps/cli/test/e2e/watch-orchestrate-ship.test.ts
@@ -60,7 +60,7 @@ function createPollerMockDb(options?: {
     _data: data,
     prepare: (sql: string) => ({
       all: (..._args: unknown[]) => {
-        if (sql.includes('pmo_tickets') && (sql.includes('ws.name') || sql.includes('unstarted'))) {
+        if (sql.includes('ticket_refs') && sql.includes('status')) {
           return data.readyTickets
         }
         if (sql.includes('agent_work')) {
@@ -110,22 +110,23 @@ function createEngineDb(): Database.Database {
     // Columns may already exist
   }
 
-  // Create minimal tables for polling
+  // Create minimal tables for polling (PRLT-1350: ticket_refs replaces dropped pmo_tickets)
   db.exec(`
-    CREATE TABLE IF NOT EXISTS pmo_workflow_statuses (
+    CREATE TABLE IF NOT EXISTS ticket_refs (
       id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      category TEXT NOT NULL
-    )
-  `)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS pmo_tickets (
-      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL DEFAULT 'pmo',
+      external_id TEXT,
+      external_key TEXT,
+      external_url TEXT,
       title TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'Backlog',
-      status_id TEXT NOT NULL,
+      description TEXT,
+      status TEXT,
+      priority TEXT,
+      category TEXT,
       assignee TEXT,
-      FOREIGN KEY (status_id) REFERENCES pmo_workflow_statuses(id)
+      project_id TEXT,
+      cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `)
   db.exec(`
@@ -146,12 +147,6 @@ function createEngineDb(): Database.Database {
       is_archived INTEGER NOT NULL DEFAULT 0
     )
   `)
-
-  // Insert statuses
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-backlog', 'Backlog', 'backlog')").run()
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ip', 'In Progress', 'started')").run()
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-review', 'Review', 'started')").run()
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-done', 'Done', 'completed')").run()
 
   return db
 }
@@ -290,7 +285,8 @@ describe('E2E: Watch -> Orchestrate -> Ship (PRLT-1333)', () => {
       const agentItem = pollResult.items.find(i => i.category === 'agents')
       expect(agentItem).to.exist
       expect(agentItem!.summary).to.include('bold-ada')
-      expect(agentItem!.summary).to.include('completed')
+      // PRLT-1348: completed agents report as DONE health state
+      expect(agentItem!.summary).to.include('DONE')
       expect(pollResult.message).to.not.be.null
 
       // -----------------------------------------------------------------------
@@ -472,9 +468,9 @@ describe('E2E: Watch -> Orchestrate -> Ship (PRLT-1333)', () => {
       const result = await poller.poll()
 
       expect(result.items.length).to.be.greaterThan(0)
-      expect(result.message).to.include('cool-turing')
-      expect(result.message).to.include('completed')
+      // PRLT-1348: done agents are summarized as counts, not listed individually
       expect(result.message).to.include('Active agents')
+      expect(result.message).to.include('1 done')
     })
 
     it('should report multiple items across categories in a single poll', async () => {
@@ -821,7 +817,9 @@ describe('E2E: Watch -> Orchestrate -> Ship (PRLT-1333)', () => {
       // Phase 1: Poll reports full state
       const agentPollResult = await poller.poll()
       expect(agentPollResult.message).to.not.be.null
-      expect(agentPollResult.message).to.include('sharp-lovelace')
+      // PRLT-1348: done agents are summarized as counts, not listed individually
+      expect(agentPollResult.message).to.include('Active agents')
+      expect(agentPollResult.message).to.include('1 done')
 
       // Phase 2: CI goes green (simulated state report from GitHub polling)
       const ciGreenMessage = 'GitHub PRs (1 open):\n- #150 (PRLT-999): "feat: implement" \u2014 CI: green, mergeable, no review\n\nReady tickets: none\n\nActive agents: none'

--- a/apps/cli/test/unit/orchestrate-daemon-supervised.test.ts
+++ b/apps/cli/test/unit/orchestrate-daemon-supervised.test.ts
@@ -31,21 +31,23 @@ function createTestDb(): Database.Database {
     // Columns may already exist
   }
 
-  // Create minimal tables for polling
+  // Create minimal tables for polling (PRLT-1350: ticket_refs replaces dropped pmo_tickets)
   db.exec(`
-    CREATE TABLE IF NOT EXISTS pmo_workflow_statuses (
+    CREATE TABLE IF NOT EXISTS ticket_refs (
       id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      category TEXT NOT NULL
-    )
-  `)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS pmo_tickets (
-      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL DEFAULT 'pmo',
+      external_id TEXT,
+      external_key TEXT,
+      external_url TEXT,
       title TEXT NOT NULL,
-      status_id TEXT NOT NULL,
+      description TEXT,
+      status TEXT,
+      priority TEXT,
+      category TEXT,
       assignee TEXT,
-      FOREIGN KEY (status_id) REFERENCES pmo_workflow_statuses(id)
+      project_id TEXT,
+      cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `)
   db.exec(`
@@ -66,10 +68,6 @@ function createTestDb(): Database.Database {
       is_archived INTEGER NOT NULL DEFAULT 0
     )
   `)
-
-  // Insert statuses
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ready', 'Ready', 'unstarted')").run()
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ip', 'In Progress', 'started')").run()
 
   return db
 }
@@ -118,8 +116,8 @@ describe('Orchestrate Daemon — Supervised Mode (PRLT-1223)', () => {
       insertSupervisedHooks(db)
 
       // Add some ready tickets that would normally trigger spawn-agent
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-1', 'Ready ticket 1', 'status-ready', NULL)").run()
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-2', 'Ready ticket 2', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-1', 'Ready ticket 1', 'Ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-2', 'Ready ticket 2', 'Ready', NULL)").run()
 
       const executedActions: OrchestrateActionResult[] = []
       const engine = new OrchestrateEngine({
@@ -155,7 +153,7 @@ describe('Orchestrate Daemon — Supervised Mode (PRLT-1223)', () => {
     it('pending confirmations should accumulate without executing', async () => {
       insertSupervisedHooks(db)
 
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-1', 'Ready', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-1', 'Ready', 'Ready', NULL)").run()
 
       const engine = new OrchestrateEngine({ db, log: () => {} })
 

--- a/apps/cli/test/unit/orchestrate-poller.test.ts
+++ b/apps/cli/test/unit/orchestrate-poller.test.ts
@@ -30,21 +30,23 @@ function createTestDb(): Database.Database {
     // May already exist
   }
 
-  // Create minimal ticket and status tables for polling
+  // Create ticket_refs (runtime ticket cache — PRLT-1350: replaces dropped pmo_tickets)
   db.exec(`
-    CREATE TABLE IF NOT EXISTS pmo_workflow_statuses (
+    CREATE TABLE IF NOT EXISTS ticket_refs (
       id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      category TEXT NOT NULL
-    )
-  `)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS pmo_tickets (
-      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL DEFAULT 'pmo',
+      external_id TEXT,
+      external_key TEXT,
+      external_url TEXT,
       title TEXT NOT NULL,
-      status_id TEXT NOT NULL,
+      description TEXT,
+      status TEXT,
+      priority TEXT,
+      category TEXT,
       assignee TEXT,
-      FOREIGN KEY (status_id) REFERENCES pmo_workflow_statuses(id)
+      project_id TEXT,
+      cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `)
   db.exec(`
@@ -66,13 +68,6 @@ function createTestDb(): Database.Database {
       value TEXT NOT NULL
     )
   `)
-
-  // Insert statuses with proper categories
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ready', 'Ready', 'unstarted')").run()
-  db.prepare("INSERT INTO pmo_workflow_statuses (id, name, category) VALUES ('status-ip', 'In Progress', 'started')").run()
-
-  // Configure the ready status name so the poller can find it
-  db.prepare("INSERT INTO pmo_settings (key, value) VALUES ('column_planned', 'Ready')").run()
 
   return db
 }
@@ -110,7 +105,7 @@ describe('OrchestratePoller', () => {
 
   describe('ticket polling', () => {
     it('should fire on_ticket_ready for unassigned todo tickets', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-1', 'Test ticket', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-1', 'Test ticket', 'Ready', NULL)").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
       await poller.poll()
@@ -121,7 +116,7 @@ describe('OrchestratePoller', () => {
     })
 
     it('should not fire for assigned tickets', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-2', 'Assigned', 'status-ready', 'agent-1')").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-2', 'Assigned', 'Ready', 'agent-1')").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
       await poller.poll()
@@ -131,7 +126,7 @@ describe('OrchestratePoller', () => {
     })
 
     it('should not fire for tickets with active agents', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-3', 'Active', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-3', 'Active', 'Ready', NULL)").run()
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status) VALUES ('aw-1', 'TKT-3', 'agent-1', 'running')").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
@@ -142,7 +137,7 @@ describe('OrchestratePoller', () => {
     })
 
     it('should not fire the same ticket twice (deduplication)', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-4', 'Dedup', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-4', 'Dedup', 'Ready', NULL)").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
       await poller.poll()
@@ -152,14 +147,36 @@ describe('OrchestratePoller', () => {
       expect(readyEvents).to.have.length(1)
     })
 
-    it('should not fire for non-todo tickets', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-5', 'In Progress', 'status-ip', NULL)").run()
+    it('should not fire for non-ready tickets', async () => {
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-5', 'In Progress', 'In Progress', NULL)").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
       await poller.poll()
 
       const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
       expect(readyEvents).to.be.empty
+    })
+
+    it('should match tickets with "Todo" status (PRLT-1350 regression)', async () => {
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-6', 'Todo ticket', 'Todo', NULL)").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.have.length(1)
+      expect(readyEvents[0].ctx.ticket).to.equal('TKT-6')
+    })
+
+    it('should match tickets with "Planned" status (PRLT-1350 regression)', async () => {
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-7', 'Planned ticket', 'Planned', NULL)").run()
+
+      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.have.length(1)
+      expect(readyEvents[0].ctx.ticket).to.equal('TKT-7')
     })
   })
 
@@ -234,7 +251,7 @@ describe('OrchestratePoller', () => {
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
 
-      // First poll: observe initial state
+      // First poll: observe initial state (no events)
       await poller.poll()
       expect(firedEvents.filter(e => e.event === 'on_agent_died')).to.be.empty
 
@@ -314,7 +331,7 @@ describe('OrchestratePoller', () => {
 
   describe('ticket dedup extended', () => {
     it('should fire on_ticket_ready only once across many poll cycles', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-DEDUP', 'Dedup', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-DEDUP', 'Dedup', 'Ready', NULL)").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
 
@@ -328,9 +345,9 @@ describe('OrchestratePoller', () => {
     })
 
     it('should fire on_ticket_ready for multiple distinct tickets', async () => {
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-A', 'Ticket A', 'status-ready', NULL)").run()
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-B', 'Ticket B', 'status-ready', NULL)").run()
-      db.prepare("INSERT INTO pmo_tickets (id, title, status_id, assignee) VALUES ('TKT-C', 'Ticket C', 'status-ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-A', 'Ticket A', 'Ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-B', 'Ticket B', 'Ready', NULL)").run()
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-C', 'Ticket C', 'Ready', NULL)").run()
 
       const poller = new OrchestratePoller({ engine, db, log: () => {} })
       await poller.poll()

--- a/apps/cli/test/unit/simple-poller.test.ts
+++ b/apps/cli/test/unit/simple-poller.test.ts
@@ -39,8 +39,8 @@ function createMockDb(options?: {
     _data: data,
     prepare: (sql: string) => ({
       all: (..._args: unknown[]) => {
-        // Match ready tickets query (by status name or unstarted category)
-        if (sql.includes('pmo_tickets') && (sql.includes('ws.name') || sql.includes('unstarted'))) {
+        // Match ready tickets query against ticket_refs (PRLT-1350)
+        if (sql.includes('ticket_refs') && sql.includes('status')) {
           return data.readyTickets
         }
         if (sql.includes('agent_work')) {
@@ -51,7 +51,7 @@ function createMockDb(options?: {
       get: (..._args: unknown[]) => {
         // Handle pmo_settings lookups for getWorkflowConfig
         if (sql.includes('pmo_settings')) {
-          return undefined // No config -> fallback to category-based query
+          return undefined // No config -> use default ready status names
         }
         return undefined
       },
@@ -207,6 +207,46 @@ describe('SimplePoller', () => {
 
       const result = await poller.poll()
       expect(result.items).to.have.length(0)
+    })
+
+    it('should query ticket_refs table, not dropped pmo_tickets (PRLT-1350 regression)', async () => {
+      // This test verifies the fix: the poller must query ticket_refs,
+      // not the dropped pmo_tickets/pmo_workflow_statuses tables.
+      const queriedTables: string[] = []
+
+      const db = {
+        _data: { readyTickets: [], agents: [] },
+        prepare: (sql: string) => {
+          // Track which tables are queried
+          if (sql.includes('ticket_refs')) queriedTables.push('ticket_refs')
+          if (sql.includes('pmo_tickets')) queriedTables.push('pmo_tickets')
+          if (sql.includes('pmo_workflow_statuses')) queriedTables.push('pmo_workflow_statuses')
+
+          return {
+            all: () => {
+              // Check ticket_refs first — its query also references agent_work in a subquery
+              if (sql.includes('ticket_refs') && sql.includes('status')) return [{ id: 'PRLT-1236', title: 'Ready ticket' }]
+              if (sql.includes('agent_work')) return []
+              return []
+            },
+            get: () => undefined,
+          }
+        },
+        close: () => {},
+      }
+      const poller = createPoller(db as any)
+
+      const result = await poller.poll()
+
+      // Must query ticket_refs, not the dropped tables
+      expect(queriedTables).to.include('ticket_refs')
+      expect(queriedTables).to.not.include('pmo_tickets')
+      expect(queriedTables).to.not.include('pmo_workflow_statuses')
+
+      // The ready ticket should be found
+      const boardItems = result.items.filter(i => i.category === 'board')
+      expect(boardItems).to.have.length(1)
+      expect(boardItems[0].summary).to.include('PRLT-1236')
     })
   })
 

--- a/apps/cli/test/unit/watch-orchestrate-loop.test.ts
+++ b/apps/cli/test/unit/watch-orchestrate-loop.test.ts
@@ -51,7 +51,7 @@ function createMockDb(options?: {
     _data: data,
     prepare: (sql: string) => ({
       all: (..._args: unknown[]) => {
-        if (sql.includes('pmo_tickets') && (sql.includes('ws.name') || sql.includes('unstarted'))) {
+        if (sql.includes('ticket_refs') && sql.includes('status')) {
           return data.readyTickets
         }
         if (sql.includes('agent_work')) {
@@ -88,8 +88,7 @@ function createEngineDb(): Database.Database {
     // Columns may already exist
   }
 
-  db.exec(`CREATE TABLE IF NOT EXISTS pmo_workflow_statuses (id TEXT PRIMARY KEY, name TEXT NOT NULL, category TEXT NOT NULL)`)
-  db.exec(`CREATE TABLE IF NOT EXISTS pmo_tickets (id TEXT PRIMARY KEY, title TEXT NOT NULL, status_id TEXT NOT NULL, assignee TEXT)`)
+  db.exec(`CREATE TABLE IF NOT EXISTS ticket_refs (id TEXT PRIMARY KEY, provider TEXT NOT NULL DEFAULT 'pmo', external_id TEXT, external_key TEXT, external_url TEXT, title TEXT NOT NULL, description TEXT, status TEXT, priority TEXT, category TEXT, assignee TEXT, project_id TEXT, cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)`)
   db.exec(`CREATE TABLE IF NOT EXISTS agent_work (id TEXT PRIMARY KEY, ticket_id TEXT NOT NULL, agent_name TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'starting', lifecycle_state TEXT, container_id TEXT, last_heartbeat TEXT)`)
   db.exec(`CREATE TABLE IF NOT EXISTS pmo_projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, is_archived INTEGER NOT NULL DEFAULT 0)`)
 


### PR DESCRIPTION
## Summary

- **Root cause**: `gatherReadyTicketState()` in SimplePoller and `pollReadyTickets()` in OrchestratePoller queried the dropped `pmo_tickets` and `pmo_workflow_statuses` tables (removed in migration 0024). The queries silently failed in try/catch blocks, causing the daemon to always report "Ready tickets: none".
- **Fix**: Replaced dead-table queries with queries against the `ticket_refs` table (the runtime ticket cache introduced post-PRLT-1299). Status matching uses a set of ready-state names (`Ready`, `Planned`, `Todo`) plus any configured workflow column name.
- Updated all related test mocks and fixtures to use `ticket_refs` instead of dead tables.
- Fixed pre-existing test assertions for PRLT-1348 health state format changes.

## Test plan

- [x] Unit tests pass for SimplePoller (including PRLT-1350 regression test)
- [x] Unit tests pass for OrchestratePoller (including new Todo/Planned status tests)
- [x] Unit tests pass for orchestrate-daemon-supervised
- [x] E2E tests pass for watch-orchestrate-ship integration
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)