### PR TITLE
feat(PRLT-1361): add api type to prlt tools — register REST APIs with base URL, auth, and docs

### DIFF
--- a/apps/cli/src/commands/tools/add.ts
+++ b/apps/cli/src/commands/tools/add.ts
@@ -12,22 +12,24 @@ import { machineOutputFlags } from '../../lib/pmo/index.js'
 import {
   addMcpServer,
   addCliTool,
+  addApiTool,
   loadToolRegistry,
 } from '../../lib/tool-registry/index.js'
 
 export default class ToolsAdd extends PromptCommand {
-  static description = 'Register an MCP server or CLI tool'
+  static description = 'Register an MCP server, CLI tool, or REST API'
 
   static examples = [
     '<%= config.bin %> tools add mcp arcade --url https://api.arcade.dev/mcp --auth ARCADE_API_KEY --description "Arcade integrations"',
     '<%= config.bin %> tools add cli gh --command gh --detect "which gh" --install "brew install gh" --description "GitHub CLI"',
+    '<%= config.bin %> tools add api posthog --url https://app.posthog.com/api --auth POSTHOG_API_KEY --description "PostHog analytics API" --docs https://posthog.com/docs/api',
   ]
 
   static args = {
     type: Args.string({
-      description: 'Tool type (mcp or cli)',
+      description: 'Tool type (mcp, cli, or api)',
       required: true,
-      options: ['mcp', 'cli'],
+      options: ['mcp', 'cli', 'api'],
     }),
     name: Args.string({
       description: 'Tool name (unique identifier)',
@@ -56,6 +58,12 @@ export default class ToolsAdd extends PromptCommand {
       char: 'd',
       description: 'Human-readable description',
       required: true,
+    }),
+    docs: Flags.string({
+      description: 'Link to API documentation',
+    }),
+    'auth-header': Flags.string({
+      description: 'Auth header format (default: "Authorization: Bearer")',
     }),
   }
 
@@ -147,6 +155,48 @@ export default class ToolsAdd extends PromptCommand {
       } else {
         this.log(chalk.green(`\nCLI tool '${args.name}' registered successfully.`))
         this.log(chalk.dim(`  Command: ${command}`))
+        this.log('')
+      }
+    } else if (args.type === 'api') {
+      if (!flags.url) {
+        if (jsonMode) {
+          outputErrorAsJson('MISSING_FLAG', 'API tool requires --url', meta())
+          return
+        } else {
+          this.error('API tool requires --url (base URL of the REST API)')
+        }
+        return
+      }
+
+      if (args.name in registry['api-tools']) {
+        if (jsonMode) {
+          outputErrorAsJson('DUPLICATE', `API tool '${args.name}' already exists`, meta())
+          return
+        } else {
+          this.error(`API tool '${args.name}' already exists. Remove it first with: prlt tools remove ${args.name}`)
+        }
+        return
+      }
+
+      addApiTool(hqPath, args.name, {
+        url: flags.url,
+        auth: flags.auth,
+        auth_header: flags['auth-header'],
+        description: flags.description,
+        docs: flags.docs,
+      })
+
+      if (jsonMode) {
+        outputSuccessAsJson(
+          { name: args.name, type: 'api', url: flags.url, description: flags.description },
+          meta()
+        )
+        return
+      } else {
+        this.log(chalk.green(`\nAPI tool '${args.name}' registered successfully.`))
+        this.log(chalk.dim(`  URL: ${flags.url}`))
+        if (flags.auth) this.log(chalk.dim(`  Auth: ${flags.auth}`))
+        if (flags.docs) this.log(chalk.dim(`  Docs: ${flags.docs}`))
         this.log('')
       }
     }

--- a/apps/cli/src/commands/tools/check.ts
+++ b/apps/cli/src/commands/tools/check.ts
@@ -32,7 +32,7 @@ export default class ToolsCheck extends Command {
     }
 
     const registry = loadToolRegistry(hqPath)
-    const results = checkAllTools(registry)
+    const results = await checkAllTools(registry)
 
     if (jsonMode) {
       this.log(JSON.stringify({ results }, null, 2))
@@ -50,7 +50,7 @@ export default class ToolsCheck extends Command {
       this.log(`\n${chalk.green('Available')}`)
       this.log('─'.repeat(40))
       for (const result of available) {
-        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : chalk.green('[CLI]')
+        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : result.type === 'api' ? chalk.magenta('[API]') : chalk.green('[CLI]')
         this.log(`  ${chalk.green('✓')} ${badge} ${result.name}`)
       }
     }
@@ -59,7 +59,7 @@ export default class ToolsCheck extends Command {
       this.log(`\n${chalk.red('Unavailable')}`)
       this.log('─'.repeat(40))
       for (const result of unavailable) {
-        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : chalk.green('[CLI]')
+        const badge = result.type === 'mcp' ? chalk.cyan('[MCP]') : result.type === 'api' ? chalk.magenta('[API]') : chalk.green('[CLI]')
         this.log(`  ${chalk.red('✗')} ${badge} ${result.name}`)
         if (result.error) this.log(`    ${chalk.dim(result.error)}`)
         if (result.installHint) this.log(`    ${chalk.dim(`Install: ${result.installHint}`)}`)

--- a/apps/cli/src/commands/tools/index.ts
+++ b/apps/cli/src/commands/tools/index.ts
@@ -7,6 +7,7 @@ import {
   loadToolRegistry,
   getMcpServers,
   getCliTools,
+  getApiTools,
 } from '../../lib/tool-registry/index.js'
 
 export default class ToolsList extends Command {
@@ -40,6 +41,7 @@ export default class ToolsList extends Command {
     const registry = loadToolRegistry(hqPath)
     const mcpServers = getMcpServers(registry)
     const cliTools = getCliTools(registry)
+    const apiTools = getApiTools(registry)
 
     if (jsonMode) {
       this.log(JSON.stringify({
@@ -56,6 +58,15 @@ export default class ToolsList extends Command {
           command: t.command,
           description: t.description,
           builtin: t.builtin || false,
+        })),
+        apiTools: apiTools.map(a => ({
+          name: a.name,
+          type: 'api',
+          url: a.url,
+          auth: a.auth,
+          auth_header: a.auth_header,
+          description: a.description,
+          docs: a.docs,
         })),
       }, null, 2))
       return
@@ -89,6 +100,21 @@ export default class ToolsList extends Command {
       for (const tool of cliTools) {
         const builtin = tool.builtin ? chalk.dim(' [built-in]') : ''
         this.log(`  ${chalk.green(tool.name)} (${tool.command}) — ${tool.description}${builtin}`)
+      }
+    }
+
+    // API Tools
+    this.log(`\n${chalk.bold('API Tools')}`)
+    this.log('─'.repeat(40))
+    if (apiTools.length === 0) {
+      this.log(chalk.dim('  No API tools registered'))
+      this.log(chalk.dim('  Add one: prlt tools add api <name> --url <url> --description "..."'))
+    } else {
+      for (const api of apiTools) {
+        const auth = api.auth ? chalk.dim(` [auth: ${api.auth}]`) : ''
+        const docs = api.docs ? chalk.dim(` [docs: ${api.docs}]`) : ''
+        this.log(`  ${chalk.magenta(api.name)} — ${api.description}`)
+        this.log(`    ${chalk.dim(api.url)}${auth}${docs}`)
       }
     }
 

--- a/apps/cli/src/lib/tool-registry/detect.ts
+++ b/apps/cli/src/lib/tool-registry/detect.ts
@@ -9,10 +9,11 @@ import type {
   ToolRegistry,
   CliToolConfig,
   McpServerConfig,
+  ApiToolConfig,
   ToolCheckResult,
 } from './types.js'
 import { COMMON_CLI_TOOLS } from './types.js'
-import { getMcpServers, getCliTools } from './registry.js'
+import { getMcpServers, getCliTools, getApiTools } from './registry.js'
 
 /**
  * Check if a CLI tool is available on the system.
@@ -49,7 +50,7 @@ export function detectAvailableTools(registry: ToolRegistry): CliToolConfig[] {
  * Check health of all registered tools.
  * Returns status for each tool (available or not).
  */
-export function checkAllTools(registry: ToolRegistry): ToolCheckResult[] {
+export async function checkAllTools(registry: ToolRegistry): Promise<ToolCheckResult[]> {
   const results: ToolCheckResult[] = []
 
   // Check MCP servers
@@ -60,6 +61,11 @@ export function checkAllTools(registry: ToolRegistry): ToolCheckResult[] {
   // Check CLI tools
   for (const tool of getCliTools(registry)) {
     results.push(checkCliTool(tool))
+  }
+
+  // Check API tools
+  for (const tool of getApiTools(registry)) {
+    results.push(await checkApiTool(tool))
   }
 
   return results
@@ -106,5 +112,44 @@ function checkCliTool(tool: CliToolConfig): ToolCheckResult {
     available,
     error: available ? undefined : `Command not found: ${tool.command}`,
     installHint: available ? undefined : tool.install,
+  }
+}
+
+async function checkApiTool(tool: ApiToolConfig): Promise<ToolCheckResult> {
+  // Check auth env var if required
+  if (tool.auth) {
+    const hasAuth = !!process.env[tool.auth]
+    if (!hasAuth) {
+      return {
+        name: tool.name,
+        type: 'api',
+        available: false,
+        error: `Missing environment variable: ${tool.auth}`,
+      }
+    }
+  }
+
+  // Check if the API URL is reachable
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 5000)
+    const response = await fetch(tool.url, {
+      method: 'HEAD',
+      signal: controller.signal,
+    })
+    clearTimeout(timeout)
+    // Any response (even 4xx/5xx) means the server is reachable
+    return {
+      name: tool.name,
+      type: 'api',
+      available: true,
+    }
+  } catch {
+    return {
+      name: tool.name,
+      type: 'api',
+      available: false,
+      error: `API not reachable: ${tool.url}`,
+    }
   }
 }

--- a/apps/cli/src/lib/tool-registry/index.ts
+++ b/apps/cli/src/lib/tool-registry/index.ts
@@ -6,6 +6,7 @@
 export type {
   McpServerConfig,
   CliToolConfig,
+  ApiToolConfig,
   ToolRegistry,
   ToolPolicy,
   ToolCheckResult,
@@ -19,8 +20,10 @@ export {
   saveToolRegistry,
   getMcpServers,
   getCliTools,
+  getApiTools,
   addMcpServer,
   addCliTool,
+  addApiTool,
   removeTool,
 } from './registry.js'
 

--- a/apps/cli/src/lib/tool-registry/policy.ts
+++ b/apps/cli/src/lib/tool-registry/policy.ts
@@ -13,6 +13,7 @@ import type {
   ToolPolicy,
   McpServerConfig,
   CliToolConfig,
+  ApiToolConfig,
 } from './types.js'
 import { BUILTIN_PRLT_TOOL } from './types.js'
 
@@ -80,9 +81,10 @@ export function listPolicies(hqPath: string): string[] {
 export function filterByPolicy(
   registry: ToolRegistry,
   policy: ToolPolicy | null
-): { mcpServers: McpServerConfig[]; cliTools: CliToolConfig[] } {
+): { mcpServers: McpServerConfig[]; cliTools: CliToolConfig[]; apiTools: ApiToolConfig[] } {
   const allMcp = Object.entries(registry['mcp-servers'])
   const allCli = Object.entries(registry['cli-tools'])
+  const allApi = Object.entries(registry['api-tools'])
 
   // No policy = full access
   if (!policy) {
@@ -93,6 +95,7 @@ export function filterByPolicy(
         // Always include prlt
         ...(allCli.some(([name]) => name === 'prlt') ? [] : [BUILTIN_PRLT_TOOL]),
       ],
+      apiTools: allApi.map(([name, config]) => ({ name, ...config })),
     }
   }
 
@@ -116,5 +119,11 @@ export function filterByPolicy(
     cliTools.push(BUILTIN_PRLT_TOOL)
   }
 
-  return { mcpServers, cliTools }
+  // Filter API tools
+  const allowedApi = new Set(policy.api || [])
+  const apiTools = allApi
+    .filter(([name]) => allowedApi.has(name))
+    .map(([name, config]) => ({ name, ...config }))
+
+  return { mcpServers, cliTools, apiTools }
 }

--- a/apps/cli/src/lib/tool-registry/registry.ts
+++ b/apps/cli/src/lib/tool-registry/registry.ts
@@ -12,6 +12,7 @@ import type {
   ToolRegistry,
   McpServerConfig,
   CliToolConfig,
+  ApiToolConfig,
 } from './types.js'
 import { BUILTIN_PRLT_TOOL } from './types.js'
 
@@ -34,6 +35,7 @@ export function loadToolRegistry(hqPath: string): ToolRegistry {
   const empty: ToolRegistry = {
     'mcp-servers': {},
     'cli-tools': {},
+    'api-tools': {},
   }
 
   if (!fs.existsSync(configPath)) {
@@ -47,6 +49,7 @@ export function loadToolRegistry(hqPath: string): ToolRegistry {
     return {
       'mcp-servers': parsed?.['mcp-servers'] ?? {},
       'cli-tools': parsed?.['cli-tools'] ?? {},
+      'api-tools': parsed?.['api-tools'] ?? {},
     }
   } catch {
     return empty
@@ -100,6 +103,16 @@ export function getCliTools(registry: ToolRegistry): CliToolConfig[] {
 }
 
 /**
+ * Get all API tools from the registry, hydrated with their names.
+ */
+export function getApiTools(registry: ToolRegistry): ApiToolConfig[] {
+  return Object.entries(registry['api-tools']).map(([name, config]) => ({
+    name,
+    ...config,
+  }))
+}
+
+/**
  * Add an MCP server to the registry.
  */
 export function addMcpServer(
@@ -126,7 +139,20 @@ export function addCliTool(
 }
 
 /**
- * Remove a tool (MCP or CLI) from the registry.
+ * Add an API tool to the registry.
+ */
+export function addApiTool(
+  hqPath: string,
+  name: string,
+  config: Omit<ApiToolConfig, 'name'>
+): void {
+  const registry = loadToolRegistry(hqPath)
+  registry['api-tools'][name] = config
+  saveToolRegistry(hqPath, registry)
+}
+
+/**
+ * Remove a tool (MCP, CLI, or API) from the registry.
  * Returns true if the tool was found and removed.
  */
 export function removeTool(hqPath: string, name: string): boolean {
@@ -144,6 +170,12 @@ export function removeTool(hqPath: string, name: string): boolean {
       return false // Can't remove built-in tools
     }
     delete registry['cli-tools'][name]
+    saveToolRegistry(hqPath, registry)
+    return true
+  }
+
+  if (name in registry['api-tools']) {
+    delete registry['api-tools'][name]
     saveToolRegistry(hqPath, registry)
     return true
   }

--- a/apps/cli/src/lib/tool-registry/spawn.ts
+++ b/apps/cli/src/lib/tool-registry/spawn.ts
@@ -10,7 +10,7 @@
 
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import type { McpServerConfig, CliToolConfig, ToolPolicy } from './types.js'
+import type { McpServerConfig, CliToolConfig, ApiToolConfig, ToolPolicy } from './types.js'
 import { loadToolRegistry } from './registry.js'
 import { loadToolPolicy, filterByPolicy } from './policy.js'
 
@@ -94,9 +94,10 @@ export function writeMcpConfigFile(
  */
 export function buildToolsPromptSection(
   mcpServers: McpServerConfig[],
-  cliTools: CliToolConfig[]
+  cliTools: CliToolConfig[],
+  apiTools: ApiToolConfig[] = []
 ): string {
-  if (mcpServers.length === 0 && cliTools.length === 0) return ''
+  if (mcpServers.length === 0 && cliTools.length === 0 && apiTools.length === 0) return ''
 
   let section = `## Available Tools\n\n`
 
@@ -116,6 +117,22 @@ export function buildToolsPromptSection(
     section += `\n`
   }
 
+  if (apiTools.length > 0) {
+    section += `**REST APIs:**\n`
+    for (const api of apiTools) {
+      const authHeader = api.auth_header || 'Authorization: Bearer'
+      let line = `- ${api.name}: ${api.description}. Base URL: ${api.url}`
+      if (api.auth) {
+        line += `. Auth: ${authHeader} $${api.auth}`
+      }
+      if (api.docs) {
+        line += `. Docs: ${api.docs}`
+      }
+      section += `${line}\n`
+    }
+    section += `\n`
+  }
+
   section += `Use these tools for external interactions. Prefer registered tools over raw curl or API calls.\n\n`
 
   return section
@@ -130,6 +147,7 @@ export interface SpawnToolsResult {
   promptSection: string
   mcpServers: McpServerConfig[]
   cliTools: CliToolConfig[]
+  apiTools: ApiToolConfig[]
 }
 
 /**
@@ -150,10 +168,10 @@ export function resolveToolsForSpawn(
     ? loadToolPolicy(hqPath, policyName)
     : null
 
-  const { mcpServers, cliTools } = filterByPolicy(registry, policy)
+  const { mcpServers, cliTools, apiTools } = filterByPolicy(registry, policy)
 
   const mcpConfigPath = writeMcpConfigFile(mcpServers, outputDir)
-  const promptSection = buildToolsPromptSection(mcpServers, cliTools)
+  const promptSection = buildToolsPromptSection(mcpServers, cliTools, apiTools)
 
-  return { mcpConfigPath, promptSection, mcpServers, cliTools }
+  return { mcpConfigPath, promptSection, mcpServers, cliTools, apiTools }
 }

--- a/apps/cli/src/lib/tool-registry/types.ts
+++ b/apps/cli/src/lib/tool-registry/types.ts
@@ -25,6 +25,25 @@ export interface McpServerConfig {
 }
 
 // =============================================================================
+// API Tool Registry
+// =============================================================================
+
+export interface ApiToolConfig {
+  /** Tool name (unique identifier) */
+  name: string
+  /** Base URL for the REST API */
+  url: string
+  /** Environment variable name holding the auth token (e.g., "POSTHOG_API_KEY") */
+  auth?: string
+  /** Auth header format (default: "Authorization: Bearer") */
+  auth_header?: string
+  /** Human-readable description */
+  description: string
+  /** Link to API documentation */
+  docs?: string
+}
+
+// =============================================================================
 // CLI Tool Registry
 // =============================================================================
 
@@ -50,6 +69,7 @@ export interface CliToolConfig {
 export interface ToolRegistry {
   'mcp-servers': Record<string, Omit<McpServerConfig, 'name'>>
   'cli-tools': Record<string, Omit<CliToolConfig, 'name'>>
+  'api-tools': Record<string, Omit<ApiToolConfig, 'name'>>
 }
 
 // =============================================================================
@@ -59,6 +79,7 @@ export interface ToolRegistry {
 export interface ToolPolicy {
   mcp: string[]
   cli: string[]
+  api: string[]
   /** Per-MCP-server fine-grained access (e.g., arcade: { allow: ['asana', 'slack'] }) */
   [serverName: string]: string[] | { allow: string[] } | undefined
 }
@@ -69,7 +90,7 @@ export interface ToolPolicy {
 
 export interface ToolCheckResult {
   name: string
-  type: 'mcp' | 'cli'
+  type: 'mcp' | 'cli' | 'api'
   available: boolean
   error?: string
   installHint?: string

--- a/apps/cli/test/unit/api-tool-type.test.ts
+++ b/apps/cli/test/unit/api-tool-type.test.ts
@@ -1,0 +1,591 @@
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import yaml from 'js-yaml'
+import type { ToolRegistry, ApiToolConfig, ToolPolicy } from '../../src/lib/tool-registry/types.js'
+
+/**
+ * Unit tests for API tool type (PRLT-1361)
+ *
+ * Tests the full lifecycle of API tools: type definitions, registry CRUD,
+ * health checking, prompt injection, and policy filtering.
+ */
+
+function createTempHQ(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prlt-api-test-'))
+  fs.mkdirSync(path.join(tmpDir, '.proletariat'), { recursive: true })
+  return tmpDir
+}
+
+function cleanupTempHQ(tmpDir: string): void {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+}
+
+function writeToolsYaml(hqPath: string, registry: Partial<ToolRegistry>): void {
+  const configPath = path.join(hqPath, '.proletariat', 'tools.yaml')
+  const content = yaml.dump(registry, { indent: 2, lineWidth: 120, noRefs: true })
+  fs.writeFileSync(configPath, content, 'utf-8')
+}
+
+describe('API Tool Type (PRLT-1361)', () => {
+  // =========================================================================
+  // Type definitions
+  // =========================================================================
+  describe('Type definitions', () => {
+    it('ApiToolConfig interface has required fields', async () => {
+      const config: ApiToolConfig = {
+        name: 'test-api',
+        url: 'https://api.example.com',
+        description: 'Test API',
+      }
+      expect(config.name).to.equal('test-api')
+      expect(config.url).to.equal('https://api.example.com')
+      expect(config.description).to.equal('Test API')
+    })
+
+    it('ApiToolConfig supports optional auth, auth_header, and docs fields', async () => {
+      const config: ApiToolConfig = {
+        name: 'posthog',
+        url: 'https://app.posthog.com/api',
+        auth: 'POSTHOG_API_KEY',
+        auth_header: 'Authorization: Bearer',
+        description: 'PostHog analytics API',
+        docs: 'https://posthog.com/docs/api',
+      }
+      expect(config.auth).to.equal('POSTHOG_API_KEY')
+      expect(config.auth_header).to.equal('Authorization: Bearer')
+      expect(config.docs).to.equal('https://posthog.com/docs/api')
+    })
+
+    it('ToolRegistry includes api-tools section', async () => {
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {},
+      }
+      expect(registry).to.have.property('api-tools')
+    })
+  })
+
+  // =========================================================================
+  // Registry operations
+  // =========================================================================
+  describe('Registry operations', () => {
+    let hqPath: string
+
+    beforeEach(() => {
+      hqPath = createTempHQ()
+    })
+
+    afterEach(() => {
+      cleanupTempHQ(hqPath)
+    })
+
+    it('loadToolRegistry returns empty api-tools when no tools.yaml exists', async () => {
+      const { loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['api-tools']).to.deep.equal({})
+    })
+
+    it('loadToolRegistry loads api-tools from tools.yaml', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: {
+            url: 'https://app.posthog.com/api',
+            auth: 'POSTHOG_API_KEY',
+            description: 'PostHog analytics API',
+            docs: 'https://posthog.com/docs/api',
+          },
+        },
+      })
+
+      const { loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['api-tools']).to.have.property('posthog')
+      expect(registry['api-tools']['posthog'].url).to.equal('https://app.posthog.com/api')
+      expect(registry['api-tools']['posthog'].auth).to.equal('POSTHOG_API_KEY')
+      expect(registry['api-tools']['posthog'].docs).to.equal('https://posthog.com/docs/api')
+    })
+
+    it('loadToolRegistry defaults api-tools to empty when tools.yaml has no api-tools key', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+      })
+
+      const { loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['api-tools']).to.deep.equal({})
+    })
+
+    it('getApiTools hydrates configs with names', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: {
+            url: 'https://app.posthog.com/api',
+            description: 'PostHog analytics API',
+          },
+          stripe: {
+            url: 'https://api.stripe.com/v1',
+            auth: 'STRIPE_SECRET_KEY',
+            description: 'Stripe payment API',
+          },
+        },
+      })
+
+      const { loadToolRegistry, getApiTools } = await import('../../src/lib/tool-registry/registry.js')
+      const registry = loadToolRegistry(hqPath)
+      const tools = getApiTools(registry)
+      expect(tools).to.have.length(2)
+      expect(tools[0].name).to.equal('posthog')
+      expect(tools[1].name).to.equal('stripe')
+    })
+
+    it('addApiTool adds an API tool to the registry', async () => {
+      const { addApiTool, loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+
+      addApiTool(hqPath, 'posthog', {
+        url: 'https://app.posthog.com/api',
+        auth: 'POSTHOG_API_KEY',
+        description: 'PostHog analytics API',
+        docs: 'https://posthog.com/docs/api',
+      })
+
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['api-tools']).to.have.property('posthog')
+      expect(registry['api-tools']['posthog'].url).to.equal('https://app.posthog.com/api')
+      expect(registry['api-tools']['posthog'].auth).to.equal('POSTHOG_API_KEY')
+    })
+
+    it('addApiTool preserves existing tools', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': { arcade: { url: 'https://arcade.dev/mcp', description: 'Arcade' } },
+        'cli-tools': { gh: { command: 'gh', description: 'GitHub CLI' } },
+        'api-tools': {},
+      })
+
+      const { addApiTool, loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+
+      addApiTool(hqPath, 'posthog', {
+        url: 'https://app.posthog.com/api',
+        description: 'PostHog analytics API',
+      })
+
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['mcp-servers']).to.have.property('arcade')
+      expect(registry['cli-tools']).to.have.property('gh')
+      expect(registry['api-tools']).to.have.property('posthog')
+    })
+
+    it('removeTool removes an API tool', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: {
+            url: 'https://app.posthog.com/api',
+            description: 'PostHog analytics API',
+          },
+        },
+      })
+
+      const { removeTool, loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+      const removed = removeTool(hqPath, 'posthog')
+      expect(removed).to.be.true
+
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['api-tools']).to.not.have.property('posthog')
+    })
+
+    it('removeTool returns false for nonexistent API tool', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {},
+      })
+
+      const { removeTool } = await import('../../src/lib/tool-registry/registry.js')
+      const removed = removeTool(hqPath, 'nonexistent')
+      expect(removed).to.be.false
+    })
+
+    it('addApiTool stores auth_header field', async () => {
+      const { addApiTool, loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+
+      addApiTool(hqPath, 'custom-api', {
+        url: 'https://api.example.com',
+        auth: 'API_TOKEN',
+        auth_header: 'X-Api-Key',
+        description: 'Custom API',
+      })
+
+      const registry = loadToolRegistry(hqPath)
+      expect(registry['api-tools']['custom-api'].auth_header).to.equal('X-Api-Key')
+    })
+  })
+
+  // =========================================================================
+  // Health checking
+  // =========================================================================
+  describe('Health checking', () => {
+    let hqPath: string
+
+    beforeEach(() => {
+      hqPath = createTempHQ()
+    })
+
+    afterEach(() => {
+      cleanupTempHQ(hqPath)
+    })
+
+    it('checkAllTools includes API tools in results', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: {
+            url: 'https://app.posthog.com/api',
+            auth: 'POSTHOG_API_KEY',
+            description: 'PostHog analytics API',
+          },
+        },
+      })
+
+      const { loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+      const { checkAllTools } = await import('../../src/lib/tool-registry/detect.js')
+      const registry = loadToolRegistry(hqPath)
+      const results = await checkAllTools(registry)
+
+      const apiResults = results.filter(r => r.type === 'api')
+      expect(apiResults).to.have.length(1)
+      expect(apiResults[0].name).to.equal('posthog')
+    })
+
+    it('API tool check fails when auth env var is missing', async () => {
+      // Make sure the env var is not set
+      const saved = process.env.TEST_MISSING_API_KEY
+      delete process.env.TEST_MISSING_API_KEY
+
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          testapi: {
+            url: 'https://api.example.com',
+            auth: 'TEST_MISSING_API_KEY',
+            description: 'Test API',
+          },
+        },
+      })
+
+      const { loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+      const { checkAllTools } = await import('../../src/lib/tool-registry/detect.js')
+      const registry = loadToolRegistry(hqPath)
+      const results = await checkAllTools(registry)
+
+      const apiResult = results.find(r => r.name === 'testapi')
+      expect(apiResult).to.exist
+      expect(apiResult!.available).to.be.false
+      expect(apiResult!.error).to.include('TEST_MISSING_API_KEY')
+
+      // Restore
+      if (saved !== undefined) process.env.TEST_MISSING_API_KEY = saved
+    })
+
+    it('ToolCheckResult type field supports api value', async () => {
+      const result = {
+        name: 'posthog',
+        type: 'api' as const,
+        available: true,
+      }
+      expect(result.type).to.equal('api')
+    })
+  })
+
+  // =========================================================================
+  // Prompt injection
+  // =========================================================================
+  describe('Prompt injection', () => {
+    it('buildToolsPromptSection includes REST APIs section', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+
+      const section = buildToolsPromptSection([], [], [
+        {
+          name: 'posthog',
+          url: 'https://app.posthog.com/api',
+          auth: 'POSTHOG_API_KEY',
+          description: 'PostHog analytics API',
+          docs: 'https://posthog.com/docs/api',
+        },
+      ])
+
+      expect(section).to.include('**REST APIs:**')
+      expect(section).to.include('posthog')
+      expect(section).to.include('https://app.posthog.com/api')
+      expect(section).to.include('$POSTHOG_API_KEY')
+      expect(section).to.include('https://posthog.com/docs/api')
+    })
+
+    it('prompt includes default auth header when none specified', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+
+      const section = buildToolsPromptSection([], [], [
+        {
+          name: 'myapi',
+          url: 'https://api.example.com',
+          auth: 'MY_API_KEY',
+          description: 'My API',
+        },
+      ])
+
+      expect(section).to.include('Authorization: Bearer')
+    })
+
+    it('prompt uses custom auth_header when specified', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+
+      const section = buildToolsPromptSection([], [], [
+        {
+          name: 'myapi',
+          url: 'https://api.example.com',
+          auth: 'MY_API_KEY',
+          auth_header: 'X-Api-Key',
+          description: 'My API',
+        },
+      ])
+
+      expect(section).to.include('X-Api-Key')
+      expect(section).to.not.include('Authorization: Bearer')
+    })
+
+    it('prompt omits auth info when no auth configured', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+
+      const section = buildToolsPromptSection([], [], [
+        {
+          name: 'publicapi',
+          url: 'https://api.example.com',
+          description: 'Public API',
+        },
+      ])
+
+      expect(section).to.include('publicapi')
+      expect(section).to.include('https://api.example.com')
+      expect(section).to.not.include('Auth:')
+    })
+
+    it('prompt omits docs when not provided', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+
+      const section = buildToolsPromptSection([], [], [
+        {
+          name: 'myapi',
+          url: 'https://api.example.com',
+          description: 'My API',
+        },
+      ])
+
+      expect(section).to.not.include('Docs:')
+    })
+
+    it('returns empty string when no tools of any type', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+      const section = buildToolsPromptSection([], [], [])
+      expect(section).to.equal('')
+    })
+
+    it('combines MCP, CLI, and API tools in one section', async () => {
+      const { buildToolsPromptSection } = await import('../../src/lib/tool-registry/spawn.js')
+
+      const section = buildToolsPromptSection(
+        [{ name: 'arcade', url: 'https://arcade.dev/mcp', description: 'Arcade' }],
+        [{ name: 'gh', command: 'gh', description: 'GitHub CLI' }],
+        [{ name: 'posthog', url: 'https://app.posthog.com/api', description: 'PostHog API' }]
+      )
+
+      expect(section).to.include('**MCP Servers:**')
+      expect(section).to.include('**CLI Tools:**')
+      expect(section).to.include('**REST APIs:**')
+    })
+  })
+
+  // =========================================================================
+  // Policy filtering
+  // =========================================================================
+  describe('Policy filtering', () => {
+    it('no policy returns all API tools', async () => {
+      const { filterByPolicy } = await import('../../src/lib/tool-registry/policy.js')
+
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: { url: 'https://app.posthog.com/api', description: 'PostHog' },
+          stripe: { url: 'https://api.stripe.com/v1', description: 'Stripe' },
+        },
+      }
+
+      const result = filterByPolicy(registry, null)
+      expect(result.apiTools).to.have.length(2)
+    })
+
+    it('policy filters API tools to allowed set', async () => {
+      const { filterByPolicy } = await import('../../src/lib/tool-registry/policy.js')
+
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: { url: 'https://app.posthog.com/api', description: 'PostHog' },
+          stripe: { url: 'https://api.stripe.com/v1', description: 'Stripe' },
+          openai: { url: 'https://api.openai.com/v1', description: 'OpenAI' },
+        },
+      }
+
+      const policy: ToolPolicy = {
+        mcp: [],
+        cli: [],
+        api: ['posthog', 'openai'],
+      }
+
+      const result = filterByPolicy(registry, policy)
+      expect(result.apiTools).to.have.length(2)
+      expect(result.apiTools.map(t => t.name)).to.include('posthog')
+      expect(result.apiTools.map(t => t.name)).to.include('openai')
+      expect(result.apiTools.map(t => t.name)).to.not.include('stripe')
+    })
+
+    it('policy with empty api list returns no API tools', async () => {
+      const { filterByPolicy } = await import('../../src/lib/tool-registry/policy.js')
+
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: { url: 'https://app.posthog.com/api', description: 'PostHog' },
+        },
+      }
+
+      const policy: ToolPolicy = {
+        mcp: [],
+        cli: [],
+        api: [],
+      }
+
+      const result = filterByPolicy(registry, policy)
+      expect(result.apiTools).to.have.length(0)
+    })
+
+    it('policy without api field returns no API tools', async () => {
+      const { filterByPolicy } = await import('../../src/lib/tool-registry/policy.js')
+
+      const registry: ToolRegistry = {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: { url: 'https://app.posthog.com/api', description: 'PostHog' },
+        },
+      }
+
+      // Simulate a policy YAML that doesn't have the api field
+      const policy = {
+        mcp: [],
+        cli: [],
+      } as unknown as ToolPolicy
+
+      const result = filterByPolicy(registry, policy)
+      expect(result.apiTools).to.have.length(0)
+    })
+  })
+
+  // =========================================================================
+  // SpawnToolsResult
+  // =========================================================================
+  describe('SpawnToolsResult', () => {
+    let hqPath: string
+
+    beforeEach(() => {
+      hqPath = createTempHQ()
+    })
+
+    afterEach(() => {
+      cleanupTempHQ(hqPath)
+    })
+
+    it('resolveToolsForSpawn includes apiTools in result', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {
+          posthog: {
+            url: 'https://app.posthog.com/api',
+            auth: 'POSTHOG_API_KEY',
+            description: 'PostHog analytics API',
+            docs: 'https://posthog.com/docs/api',
+          },
+        },
+      })
+
+      const { resolveToolsForSpawn } = await import('../../src/lib/tool-registry/spawn.js')
+      const result = resolveToolsForSpawn(hqPath, undefined, path.join(hqPath, '.proletariat', 'scripts'))
+
+      expect(result.apiTools).to.have.length(1)
+      expect(result.apiTools[0].name).to.equal('posthog')
+      expect(result.promptSection).to.include('posthog')
+      expect(result.promptSection).to.include('https://app.posthog.com/api')
+    })
+
+    it('resolveToolsForSpawn returns empty apiTools when none registered', async () => {
+      writeToolsYaml(hqPath, {
+        'mcp-servers': {},
+        'cli-tools': {},
+        'api-tools': {},
+      })
+
+      const { resolveToolsForSpawn } = await import('../../src/lib/tool-registry/spawn.js')
+      const result = resolveToolsForSpawn(hqPath, undefined, path.join(hqPath, '.proletariat', 'scripts'))
+
+      expect(result.apiTools).to.have.length(0)
+    })
+  })
+
+  // =========================================================================
+  // Auth storage (env var reference, not secret)
+  // =========================================================================
+  describe('Auth storage', () => {
+    let hqPath: string
+
+    beforeEach(() => {
+      hqPath = createTempHQ()
+    })
+
+    afterEach(() => {
+      cleanupTempHQ(hqPath)
+    })
+
+    it('stores auth as env var name, not the actual secret', async () => {
+      const { addApiTool, loadToolRegistry } = await import('../../src/lib/tool-registry/registry.js')
+
+      addApiTool(hqPath, 'posthog', {
+        url: 'https://app.posthog.com/api',
+        auth: 'POSTHOG_API_KEY',
+        description: 'PostHog analytics API',
+      })
+
+      const registry = loadToolRegistry(hqPath)
+      // Auth should be the env var name, not wrapped in ${} like MCP servers do
+      expect(registry['api-tools']['posthog'].auth).to.equal('POSTHOG_API_KEY')
+      // Should not contain actual secret values
+      const configPath = path.join(hqPath, '.proletariat', 'tools.yaml')
+      const content = fs.readFileSync(configPath, 'utf-8')
+      expect(content).to.include('POSTHOG_API_KEY')
+      // The YAML should not contain the resolved value
+      expect(content).to.not.include('${')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a new `api` tool type alongside existing `mcp` and `cli` types, allowing agents to register REST APIs with base URL, auth, and docs
- API tool info is injected into agent/orchestrator prompts so agents know how to call registered APIs
- Auth tokens are stored as env var references (not actual secrets), and `prlt tools check` verifies API reachability

## Changes
- **types.ts**: Added `ApiToolConfig` interface, updated `ToolRegistry`, `ToolCheckResult`, and `ToolPolicy`
- **registry.ts**: Added `getApiTools()`, `addApiTool()`, updated `loadToolRegistry()`/`saveToolRegistry()`/`removeTool()`
- **detect.ts**: Added async `checkApiTool()` with URL reachability check and auth env var validation
- **spawn.ts**: Updated `buildToolsPromptSection()` to render REST APIs section with base URL, auth header, and docs link
- **policy.ts**: Updated `filterByPolicy()` to handle API tools
- **commands/tools/add.ts**: Added `api` type with `--url`, `--auth`, `--auth-header`, `--docs` flags
- **commands/tools/index.ts**: Added API tools listing section
- **commands/tools/check.ts**: Added `[API]` badge for API tool health results

## Test plan
- [x] 29 unit tests covering types, registry CRUD, health checks, prompt injection, policy filtering, spawn integration, and auth storage
- [x] Build passes (`pnpm build`)
- [x] Smoke tests pass (`pnpm test:smoke:unit`)

Closes PRLT-1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)