### PR TITLE
feat(PRLT-1353): include repo name and linked ticket ID in watch daemon PR summaries

### DIFF
--- a/apps/cli/src/lib/orchestrate/simple-poller.ts
+++ b/apps/cli/src/lib/orchestrate/simple-poller.ts
@@ -166,8 +166,8 @@ export class SimplePoller {
         this.log(`[watch] Polled ${openPRs.length} open PR(s) from ${path.basename(repoDir)}`)
 
         for (const pr of openPRs) {
+          const repoName = path.basename(repoDir)
           const ticketId = this.extractTicketFromBranch(pr.headBranch)
-          const label = `#${pr.number}${ticketId ? ` (${ticketId})` : ''}`
 
           // Get CI status
           let ciState: 'pending' | 'success' | 'failure' | 'unknown' = 'unknown'
@@ -214,20 +214,17 @@ export class SimplePoller {
           }
 
           // Build state summary
-          const parts = [`${label}: "${pr.title}"`]
-          parts.push(`CI: ${ciState}`)
-          if (mergeable === 'CONFLICTING') {
-            parts.push('has merge conflicts')
-          } else if (mergeable === 'MERGEABLE') {
-            parts.push('mergeable')
-          }
-          if (reviewDecision) {
-            parts.push(`review: ${reviewDecision}`)
-          } else {
-            parts.push('no review')
-          }
+          const summary = SimplePoller.formatPRSummary({
+            repoName,
+            prNumber: pr.number,
+            title: pr.title,
+            ticketId,
+            ciState,
+            mergeable,
+            reviewDecision,
+          })
 
-          items.push({ category: 'github', summary: parts.join(' — ') })
+          items.push({ category: 'github', summary })
         }
       } catch (err) {
         this.log(`[watch] GitHub poll error for ${path.basename(repoDir)}: ${err instanceof Error ? err.message : String(err)}`)
@@ -462,5 +459,44 @@ export class SimplePoller {
   private extractTicketFromBranch(branch: string): string | undefined {
     const match = branch.match(/^([A-Z]+-\d+|TKT-\d+)\//)
     return match ? match[1] : undefined
+  }
+
+  /**
+   * Format a single PR's state summary line.
+   *
+   * Format: `repo#number (TICKET-ID): title — ...` when ticket is linked,
+   *         `repo#number: title — no linked ticket — ...` otherwise.
+   *
+   * Exposed as static for testability (PRLT-1353).
+   */
+  static formatPRSummary(options: {
+    repoName: string
+    prNumber: number
+    title: string
+    ticketId?: string
+    ciState: 'pending' | 'success' | 'failure' | 'unknown'
+    mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+    reviewDecision: string | null
+  }): string {
+    const { repoName, prNumber, title, ticketId, ciState, mergeable, reviewDecision } = options
+    const label = ticketId
+      ? `${repoName}#${prNumber} (${ticketId})`
+      : `${repoName}#${prNumber}`
+
+    const parts = [`${label}: ${title}`]
+    if (!ticketId) parts.push('no linked ticket')
+    parts.push(`CI: ${ciState}`)
+    if (mergeable === 'CONFLICTING') {
+      parts.push('has merge conflicts')
+    } else if (mergeable === 'MERGEABLE') {
+      parts.push('mergeable')
+    }
+    if (reviewDecision) {
+      parts.push(`review: ${reviewDecision}`)
+    } else {
+      parts.push('no review')
+    }
+
+    return parts.join(' — ')
   }
 }

--- a/apps/cli/test/unit/simple-poller.test.ts
+++ b/apps/cli/test/unit/simple-poller.test.ts
@@ -508,6 +508,145 @@ describe('SimplePoller', () => {
   })
 
   // ===========================================================================
+  // PR Summary Format (PRLT-1353)
+  // ===========================================================================
+
+  describe('formatPRSummary', () => {
+    it('should include repo name in PR label', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'proletariat',
+        prNumber: 1224,
+        title: 'fix ready ticket query',
+        ticketId: 'PRLT-1350',
+        ciState: 'success',
+        mergeable: 'MERGEABLE',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.include('proletariat#1224')
+    })
+
+    it('should include ticket ID in parentheses when linked', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'proletariat',
+        prNumber: 1224,
+        title: 'fix ready ticket query',
+        ticketId: 'PRLT-1350',
+        ciState: 'success',
+        mergeable: 'MERGEABLE',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.include('proletariat#1224 (PRLT-1350)')
+      expect(summary).to.not.include('no linked ticket')
+    })
+
+    it('should show "no linked ticket" when no ticket ID', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'proletariat-marketing',
+        prNumber: 16,
+        title: 'Add security sandboxing',
+        ciState: 'pending',
+        mergeable: 'UNKNOWN',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.include('proletariat-marketing#16')
+      expect(summary).to.include('no linked ticket')
+      expect(summary).to.not.include('(')
+    })
+
+    it('should format title without quotes', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'my-repo',
+        prNumber: 42,
+        title: 'Add new feature',
+        ticketId: 'TKT-001',
+        ciState: 'unknown',
+        mergeable: 'UNKNOWN',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.include(': Add new feature')
+      expect(summary).to.not.include('"Add new feature"')
+    })
+
+    it('should include CI state', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'repo',
+        prNumber: 1,
+        title: 'test',
+        ticketId: 'TKT-001',
+        ciState: 'failure',
+        mergeable: 'UNKNOWN',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.include('CI: failure')
+    })
+
+    it('should show merge conflicts when CONFLICTING', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'repo',
+        prNumber: 1,
+        title: 'test',
+        ticketId: 'TKT-001',
+        ciState: 'success',
+        mergeable: 'CONFLICTING',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.include('has merge conflicts')
+    })
+
+    it('should show review decision when present', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'repo',
+        prNumber: 1,
+        title: 'test',
+        ticketId: 'TKT-001',
+        ciState: 'success',
+        mergeable: 'MERGEABLE',
+        reviewDecision: 'APPROVED',
+      })
+
+      expect(summary).to.include('review: APPROVED')
+      expect(summary).to.not.include('no review')
+    })
+
+    it('should produce full expected format: repo#N (TICKET): title — CI — mergeable — review', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'proletariat',
+        prNumber: 1224,
+        title: 'fix watch daemon pollers',
+        ticketId: 'PRLT-1350',
+        ciState: 'success',
+        mergeable: 'MERGEABLE',
+        reviewDecision: 'APPROVED',
+      })
+
+      expect(summary).to.equal(
+        'proletariat#1224 (PRLT-1350): fix watch daemon pollers — CI: success — mergeable — review: APPROVED',
+      )
+    })
+
+    it('should produce full expected format for unlinked PR', () => {
+      const summary = SimplePoller.formatPRSummary({
+        repoName: 'proletariat-marketing',
+        prNumber: 16,
+        title: 'Add security sandboxing',
+        ciState: 'pending',
+        mergeable: 'UNKNOWN',
+        reviewDecision: null,
+      })
+
+      expect(summary).to.equal(
+        'proletariat-marketing#16: Add security sandboxing — no linked ticket — CI: pending — no review',
+      )
+    })
+  })
+
+  // ===========================================================================
   // Repo Directory Resolution (PRLT-1313 fix)
   // ===========================================================================
 


### PR DESCRIPTION
## Summary

- Watch daemon poke now includes repo name in PR labels (e.g. `proletariat#1224` instead of `#1224`)
- Shows linked ticket ID in parentheses when available: `proletariat#1224 (PRLT-1350): title`
- Shows "no linked ticket" for PRs without a ticket branch prefix: `proletariat-marketing#16: title — no linked ticket`
- Removes unnecessary quotes around PR titles in the summary

## Changes

- `apps/cli/src/lib/orchestrate/simple-poller.ts`: Extract `formatPRSummary()` static method with new format, update `gatherGitHubPRState()` to use it
- `apps/cli/test/unit/simple-poller.test.ts`: Add 9 unit tests covering repo name inclusion, ticket ID presence/absence, title formatting, CI state, merge conflicts, review decisions, and full end-to-end format assertions

## Test plan

- [x] All 9 new `formatPRSummary` tests pass
- [x] All 40 existing SimplePoller tests still pass
- [x] TypeScript build passes

Fixes: PRLT-1353