### PR TITLE
feat(PRLT-1356): disable telemetry in CI environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable prlt telemetry in CI to prevent ghost machine IDs in PostHog.
+# Each CI run would otherwise generate a fresh UUID and send events, polluting analytics.
+# The telemetry code also auto-detects CI=true, but this is explicit belt-and-suspenders.
+env:
+  PRLT_TELEMETRY_DISABLED: '1'
+
 # Native module CI expectations:
 # - better-sqlite3 requires a native .node binding compiled for the exact Node.js ABI in use.
 # - pnpm-workspace.yaml lists better-sqlite3 under ignoredBuiltDependencies, so pnpm install

--- a/apps/cli/src/lib/telemetry.ts
+++ b/apps/cli/src/lib/telemetry.ts
@@ -85,6 +85,7 @@ export function writeTelemetryConfig(telemetry: TelemetryConfig): void {
  * Check if telemetry is enabled.
  *
  * Disabled when any of:
+ * - CI=true (standard CI environment variable — GitHub Actions, GitLab CI, etc.)
  * - DO_NOT_TRACK=1 (consoledonottrack.com standard)
  * - PRLT_TELEMETRY_DISABLED=1
  * - User ran `prlt telemetry disable` (config.telemetry === false)
@@ -93,6 +94,7 @@ export function writeTelemetryConfig(telemetry: TelemetryConfig): void {
  */
 export function isTelemetryEnabled(): boolean {
   // Env vars take precedence
+  if (process.env.CI === 'true' || process.env.CI === '1') return false
   if (process.env.DO_NOT_TRACK === '1') return false
   if (process.env.PRLT_TELEMETRY_DISABLED === '1') return false
 

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -133,6 +133,9 @@ function writeTelemetryConfig(config: TelemetryConfig): void {
  * Check if telemetry is disabled by environment variables or config.
  */
 export function isTelemetryEnabled(): boolean {
+  // CI environments should never send telemetry (prevents ghost machine IDs in PostHog)
+  if (process.env.CI === 'true' || process.env.CI === '1') return false
+
   // Environment variable opt-outs (standard + prlt-specific)
   if (process.env.DO_NOT_TRACK === '1' || process.env.DO_NOT_TRACK === 'true') return false
   if (process.env.PRLT_TELEMETRY_DISABLED === '1' || process.env.PRLT_TELEMETRY_DISABLED === 'true') return false
@@ -176,6 +179,9 @@ export function getTelemetryStatus(): {
   const config = readTelemetryConfig()
 
   // Check for env var overrides
+  if (process.env.CI === 'true' || process.env.CI === '1') {
+    return { enabled: false, machineId: config.machineId, envOverride: true, envVar: 'CI' }
+  }
   if (process.env.DO_NOT_TRACK === '1' || process.env.DO_NOT_TRACK === 'true') {
     return { enabled: false, machineId: config.machineId, envOverride: true, envVar: 'DO_NOT_TRACK' }
   }

--- a/apps/cli/test/unit/analytics-queue.test.ts
+++ b/apps/cli/test/unit/analytics-queue.test.ts
@@ -144,6 +144,7 @@ ${script}
         env: {
           ...process.env,
           HOME: testDir,
+          CI: '',
           DO_NOT_TRACK: '',
           PRLT_TELEMETRY_DISABLED: '',
         },

--- a/apps/cli/test/unit/granular-telemetry.test.ts
+++ b/apps/cli/test/unit/granular-telemetry.test.ts
@@ -17,6 +17,7 @@ import * as os from 'node:os'
 // because analytics reads from ~/.proletariat/telemetry.json
 let testDir: string
 let originalHome: string | undefined
+let originalCI: string | undefined
 let originalDoNotTrack: string | undefined
 let originalPrltTelemetryDisabled: string | undefined
 
@@ -45,9 +46,11 @@ describe('Granular Telemetry Events (PRLT-1070)', () => {
     originalHome = process.env.HOME
     process.env.HOME = testDir
 
-    // Ensure telemetry is enabled
+    // Ensure telemetry is enabled (CI must be cleared so tests can assert telemetry-enabled behavior)
+    originalCI = process.env.CI
     originalDoNotTrack = process.env.DO_NOT_TRACK
     originalPrltTelemetryDisabled = process.env.PRLT_TELEMETRY_DISABLED
+    delete process.env.CI
     delete process.env.DO_NOT_TRACK
     delete process.env.PRLT_TELEMETRY_DISABLED
 
@@ -71,6 +74,12 @@ describe('Granular Telemetry Events (PRLT-1070)', () => {
       process.env.HOME = originalHome
     } else {
       delete process.env.HOME
+    }
+
+    if (originalCI !== undefined) {
+      process.env.CI = originalCI
+    } else {
+      delete process.env.CI
     }
 
     if (originalDoNotTrack !== undefined) {

--- a/apps/cli/test/unit/telemetry-bridge.test.ts
+++ b/apps/cli/test/unit/telemetry-bridge.test.ts
@@ -17,6 +17,7 @@ import * as os from 'node:os'
 
 let testDir: string
 let originalHome: string | undefined
+let originalCI: string | undefined
 let originalDoNotTrack: string | undefined
 let originalPrltTelemetryDisabled: string | undefined
 
@@ -45,8 +46,10 @@ describe('Telemetry Bridge (PRLT-1070)', () => {
     originalHome = process.env.HOME
     process.env.HOME = testDir
 
+    originalCI = process.env.CI
     originalDoNotTrack = process.env.DO_NOT_TRACK
     originalPrltTelemetryDisabled = process.env.PRLT_TELEMETRY_DISABLED
+    delete process.env.CI
     delete process.env.DO_NOT_TRACK
     delete process.env.PRLT_TELEMETRY_DISABLED
 
@@ -77,6 +80,12 @@ describe('Telemetry Bridge (PRLT-1070)', () => {
       process.env.HOME = originalHome
     } else {
       delete process.env.HOME
+    }
+
+    if (originalCI !== undefined) {
+      process.env.CI = originalCI
+    } else {
+      delete process.env.CI
     }
 
     if (originalDoNotTrack !== undefined) {

--- a/apps/cli/test/unit/telemetry-identity.test.ts
+++ b/apps/cli/test/unit/telemetry-identity.test.ts
@@ -57,6 +57,7 @@ ${script}
         env: {
           ...process.env,
           HOME: testDir,
+          CI: '',
           DO_NOT_TRACK: '',
           PRLT_TELEMETRY_DISABLED: '',
           // Clear agent-related env vars by default

--- a/apps/cli/test/unit/telemetry.test.ts
+++ b/apps/cli/test/unit/telemetry.test.ts
@@ -13,6 +13,7 @@ import {
 describe('Telemetry', () => {
   let testDir: string;
   let originalHome: string | undefined;
+  let originalCI: string | undefined;
   let originalDoNotTrack: string | undefined;
   let originalPrltTelemetryDisabled: string | undefined;
 
@@ -21,9 +22,11 @@ describe('Telemetry', () => {
     originalHome = process.env.HOME;
     process.env.HOME = testDir;
 
-    // Save and clear env vars
+    // Save and clear env vars (CI must be cleared so tests can assert telemetry-enabled behavior)
+    originalCI = process.env.CI;
     originalDoNotTrack = process.env.DO_NOT_TRACK;
     originalPrltTelemetryDisabled = process.env.PRLT_TELEMETRY_DISABLED;
+    delete process.env.CI;
     delete process.env.DO_NOT_TRACK;
     delete process.env.PRLT_TELEMETRY_DISABLED;
   });
@@ -36,6 +39,12 @@ describe('Telemetry', () => {
     }
 
     // Restore env vars
+    if (originalCI !== undefined) {
+      process.env.CI = originalCI;
+    } else {
+      delete process.env.CI;
+    }
+
     if (originalDoNotTrack !== undefined) {
       process.env.DO_NOT_TRACK = originalDoNotTrack;
     } else {
@@ -153,6 +162,22 @@ describe('Telemetry', () => {
     it('env var PRLT_TELEMETRY_DISABLED overrides config', () => {
       writeTelemetryConfig({ enabled: true });
       process.env.PRLT_TELEMETRY_DISABLED = '1';
+      expect(isTelemetryEnabled()).to.be.false;
+    });
+
+    it('returns false when CI=true (auto-detect CI environment)', () => {
+      process.env.CI = 'true';
+      expect(isTelemetryEnabled()).to.be.false;
+    });
+
+    it('returns false when CI=1', () => {
+      process.env.CI = '1';
+      expect(isTelemetryEnabled()).to.be.false;
+    });
+
+    it('CI env var overrides config', () => {
+      writeTelemetryConfig({ enabled: true });
+      process.env.CI = 'true';
       expect(isTelemetryEnabled()).to.be.false;
     });
   });


### PR DESCRIPTION
## Summary

- Auto-detect CI environments (CI=true/1) in both telemetry modules to prevent ghost machine IDs in PostHog
- Add PRLT_TELEMETRY_DISABLED=1 as workflow-level env var in test.yml as belt-and-suspenders
- Update all telemetry test files to save/restore CI env var so tests pass in CI

## Test plan

- [x] New tests: CI=true and CI=1 disable telemetry (telemetry.test.ts)
- [x] New test: CI env var overrides user config
- [x] All 57 telemetry tests pass
- [x] Build passes