### PR TITLE
feat(PRLT-1357): add error_message and ticket_id to agent_errored telemetry

### DIFF
--- a/apps/cli/src/commands/work/start.ts
+++ b/apps/cli/src/commands/work/start.ts
@@ -2622,9 +2622,13 @@ export default class WorkStart extends PMOCommand {
         })
 
         // Enrich telemetry bridge session so agent_completed/agent_errored
-        // events report the correct action name
+        // events report the correct action name and ticket
         if (result.sessionId) {
-          enrichAgentSession(result.sessionId, context.actionId || 'implement')
+          enrichAgentSession(
+            result.sessionId,
+            context.actionId || 'implement',
+            ticketExternalMetadata.key || context.ticketId,
+          )
         }
 
         // Register in machine-wide agent registry
@@ -3607,6 +3611,15 @@ export default class WorkStart extends PMOCommand {
         sessionId: result.sessionId,
         containerId: result.containerId,
       })
+
+      // Enrich telemetry bridge session for batch-spawned agents
+      if (result.sessionId) {
+        enrichAgentSession(
+          result.sessionId,
+          context.actionId || 'implement',
+          ticketExternalMetadata.key || context.ticketId,
+        )
+      }
 
       // Register in machine-wide agent registry
       try {

--- a/apps/cli/src/lib/telemetry/analytics.ts
+++ b/apps/cli/src/lib/telemetry/analytics.ts
@@ -535,18 +535,23 @@ export function trackAgentCompleted(options: {
 /**
  * Track an agent encountering an error.
  *
- * Privacy: No ticket IDs, error messages (may contain PII), or stack traces.
+ * Includes error_message (truncated to 256 chars) and ticket_id for debugging.
+ * Error messages are capped to limit PII exposure while remaining useful for triage.
  */
 export function trackAgentErrored(options: {
   action: string
   durationMs: number
   exitReason: 'errored'
   errorType?: string
+  errorMessage?: string
+  ticketId?: string
 }): void {
   trackEvent('agent_errored', options.durationMs, {
     action: options.action,
     exit_reason: options.exitReason,
     ...(options.errorType ? { error_type: options.errorType } : {}),
+    ...(options.errorMessage ? { error_message: options.errorMessage.slice(0, 256) } : {}),
+    ...(options.ticketId ? { ticket_id: options.ticketId } : {}),
   })
 }
 

--- a/apps/cli/src/lib/telemetry/telemetry-bridge.ts
+++ b/apps/cli/src/lib/telemetry/telemetry-bridge.ts
@@ -18,7 +18,7 @@ import {
 } from './analytics.js'
 
 // Track agent spawn times by sessionId for duration calculation
-const agentSpawnTimes = new Map<string, { timestamp: Date; action: string }>()
+const agentSpawnTimes = new Map<string, { timestamp: Date; action: string; ticketId?: string }>()
 
 // Track primitive start times by command ID
 const primitiveStartTimes = new Map<string, { timestamp: Date; primitive: string }>()
@@ -60,6 +60,7 @@ export function startTelemetryBridge(): void {
           action: spawnInfo?.action ?? 'unknown',
           durationMs,
           exitReason: 'errored',
+          ticketId: spawnInfo?.ticketId,
         })
       } else {
         trackAgentCompleted({
@@ -87,6 +88,8 @@ export function startTelemetryBridge(): void {
         durationMs,
         exitReason: 'errored',
         errorType: classifyError(event.error),
+        errorMessage: event.error,
+        ticketId: spawnInfo?.ticketId,
       })
 
       agentSpawnTimes.delete(event.sessionId)
@@ -134,13 +137,16 @@ export function endPrimitiveTracking(id: string, success: boolean, errorType?: s
 }
 
 /**
- * Enrich an agent session with its action name (called from work:start).
- * This lets agent_completed/agent_errored events report the correct action.
+ * Enrich an agent session with its action name and ticket ID (called from work:start).
+ * This lets agent_completed/agent_errored events report the correct action and ticket.
  */
-export function enrichAgentSession(sessionId: string, action: string): void {
+export function enrichAgentSession(sessionId: string, action: string, ticketId?: string): void {
   const existing = agentSpawnTimes.get(sessionId)
   if (existing) {
     existing.action = action
+    if (ticketId) {
+      existing.ticketId = ticketId
+    }
   }
 }
 

--- a/apps/cli/test/unit/granular-telemetry.test.ts
+++ b/apps/cli/test/unit/granular-telemetry.test.ts
@@ -231,6 +231,62 @@ describe('Granular Telemetry Events (PRLT-1070)', () => {
       expect(event!.metadata?.exit_reason).to.equal('errored')
       expect(event!.metadata?.error_type).to.equal('timeout')
     })
+
+    it('includes error_message and ticket_id when provided (PRLT-1357)', async () => {
+      const { trackAgentErrored } = await import('../../src/lib/telemetry/analytics.js')
+
+      clearQueue()
+      trackAgentErrored({
+        action: 'implement',
+        durationMs: 8000,
+        exitReason: 'errored',
+        errorType: 'container',
+        errorMessage: 'Docker container exited with code 137',
+        ticketId: 'PRLT-1234',
+      })
+
+      const events = readQueue()
+      const event = events.find(e => e.name === 'agent_errored')
+      expect(event).to.exist
+      expect(event!.metadata?.error_message).to.equal('Docker container exited with code 137')
+      expect(event!.metadata?.ticket_id).to.equal('PRLT-1234')
+      expect(event!.metadata?.error_type).to.equal('container')
+    })
+
+    it('truncates error_message to 256 characters (PRLT-1357)', async () => {
+      const { trackAgentErrored } = await import('../../src/lib/telemetry/analytics.js')
+
+      clearQueue()
+      const longMessage = 'x'.repeat(500)
+      trackAgentErrored({
+        action: 'implement',
+        durationMs: 1000,
+        exitReason: 'errored',
+        errorMessage: longMessage,
+      })
+
+      const events = readQueue()
+      const event = events.find(e => e.name === 'agent_errored')
+      expect(event).to.exist
+      expect(event!.metadata?.error_message).to.have.length(256)
+    })
+
+    it('omits error_message and ticket_id when not provided', async () => {
+      const { trackAgentErrored } = await import('../../src/lib/telemetry/analytics.js')
+
+      clearQueue()
+      trackAgentErrored({
+        action: 'review',
+        durationMs: 3000,
+        exitReason: 'errored',
+      })
+
+      const events = readQueue()
+      const event = events.find(e => e.name === 'agent_errored')
+      expect(event).to.exist
+      expect(event!.metadata).to.not.have.property('error_message')
+      expect(event!.metadata).to.not.have.property('ticket_id')
+    })
   })
 
   describe('trackTicketOperation', () => {
@@ -356,11 +412,10 @@ describe('Granular Telemetry Events (PRLT-1070)', () => {
   })
 
   describe('Privacy compliance', () => {
-    it('none of the new events include ticket IDs', async () => {
+    it('non-error events do not include ticket IDs or sensitive data', async () => {
       const {
         trackPrimitiveExecuted,
         trackAgentCompleted,
-        trackAgentErrored,
         trackTicketOperation,
       } = await import('../../src/lib/telemetry/analytics.js')
 
@@ -368,7 +423,6 @@ describe('Granular Telemetry Events (PRLT-1070)', () => {
 
       trackPrimitiveExecuted({ primitive: 'implement', durationMs: 100, success: true })
       trackAgentCompleted({ action: 'implement', durationMs: 100, exitReason: 'completed', prCreated: false })
-      trackAgentErrored({ action: 'review', durationMs: 100, exitReason: 'errored' })
       trackTicketOperation({ operation: 'move', provider: 'linear', durationMs: 100, success: true })
 
       const events = readQueue()
@@ -385,6 +439,33 @@ describe('Granular Telemetry Events (PRLT-1070)', () => {
           expect(keys).to.not.include('description')
         }
       }
+    })
+
+    it('agent_errored intentionally includes ticket_id and error_message for debugging (PRLT-1357)', async () => {
+      const { trackAgentErrored } = await import('../../src/lib/telemetry/analytics.js')
+
+      clearQueue()
+      trackAgentErrored({
+        action: 'implement',
+        durationMs: 100,
+        exitReason: 'errored',
+        errorMessage: 'test error',
+        ticketId: 'PRLT-42',
+      })
+
+      const events = readQueue()
+      const event = events.find(e => e.name === 'agent_errored')
+      expect(event).to.exist
+      // These are intentionally present for error triage
+      expect(event!.metadata?.ticket_id).to.equal('PRLT-42')
+      expect(event!.metadata?.error_message).to.equal('test error')
+      // But still no sensitive data
+      const keys = Object.keys(event!.metadata!)
+      expect(keys).to.not.include('branch')
+      expect(keys).to.not.include('username')
+      expect(keys).to.not.include('api_key')
+      expect(keys).to.not.include('file_path')
+      expect(keys).to.not.include('code')
     })
   })
 })

--- a/apps/cli/test/unit/telemetry-bridge.test.ts
+++ b/apps/cli/test/unit/telemetry-bridge.test.ts
@@ -197,6 +197,110 @@ describe('Telemetry Bridge (PRLT-1070)', () => {
     expect(errorEvent!.metadata?.error_type).to.equal('timeout')
   })
 
+  it('includes error_message from agent:error events (PRLT-1357)', async () => {
+    const { startTelemetryBridge } = await import('../../src/lib/telemetry/telemetry-bridge.js')
+    const { getEventBus } = await import('../../src/lib/events/event-bus.js')
+
+    clearQueue()
+    startTelemetryBridge()
+
+    const bus = getEventBus()
+    const now = new Date()
+
+    bus.emit('agent:spawned', {
+      sessionId: 'error-msg-test',
+      runner: 'claude-code',
+      task: 'implement feature',
+      workdir: '/tmp/test',
+      background: false,
+      timestamp: now,
+    })
+
+    bus.emit('agent:error', {
+      sessionId: 'error-msg-test',
+      runner: 'claude-code',
+      error: 'Process exceeded memory limit (OOM killed)',
+      timestamp: new Date(now.getTime() + 100),
+    })
+
+    const events = readQueue()
+    const errorEvent = events.find(e => e.name === 'agent_errored')
+    expect(errorEvent).to.exist
+    expect(errorEvent!.metadata?.error_message).to.equal('Process exceeded memory limit (OOM killed)')
+    expect(errorEvent!.metadata?.error_type).to.equal('memory')
+  })
+
+  it('includes ticket_id from enriched session on agent:error (PRLT-1357)', async () => {
+    const { startTelemetryBridge, enrichAgentSession } = await import('../../src/lib/telemetry/telemetry-bridge.js')
+    const { getEventBus } = await import('../../src/lib/events/event-bus.js')
+
+    clearQueue()
+    startTelemetryBridge()
+
+    const bus = getEventBus()
+    const now = new Date()
+
+    bus.emit('agent:spawned', {
+      sessionId: 'ticket-error-test',
+      runner: 'claude-code',
+      task: 'implement feature',
+      workdir: '/tmp/test',
+      background: false,
+      timestamp: now,
+    })
+
+    enrichAgentSession('ticket-error-test', 'implement', 'PRLT-1357')
+
+    bus.emit('agent:error', {
+      sessionId: 'ticket-error-test',
+      runner: 'claude-code',
+      error: 'Build step timed out',
+      timestamp: new Date(now.getTime() + 300),
+    })
+
+    const events = readQueue()
+    const errorEvent = events.find(e => e.name === 'agent_errored')
+    expect(errorEvent).to.exist
+    expect(errorEvent!.metadata?.ticket_id).to.equal('PRLT-1357')
+    expect(errorEvent!.metadata?.error_message).to.equal('Build step timed out')
+    expect(errorEvent!.metadata?.action).to.equal('implement')
+  })
+
+  it('includes ticket_id on agent:stopped with error reason (PRLT-1357)', async () => {
+    const { startTelemetryBridge, enrichAgentSession } = await import('../../src/lib/telemetry/telemetry-bridge.js')
+    const { getEventBus } = await import('../../src/lib/events/event-bus.js')
+
+    clearQueue()
+    startTelemetryBridge()
+
+    const bus = getEventBus()
+    const now = new Date()
+
+    bus.emit('agent:spawned', {
+      sessionId: 'stopped-error-test',
+      runner: 'claude-code',
+      task: 'review code',
+      workdir: '/tmp/test',
+      background: false,
+      timestamp: now,
+    })
+
+    enrichAgentSession('stopped-error-test', 'review', 'PRLT-999')
+
+    bus.emit('agent:stopped', {
+      sessionId: 'stopped-error-test',
+      runner: 'claude-code',
+      reason: 'error',
+      timestamp: new Date(now.getTime() + 500),
+    })
+
+    const events = readQueue()
+    const errorEvent = events.find(e => e.name === 'agent_errored')
+    expect(errorEvent).to.exist
+    expect(errorEvent!.metadata?.ticket_id).to.equal('PRLT-999')
+    expect(errorEvent!.metadata?.action).to.equal('review')
+  })
+
   it('classifies error messages into safe categories', async () => {
     const { startTelemetryBridge } = await import('../../src/lib/telemetry/telemetry-bridge.js')
     const { getEventBus } = await import('../../src/lib/events/event-bus.js')


### PR DESCRIPTION
## Summary

- Add `error_message` (truncated to 256 chars) and `ticket_id` as optional properties on `agent_errored` PostHog events for error triage
- Extend `enrichAgentSession()` to accept and store `ticketId` alongside action name
- Thread external ticket ID (e.g. PRLT-xxx) from `work:start` into the telemetry bridge for both single and batch spawn paths
- Update privacy tests to reflect intentional inclusion of ticket_id/error_message on error events only

## Test plan

- [x] New unit tests for `trackAgentErrored` with error_message and ticket_id
- [x] New unit test for error_message truncation at 256 chars
- [x] New unit test verifying omission when not provided
- [x] New bridge tests for error_message flowing through agent:error events
- [x] New bridge tests for ticket_id flowing through enriched sessions
- [x] Updated privacy tests: non-error events still exclude ticket_id; agent_errored intentionally includes it
- [x] All 28 telemetry tests pass

Closes PRLT-1357