### PR TITLE
fix(PRLT-1354): query live provider for ready tickets instead of stale ticket_refs.status

### DIFF
--- a/apps/cli/src/lib/orchestrate/poller.ts
+++ b/apps/cli/src/lib/orchestrate/poller.ts
@@ -17,6 +17,7 @@ import { isGHInstalled, isGHAuthenticated, listOpenPRs, getPRChecks, getPRByNumb
 import type { PRReviewDecision } from '../pr/index.js'
 import { runSyncCycle, type SyncReport } from '../sync/engine.js'
 import { SQLiteStorage } from '../pmo/storage-sqlite.js'
+import { resolveProjectProvider } from '../providers/resolver.js'
 import type { OrchestrateEngine } from './engine.js'
 import { getWorkflowConfig } from '../work-lifecycle/settings.js'
 
@@ -30,6 +31,11 @@ export interface PollerOptions {
   log: (msg: string) => void
   /** Working directory for gh CLI commands */
   cwd?: string
+  /**
+   * Override ready ticket fetching for testing.
+   * When provided, replaces the default live-provider query.
+   */
+  fetchReadyTickets?: (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>>
 }
 
 interface TrackedPR {
@@ -48,6 +54,7 @@ export class OrchestratePoller {
   private db: Database.Database
   private log: (msg: string) => void
   private cwd?: string
+  private fetchReadyTicketsFn?: (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>>
 
   /** Tracks known PR state to detect transitions. */
   private trackedPRs = new Map<number, TrackedPR>()
@@ -68,6 +75,7 @@ export class OrchestratePoller {
     this.db = options.db
     this.log = options.log
     this.cwd = options.cwd
+    this.fetchReadyTicketsFn = options.fetchReadyTickets
   }
 
   /**
@@ -88,14 +96,12 @@ export class OrchestratePoller {
    * Check for tickets in the configured "ready" status with no active agent.
    * Fires on_ticket_ready for each.
    *
-   * Uses the configured ready/planned column name from pmo_settings.
-   * Falls back to category-based matching if no config is available.
+   * Queries the live ticket provider (Linear, Jira, etc.) for accurate status
+   * instead of the stale ticket_refs cache (PRLT-1354).
    */
   private async pollReadyTickets(): Promise<void> {
     try {
       // Build list of status names that represent "ready" tickets.
-      // Include the configured planned column name and common synonyms
-      // that external providers use (e.g. Linear uses "Ready", "Todo").
       const readyNames = new Set(['ready', 'planned', 'todo'])
       try {
         const config = getWorkflowConfig(this.db)
@@ -104,23 +110,21 @@ export class OrchestratePoller {
         // pmo_settings may not exist yet
       }
 
-      const nameList = [...readyNames]
-      const placeholders = nameList.map(() => '?').join(', ')
+      // Get active agent ticket IDs to exclude
+      const activeAgentTickets = new Set(
+        (this.db.prepare(
+          `SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')`,
+        ).all() as Array<{ ticket_id: string }>).map(r => r.ticket_id),
+      )
 
-      // Query ticket_refs (runtime ticket cache) instead of the dropped
-      // pmo_tickets / pmo_workflow_statuses tables (PRLT-1350).
-      const readyTickets = this.db.prepare(`
-        SELECT id, title
-        FROM ticket_refs
-        WHERE LOWER(status) IN (${placeholders})
-          AND (assignee IS NULL OR assignee = '')
-          AND id NOT IN (
-            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-          )
-        LIMIT 10
-      `).all(...nameList) as Array<{ id: string; title: string }>
+      // Fetch ready tickets from the live provider (PRLT-1354).
+      // ticket_refs.status is empty — the provider has the truth.
+      const readyTickets = this.fetchReadyTicketsFn
+        ? await this.fetchReadyTicketsFn(readyNames)
+        : await this.fetchReadyTicketsFromProvider(readyNames)
 
       for (const ticket of readyTickets) {
+        if (activeAgentTickets.has(ticket.id)) continue
         if (this.firedReadyTickets.has(ticket.id)) continue
         this.firedReadyTickets.add(ticket.id)
 
@@ -133,6 +137,43 @@ export class OrchestratePoller {
     } catch {
       // Non-fatal polling error
     }
+  }
+
+  /**
+   * Default implementation: query live provider for ready, unassigned tickets.
+   */
+  private async fetchReadyTicketsFromProvider(
+    readyNames: Set<string>,
+  ): Promise<Array<{ id: string; title: string }>> {
+    const dbPath = this.getDbPath()
+    if (!dbPath) return []
+
+    const storage = new SQLiteStorage(dbPath)
+
+    const projects = this.db.prepare(
+      `SELECT id FROM pmo_projects WHERE is_archived = 0 LIMIT 20`,
+    ).all() as Array<{ id: string }>
+
+    const tickets: Array<{ id: string; title: string }> = []
+
+    for (const project of projects) {
+      try {
+        const provider = resolveProjectProvider(this.db, storage, project.id)
+        const result = await provider.listTickets(project.id)
+        if (!result.success) continue
+
+        for (const ticket of result.tickets) {
+          const statusLower = (ticket.statusName || '').toLowerCase()
+          if (readyNames.has(statusLower) && !ticket.assignee) {
+            tickets.push({ id: ticket.id, title: ticket.title })
+          }
+        }
+      } catch {
+        // Non-fatal: skip project on error
+      }
+    }
+
+    return tickets
   }
 
   // ===========================================================================

--- a/apps/cli/src/lib/orchestrate/simple-poller.ts
+++ b/apps/cli/src/lib/orchestrate/simple-poller.ts
@@ -29,6 +29,8 @@ import {
   captureTmuxPane,
 } from '../execution/session-utils.js'
 import { getWorkflowConfig } from '../work-lifecycle/settings.js'
+import { SQLiteStorage } from '../pmo/storage-sqlite.js'
+import { resolveProjectProvider } from '../providers/resolver.js'
 
 // =============================================================================
 // Types
@@ -39,6 +41,11 @@ export interface SimplePollerOptions {
   log: (msg: string) => void
   /** Working directory for gh CLI commands */
   cwd?: string
+  /**
+   * Override ready ticket fetching for testing.
+   * When provided, replaces the default live-provider query.
+   */
+  fetchReadyTickets?: (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>>
 }
 
 /** A single item in the state report. */
@@ -66,6 +73,7 @@ export class SimplePoller {
   private db: Database.Database
   private log: (msg: string) => void
   private cwd?: string
+  private fetchReadyTicketsFn?: (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>>
 
   /** Git repo directories to poll for PRs. Resolved from cwd on construction. */
   private repoDirs: string[]
@@ -77,6 +85,7 @@ export class SimplePoller {
     this.db = options.db
     this.log = options.log
     this.cwd = options.cwd
+    this.fetchReadyTicketsFn = options.fetchReadyTickets
     this.repoDirs = SimplePoller.resolveRepoDirs(options.cwd, options.log)
   }
 
@@ -141,7 +150,7 @@ export class SimplePoller {
 
     items.push(...this.gatherGitHubPRState())
     items.push(...this.gatherAgentState())
-    items.push(...this.gatherReadyTicketState())
+    items.push(...await this.gatherReadyTicketState())
 
     const message = this.formatStateMessage(items)
     return { items, message }
@@ -357,13 +366,16 @@ export class SimplePoller {
   // Board / Ready Ticket State
   // ===========================================================================
 
-  private gatherReadyTicketState(): StateItem[] {
+  /**
+   * Gather ready ticket state from the live provider (PRLT-1354).
+   * Queries the configured ticket provider (Linear, Jira, etc.) for accurate
+   * status instead of the stale ticket_refs cache.
+   */
+  private async gatherReadyTicketState(): Promise<StateItem[]> {
     const items: StateItem[] = []
 
     try {
       // Build list of status names that represent "ready" tickets.
-      // Include the configured planned column name and common synonyms
-      // that external providers use (e.g. Linear uses "Ready", "Todo").
       const readyNames = new Set(['ready', 'planned', 'todo'])
       try {
         const config = getWorkflowConfig(this.db)
@@ -372,30 +384,79 @@ export class SimplePoller {
         // pmo_settings may not exist yet
       }
 
-      const nameList = [...readyNames]
-      const placeholders = nameList.map(() => '?').join(', ')
+      // Get active agent ticket IDs to exclude
+      let activeAgentTickets = new Set<string>()
+      try {
+        activeAgentTickets = new Set(
+          (this.db.prepare(
+            `SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')`,
+          ).all() as Array<{ ticket_id: string }>).map(r => r.ticket_id),
+        )
+      } catch {
+        // agent_work table may not exist
+      }
 
-      // Query ticket_refs (runtime ticket cache) instead of the dropped
-      // pmo_tickets / pmo_workflow_statuses tables (PRLT-1350).
-      const readyTickets = this.db.prepare(`
-        SELECT id, title
-        FROM ticket_refs
-        WHERE LOWER(status) IN (${placeholders})
-          AND (assignee IS NULL OR assignee = '')
-          AND id NOT IN (
-            SELECT ticket_id FROM agent_work WHERE status IN ('starting', 'running')
-          )
-        LIMIT 20
-      `).all(...nameList) as Array<{ id: string; title: string }>
+      // Fetch ready tickets from the live provider (PRLT-1354).
+      const readyTickets = this.fetchReadyTicketsFn
+        ? await this.fetchReadyTicketsFn(readyNames)
+        : await this.fetchReadyTicketsFromProvider(readyNames)
 
       for (const ticket of readyTickets) {
+        if (activeAgentTickets.has(ticket.id)) continue
         items.push({ category: 'board', summary: `${ticket.id} "${ticket.title}": ready, unassigned` })
       }
     } catch {
-      // Non-fatal DB error (table may not exist)
+      // Non-fatal error
     }
 
     return items
+  }
+
+  /**
+   * Default implementation: query live provider for ready, unassigned tickets.
+   */
+  private async fetchReadyTicketsFromProvider(
+    readyNames: Set<string>,
+  ): Promise<Array<{ id: string; title: string }>> {
+    if (!this.cwd) return []
+
+    const dbPath = path.join(this.cwd, '.proletariat', 'workspace.db')
+    let storage: InstanceType<typeof SQLiteStorage>
+    try {
+      storage = new SQLiteStorage(dbPath)
+    } catch {
+      return []
+    }
+
+    let projects: Array<{ id: string }> = []
+    try {
+      projects = this.db.prepare(
+        `SELECT id FROM pmo_projects WHERE is_archived = 0 LIMIT 20`,
+      ).all() as Array<{ id: string }>
+    } catch {
+      return []
+    }
+
+    const tickets: Array<{ id: string; title: string }> = []
+
+    for (const project of projects) {
+      try {
+        const provider = resolveProjectProvider(this.db, storage, project.id)
+        const result = await provider.listTickets(project.id)
+        if (!result.success) continue
+
+        for (const ticket of result.tickets) {
+          const statusLower = (ticket.statusName || '').toLowerCase()
+          if (readyNames.has(statusLower) && !ticket.assignee) {
+            tickets.push({ id: ticket.id, title: ticket.title })
+          }
+        }
+      } catch {
+        // Non-fatal: skip project on error
+      }
+    }
+
+    return tickets
   }
 
   // ===========================================================================

--- a/apps/cli/test/unit/orchestrate-poller.test.ts
+++ b/apps/cli/test/unit/orchestrate-poller.test.ts
@@ -9,7 +9,7 @@ import type { OrchestrateEventContext } from '../../src/lib/orchestrate/types.js
  * Unit tests for OrchestratePoller.
  *
  * Tests cover:
- * - Ticket polling (on_ticket_ready)
+ * - Ticket polling (on_ticket_ready) via live provider
  * - Agent lifecycle polling (on_agent_died, on_agent_completed, on_agent_idle)
  * - Deduplication (same ticket not fired twice)
  * - Graceful error handling
@@ -30,7 +30,7 @@ function createTestDb(): Database.Database {
     // May already exist
   }
 
-  // Create ticket_refs (runtime ticket cache — PRLT-1350: replaces dropped pmo_tickets)
+  // Create ticket_refs (kept for other uses — ready ticket polling now uses provider)
   db.exec(`
     CREATE TABLE IF NOT EXISTS ticket_refs (
       id TEXT PRIMARY KEY,
@@ -72,6 +72,29 @@ function createTestDb(): Database.Database {
   return db
 }
 
+/**
+ * Create a fetchReadyTickets function that returns the given tickets.
+ * Simulates the live provider returning ready, unassigned tickets.
+ */
+function mockFetchReadyTickets(
+  tickets: Array<{ id: string; title: string }>,
+): (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>> {
+  return async (_readyNames: Set<string>) => tickets
+}
+
+/**
+ * Create a fetchReadyTickets function that filters tickets by readyNames.
+ * Simulates provider returning tickets with a statusName field.
+ */
+function mockFetchReadyTicketsWithStatus(
+  tickets: Array<{ id: string; title: string; statusName: string }>,
+): (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>> {
+  return async (readyNames: Set<string>) =>
+    tickets
+      .filter(t => readyNames.has(t.statusName.toLowerCase()))
+      .map(({ id, title }) => ({ id, title }))
+}
+
 describe('OrchestratePoller', () => {
   let db: Database.Database
   let engine: OrchestrateEngine
@@ -100,14 +123,19 @@ describe('OrchestratePoller', () => {
   })
 
   // ===========================================================================
-  // Ticket Polling
+  // Ticket Polling (via live provider — PRLT-1354)
   // ===========================================================================
 
   describe('ticket polling', () => {
-    it('should fire on_ticket_ready for unassigned todo tickets', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-1', 'Test ticket', 'Ready', NULL)").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+    it('should fire on_ticket_ready for unassigned ready tickets from provider', async () => {
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([
+          { id: 'TKT-1', title: 'Test ticket' },
+        ]),
+      })
       await poller.poll()
 
       const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
@@ -115,21 +143,17 @@ describe('OrchestratePoller', () => {
       expect(readyEvents[0].ctx.ticket).to.equal('TKT-1')
     })
 
-    it('should not fire for assigned tickets', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-2', 'Assigned', 'Ready', 'agent-1')").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
-      await poller.poll()
-
-      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
-      expect(readyEvents).to.be.empty
-    })
-
     it('should not fire for tickets with active agents', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-3', 'Active', 'Ready', NULL)").run()
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status) VALUES ('aw-1', 'TKT-3', 'agent-1', 'running')").run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([
+          { id: 'TKT-3', title: 'Active agent ticket' },
+        ]),
+      })
       await poller.poll()
 
       const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
@@ -137,9 +161,14 @@ describe('OrchestratePoller', () => {
     })
 
     it('should not fire the same ticket twice (deduplication)', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-4', 'Dedup', 'Ready', NULL)").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([
+          { id: 'TKT-4', title: 'Dedup' },
+        ]),
+      })
       await poller.poll()
       await poller.poll()
 
@@ -147,36 +176,58 @@ describe('OrchestratePoller', () => {
       expect(readyEvents).to.have.length(1)
     })
 
-    it('should not fire for non-ready tickets', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-5', 'In Progress', 'In Progress', NULL)").run()
+    it('should respect readyNames filtering via provider (PRLT-1354)', async () => {
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTicketsWithStatus([
+          { id: 'TKT-5', title: 'In Progress', statusName: 'In Progress' },
+          { id: 'TKT-6', title: 'Todo ticket', statusName: 'Todo' },
+          { id: 'TKT-7', title: 'Ready ticket', statusName: 'Ready' },
+        ]),
+      })
+      await poller.poll()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.have.length(2)
+      const ticketIds = readyEvents.map(e => e.ctx.ticket)
+      expect(ticketIds).to.include('TKT-6')
+      expect(ticketIds).to.include('TKT-7')
+    })
+
+    it('should match tickets with "Planned" status via provider', async () => {
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTicketsWithStatus([
+          { id: 'TKT-8', title: 'Planned ticket', statusName: 'Planned' },
+        ]),
+      })
+      await poller.poll()
+
+      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
+      expect(readyEvents).to.have.length(1)
+      expect(readyEvents[0].ctx.ticket).to.equal('TKT-8')
+    })
+
+    it('should not fire when provider returns empty results (PRLT-1354 regression)', async () => {
+      // This is the key regression test: even if ticket_refs has rows with
+      // empty status, the poller must query the live provider — which may
+      // return nothing if no tickets are truly ready.
+      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-STALE', 'Stale ref', '', NULL)").run()
+
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
       await poller.poll()
 
       const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
       expect(readyEvents).to.be.empty
-    })
-
-    it('should match tickets with "Todo" status (PRLT-1350 regression)', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-6', 'Todo ticket', 'Todo', NULL)").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
-      await poller.poll()
-
-      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
-      expect(readyEvents).to.have.length(1)
-      expect(readyEvents[0].ctx.ticket).to.equal('TKT-6')
-    })
-
-    it('should match tickets with "Planned" status (PRLT-1350 regression)', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-7', 'Planned ticket', 'Planned', NULL)").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
-      await poller.poll()
-
-      const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
-      expect(readyEvents).to.have.length(1)
-      expect(readyEvents[0].ctx.ticket).to.equal('TKT-7')
     })
   })
 
@@ -188,7 +239,10 @@ describe('OrchestratePoller', () => {
     it('should fire on_agent_died when lifecycle_state transitions to died', async () => {
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-1', 'TKT-1', 'agent-1', 'running', 'healthy')").run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
       // First poll: observe initial state
       await poller.poll()
       expect(firedEvents.filter(e => e.event === 'on_agent_died')).to.be.empty
@@ -205,7 +259,10 @@ describe('OrchestratePoller', () => {
     it('should fire on_agent_completed when lifecycle_state transitions to completed', async () => {
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-2', 'TKT-2', 'agent-2', 'running', 'healthy')").run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
       await poller.poll() // observe initial
 
       db.prepare("UPDATE agent_work SET lifecycle_state = 'completed' WHERE id = 'aw-2'").run()
@@ -219,7 +276,10 @@ describe('OrchestratePoller', () => {
     it('should not fire on first observation (no transition)', async () => {
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-3', 'TKT-3', 'agent-3', 'error', 'died')").run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
       await poller.poll()
 
       // Should not fire because this is the first observation, not a transition
@@ -233,7 +293,10 @@ describe('OrchestratePoller', () => {
 
   describe('PRLT-1222: conflict resolution deduplication', () => {
     it('should expose activeConflictResolutions set for tracking', () => {
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
       // The poller should have the activeConflictResolutions tracking
       // This is a structural test — the set is private, so we verify
       // the poller can be created without errors
@@ -249,7 +312,10 @@ describe('OrchestratePoller', () => {
     it('should not fire same event twice for same agent state', async () => {
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-d1', 'TKT-D1', 'agent-d1', 'running', 'healthy')").run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
 
       // First poll: observe initial state
       await poller.poll()
@@ -275,7 +341,10 @@ describe('OrchestratePoller', () => {
         VALUES ('aw-idle', 'TKT-IDLE', 'idle-agent', 'running', 'healthy', datetime('now'))
       `).run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
 
       // First poll: observe initial state (records prevState as 'healthy')
       await poller.poll()
@@ -295,7 +364,10 @@ describe('OrchestratePoller', () => {
     it('should fire events only on state transitions, not on every poll', async () => {
       db.prepare("INSERT INTO agent_work (id, ticket_id, agent_name, status, lifecycle_state) VALUES ('aw-t1', 'TKT-T1', 'agent-t1', 'running', 'healthy')").run()
 
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
 
       // First poll: observe initial state (no events)
       await poller.poll()
@@ -331,9 +403,12 @@ describe('OrchestratePoller', () => {
 
   describe('ticket dedup extended', () => {
     it('should fire on_ticket_ready only once across many poll cycles', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-DEDUP', 'Dedup', 'Ready', NULL)").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([
+          { id: 'TKT-DEDUP', title: 'Dedup' },
+        ]),
+      })
 
       // Poll 5 times
       for (let i = 0; i < 5; i++) {
@@ -345,11 +420,14 @@ describe('OrchestratePoller', () => {
     })
 
     it('should fire on_ticket_ready for multiple distinct tickets', async () => {
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-A', 'Ticket A', 'Ready', NULL)").run()
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-B', 'Ticket B', 'Ready', NULL)").run()
-      db.prepare("INSERT INTO ticket_refs (id, title, status, assignee) VALUES ('TKT-C', 'Ticket C', 'Ready', NULL)").run()
-
-      const poller = new OrchestratePoller({ engine, db, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine, db, log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([
+          { id: 'TKT-A', title: 'Ticket A' },
+          { id: 'TKT-B', title: 'Ticket B' },
+          { id: 'TKT-C', title: 'Ticket C' },
+        ]),
+      })
       await poller.poll()
 
       const readyEvents = firedEvents.filter(e => e.event === 'on_ticket_ready')
@@ -371,11 +449,29 @@ describe('OrchestratePoller', () => {
       const badDb = new Database(':memory:')
       // Don't create tables — queries will fail
       const badEngine = new OrchestrateEngine({ db: badDb, log: () => {} })
-      const poller = new OrchestratePoller({ engine: badEngine, db: badDb, log: () => {} })
+      const poller = new OrchestratePoller({
+        engine: badEngine,
+        db: badDb,
+        log: () => {},
+        fetchReadyTickets: mockFetchReadyTickets([]),
+      })
 
       // Should not throw
       await poller.poll()
       badDb.close()
+    })
+
+    it('should handle fetchReadyTickets throwing gracefully', async () => {
+      const poller = new OrchestratePoller({
+        engine,
+        db,
+        log: () => {},
+        fetchReadyTickets: async () => { throw new Error('provider unavailable') },
+      })
+
+      // Should not throw — error is caught by the outer try/catch
+      await poller.poll()
+      expect(firedEvents.filter(e => e.event === 'on_ticket_ready')).to.be.empty
     })
   })
 })

--- a/apps/cli/test/unit/simple-poller.test.ts
+++ b/apps/cli/test/unit/simple-poller.test.ts
@@ -10,11 +10,10 @@ import { SimplePoller } from '../../src/lib/orchestrate/simple-poller.js'
 // =============================================================================
 
 /**
- * Create a mock DB where the prepare().all() results can be configured
- * to return specific state for each poll cycle.
+ * Create a mock DB for agent state queries.
+ * Ready tickets now come from the injected fetchReadyTickets, not from DB.
  */
 function createMockDb(options?: {
-  readyTickets?: Array<{ id: string; title: string }>
   agents?: Array<{
     id: string
     ticket_id: string
@@ -25,23 +24,24 @@ function createMockDb(options?: {
     session_id?: string | null
     environment?: string | null
   }>
+  activeAgentTicketIds?: string[]
 }) {
   const data = {
-    readyTickets: options?.readyTickets ?? [],
     agents: (options?.agents ?? []).map(a => ({
       ...a,
       session_id: a.session_id ?? null,
       environment: a.environment ?? 'host',
     })),
+    activeAgentTicketIds: options?.activeAgentTicketIds ?? [],
   }
 
   return {
     _data: data,
     prepare: (sql: string) => ({
       all: (..._args: unknown[]) => {
-        // Match ready tickets query against ticket_refs (PRLT-1350)
-        if (sql.includes('ticket_refs') && sql.includes('status')) {
-          return data.readyTickets
+        // Active agent ticket_ids query (for ready ticket exclusion)
+        if (sql.includes('agent_work') && sql.includes('ticket_id') && !sql.includes('agent_name')) {
+          return data.activeAgentTicketIds.map(id => ({ ticket_id: id }))
         }
         if (sql.includes('agent_work')) {
           return data.agents
@@ -61,14 +61,40 @@ function createMockDb(options?: {
 }
 
 /**
+ * Create a fetchReadyTickets mock that returns the given tickets.
+ */
+function mockFetchReadyTickets(
+  tickets: Array<{ id: string; title: string }>,
+): (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>> {
+  return async (_readyNames: Set<string>) => tickets
+}
+
+/**
+ * Create a fetchReadyTickets mock that filters by readyNames.
+ */
+function mockFetchReadyTicketsWithStatus(
+  tickets: Array<{ id: string; title: string; statusName: string }>,
+): (readyNames: Set<string>) => Promise<Array<{ id: string; title: string }>> {
+  return async (readyNames: Set<string>) =>
+    tickets
+      .filter(t => readyNames.has(t.statusName.toLowerCase()))
+      .map(({ id, title }) => ({ id, title }))
+}
+
+/**
  * Create a SimplePoller with GitHub CLI disabled (no external calls).
  * This lets us test DB-driven polling (agents + board) in isolation.
  */
-function createPoller(db: ReturnType<typeof createMockDb>, log?: (msg: string) => void) {
+function createPoller(
+  db: ReturnType<typeof createMockDb>,
+  readyTickets?: Array<{ id: string; title: string }>,
+  log?: (msg: string) => void,
+) {
   return new SimplePoller({
     db: db as any,
     log: log ?? (() => {}),
     cwd: '/nonexistent-test-dir',
+    fetchReadyTickets: mockFetchReadyTickets(readyTickets ?? []),
   })
 }
 
@@ -113,12 +139,11 @@ describe('SimplePoller', () => {
   describe('stateless state reporting', () => {
     it('should return full state on every poll — no baseline, no diffing', async () => {
       const db = createMockDb({
-        readyTickets: [{ id: 'TKT-001', title: 'Test ticket' }],
         agents: [
           { id: 'exec-1', ticket_id: 'TKT-001', agent_name: 'bold-ada', status: 'running', lifecycle_state: null, container_id: null },
         ],
       })
-      const poller = createPoller(db)
+      const poller = createPoller(db, [{ id: 'TKT-001', title: 'Test ticket' }])
 
       // First poll returns full state (not empty like the old baseline behavior)
       const r1 = await poller.poll()
@@ -146,35 +171,40 @@ describe('SimplePoller', () => {
     })
 
     it('should reflect state changes immediately without needing a prior baseline', async () => {
-      const db = createMockDb({ readyTickets: [] })
-      const poller = createPoller(db)
+      let currentTickets: Array<{ id: string; title: string }> = []
+      const db = createMockDb()
+      const poller = new SimplePoller({
+        db: db as any,
+        log: () => {},
+        cwd: '/nonexistent-test-dir',
+        fetchReadyTickets: async () => currentTickets,
+      })
 
       // First poll: nothing
       const r1 = await poller.poll()
-      expect(r1.items).to.have.length(0)
+      expect(r1.items.filter(i => i.category === 'board')).to.have.length(0)
 
       // Ticket appears — immediately reported, no baseline needed
-      db._data.readyTickets = [{ id: 'TKT-010', title: 'New feature' }]
+      currentTickets = [{ id: 'TKT-010', title: 'New feature' }]
       const r2 = await poller.poll()
-      expect(r2.items).to.have.length(1)
-      expect(r2.items[0].summary).to.include('TKT-010')
-      expect(r2.items[0].summary).to.include('New feature')
+      const boardItems = r2.items.filter(i => i.category === 'board')
+      expect(boardItems).to.have.length(1)
+      expect(boardItems[0].summary).to.include('TKT-010')
+      expect(boardItems[0].summary).to.include('New feature')
     })
   })
 
   // ===========================================================================
-  // Ready Ticket State
+  // Ready Ticket State (PRLT-1354: via live provider)
   // ===========================================================================
 
   describe('ready ticket state', () => {
-    it('should report all ready tickets', async () => {
-      const db = createMockDb({
-        readyTickets: [
-          { id: 'TKT-011', title: 'Feature A' },
-          { id: 'TKT-012', title: 'Feature B' },
-        ],
-      })
-      const poller = createPoller(db)
+    it('should report all ready tickets from provider', async () => {
+      const db = createMockDb()
+      const poller = createPoller(db, [
+        { id: 'TKT-011', title: 'Feature A' },
+        { id: 'TKT-012', title: 'Feature B' },
+      ])
 
       const result = await poller.poll()
 
@@ -187,9 +217,9 @@ describe('SimplePoller', () => {
       expect(boardItems[1].summary).to.include('TKT-012')
     })
 
-    it('should report no board items when no tickets are ready', async () => {
-      const db = createMockDb({ readyTickets: [] })
-      const poller = createPoller(db)
+    it('should report no board items when provider returns no ready tickets', async () => {
+      const db = createMockDb()
+      const poller = createPoller(db, [])
 
       const result = await poller.poll()
 
@@ -197,53 +227,63 @@ describe('SimplePoller', () => {
       expect(boardItems).to.have.length(0)
     })
 
-    it('should handle DB errors gracefully without throwing', async () => {
-      const db = {
-        _data: { readyTickets: [], agents: [] },
-        prepare: () => { throw new Error('table does not exist') },
-        close: () => {},
-      }
-      const poller = createPoller(db as any)
+    it('should handle fetchReadyTickets errors gracefully without throwing', async () => {
+      const db = createMockDb()
+      const poller = new SimplePoller({
+        db: db as any,
+        log: () => {},
+        cwd: '/nonexistent-test-dir',
+        fetchReadyTickets: async () => { throw new Error('provider unavailable') },
+      })
 
       const result = await poller.poll()
-      expect(result.items).to.have.length(0)
+      expect(result.items.filter(i => i.category === 'board')).to.have.length(0)
     })
 
-    it('should query ticket_refs table, not dropped pmo_tickets (PRLT-1350 regression)', async () => {
-      // This test verifies the fix: the poller must query ticket_refs,
-      // not the dropped pmo_tickets/pmo_workflow_statuses tables.
-      const queriedTables: string[] = []
-
-      const db = {
-        _data: { readyTickets: [], agents: [] },
-        prepare: (sql: string) => {
-          // Track which tables are queried
-          if (sql.includes('ticket_refs')) queriedTables.push('ticket_refs')
-          if (sql.includes('pmo_tickets')) queriedTables.push('pmo_tickets')
-          if (sql.includes('pmo_workflow_statuses')) queriedTables.push('pmo_workflow_statuses')
-
-          return {
-            all: () => {
-              // Check ticket_refs first — its query also references agent_work in a subquery
-              if (sql.includes('ticket_refs') && sql.includes('status')) return [{ id: 'PRLT-1236', title: 'Ready ticket' }]
-              if (sql.includes('agent_work')) return []
-              return []
-            },
-            get: () => undefined,
-          }
-        },
-        close: () => {},
-      }
-      const poller = createPoller(db as any)
+    it('should exclude tickets with active agents', async () => {
+      const db = createMockDb({
+        activeAgentTicketIds: ['TKT-ACTIVE'],
+      })
+      const poller = new SimplePoller({
+        db: db as any,
+        log: () => {},
+        cwd: '/nonexistent-test-dir',
+        fetchReadyTickets: mockFetchReadyTickets([
+          { id: 'TKT-ACTIVE', title: 'Has running agent' },
+          { id: 'TKT-FREE', title: 'No agent' },
+        ]),
+      })
 
       const result = await poller.poll()
 
-      // Must query ticket_refs, not the dropped tables
-      expect(queriedTables).to.include('ticket_refs')
-      expect(queriedTables).to.not.include('pmo_tickets')
-      expect(queriedTables).to.not.include('pmo_workflow_statuses')
+      const boardItems = result.items.filter(i => i.category === 'board')
+      expect(boardItems).to.have.length(1)
+      expect(boardItems[0].summary).to.include('TKT-FREE')
+    })
 
-      // The ready ticket should be found
+    it('should use live provider, not stale ticket_refs.status (PRLT-1354 regression)', async () => {
+      // The key regression test: ticket_refs.status is empty for all rows.
+      // The poller must use the live provider, not the stale local cache.
+      // Verify by ensuring the fetchReadyTickets function is called instead
+      // of any ticket_refs SQL query.
+      let providerCalled = false
+      const db = createMockDb()
+      const poller = new SimplePoller({
+        db: db as any,
+        log: () => {},
+        cwd: '/nonexistent-test-dir',
+        fetchReadyTickets: async (readyNames: Set<string>) => {
+          providerCalled = true
+          expect(readyNames).to.include('ready')
+          expect(readyNames).to.include('todo')
+          expect(readyNames).to.include('planned')
+          return [{ id: 'PRLT-1236', title: 'Ready ticket from provider' }]
+        },
+      })
+
+      const result = await poller.poll()
+
+      expect(providerCalled).to.be.true
       const boardItems = result.items.filter(i => i.category === 'board')
       expect(boardItems).to.have.length(1)
       expect(boardItems[0].summary).to.include('PRLT-1236')
@@ -378,12 +418,11 @@ describe('SimplePoller', () => {
 
     it('should format message with section headers', async () => {
       const db = createMockDb({
-        readyTickets: [{ id: 'TKT-060', title: 'New ready ticket' }],
         agents: [
           { id: 'exec-m1', ticket_id: 'TKT-050', agent_name: 'multi-agent', status: 'completed', lifecycle_state: 'completed', container_id: null },
         ],
       })
-      const poller = createPoller(db)
+      const poller = createPoller(db, [{ id: 'TKT-060', title: 'New ready ticket' }])
 
       const result = await poller.poll()
 
@@ -394,13 +433,11 @@ describe('SimplePoller', () => {
     })
 
     it('should include counts in section headers', async () => {
-      const db = createMockDb({
-        readyTickets: [
-          { id: 'TKT-070', title: 'First' },
-          { id: 'TKT-071', title: 'Second' },
-        ],
-      })
-      const poller = createPoller(db)
+      const db = createMockDb()
+      const poller = createPoller(db, [
+        { id: 'TKT-070', title: 'First' },
+        { id: 'TKT-071', title: 'Second' },
+      ])
 
       const result = await poller.poll()
 
@@ -408,10 +445,8 @@ describe('SimplePoller', () => {
     })
 
     it('should show "none" sections when category is empty', async () => {
-      const db = createMockDb({
-        readyTickets: [{ id: 'TKT-001', title: 'Solo' }],
-      })
-      const poller = createPoller(db)
+      const db = createMockDb()
+      const poller = createPoller(db, [{ id: 'TKT-001', title: 'Solo' }])
 
       const result = await poller.poll()
 
@@ -421,13 +456,11 @@ describe('SimplePoller', () => {
     })
 
     it('should list ticket items as bullet points', async () => {
-      const db = createMockDb({
-        readyTickets: [
-          { id: 'TKT-070', title: 'First' },
-          { id: 'TKT-071', title: 'Second' },
-        ],
-      })
-      const poller = createPoller(db)
+      const db = createMockDb()
+      const poller = createPoller(db, [
+        { id: 'TKT-070', title: 'First' },
+        { id: 'TKT-071', title: 'Second' },
+      ])
 
       const result = await poller.poll()
 
@@ -470,12 +503,11 @@ describe('SimplePoller', () => {
   describe('combined state across categories', () => {
     it('should report agents and tickets together', async () => {
       const db = createMockDb({
-        readyTickets: [{ id: 'TKT-080', title: 'Feature X' }],
         agents: [
           { id: 'exec-1', ticket_id: 'TKT-090', agent_name: 'lifecycle-agent', status: 'starting', lifecycle_state: null, container_id: null },
         ],
       })
-      const poller = createPoller(db)
+      const poller = createPoller(db, [{ id: 'TKT-080', title: 'Feature X' }])
 
       const result = await poller.poll()
 

--- a/apps/cli/test/unit/watch-orchestrate-loop.test.ts
+++ b/apps/cli/test/unit/watch-orchestrate-loop.test.ts
@@ -51,8 +51,8 @@ function createMockDb(options?: {
     _data: data,
     prepare: (sql: string) => ({
       all: (..._args: unknown[]) => {
-        if (sql.includes('ticket_refs') && sql.includes('status')) {
-          return data.readyTickets
+        if (sql.includes('agent_work') && sql.includes('ticket_id') && !sql.includes('agent_name')) {
+          return [] // No active agent exclusions
         }
         if (sql.includes('agent_work')) {
           return data.agents
@@ -70,6 +70,7 @@ function createTestPoller(db: ReturnType<typeof createMockDb>) {
     db: db as any,
     log: () => {},
     cwd: '/nonexistent-test-dir',
+    fetchReadyTickets: async () => db._data.readyTickets,
   })
 }
 


### PR DESCRIPTION
## Summary

- Watch daemon pollers (`OrchestratePoller` and `SimplePoller`) now query the live ticket provider (Linear, Jira, etc.) instead of the stale `ticket_refs.status` column
- `ticket_refs.status` was empty for all 56 rows — the pollers never found ready tickets
- Both pollers accept an injectable `fetchReadyTickets` function for testability, defaulting to `resolveProjectProvider().listTickets()` in production

## Test plan

- [x] Unit tests updated for both `OrchestratePoller` and `SimplePoller`
- [x] PRLT-1354 regression test: verifies provider is called, not stale ticket_refs
- [x] `watch-orchestrate-loop.test.ts` updated to use new injection pattern
- [x] All 64 related tests pass
- [x] Build passes cleanly

Fixes: PRLT-1354