### PR TITLE
feat(PRLT-1355): stable machine fingerprint for telemetry identity

### DIFF
--- a/apps/cli/src/lib/execution/runners/orchestrator.ts
+++ b/apps/cli/src/lib/execution/runners/orchestrator.ts
@@ -34,6 +34,8 @@ import {
   getCCAppPermissionSettings,
 } from '../cc-version.js'
 
+import { getMachineId } from '../../telemetry/analytics.js'
+
 /**
  * Run orchestrator in a Docker container using the sibling container pattern.
  *
@@ -152,6 +154,8 @@ export async function runOrchestratorInDocker(
       ...(process.env.GH_TOKEN ? [`-e GH_TOKEN="${process.env.GH_TOKEN}"`] : []),
       // Pass ANTHROPIC_API_KEY if available (for cases where OAuth is not set up)
       ...(process.env.ANTHROPIC_API_KEY ? [`-e ANTHROPIC_API_KEY="${process.env.ANTHROPIC_API_KEY}"`] : []),
+      // PRLT-1355: Propagate host machine ID so orchestrator telemetry uses same distinct_id
+      `-e PRLT_TELEMETRY_MACHINE_ID="${getMachineId()}"`,
     ]
 
     // Create and start container

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -25,6 +25,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as crypto from 'node:crypto'
+import * as os from 'node:os'
 import { getMachineConfigDir, ensureMachineConfigDir } from '../machine-config.js'
 
 // PostHog API key (public — PostHog client keys are meant to be public)
@@ -74,6 +75,24 @@ let cliVersion: string | null = null
 let initPromise: Promise<void> | null = null
 let analyticsShutdown = false
 
+// ─── Stable Machine Fingerprint ─────────────────────────────────────────────
+
+/**
+ * Generate a deterministic machine ID from hostname + username.
+ * Returns a UUID-shaped hex string so it slots into PostHog's distinct_id
+ * without changing the schema. The same physical machine always produces
+ * the same ID regardless of CWD, worktree, or container context.
+ *
+ * Exported for testing.
+ */
+export function generateStableFingerprint(): string {
+  const hostname = os.hostname()
+  const username = os.userInfo().username
+  const hash = crypto.createHash('sha256').update(`${hostname}:${username}`).digest('hex')
+  // Format as UUID-shaped string: 8-4-4-4-12
+  return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-${hash.slice(12, 16)}-${hash.slice(16, 20)}-${hash.slice(20, 32)}`
+}
+
 // ─── Telemetry Config ────────────────────────────────────────────────────────
 
 function getTelemetryConfigPath(): string {
@@ -95,8 +114,11 @@ function readTelemetryConfig(): TelemetryConfig {
     }
   }
 
-  // Use inherited machine ID from host (Docker containers), or generate a new one
-  const machineId = process.env.PRLT_TELEMETRY_MACHINE_ID || crypto.randomUUID()
+  // Use inherited machine ID from host (Docker containers), or derive a stable fingerprint.
+  // The fingerprint is a SHA-256 hash of hostname + username, formatted as a UUID v4-like
+  // string. This ensures the same physical machine always gets the same ID — even across
+  // worktrees, containers that fail to inherit the env var, or fresh config files.
+  const machineId = process.env.PRLT_TELEMETRY_MACHINE_ID || generateStableFingerprint()
 
   telemetryConfig = {
     enabled: true,
@@ -377,12 +399,15 @@ export function trackEvent(eventName: string, value?: string | number | null, me
 
   try {
     // Derive telemetry source context from environment
-    const telemetrySource = process.env.PRLT_AGENT_NAME ? 'agent' : 'host'
-    const runtimeEnvironment = process.env.PRLT_AGENT_NAME ? 'docker' : 'host'
+    const isAgent = !!process.env.PRLT_AGENT_NAME
+    const telemetrySource = isAgent ? 'agent' : 'host'
+    const runtimeEnvironment = isAgent ? 'docker' : 'host'
     const sourceContext: Record<string, unknown> = {
       telemetry_source: telemetrySource,
       runtime_environment: runtimeEnvironment,
-      ...(process.env.PRLT_AGENT_NAME ? { agent_name: process.env.PRLT_AGENT_NAME } : {}),
+      // PRLT-1355: Explicit boolean so PostHog can filter agent events
+      agent: isAgent,
+      ...(isAgent ? { agent_name: process.env.PRLT_AGENT_NAME } : {}),
     }
 
     // Convert metadata values to strings as required by the client SDK

--- a/apps/cli/test/unit/telemetry-identity.test.ts
+++ b/apps/cli/test/unit/telemetry-identity.test.ts
@@ -5,15 +5,17 @@ import * as os from 'node:os'
 import { execFileSync } from 'node:child_process'
 
 /**
- * Tests for telemetry identity unification (PRLT-1111).
+ * Tests for telemetry identity unification (PRLT-1111, PRLT-1355).
  *
  * Verifies:
  * - Host machine ID is inherited via PRLT_TELEMETRY_MACHINE_ID env var
- * - Events include telemetry_source, environment, and agent_name context
+ * - Stable fingerprint fallback (hostname + username hash) instead of random UUID
+ * - Events include telemetry_source, environment, agent_name, and agent context
  * - Docker container creation passes PRLT_TELEMETRY_MACHINE_ID
+ * - Orchestrator container passes PRLT_TELEMETRY_MACHINE_ID
  */
 
-describe('Telemetry Identity (PRLT-1111)', () => {
+describe('Telemetry Identity (PRLT-1111, PRLT-1355)', () => {
   let testDir: string
   // Use source path (not dist/) — tests must not depend on build artifacts
   // .js extension for Node16 module resolution (ts-node/esm resolves .js → .ts)
@@ -43,7 +45,7 @@ describe('Telemetry Identity (PRLT-1111)', () => {
     const fullScript = `
 const ANALYTICS_URL = ${JSON.stringify(analyticsUrl)};
 const analytics = await import(ANALYTICS_URL);
-const { initAnalytics, trackEvent, trackCommandRun, getMachineId, shutdownAnalytics } = analytics;
+const { initAnalytics, trackEvent, trackCommandRun, getMachineId, generateStableFingerprint, shutdownAnalytics } = analytics;
 ${script}
 `
 
@@ -114,17 +116,36 @@ ${script}
       expect(stderr).to.equal('')
     })
 
-    it('generates a new UUID when PRLT_TELEMETRY_MACHINE_ID is not set', () => {
+    it('generates a stable fingerprint when PRLT_TELEMETRY_MACHINE_ID is not set', () => {
       const { telemetryConfig, stderr } = runAnalyticsScript(`
         const id = getMachineId();
       `)
 
       expect(telemetryConfig, `telemetry config should exist, stderr: ${stderr}`).to.not.be.null
-      // Should be a valid UUID v4 (not the inherited one)
+      // Should be a UUID-shaped hex string (stable fingerprint, not random)
       expect(telemetryConfig!.machineId).to.be.a('string')
       expect(telemetryConfig!.machineId as string).to.match(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       )
+    })
+
+    it('produces the same fingerprint across multiple runs (deterministic)', () => {
+      // Run 1: generate the machine ID
+      const { telemetryConfig: config1, stderr: stderr1 } = runAnalyticsScript(`
+        const id = getMachineId();
+        process.stdout.write('machineId:' + id);
+      `)
+      expect(config1, `run 1 config should exist, stderr: ${stderr1}`).to.not.be.null
+
+      // Run 2: generate again (fresh process, no existing config)
+      const { telemetryConfig: config2, stderr: stderr2 } = runAnalyticsScript(`
+        const id = getMachineId();
+        process.stdout.write('machineId:' + id);
+      `)
+      expect(config2, `run 2 config should exist, stderr: ${stderr2}`).to.not.be.null
+
+      // Same host + username → same fingerprint
+      expect(config1!.machineId).to.equal(config2!.machineId)
     })
 
     it('preserves existing machine ID when config already exists', () => {
@@ -181,7 +202,7 @@ ${script}
   // ── Source Context Properties ──────────────────────────────────────────
 
   describe('Telemetry source context in events', () => {
-    it('tags events with telemetry_source=host when not in agent container', () => {
+    it('tags events with telemetry_source=host and agent=false when not in agent container', () => {
       const { queue, stderr } = runAnalyticsScript(`
         trackEvent('test_event', null, { custom: 'value' });
       `)
@@ -191,10 +212,11 @@ ${script}
       const event = queue![0]
       expect(event.metadata?.telemetry_source).to.equal('host')
       expect(event.metadata?.runtime_environment).to.equal('host')
+      expect(event.metadata?.agent).to.equal('false')
       expect(event.metadata).to.not.have.property('agent_name')
     })
 
-    it('tags events with telemetry_source=agent when PRLT_AGENT_NAME is set', () => {
+    it('tags events with telemetry_source=agent and agent=true when PRLT_AGENT_NAME is set', () => {
       const { queue, stderr } = runAnalyticsScript(`
         trackEvent('test_event', null, { custom: 'value' });
       `, { PRLT_AGENT_NAME: 'test-agent-alpha' })
@@ -204,10 +226,11 @@ ${script}
       const event = queue![0]
       expect(event.metadata?.telemetry_source).to.equal('agent')
       expect(event.metadata?.runtime_environment).to.equal('docker')
+      expect(event.metadata?.agent).to.equal('true')
       expect(event.metadata?.agent_name).to.equal('test-agent-alpha')
     })
 
-    it('includes source context in trackCommandRun events', () => {
+    it('includes source context with agent=true in trackCommandRun events', () => {
       const { queue, stderr } = runAnalyticsScript(`
         trackCommandRun({ command: 'work:start', durationMs: 100, success: true, flags: [] });
       `, { PRLT_AGENT_NAME: 'my-agent' })
@@ -216,6 +239,7 @@ ${script}
       const event = queue![0]
       expect(event.metadata?.telemetry_source).to.equal('agent')
       expect(event.metadata?.runtime_environment).to.equal('docker')
+      expect(event.metadata?.agent).to.equal('true')
       expect(event.metadata?.agent_name).to.equal('my-agent')
       // Original metadata should still be present
       expect(event.metadata?.command).to.equal('work:start')
@@ -233,6 +257,48 @@ ${script}
     })
   })
 
+  // ── Stable fingerprint ─────────────────────────────────────────────────
+
+  describe('Stable fingerprint (PRLT-1355)', () => {
+    it('generateStableFingerprint returns a UUID-shaped deterministic string', () => {
+      const { stdout, stderr } = runAnalyticsScript(`
+        const fp = generateStableFingerprint();
+        process.stdout.write('fp:' + fp);
+      `)
+
+      expect(stderr).to.equal('')
+      const fp = stdout.split('fp:')[1]
+      expect(fp).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    })
+
+    it('generateStableFingerprint is deterministic across calls', () => {
+      const { stdout: stdout1 } = runAnalyticsScript(`
+        const fp = generateStableFingerprint();
+        process.stdout.write('fp:' + fp);
+      `)
+      const { stdout: stdout2 } = runAnalyticsScript(`
+        const fp = generateStableFingerprint();
+        process.stdout.write('fp:' + fp);
+      `)
+
+      const fp1 = stdout1.split('fp:')[1]
+      const fp2 = stdout2.split('fp:')[1]
+      expect(fp1).to.equal(fp2)
+    })
+
+    it('fallback uses stable fingerprint instead of random UUID when no env var set', () => {
+      // Run twice without PRLT_TELEMETRY_MACHINE_ID — both should produce the same machine ID
+      const { telemetryConfig: config1 } = runAnalyticsScript(`
+        getMachineId();
+      `)
+      const { telemetryConfig: config2 } = runAnalyticsScript(`
+        getMachineId();
+      `)
+
+      expect(config1!.machineId).to.equal(config2!.machineId)
+    })
+  })
+
   // ── Docker env var passthrough ─────────────────────────────────────────
 
   describe('Docker container PRLT_TELEMETRY_MACHINE_ID passthrough', () => {
@@ -240,6 +306,17 @@ ${script}
       // Verify the import relationship exists by checking the source
       const dockerMgmtPath = path.resolve(process.cwd(), 'src/lib/execution/runners/docker-management.ts')
       const content = fs.readFileSync(dockerMgmtPath, 'utf-8')
+      expect(content).to.include('getMachineId')
+      expect(content).to.include('PRLT_TELEMETRY_MACHINE_ID')
+    })
+  })
+
+  // ── Orchestrator env var passthrough (PRLT-1355) ──────────────────────
+
+  describe('Orchestrator container PRLT_TELEMETRY_MACHINE_ID passthrough (PRLT-1355)', () => {
+    it('orchestrator runner imports getMachineId and passes PRLT_TELEMETRY_MACHINE_ID', () => {
+      const orchestratorPath = path.resolve(process.cwd(), 'src/lib/execution/runners/orchestrator.ts')
+      const content = fs.readFileSync(orchestratorPath, 'utf-8')
       expect(content).to.include('getMachineId')
       expect(content).to.include('PRLT_TELEMETRY_MACHINE_ID')
     })


### PR DESCRIPTION
## Summary

- Replace `crypto.randomUUID()` fallback with a deterministic SHA-256 fingerprint of `hostname + username`, so the same physical machine always gets the same telemetry ID — even across worktrees or failed config reads
- Pass `PRLT_TELEMETRY_MACHINE_ID` from the orchestrator container (was missing — only docker-management.ts had it)
- Add explicit `agent: true/false` boolean property to all telemetry events for easy PostHog filtering

## Problem

PostHog showed 68 distinct IDs from only 2 real machines. Agent worktrees each generated a new random UUID on first `prlt` command, polluting analytics.

## Test plan

- [x] Stable fingerprint is UUID-shaped and deterministic across runs
- [x] `PRLT_TELEMETRY_MACHINE_ID` env var still takes precedence
- [x] Existing config still preserved (not overwritten)
- [x] Agent events tagged with `agent=true`, host events with `agent=false`
- [x] Orchestrator source includes `getMachineId` import and `PRLT_TELEMETRY_MACHINE_ID` env var
- [x] All 14 telemetry identity tests pass

Closes PRLT-1355