### PR TITLE
feat(PRLT-1361): add api type to prlt tools — register REST APIs with base URL, auth, and docs

### DIFF
--- a/apps/cli/src/commands/tools/add.ts
+++ b/apps/cli/src/commands/tools/add.ts
@@ -12,22 +12,24 @@ import { machineOutputFlags } from '../../lib/pmo/index.js'
 import {
   addMcpServer,
   addCliTool,
+  addApiTool,
   loadToolRegistry,
 } from '../../lib/tool-registry/index.js'
 
 export default class ToolsAdd extends PromptCommand {
-  static description = 'Register an MCP server or CLI tool'
+  static description = 'Register an MCP server, CLI tool, or REST API'
 
   static examples = [
     '<%= config.bin %> tools add mcp arcade --url https://api.arcade.dev/mcp --auth ARCADE_API_KEY --description "Arcade integrations"',
     '<%= config.bin %> tools add cli gh --command gh --detect "which gh" --install "brew install gh" --description "GitHub CLI"',
+    '<%= config.bin %> tools add api posthog --url https://app.posthog.com/api --auth POSTHOG_API_KEY --description "PostHog analytics API" --docs https://posthog.com/docs/api',
   ]
 
   static args = {
     type: Args.string({
-      description: 'Tool type (mcp or cli)',
+      description: 'Tool type (mcp, cli, or api)',
       required: true,
-      options: ['mcp', 'cli'],
+      options: ['mcp', 'cli', 'api'],
     }),
     name: Args.string({
       description: 'Tool name (unique identifier)',
@@ -56,6 +58,12 @@ export default class ToolsAdd extends PromptCommand {
       char: 'd',
       description: 'Human-readable description',
       required: true,
+    }),
+    docs: Flags.string({
+      description: 'Link to API documentation (for api type)',
+    }),
+    'auth-header': Flags.string({
+      description: 'Auth header format (default: "Authorization: Bearer", for api type)',
     }),
   }
 
@@ -147,6 +155,58 @@ export default class ToolsAdd extends PromptCommand {
       } else {
         this.log(chalk.green(`\nCLI tool '${args.name}' registered successfully.`))
         this.log(chalk.dim(`  Command: ${command}`))
+        this.log('')
+      }
+    } else if (args.type === 'api') {
+      if (!flags.url) {
+        if (jsonMode) {
+          outputErrorAsJson('MISSING_FLAG', 'API tool requires --url', meta())
+          return
+        } else {
+          this.error('API tool requires --url (base URL of the REST API)')
+        }
+        return
+      }
+
+      if (!flags.auth) {
+        if (jsonMode) {
+          outputErrorAsJson('MISSING_FLAG', 'API tool requires --auth', meta())
+          return
+        } else {
+          this.error('API tool requires --auth (environment variable name holding the API token)')
+        }
+        return
+      }
+
+      if (args.name in registry['api-tools']) {
+        if (jsonMode) {
+          outputErrorAsJson('DUPLICATE', `API tool '${args.name}' already exists`, meta())
+          return
+        } else {
+          this.error(`API tool '${args.name}' already exists. Remove it first with: prlt tools remove ${args.name}`)
+        }
+        return
+      }
+
+      addApiTool(hqPath, args.name, {
+        url: flags.url,
+        auth: flags.auth,
+        auth_header: flags['auth-header'],
+        description: flags.description,
+        docs: flags.docs,
+      })
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { name: args.name, type: 'api', url: flags.url, description: flags.description },
+          meta()
+        )
+        return
+      } else {
+        this.log(chalk.green(`\nAPI tool '${args.name}' registered successfully.`))
+        this.log(chalk.dim(`  URL: ${flags.url}`))
+        this.log(chalk.dim(`  Auth: $${flags.auth}`))
+        if (flags.docs) this.log(chalk.dim(`  Docs: ${flags.docs}`))
         this.log('')
       }
     }

--- a/apps/cli/src/commands/tools/check.ts
+++ b/apps/cli/src/commands/tools/check.ts
@@ -50,7 +50,7 @@ export default class ToolsCheck extends Command {
       this.log(`\n${chalk.green('Available')}`)
       this.log('─'.repeat(40))
       for (const result of available) {
-        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : chalk.green('[CLI]')
+        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : result.type === 'api' ? chalk.yellow('[API]') : chalk.green('[CLI]')
         this.log(`  ${chalk.green('✓')} ${badge} ${result.name}`)
       }
     }
@@ -59,7 +59,7 @@ export default class ToolsCheck extends Command {
       this.log(`\n${chalk.red('Unavailable')}`)
       this.log('─'.repeat(40))
       for (const result of unavailable) {
-        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : chalk.green('[CLI]')
+        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : result.type === 'api' ? chalk.yellow('[API]') : chalk.green('[CLI]')
         this.log(`  ${chalk.red('✗')} ${badge} ${result.name}`)
         if (result.error) this.log(`    ${chalk.dim(result.error)}`)
         if (result.installHint) this.log(`    ${chalk.dim(`Install: ${result.installHint}`)}`)

--- a/apps/cli/src/commands/tools/index.ts
+++ b/apps/cli/src/commands/tools/index.ts
@@ -7,6 +7,7 @@ import {
   loadToolRegistry,
   getMcpServers,
   getCliTools,
+  getApiTools,
 } from '../../lib/tool-registry/index.js'
 
 export default class ToolsList extends Command {
@@ -40,6 +41,7 @@ export default class ToolsList extends Command {
     const registry = loadToolRegistry(hqPath)
     const mcpServers = getMcpServers(registry)
     const cliTools = getCliTools(registry)
+    const apiTools = getApiTools(registry)
 
     if (jsonMode) {
       this.log(JSON.stringify({
@@ -56,6 +58,15 @@ export default class ToolsList extends Command {
           command: t.command,
           description: t.description,
           builtin: t.builtin || false,
+        })),
+        apiTools: apiTools.map(a => ({
+          name: a.name,
+          type: 'api',
+          url: a.url,
+          auth: a.auth,
+          auth_header: a.auth_header,
+          description: a.description,
+          docs: a.docs,
         })),
       }, null, 2))
       return
@@ -89,6 +100,20 @@ export default class ToolsList extends Command {
       for (const tool of cliTools) {
         const builtin = tool.builtin ? chalk.dim(' [built-in]') : ''
         this.log(`  ${chalk.green(tool.name)} (${tool.command}) — ${tool.description}${builtin}`)
+      }
+    }
+
+    // API Tools
+    this.log(`\n${chalk.bold('REST APIs')}`)
+    this.log('─'.repeat(40))
+    if (apiTools.length === 0) {
+      this.log(chalk.dim('  No API tools registered'))
+      this.log(chalk.dim('  Add one: prlt tools add api <name> --url <url> --auth <ENV_VAR>'))
+    } else {
+      for (const api of apiTools) {
+        const docs = api.docs ? chalk.dim(` [docs: ${api.docs}]`) : ''
+        this.log(`  ${chalk.yellow(api.name)} — ${api.description}`)
+        this.log(`    ${chalk.dim(api.url)} [auth: $${api.auth}]${docs}`)
       }
     }
 

--- a/apps/cli/src/lib/tool-registry/detect.ts
+++ b/apps/cli/src/lib/tool-registry/detect.ts
@@ -9,10 +9,11 @@ import type {
   ToolRegistry,
   CliToolConfig,
   McpServerConfig,
+  ApiToolConfig,
   ToolCheckResult,
 } from './types.js'
 import { COMMON_CLI_TOOLS } from './types.js'
-import { getMcpServers, getCliTools } from './registry.js'
+import { getMcpServers, getCliTools, getApiTools } from './registry.js'
 
 /**
  * Check if a CLI tool is available on the system.
@@ -62,6 +63,11 @@ export function checkAllTools(registry: ToolRegistry): ToolCheckResult[] {
     results.push(checkCliTool(tool))
   }
 
+  // Check API tools
+  for (const api of getApiTools(registry)) {
+    results.push(checkApiTool(api))
+  }
+
   return results
 }
 
@@ -106,5 +112,30 @@ function checkCliTool(tool: CliToolConfig): ToolCheckResult {
     available,
     error: available ? undefined : `Command not found: ${tool.command}`,
     installHint: available ? undefined : tool.install,
+  }
+}
+
+function checkApiTool(api: ApiToolConfig): ToolCheckResult {
+  // Check if the auth env var is set
+  if (!process.env[api.auth]) {
+    return {
+      name: api.name,
+      type: 'api',
+      available: false,
+      error: `Missing environment variable: ${api.auth}`,
+    }
+  }
+
+  // Check if the URL is reachable via a HEAD request
+  try {
+    execSync(`curl -s -o /dev/null -w '%{http_code}' --max-time 5 --head "${api.url}"`, { stdio: 'pipe' })
+    return { name: api.name, type: 'api', available: true }
+  } catch {
+    return {
+      name: api.name,
+      type: 'api',
+      available: false,
+      error: `API not reachable: ${api.url}`,
+    }
   }
 }

--- a/apps/cli/src/lib/tool-registry/index.ts
+++ b/apps/cli/src/lib/tool-registry/index.ts
@@ -6,6 +6,7 @@
 export type {
   McpServerConfig,
   CliToolConfig,
+  ApiToolConfig,
   ToolRegistry,
   ToolPolicy,
   ToolCheckResult,
@@ -19,8 +20,10 @@ export {
   saveToolRegistry,
   getMcpServers,
   getCliTools,
+  getApiTools,
   addMcpServer,
   addCliTool,
+  addApiTool,
   removeTool,
 } from './registry.js'
 

--- a/apps/cli/src/lib/tool-registry/policy.ts
+++ b/apps/cli/src/lib/tool-registry/policy.ts
@@ -13,6 +13,7 @@ import type {
   ToolPolicy,
   McpServerConfig,
   CliToolConfig,
+  ApiToolConfig,
 } from './types.js'
 import { BUILTIN_PRLT_TOOL } from './types.js'
 
@@ -80,9 +81,10 @@ export function listPolicies(hqPath: string): string[] {
 export function filterByPolicy(
   registry: ToolRegistry,
   policy: ToolPolicy | null
-): { mcpServers: McpServerConfig[]; cliTools: CliToolConfig[] } {
+): { mcpServers: McpServerConfig[]; cliTools: CliToolConfig[]; apiTools: ApiToolConfig[] } {
   const allMcp = Object.entries(registry['mcp-servers'])
   const allCli = Object.entries(registry['cli-tools'])
+  const allApi = Object.entries(registry['api-tools'])
 
   // No policy = full access
   if (!policy) {
@@ -93,6 +95,7 @@ export function filterByPolicy(
         // Always include prlt
         ...(allCli.some(([name]) => name === 'prlt') ? [] : [BUILTIN_PRLT_TOOL]),
       ],
+      apiTools: allApi.map(([name, config]) => ({ name, ...config })),
     }
   }
 
@@ -116,5 +119,11 @@ export function filterByPolicy(
     cliTools.push(BUILTIN_PRLT_TOOL)
   }
 
-  return { mcpServers, cliTools }
+  // Filter API tools
+  const allowedApi = new Set(policy.api || [])
+  const apiTools = allApi
+    .filter(([name]) => allowedApi.has(name))
+    .map(([name, config]) => ({ name, ...config }))
+
+  return { mcpServers, cliTools, apiTools }
 }

--- a/apps/cli/src/lib/tool-registry/registry.ts
+++ b/apps/cli/src/lib/tool-registry/registry.ts
@@ -12,6 +12,7 @@ import type {
   ToolRegistry,
   McpServerConfig,
   CliToolConfig,
+  ApiToolConfig,
 } from './types.js'
 import { BUILTIN_PRLT_TOOL } from './types.js'
 
@@ -34,6 +35,7 @@ export function loadToolRegistry(hqPath: string): ToolRegistry {
   const empty: ToolRegistry = {
     'mcp-servers': {},
     'cli-tools': {},
+    'api-tools': {},
   }
 
   if (!fs.existsSync(configPath)) {
@@ -47,6 +49,7 @@ export function loadToolRegistry(hqPath: string): ToolRegistry {
     return {
       'mcp-servers': parsed?.['mcp-servers'] ?? {},
       'cli-tools': parsed?.['cli-tools'] ?? {},
+      'api-tools': parsed?.['api-tools'] ?? {},
     }
   } catch {
     return empty
@@ -100,6 +103,16 @@ export function getCliTools(registry: ToolRegistry): CliToolConfig[] {
 }
 
 /**
+ * Get all API tools from the registry, hydrated with their names.
+ */
+export function getApiTools(registry: ToolRegistry): ApiToolConfig[] {
+  return Object.entries(registry['api-tools']).map(([name, config]) => ({
+    name,
+    ...config,
+  }))
+}
+
+/**
  * Add an MCP server to the registry.
  */
 export function addMcpServer(
@@ -126,7 +139,20 @@ export function addCliTool(
 }
 
 /**
- * Remove a tool (MCP or CLI) from the registry.
+ * Add an API tool to the registry.
+ */
+export function addApiTool(
+  hqPath: string,
+  name: string,
+  config: Omit<ApiToolConfig, 'name'>
+): void {
+  const registry = loadToolRegistry(hqPath)
+  registry['api-tools'][name] = config
+  saveToolRegistry(hqPath, registry)
+}
+
+/**
+ * Remove a tool (MCP, CLI, or API) from the registry.
  * Returns true if the tool was found and removed.
  */
 export function removeTool(hqPath: string, name: string): boolean {
@@ -144,6 +170,12 @@ export function removeTool(hqPath: string, name: string): boolean {
       return false // Can't remove built-in tools
     }
     delete registry['cli-tools'][name]
+    saveToolRegistry(hqPath, registry)
+    return true
+  }
+
+  if (name in registry['api-tools']) {
+    delete registry['api-tools'][name]
     saveToolRegistry(hqPath, registry)
     return true
   }

--- a/apps/cli/src/lib/tool-registry/spawn.ts
+++ b/apps/cli/src/lib/tool-registry/spawn.ts
@@ -10,7 +10,7 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import type { McpServerConfig, CliToolConfig, ToolPolicy } from './types.js'
+import type { McpServerConfig, CliToolConfig, ApiToolConfig, ToolPolicy } from './types.js'
 import { loadToolRegistry } from './registry.js'
 import { loadToolPolicy, filterByPolicy } from './policy.js'
 
@@ -94,9 +94,10 @@ export function writeMcpConfigFile(
  */
 export function buildToolsPromptSection(
   mcpServers: McpServerConfig[],
-  cliTools: CliToolConfig[]
+  cliTools: CliToolConfig[],
+  apiTools: ApiToolConfig[] = []
 ): string {
-  if (mcpServers.length === 0 && cliTools.length === 0) return ''
+  if (mcpServers.length === 0 && cliTools.length === 0 && apiTools.length === 0) return ''
 
   let section = `## Available Tools\n\n`
 
@@ -116,6 +117,19 @@ export function buildToolsPromptSection(
     section += `\n`
   }
 
+  if (apiTools.length > 0) {
+    section += `**REST APIs:**\n`
+    for (const api of apiTools) {
+      const authHeader = api.auth_header || 'Authorization: Bearer'
+      section += `- ${api.name} API is available at ${api.url}. Auth: ${authHeader} $${api.auth}. ${api.description}`
+      if (api.docs) {
+        section += `. Docs: ${api.docs}`
+      }
+      section += `\n`
+    }
+    section += `\n`
+  }
+
   section += `Use these tools for external interactions. Prefer registered tools over raw curl or API calls.\n\n`
 
   return section
@@ -130,6 +144,7 @@ export interface SpawnToolsResult {
   promptSection: string
   mcpServers: McpServerConfig[]
   cliTools: CliToolConfig[]
+  apiTools: ApiToolConfig[]
 }
 
 /**
@@ -150,10 +165,10 @@ export function resolveToolsForSpawn(
     ? loadToolPolicy(hqPath, policyName)
     : null
 
-  const { mcpServers, cliTools } = filterByPolicy(registry, policy)
+  const { mcpServers, cliTools, apiTools } = filterByPolicy(registry, policy)
 
   const mcpConfigPath = writeMcpConfigFile(mcpServers, outputDir)
-  const promptSection = buildToolsPromptSection(mcpServers, cliTools)
+  const promptSection = buildToolsPromptSection(mcpServers, cliTools, apiTools)
 
-  return { mcpConfigPath, promptSection, mcpServers, cliTools }
+  return { mcpConfigPath, promptSection, mcpServers, cliTools, apiTools }
 }

--- a/apps/cli/src/lib/tool-registry/types.ts
+++ b/apps/cli/src/lib/tool-registry/types.ts
@@ -25,6 +25,25 @@ export interface McpServerConfig {
 }
 
 // =============================================================================
+// API Tool Registry
+// =============================================================================
+
+export interface ApiToolConfig {
+  /** Tool name (unique identifier) */
+  name: string
+  /** Base URL of the REST API */
+  url: string
+  /** Environment variable name holding the auth token (e.g., "POSTHOG_API_KEY") */
+  auth: string
+  /** Auth header format (default: "Authorization: Bearer") */
+  auth_header?: string
+  /** Human-readable description */
+  description: string
+  /** Link to API documentation */
+  docs?: string
+}
+
+// =============================================================================
 // CLI Tool Registry
 // =============================================================================
 
@@ -50,6 +69,7 @@ export interface CliToolConfig {
 export interface ToolRegistry {
   'mcp-servers': Record<string, Omit<McpServerConfig, 'name'>>
   'cli-tools': Record<string, Omit<CliToolConfig, 'name'>>
+  'api-tools': Record<string, Omit<ApiToolConfig, 'name'>>
 }
 
 // =============================================================================
@@ -59,6 +79,7 @@ export interface ToolRegistry {
 export interface ToolPolicy {
   mcp: string[]
   cli: string[]
+  api: string[]
   /** Per-MCP-server fine-grained access (e.g., arcade: { allow: ['asana', 'slack'] }) */
   [serverName: string]: string[] | { allow: string[] } | undefined
 }
@@ -69,7 +90,7 @@ export interface ToolPolicy {
 
 export interface ToolCheckResult {
   name: string
-  type: 'mcp' | 'cli'
+  type: 'mcp' | 'cli' | 'api'
   available: boolean
   error?: string
   installHint?: string

--- a/apps/cli/test/unit/api-tool-registry.test.ts
+++ b/apps/cli/test/unit/api-tool-registry.test.ts
@@ -1,0 +1,403 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  loadToolRegistry,
+  saveToolRegistry,
+  getApiTools,
+  addApiTool,
+  removeTool,
+  checkAllTools,
+  buildToolsPromptSection,
+  filterByPolicy,
+} from '../../src/lib/tool-registry/index.js'
+import type {
+  ToolRegistry,
+  ApiToolConfig,
+  ToolPolicy,
+} from '../../src/lib/tool-registry/index.js'
+
+describe('API Tool Registry', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'api-tool-test-'))
+    fs.mkdirSync(path.join(tmpDir, '.proletariat'), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  // ===========================================================================
+  // types.ts — ApiToolConfig in ToolRegistry
+  // ===========================================================================
+
+  describe('ToolRegistry with api-tools', () => {
+    it('loadToolRegistry returns empty api-tools when no file exists', () => {
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']).to.deep.equal({})
+    })
+
+    it('loadToolRegistry returns empty api-tools when file has no api-tools section', () => {
+      const configPath = path.join(tmpDir, '.proletariat', 'tools.yaml')
+      fs.writeFileSync(configPath, 'mcp-servers: {}\ncli-tools: {}\n', 'utf-8')
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']).to.deep.equal({})
+    })
+
+    it('loadToolRegistry reads api-tools from YAML', () => {
+      const configPath = path.join(tmpDir, '.proletariat', 'tools.yaml')
+      fs.writeFileSync(configPath, [
+        'api-tools:',
+        '  posthog:',
+        '    url: https://app.posthog.com/api',
+        '    auth: POSTHOG_API_KEY',
+        '    description: PostHog analytics API',
+        '    docs: https://posthog.com/docs/api',
+        'cli-tools: {}',
+        'mcp-servers: {}',
+      ].join('\n'), 'utf-8')
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']).to.have.property('posthog')
+      expect(registry['api-tools']['posthog'].url).to.equal('https://app.posthog.com/api')
+      expect(registry['api-tools']['posthog'].auth).to.equal('POSTHOG_API_KEY')
+      expect(registry['api-tools']['posthog'].docs).to.equal('https://posthog.com/docs/api')
+    })
+
+    it('saveToolRegistry persists api-tools to YAML', () => {
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          stripe: {
+            url: 'https://api.stripe.com',
+            auth: 'STRIPE_SECRET_KEY',
+            description: 'Stripe payments API',
+          },
+        },
+      }
+      saveToolRegistry(tmpDir, registry)
+      const reloaded = loadToolRegistry(tmpDir)
+      expect(reloaded['api-tools']['stripe'].url).to.equal('https://api.stripe.com')
+      expect(reloaded['api-tools']['stripe'].auth).to.equal('STRIPE_SECRET_KEY')
+    })
+  })
+
+  // ===========================================================================
+  // registry.ts — getApiTools, addApiTool, removeTool
+  // ===========================================================================
+
+  describe('getApiTools', () => {
+    it('returns empty array when no api tools registered', () => {
+      const registry = loadToolRegistry(tmpDir)
+      expect(getApiTools(registry)).to.deep.equal([])
+    })
+
+    it('hydrates name field into each api tool config', () => {
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: {
+            url: 'https://app.posthog.com/api',
+            auth: 'POSTHOG_API_KEY',
+            description: 'PostHog analytics API',
+          },
+        },
+      }
+      const tools = getApiTools(registry)
+      expect(tools).to.have.length(1)
+      expect(tools[0].name).to.equal('posthog')
+      expect(tools[0].url).to.equal('https://app.posthog.com/api')
+    })
+  })
+
+  describe('addApiTool', () => {
+    it('adds an api tool to the registry', () => {
+      addApiTool(tmpDir, 'posthog', {
+        url: 'https://app.posthog.com/api',
+        auth: 'POSTHOG_API_KEY',
+        description: 'PostHog analytics API',
+        docs: 'https://posthog.com/docs/api',
+      })
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']).to.have.property('posthog')
+      expect(registry['api-tools']['posthog'].url).to.equal('https://app.posthog.com/api')
+      expect(registry['api-tools']['posthog'].auth).to.equal('POSTHOG_API_KEY')
+      expect(registry['api-tools']['posthog'].docs).to.equal('https://posthog.com/docs/api')
+    })
+
+    it('stores auth_header when provided', () => {
+      addApiTool(tmpDir, 'custom', {
+        url: 'https://api.custom.io',
+        auth: 'CUSTOM_KEY',
+        auth_header: 'X-API-Key',
+        description: 'Custom API',
+      })
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']['custom'].auth_header).to.equal('X-API-Key')
+    })
+
+    it('does not store docs when not provided', () => {
+      addApiTool(tmpDir, 'simple', {
+        url: 'https://api.simple.io',
+        auth: 'SIMPLE_KEY',
+        description: 'Simple API',
+      })
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']['simple'].docs).to.be.undefined
+    })
+
+    it('stores auth as plain env var name, not as a secret', () => {
+      addApiTool(tmpDir, 'test-api', {
+        url: 'https://api.test.io',
+        auth: 'TEST_API_KEY',
+        description: 'Test API',
+      })
+      const registry = loadToolRegistry(tmpDir)
+      // auth should be the env var NAME, not the value
+      expect(registry['api-tools']['test-api'].auth).to.equal('TEST_API_KEY')
+      // Should not contain any actual secret values
+      const content = fs.readFileSync(
+        path.join(tmpDir, '.proletariat', 'tools.yaml'), 'utf-8'
+      )
+      expect(content).to.include('TEST_API_KEY')
+      expect(content).not.to.include('sk-') // no actual secrets
+    })
+  })
+
+  describe('removeTool (api)', () => {
+    it('removes an api tool from the registry', () => {
+      addApiTool(tmpDir, 'posthog', {
+        url: 'https://app.posthog.com/api',
+        auth: 'POSTHOG_API_KEY',
+        description: 'PostHog analytics API',
+      })
+      const removed = removeTool(tmpDir, 'posthog')
+      expect(removed).to.be.true
+      const registry = loadToolRegistry(tmpDir)
+      expect(registry['api-tools']).to.not.have.property('posthog')
+    })
+
+    it('returns false for non-existent api tool', () => {
+      const removed = removeTool(tmpDir, 'nonexistent')
+      expect(removed).to.be.false
+    })
+  })
+
+  // ===========================================================================
+  // detect.ts — checkAllTools with API tools
+  // ===========================================================================
+
+  describe('checkAllTools with API tools', () => {
+    it('reports missing env var as unavailable', () => {
+      // Save with env var that definitely does not exist
+      const envVar = `_PRLT_TEST_NONEXISTENT_${Date.now()}`
+      delete process.env[envVar]
+
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          testapi: {
+            url: 'https://api.example.com',
+            auth: envVar,
+            description: 'Test API',
+          },
+        },
+      }
+
+      const results = checkAllTools(registry)
+      const apiResult = results.find(r => r.name === 'testapi')
+      expect(apiResult).to.exist
+      expect(apiResult!.type).to.equal('api')
+      expect(apiResult!.available).to.be.false
+      expect(apiResult!.error).to.include('Missing environment variable')
+    })
+
+    it('includes api type in check results', () => {
+      // Set a temporary env var so auth check passes
+      const envVar = `_PRLT_TEST_API_CHECK_${Date.now()}`
+      process.env[envVar] = 'test-value'
+
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          testapi: {
+            url: 'https://api.example.com',
+            auth: envVar,
+            description: 'Test API',
+          },
+        },
+      }
+
+      const results = checkAllTools(registry)
+      const apiResult = results.find(r => r.name === 'testapi')
+      expect(apiResult).to.exist
+      expect(apiResult!.type).to.equal('api')
+
+      // Clean up
+      delete process.env[envVar]
+    })
+  })
+
+  // ===========================================================================
+  // spawn.ts — buildToolsPromptSection with API tools
+  // ===========================================================================
+
+  describe('buildToolsPromptSection with API tools', () => {
+    it('includes API tools in prompt section', () => {
+      const apiTools: ApiToolConfig[] = [
+        {
+          name: 'posthog',
+          url: 'https://app.posthog.com/api',
+          auth: 'POSTHOG_API_KEY',
+          description: 'PostHog analytics API',
+          docs: 'https://posthog.com/docs/api',
+        },
+      ]
+      const section = buildToolsPromptSection([], [], apiTools)
+      expect(section).to.include('REST APIs')
+      expect(section).to.include('posthog')
+      expect(section).to.include('https://app.posthog.com/api')
+      expect(section).to.include('$POSTHOG_API_KEY')
+      expect(section).to.include('https://posthog.com/docs/api')
+    })
+
+    it('uses default auth header when not specified', () => {
+      const apiTools: ApiToolConfig[] = [
+        {
+          name: 'stripe',
+          url: 'https://api.stripe.com',
+          auth: 'STRIPE_KEY',
+          description: 'Stripe API',
+        },
+      ]
+      const section = buildToolsPromptSection([], [], apiTools)
+      expect(section).to.include('Authorization: Bearer')
+    })
+
+    it('uses custom auth header when specified', () => {
+      const apiTools: ApiToolConfig[] = [
+        {
+          name: 'custom',
+          url: 'https://api.custom.io',
+          auth: 'CUSTOM_KEY',
+          auth_header: 'X-API-Key',
+          description: 'Custom API',
+        },
+      ]
+      const section = buildToolsPromptSection([], [], apiTools)
+      expect(section).to.include('X-API-Key')
+      expect(section).not.to.include('Authorization: Bearer')
+    })
+
+    it('omits docs when not provided', () => {
+      const apiTools: ApiToolConfig[] = [
+        {
+          name: 'simple',
+          url: 'https://api.simple.io',
+          auth: 'SIMPLE_KEY',
+          description: 'Simple API',
+        },
+      ]
+      const section = buildToolsPromptSection([], [], apiTools)
+      expect(section).not.to.include('Docs:')
+    })
+
+    it('includes docs when provided', () => {
+      const apiTools: ApiToolConfig[] = [
+        {
+          name: 'documented',
+          url: 'https://api.documented.io',
+          auth: 'DOC_KEY',
+          description: 'Documented API',
+          docs: 'https://docs.documented.io',
+        },
+      ]
+      const section = buildToolsPromptSection([], [], apiTools)
+      expect(section).to.include('Docs: https://docs.documented.io')
+    })
+
+    it('returns empty string when no tools of any type', () => {
+      const section = buildToolsPromptSection([], [], [])
+      expect(section).to.equal('')
+    })
+
+    it('includes all tool types in combined prompt', () => {
+      const section = buildToolsPromptSection(
+        [{ name: 'arcade', description: 'Arcade integrations', url: 'https://arcade.dev' }],
+        [{ name: 'gh', command: 'gh', description: 'GitHub CLI' }],
+        [{ name: 'posthog', url: 'https://posthog.com/api', auth: 'PH_KEY', description: 'PostHog' }]
+      )
+      expect(section).to.include('MCP Servers')
+      expect(section).to.include('CLI Tools')
+      expect(section).to.include('REST APIs')
+    })
+  })
+
+  // ===========================================================================
+  // policy.ts — filterByPolicy with API tools
+  // ===========================================================================
+
+  describe('filterByPolicy with API tools', () => {
+    const registryWithApis: ToolRegistry = {
+      'mcp-servers': {},
+      'cli-tools': {},
+      'api-tools': {
+        posthog: {
+          url: 'https://app.posthog.com/api',
+          auth: 'POSTHOG_API_KEY',
+          description: 'PostHog analytics API',
+        },
+        stripe: {
+          url: 'https://api.stripe.com',
+          auth: 'STRIPE_KEY',
+          description: 'Stripe payments API',
+        },
+      },
+    }
+
+    it('returns all api tools when no policy is provided', () => {
+      const result = filterByPolicy(registryWithApis, null)
+      expect(result.apiTools).to.have.length(2)
+      const names = result.apiTools.map(t => t.name)
+      expect(names).to.include('posthog')
+      expect(names).to.include('stripe')
+    })
+
+    it('filters api tools by policy', () => {
+      const policy: ToolPolicy = {
+        mcp: [],
+        cli: [],
+        api: ['posthog'],
+      }
+      const result = filterByPolicy(registryWithApis, policy)
+      expect(result.apiTools).to.have.length(1)
+      expect(result.apiTools[0].name).to.equal('posthog')
+    })
+
+    it('returns empty api tools when policy has no api field', () => {
+      const policy: ToolPolicy = {
+        mcp: [],
+        cli: [],
+        api: [],
+      }
+      const result = filterByPolicy(registryWithApis, policy)
+      expect(result.apiTools).to.have.length(0)
+    })
+
+    it('still includes prlt in cli tools when filtering with policy', () => {
+      const policy: ToolPolicy = {
+        mcp: [],
+        cli: [],
+        api: ['posthog'],
+      }
+      const result = filterByPolicy(registryWithApis, policy)
+      expect(result.cliTools.some(t => t.name === 'prlt')).to.be.true
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a new `api` tool type to `prlt tools` alongside existing `mcp` and `cli` types
- REST APIs can be registered with `prlt tools add api <name> --url <base-url> --auth <ENV_VAR> --description "..." [--docs <url>] [--auth-header "..."]`
- API tool info is injected into agent/orchestrator prompts with URL, auth header format, env var reference, and optional docs link
- `prlt tools check` verifies API reachability (env var set + URL responds) 
- Policy-based filtering supports the new `api` tool type

## Changes
- **types.ts**: Added `ApiToolConfig` interface, updated `ToolRegistry`, `ToolCheckResult`, and `ToolPolicy`
- **registry.ts**: Added `getApiTools()`, `addApiTool()`, updated `loadToolRegistry()`, `removeTool()`
- **detect.ts**: Added `checkApiTool()` with env var + URL reachability checks
- **spawn.ts**: Updated `buildToolsPromptSection()` and `SpawnToolsResult` to include API tools
- **policy.ts**: Updated `filterByPolicy()` to handle API tools
- **commands/tools/add.ts**: Added `api` type with `--url`, `--auth`, `--auth-header`, `--docs` flags
- **commands/tools/index.ts**: Added REST APIs display section to `prlt tools list`
- **commands/tools/check.ts**: Added `[API]` badge for API tool check results
- **index.ts**: Exported new types and functions

## Test plan
- [x] 25 unit tests covering all new functionality
- [x] Registry CRUD (load, save, add, remove API tools)
- [x] Health checking (missing env var, reachability)
- [x] Prompt injection (auth header format, docs URL, combined tool types)
- [x] Policy filtering (allow/deny API tools)
- [x] Auth stored as env var reference, not actual secret
- [x] Build passes with no type errors

Linear: PRLT-1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)