### PR TITLE
feat(PRLT-1359): auto-prune agents whose work is done

### DIFF
--- a/apps/cli/src/commands/session/prune.ts
+++ b/apps/cli/src/commands/session/prune.ts
@@ -5,6 +5,7 @@ import {
   getWorkspaceInfo,
   cleanupAgent,
   getCleanableAgents,
+  getShippedAgents,
   killTmuxSession,
   CleanupResult,
 } from '../../lib/agents/commands.js'
@@ -34,6 +35,7 @@ interface PruneResult {
   orphanSessionsKilled: string[]
   deadContainersKilled: string[]
   ephemeralAgentsCleaned: CleanupResult[]
+  shippedAgentsCleaned: CleanupResult[]
   errors: string[]
 }
 
@@ -105,6 +107,7 @@ export default class SessionPrune extends PromptCommand {
         orphanSessionsKilled: [],
         deadContainersKilled: [],
         ephemeralAgentsCleaned: [],
+        shippedAgentsCleaned: [],
         errors: [],
       }
 
@@ -251,9 +254,38 @@ export default class SessionPrune extends PromptCommand {
         })
       }
 
+      // =====================================================================
+      // Step 5: Clean up agents whose work has been shipped (PRLT-1359)
+      // =====================================================================
+      // Find agents with completed executions but still active sessions/worktrees.
+      // These are "zombie" agents — their ticket is Done, PR is merged, but
+      // their tmux sessions and worktrees still consume resources.
+      const shippedExecutions = executionStorage.listExecutions({ status: 'completed' })
+      const stoppedExecutions = executionStorage.listExecutions({ status: 'stopped' })
+      const completedAgentNames = new Set(
+        [...shippedExecutions, ...stoppedExecutions].map(e => e.agentName),
+      )
+      const busyAgentNames = new Set(
+        [...runningExecutions, ...startingExecutions].map(e => e.agentName),
+      )
+      let shippedAgents = getShippedAgents(freshWorkspaceInfo, completedAgentNames, busyAgentNames)
+
+      // Remove agents already in the cleanableAgents list to avoid double-cleanup
+      const cleanableNames = new Set(cleanableAgents.map(a => a.name))
+      shippedAgents = shippedAgents.filter(a => !cleanableNames.has(a.name))
+
+      // Apply age filter if specified
+      if (ageHours > 0) {
+        const cutoffMs = ageHours * 60 * 60 * 1000
+        shippedAgents = shippedAgents.filter(agent => {
+          const agentCreated = agent.created_at ? new Date(agent.created_at).getTime() : 0
+          return agentCreated > 0 && (Date.now() - agentCreated) > cutoffMs
+        })
+      }
+
       // Determine total work to be done
       const totalOrphans = orphanHostSessions.length + orphanContainerSessions.length
-      const totalWork = staleCount + totalOrphans + cleanableAgents.length + result.deadContainersKilled.length
+      const totalWork = staleCount + totalOrphans + cleanableAgents.length + shippedAgents.length + result.deadContainersKilled.length
 
       if (totalWork === 0) {
         if (jsonMode) {
@@ -299,11 +331,18 @@ export default class SessionPrune extends PromptCommand {
             this.log(styles.muted(`    - ${agent.name}`))
           }
         }
+        if (shippedAgents.length > 0) {
+          this.log(styles.info(`  ${shippedAgents.length} shipped agent(s) ${dryRun ? 'would be ' : ''}cleaned up (work done, PR merged):`))
+          for (const agent of shippedAgents) {
+            this.log(styles.muted(`    - ${agent.name}`))
+          }
+        }
         this.log('')
       }
 
       // Confirm unless --yes or --dry-run
-      if (!skipConfirm && !dryRun && (cleanableAgents.length > 0 || result.deadContainersKilled.length > 0)) {
+      const hasDestructiveWork = cleanableAgents.length > 0 || shippedAgents.length > 0 || result.deadContainersKilled.length > 0
+      if (!skipConfirm && !dryRun && hasDestructiveWork) {
         if (jsonMode) {
           outputSuccessAsJson({
             message: 'Confirmation required',
@@ -312,6 +351,7 @@ export default class SessionPrune extends PromptCommand {
               orphanSessions: totalOrphans,
               deadContainers: result.deadContainersKilled.length,
               ephemeralAgents: cleanableAgents.map(a => a.name),
+              shippedAgents: shippedAgents.map(a => a.name),
             },
           }, createMetadata('session prune', flags))
           return
@@ -374,6 +414,42 @@ export default class SessionPrune extends PromptCommand {
         }
       }
 
+      // Clean up shipped agents (PRLT-1359)
+      if (!dryRun) {
+        for (const agent of shippedAgents) {
+          if (!jsonMode) {
+            this.log(styles.info(`  Cleaning up shipped agent: ${agent.name}`))
+          }
+
+          // eslint-disable-next-line no-await-in-loop -- Sequential cleanup
+          const cleanupResult = await cleanupAgent(freshWorkspaceInfo, agent.name, {
+            log: jsonMode ? undefined : (msg) => this.log(styles.muted(`    ${msg}`)),
+            dryRun: false,
+            force: true, // Work is shipped — safe to force cleanup
+          })
+
+          result.shippedAgentsCleaned.push(cleanupResult)
+
+          if (!cleanupResult.success && !jsonMode) {
+            this.log(styles.warning(`    Failed to clean up ${agent.name}: ${cleanupResult.errors.join(', ')}`))
+          }
+        }
+      } else {
+        for (const agent of shippedAgents) {
+          result.shippedAgentsCleaned.push({
+            agent: agent.name,
+            success: true,
+            tmuxSessionsKilled: [],
+            containersRemoved: [],
+            directoriesRemoved: [],
+            branchesDeleted: [],
+            remoteBranchesDeleted: [],
+            executionRecordsCleaned: 0,
+            errors: [],
+          })
+        }
+      }
+
       // Output results
       if (jsonMode) {
         outputSuccessAsJson({
@@ -386,6 +462,8 @@ export default class SessionPrune extends PromptCommand {
             deadContainersKilled: result.deadContainersKilled.length,
             ephemeralAgentsCleaned: result.ephemeralAgentsCleaned.filter(r => r.success).length,
             ephemeralAgentsFailed: result.ephemeralAgentsCleaned.filter(r => !r.success).length,
+            shippedAgentsCleaned: result.shippedAgentsCleaned.filter(r => r.success).length,
+            shippedAgentsFailed: result.shippedAgentsCleaned.filter(r => !r.success).length,
           },
         }, createMetadata('session prune', flags))
         return
@@ -414,6 +492,16 @@ export default class SessionPrune extends PromptCommand {
       }
       if (failedCleanups.length > 0) {
         this.log(styles.warning(`  ${failedCleanups.length} agent(s) skipped (unsaved work)`))
+      }
+
+      const successfulShipped = result.shippedAgentsCleaned.filter(r => r.success)
+      const failedShipped = result.shippedAgentsCleaned.filter(r => !r.success)
+
+      if (successfulShipped.length > 0) {
+        this.log(styles.success(`  ${successfulShipped.length} shipped agent(s) ${dryRun ? 'would be ' : ''}cleaned up`))
+      }
+      if (failedShipped.length > 0) {
+        this.log(styles.warning(`  ${failedShipped.length} shipped agent(s) failed to clean up`))
       }
       if (result.errors.length > 0) {
         for (const err of result.errors) {

--- a/apps/cli/src/commands/work/ship.ts
+++ b/apps/cli/src/commands/work/ship.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { PMOCommand, pmoBaseFlags, autoExportToBoard } from '../../lib/pmo/index.js';
 import { styles } from '../../lib/styles.js';
-import { getWorkspaceInfo } from '../../lib/agents/commands.js';
+import { getWorkspaceInfo, cleanupAgent } from '../../lib/agents/commands.js';
 import { ExecutionStorage } from '../../lib/execution/storage.js';
 import {
   requireGhCli,
@@ -89,6 +89,11 @@ export default class WorkShip extends PMOCommand {
     'no-transition': Flags.boolean({
       description: 'Skip board state transition (still merges PR)',
       default: false,
+    }),
+    'auto-prune': Flags.boolean({
+      description: 'Automatically clean up the agent that worked on this ticket after shipping',
+      default: true,
+      allowNo: true,
     }),
   };
 
@@ -200,6 +205,38 @@ export default class WorkShip extends PMOCommand {
         await autoExportToBoard(this.pmoPath, this.storage);
       }
 
+      // --- Auto-prune agent (PRLT-1359) ---
+      let prunedAgent: string | undefined;
+      if (result.success && !flags['dry-run'] && flags['auto-prune']) {
+        try {
+          const ticketIdForLookup = result.ticket?.id ?? args.ticketId;
+          if (ticketIdForLookup) {
+            const executionStorage = new ExecutionStorage(db);
+            const completedExecs = executionStorage.listExecutions({ ticketId: ticketIdForLookup });
+            const completedExec = completedExecs.find(e => e.status === 'completed');
+            if (completedExec) {
+              const freshWorkspace = getWorkspaceInfo();
+              const agent = freshWorkspace.agents.find(a => a.name === completedExec.agentName);
+              if (agent && agent.type === 'ephemeral' && (agent.status === 'active' || agent.status === 'running')) {
+                // Ensure agent has no other running work
+                const runningExecs = executionStorage.getAgentRunningExecutions(agent.name);
+                if (runningExecs.length === 0) {
+                  const cleanupResult = await cleanupAgent(freshWorkspace, agent.name, {
+                    force: true, // Work is shipped — safe to force cleanup
+                    log: jsonMode ? undefined : (msg) => this.log(styles.muted(`   ${msg}`)),
+                  });
+                  if (cleanupResult.success) {
+                    prunedAgent = agent.name;
+                  }
+                }
+              }
+            }
+          }
+        } catch {
+          // Non-critical — don't fail ship because of cleanup
+        }
+      }
+
       // --- Output ---
       if (flags['dry-run'] && result.dryRunDetails) {
         this.outputDryRun(result, flags);
@@ -215,9 +252,10 @@ export default class WorkShip extends PMOCommand {
           newState: result.newState ?? null,
           siblingsRebased: result.siblingsRebased,
           siblingCount: result.siblingCount,
+          prunedAgent: prunedAgent ?? null,
         }, createMetadata('work ship', flags));
       } else {
-        this.outputHuman(result);
+        this.outputHuman(result, prunedAgent);
       }
     } catch (error) {
       if (error instanceof ServiceError) {
@@ -242,7 +280,7 @@ export default class WorkShip extends PMOCommand {
     }
   }
 
-  private outputHuman(result: any): void {
+  private outputHuman(result: any, prunedAgent?: string): void {
     this.log('');
     if (result.alreadyMerged) {
       this.log(styles.success(`Synced: ${result.ticket?.id ?? `PR #${result.pr?.number}`} (PR already merged)`));
@@ -258,6 +296,9 @@ export default class WorkShip extends PMOCommand {
     }
     if (result.siblingsRebased) {
       this.log(styles.muted(`   Sibling rebases: ${result.siblingCount}`));
+    }
+    if (prunedAgent) {
+      this.log(styles.muted(`   Pruned agent: ${prunedAgent}`));
     }
   }
 

--- a/apps/cli/src/lib/agents/commands.ts
+++ b/apps/cli/src/lib/agents/commands.ts
@@ -1547,3 +1547,32 @@ export function getCleanableAgents(
     return sessions.length === 0;
   });
 }
+
+/**
+ * Get agents whose work has been shipped (execution completed/stopped).
+ *
+ * PRLT-1359: Unlike getCleanableAgents() which finds idle agents without
+ * tmux sessions, this finds agents with completed work that may still have
+ * active sessions — the "zombie" agents consuming resources after ship.
+ *
+ * @param workspaceInfo - Workspace info with agent list
+ * @param completedAgentNames - Agent names with completed/stopped executions
+ * @param busyAgentNames - Agent names with running/starting executions (excluded for safety)
+ */
+export function getShippedAgents(
+  workspaceInfo: WorkspaceInfo,
+  completedAgentNames: Set<string>,
+  busyAgentNames: Set<string>,
+): Agent[] {
+  return workspaceInfo.agents.filter(agent => {
+    // Only clean ephemeral agents
+    if (agent.type !== 'ephemeral') return false;
+    // Only clean agents still in active/running lifecycle state
+    if (agent.status !== 'active' && agent.status !== 'running') return false;
+    // Must have completed work
+    if (!completedAgentNames.has(agent.name)) return false;
+    // Safety: don't clean agents with other running executions
+    if (busyAgentNames.has(agent.name)) return false;
+    return true;
+  });
+}

--- a/apps/cli/test/unit/auto-prune-shipped-agents.test.ts
+++ b/apps/cli/test/unit/auto-prune-shipped-agents.test.ts
@@ -1,0 +1,165 @@
+import { expect } from 'chai'
+import { getShippedAgents, WorkspaceInfo } from '../../src/lib/agents/commands.js'
+import type { Agent } from '../../src/lib/database/agents.js'
+
+/**
+ * Tests for PRLT-1359: Auto-prune agents whose work is done
+ *
+ * getShippedAgents() finds agents with completed/stopped executions that
+ * are still in active/running lifecycle state — the "zombie" agents
+ * consuming resources after their work has been shipped.
+ */
+describe('@smoke getShippedAgents identifies agents with completed work (PRLT-1359)', () => {
+  function makeAgent(overrides: Partial<Agent> & { name: string }): Agent {
+    return {
+      type: 'ephemeral',
+      status: 'active',
+      base_name: null,
+      theme_id: null,
+      worktree_path: null,
+      mount_mode: 'worktree',
+      created_at: new Date().toISOString(),
+      cleaned_at: null,
+      ...overrides,
+    }
+  }
+
+  function makeWorkspaceInfo(agents: Agent[]): WorkspaceInfo {
+    return {
+      path: '/tmp/test-workspace',
+      type: 'hq',
+      workspaceName: 'test',
+      hasPMO: false,
+      agents,
+      repositories: [],
+      agentsPath: '/tmp/test-workspace/temp',
+      activeThemeId: null,
+      persistentAgentsDir: 'staff',
+      ephemeralAgentsDir: 'temp',
+    }
+  }
+
+  it('returns agents with completed executions that are still active', () => {
+    const agents = [
+      makeAgent({ name: 'shipped-agent', status: 'active' }),
+      makeAgent({ name: 'idle-agent', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set(['shipped-agent'])
+    const busyAgentNames = new Set<string>()
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    const names = shipped.map(a => a.name)
+
+    expect(names).to.deep.equal(['shipped-agent'])
+  })
+
+  it('returns agents with completed executions that are still running', () => {
+    const agents = [
+      makeAgent({ name: 'shipped-running', status: 'running' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set(['shipped-running'])
+    const busyAgentNames = new Set<string>()
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    expect(shipped).to.have.length(1)
+    expect(shipped[0].name).to.equal('shipped-running')
+  })
+
+  it('excludes agents with other running executions (safety)', () => {
+    const agents = [
+      makeAgent({ name: 'multi-task-agent', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set(['multi-task-agent'])
+    const busyAgentNames = new Set(['multi-task-agent']) // Still has running work
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    expect(shipped).to.have.length(0)
+  })
+
+  it('excludes persistent agents', () => {
+    const agents = [
+      makeAgent({ name: 'persistent-done', type: 'persistent', status: 'active' }),
+      makeAgent({ name: 'ephemeral-done', type: 'ephemeral', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set(['persistent-done', 'ephemeral-done'])
+    const busyAgentNames = new Set<string>()
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    const names = shipped.map(a => a.name)
+
+    expect(names).to.not.include('persistent-done')
+    expect(names).to.include('ephemeral-done')
+  })
+
+  it('excludes already-cleaned agents', () => {
+    const agents = [
+      makeAgent({ name: 'already-cleaned', status: 'cleaned' }),
+      makeAgent({ name: 'already-completed', status: 'completed' }),
+      makeAgent({ name: 'already-dead', status: 'dead' }),
+      makeAgent({ name: 'still-active', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set([
+      'already-cleaned', 'already-completed', 'already-dead', 'still-active',
+    ])
+    const busyAgentNames = new Set<string>()
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    const names = shipped.map(a => a.name)
+
+    expect(names).to.deep.equal(['still-active'])
+  })
+
+  it('excludes agents without completed executions', () => {
+    const agents = [
+      makeAgent({ name: 'agent-1', status: 'active' }),
+      makeAgent({ name: 'agent-2', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set(['agent-1']) // only agent-1 has completed work
+    const busyAgentNames = new Set<string>()
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    const names = shipped.map(a => a.name)
+
+    expect(names).to.deep.equal(['agent-1'])
+    expect(names).to.not.include('agent-2')
+  })
+
+  it('returns empty array when no agents have completed work', () => {
+    const agents = [
+      makeAgent({ name: 'agent-1', status: 'active' }),
+      makeAgent({ name: 'agent-2', status: 'running' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set<string>()
+    const busyAgentNames = new Set<string>()
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    expect(shipped).to.have.length(0)
+  })
+
+  it('handles multiple shipped agents correctly', () => {
+    const agents = [
+      makeAgent({ name: 'shipped-1', status: 'active' }),
+      makeAgent({ name: 'shipped-2', status: 'running' }),
+      makeAgent({ name: 'not-shipped', status: 'active' }),
+      makeAgent({ name: 'shipped-but-busy', status: 'active' }),
+    ]
+    const workspace = makeWorkspaceInfo(agents)
+    const completedAgentNames = new Set(['shipped-1', 'shipped-2', 'shipped-but-busy'])
+    const busyAgentNames = new Set(['shipped-but-busy'])
+
+    const shipped = getShippedAgents(workspace, completedAgentNames, busyAgentNames)
+    const names = shipped.map(a => a.name)
+
+    expect(names).to.include('shipped-1')
+    expect(names).to.include('shipped-2')
+    expect(names).to.not.include('not-shipped')
+    expect(names).to.not.include('shipped-but-busy')
+  })
+})


### PR DESCRIPTION
## Summary

- **New `getShippedAgents()` function** in `lib/agents/commands.ts` — identifies ephemeral agents with completed/stopped executions that are still in active/running lifecycle state (the "zombie" agents consuming resources)
- **Step 5 in `session prune`** — automatically cleans up shipped agents (completed work, PR merged) alongside existing idle agent cleanup
- **Auto-prune after `work ship`** — when a PR is shipped, automatically cleans up the agent that worked on it. Opt out with `--no-auto-prune`

Fixes: 50 zombie agent sessions consuming resources because `session prune` only killed dead tmux sessions, not idle ones whose work was done.

## Changes

- `apps/cli/src/lib/agents/commands.ts` — Added `getShippedAgents()` export
- `apps/cli/src/commands/session/prune.ts` — Added Step 5 shipped agent cleanup phase with display, confirmation, and execution
- `apps/cli/src/commands/work/ship.ts` — Added `--auto-prune` flag (default: true) and post-ship agent cleanup
- `apps/cli/test/unit/auto-prune-shipped-agents.test.ts` — 8 unit tests for `getShippedAgents()`

## Test plan

- [x] Unit tests pass for `getShippedAgents()` — verifies filtering by agent type, lifecycle status, completion state, and busy safety check
- [ ] Manual: `prlt work ship <ticket>` cleans up the agent after merge
- [ ] Manual: `prlt work ship <ticket> --no-auto-prune` skips cleanup
- [ ] Manual: `prlt session prune` identifies and cleans shipped agents
- [ ] Manual: `prlt session prune --dry-run` shows shipped agents that would be cleaned
- [ ] CI passes

Linear: PRLT-1359