### PR TITLE
fix(PRLT-1351): fix tmux set-option parsed by bash instead of tmux in docker spawn

### DIFF
--- a/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
+++ b/apps/cli/src/lib/execution/runners/devcontainer-tmux.ts
@@ -22,6 +22,7 @@ import {
   buildWindowTitle,
   shouldUseControlMode,
   buildTmuxMouseOption,
+  buildTmuxTitleOptions,
   buildTmuxAttachCommand,
   configureITermTmuxWindowMode,
 } from './shared.js'
@@ -141,7 +142,8 @@ ${containerPostExec}
     } catch { /* Session doesn't exist */ }
 
     // Create tmux session
-    const createSessionCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "bash ${scriptPath}"${mouseOption} \; set-option -g set-titles on \; set-option -g set-titles-string "#{window_name}"`
+    const titleOptions = buildTmuxTitleOptions()
+    const createSessionCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "bash ${scriptPath}"${mouseOption}${titleOptions}`
     try {
       execSync(`docker exec ${actualContainerId} bash -c '${createSessionCmd}'`, { stdio: 'pipe' })
     } catch (error) {

--- a/apps/cli/src/lib/execution/runners/host.ts
+++ b/apps/cli/src/lib/execution/runners/host.ts
@@ -8,7 +8,7 @@ import {
   resolveCodexExecutionContext, validateCodexMode, getCodexCommand, resolveToolsForSpawn,
   RunnerResult, buildWindowTitle, buildTmuxWindowName,
   buildPrompt, buildOrchestratorSystemPrompt, getExecutorCommand, isClaudeExecutor,
-  shouldUseControlMode, buildTmuxMouseOption, buildTmuxAttachCommand, configureITermTmuxWindowMode,
+  shouldUseControlMode, buildTmuxMouseOption, buildTmuxTitleOptions, buildTmuxAttachCommand, configureITermTmuxWindowMode,
 } from './shared.js'
 import { buildSrtCommand } from './sandbox.js'
 
@@ -254,7 +254,8 @@ ${postExecBlock}`
     // Step 1: Create host tmux session (detached)
     // Only enable mouse mode if NOT using control mode (control mode lets iTerm handle mouse natively)
     const mouseOption = buildTmuxMouseOption(useControlMode)
-    const tmuxCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "${scriptPath}"${mouseOption} \\; set-option -g set-titles on \\; set-option -g set-titles-string "#{window_name}"`
+    const titleOptions = buildTmuxTitleOptions()
+    const tmuxCmd = `tmux new-session -d -s "${sessionName}" -n "${sessionName}" "${scriptPath}"${mouseOption}${titleOptions}`
 
     try {
       execSync(tmuxCmd, { stdio: 'pipe' })

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -112,6 +112,20 @@ export function buildTmuxMouseOption(_useControlMode: boolean): string {
   return ' \\; set-option -g mouse on'
 }
 
+/**
+ * Build tmux set-titles options string.
+ * Uses \\; which produces \; in the output — required so that
+ * bash interprets the semicolons as literal characters (not command
+ * separators) and passes them through to tmux as tmux command separators.
+ *
+ * PRLT-1351: Extracted to prevent escaping divergence between host.ts
+ * and devcontainer-tmux.ts (where \; in a JS template literal silently
+ * becomes a bare ; and bash runs set-option as a shell command).
+ */
+export function buildTmuxTitleOptions(): string {
+  return ' \\; set-option -g set-titles on \\; set-option -g set-titles-string "#{window_name}"'
+}
+
 export function buildTmuxAttachCommand(useControlMode: boolean, includeUnicodeFlag: boolean = false): string {
   const unicodeFlag = includeUnicodeFlag ? '-u ' : ''
   if (useControlMode) {

--- a/apps/cli/test/unit/runner-shared.test.ts
+++ b/apps/cli/test/unit/runner-shared.test.ts
@@ -5,6 +5,7 @@ import {
   buildTmuxWindowName,
   shouldUseControlMode,
   buildTmuxMouseOption,
+  buildTmuxTitleOptions,
   buildTmuxAttachCommand,
   isDockerRunning,
   checkDockerDaemon,
@@ -150,6 +151,52 @@ describe('Runner Shared Utilities (TKT-140)', () => {
     it('should always return mouse-on option regardless of param', () => {
       expect(buildTmuxMouseOption(true)).to.include('mouse on')
       expect(buildTmuxMouseOption(false)).to.include('mouse on')
+    })
+  })
+
+  // =========================================================================
+  // PRLT-1351: tmux title options escaping
+  // =========================================================================
+  describe('buildTmuxTitleOptions', () => {
+    it('should include set-titles on and set-titles-string', () => {
+      const result = buildTmuxTitleOptions()
+      expect(result).to.include('set-titles on')
+      expect(result).to.include('set-titles-string')
+    })
+
+    it('should contain backslash-escaped semicolons for bash passthrough', () => {
+      // PRLT-1351 regression: without \\; in the JS source, template literals
+      // produce bare ; which bash treats as a command separator instead of
+      // passing it through to tmux. The string value must contain literal \;
+      const result = buildTmuxTitleOptions()
+      expect(result).to.include('\\;')
+      // Must NOT contain bare ; (without preceding backslash) as a tmux separator
+      // Split on \; first, then check remaining parts don't have bare ;
+      const withoutEscaped = result.replace(/\\;/g, '')
+      expect(withoutEscaped).to.not.include(';',
+        'bare semicolons without backslash escape will be parsed by bash, not tmux')
+    })
+
+    it('should use same escaping pattern as buildTmuxMouseOption', () => {
+      // Both helpers must use \\; so they are safe when concatenated into
+      // a command string passed through bash -c (devcontainer) or execSync (host)
+      const mouseOpt = buildTmuxMouseOption(false)
+      const titleOpt = buildTmuxTitleOptions()
+      // Both should have \; in the runtime string value
+      expect(mouseOpt).to.include('\\;')
+      expect(titleOpt).to.include('\\;')
+    })
+
+    it('should produce command that bash -c passes through to tmux correctly', () => {
+      // Simulate what happens when the options are embedded in a bash -c command:
+      // The \\; in JS becomes \; in the string, which inside bash -c single quotes
+      // is interpreted as a literal ; and forwarded to tmux as a command separator.
+      const mouseOpt = buildTmuxMouseOption(false)
+      const titleOpt = buildTmuxTitleOptions()
+      const cmd = `tmux new-session -d -s "test" "script.sh"${mouseOpt}${titleOpt}`
+      // Count bare semicolons (not preceded by backslash) — should be zero
+      const bareSemicolons = cmd.match(/(?<!\\);/g)
+      expect(bareSemicolons).to.be.null
     })
   })
 


### PR DESCRIPTION
## Summary

- **Bug:** When spawning an agent in Docker via `devcontainer-tmux.ts`, the tmux `set-option` commands for `set-titles` were being parsed by bash as shell commands instead of being passed to tmux. This caused `bash: line 1: set-option: command not found`.
- **Root cause:** `\;` in a JavaScript template literal silently drops the backslash (not a recognized escape), producing a bare `;` that bash interprets as a command separator. The `buildTmuxMouseOption()` helper used `\;` (correct), but the inline title options used `\;` (broken).
- **Fix:** Extracted `buildTmuxTitleOptions()` helper with correct `\;` escaping (matching `buildTmuxMouseOption` pattern), used by both `devcontainer-tmux.ts` and `host.ts` to prevent future divergence.

## Test plan

- [x] Added regression tests in `runner-shared.test.ts` verifying `buildTmuxTitleOptions()` contains backslash-escaped semicolons
- [x] Added test that combined mouse + title options produce zero bare semicolons
- [x] Verified all 6 related tests pass
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)