### PR TITLE
fix(PRLT-1362): Docker agent credential mount and freshness

### DIFF
--- a/apps/cli/src/lib/execution/runners/docker-credentials.ts
+++ b/apps/cli/src/lib/execution/runners/docker-credentials.ts
@@ -94,11 +94,22 @@ export function getDockerCredentialInfo(): { expiresAt: Date; subscriptionType?:
 }
 
 /**
- * PRLT-1296: Refresh the claude-credentials Docker volume with fresh credentials from the host.
+ * Files from ~/.claude/ that should be synced into the credential volume.
+ * Only credential and config files — skip caches, sessions, and large dirs.
+ */
+export const CREDENTIAL_SYNC_FILES = [
+  '.credentials.json',
+  'settings.json',
+]
+
+/**
+ * PRLT-1296 / PRLT-1362: Refresh the claude-credentials Docker volume with
+ * fresh credentials AND settings from the host.
  *
- * OAuth tokens expire every ~24h. The host's Claude Code auto-refreshes its tokens,
- * but the Docker volume is a snapshot that goes stale. This copies the host's current
- * credentials into the volume before each container spawn, ensuring fresh tokens.
+ * OAuth tokens expire every ~24h. The host's Claude Code auto-refreshes its
+ * tokens, but the Docker volume is a snapshot that goes stale. This copies
+ * ALL relevant files from the host's ~/.claude/ into the volume before each
+ * container spawn, ensuring fresh tokens and current settings.
  *
  * Creates the volume if it doesn't exist.
  * Sets file ownership to UID 1000 (node user) so the container can read them.
@@ -107,42 +118,57 @@ export function getDockerCredentialInfo(): { expiresAt: Date; subscriptionType?:
  */
 export function refreshCredentialVolume(): boolean {
   const homeDir = process.env.HOME || os.homedir()
-  const hostCredPath = path.join(homeDir, '.claude', '.credentials.json')
+  const hostClaudeDir = path.join(homeDir, '.claude')
 
-  // Check if host has credentials to copy
-  if (!fs.existsSync(hostCredPath)) {
-    console.debug('[runners:credentials] No host credentials at ~/.claude/.credentials.json, skipping refresh')
+  // Check if host has a ~/.claude directory at all
+  if (!fs.existsSync(hostClaudeDir)) {
+    console.debug('[runners:credentials] No host ~/.claude directory, skipping refresh')
     return false
   }
+
+  // Determine which files exist on the host and need syncing
+  const filesToSync = CREDENTIAL_SYNC_FILES.filter(f =>
+    fs.existsSync(path.join(hostClaudeDir, f))
+  )
+
+  if (filesToSync.length === 0) {
+    console.debug('[runners:credentials] No credential files found in ~/.claude/, skipping refresh')
+    return false
+  }
+
+  // Build the copy + chown command for all files
+  const copyCommands = filesToSync
+    .map(f => `cp /src/${f} /dest/${f} && chown 1000:1000 /dest/${f}`)
+    .join(' && ')
 
   try {
     // Use a temporary container to copy host credentials into the named volume.
     // -v ~/.claude:/src:ro  → mount host credentials read-only
     // -v claude-credentials:/dest  → mount the target volume
-    // cp + chown ensures node user (UID 1000) owns the file inside the container.
+    // cp + chown ensures node user (UID 1000) owns the files inside the container.
     // --pull never avoids Docker Hub auth issues on locked keychains / headless environments.
     const refreshCmd = [
       'docker run --rm --pull never',
-      `-v "${path.join(homeDir, '.claude')}:/src:ro"`,
+      `-v "${hostClaudeDir}:/src:ro"`,
       `-v "${CLAUDE_CREDENTIALS_VOLUME}:/dest"`,
-      `alpine sh -c 'cp /src/.credentials.json /dest/.credentials.json && chown 1000:1000 /dest/.credentials.json'`,
+      `alpine sh -c '${copyCommands}'`,
     ].join(' ')
 
     execSync(refreshCmd, { stdio: 'pipe', timeout: 15000 })
-    console.debug('[runners:credentials] Refreshed credential volume with host credentials')
+    console.debug(`[runners:credentials] Refreshed credential volume with ${filesToSync.length} files: ${filesToSync.join(', ')}`)
     return true
   } catch (error) {
     // alpine image may not be cached — try with node:22 which is already pulled for agent builds
     try {
       const fallbackCmd = [
         'docker run --rm --pull never',
-        `-v "${path.join(homeDir, '.claude')}:/src:ro"`,
+        `-v "${hostClaudeDir}:/src:ro"`,
         `-v "${CLAUDE_CREDENTIALS_VOLUME}:/dest"`,
-        `node:22 bash -c 'cp /src/.credentials.json /dest/.credentials.json && chown 1000:1000 /dest/.credentials.json'`,
+        `node:22 bash -c '${copyCommands}'`,
       ].join(' ')
 
       execSync(fallbackCmd, { stdio: 'pipe', timeout: 15000 })
-      console.debug('[runners:credentials] Refreshed credential volume with host credentials (node:22 fallback)')
+      console.debug(`[runners:credentials] Refreshed credential volume with ${filesToSync.length} files (node:22 fallback)`)
       return true
     } catch {
       console.debug('[runners:credentials] Failed to refresh credential volume:', error)

--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -16,6 +16,7 @@ import {
 } from '../types.js'
 import { readDevcontainerJson } from '../devcontainer.js'
 import { isClaudeExecutor } from './executor.js'
+import { CLAUDE_CREDENTIALS_VOLUME } from './docker-credentials.js'
 import { getMachineId } from '../../telemetry/analytics.js'
 import {
   getCCAppPermissionSettings,
@@ -305,7 +306,7 @@ export function buildContainerMounts(
     ...(context.repoWorktrees || []).map(
       repoName => `-v "${context.hqPath}/repos/${repoName}:/hq/repos/${repoName}:cached"`
     ),
-    ...(isClaudeExecutor(executor) ? [`-v "claude-credentials:/home/node/.claude"`] : []),
+    ...(isClaudeExecutor(executor) ? [`-v "${CLAUDE_CREDENTIALS_VOLUME}:/home/node/.claude"`] : []),
     // PRLT-1130: Mount pnpm store cache read-only for fast installs.
     // If the cache volume doesn't exist, Docker creates an empty one (harmless).
     ...(pnpmStoreCacheExists() ? [`-v "${PNPM_STORE_CACHE_VOLUME}:/tmp/pnpm-store-cache:ro"`] : []),
@@ -422,6 +423,35 @@ export function verifyWorkspaceMount(containerId: string): SpawnStageError | nul
       message: `Failed to inspect /workspace in container ${containerId}: ${err.message || 'docker exec failed'}`,
       stderr,
     }
+  }
+}
+
+/**
+ * PRLT-1362: Verify that a reused container has the claude-credentials volume
+ * mounted at /home/node/.claude. Containers created before the mount was added
+ * (or with a different executor) will lack this mount and need recreation.
+ *
+ * Returns true if the mount exists or the executor doesn't need it,
+ * false if the mount is missing and the container should be recreated.
+ */
+export function verifyCredentialMount(containerId: string, executor: ExecutorType = 'claude-code'): boolean {
+  if (!isClaudeExecutor(executor)) {
+    return true
+  }
+
+  try {
+    const inspectOutput = execSync(
+      `docker inspect --format '{{json .Mounts}}' ${containerId}`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
+    )
+    const mounts = JSON.parse(inspectOutput.trim()) as Array<{ Destination?: string; Name?: string }>
+    return mounts.some(m =>
+      m.Destination === '/home/node/.claude' ||
+      m.Name === CLAUDE_CREDENTIALS_VOLUME
+    )
+  } catch {
+    // If inspect fails, assume the mount is missing to be safe
+    return false
   }
 }
 
@@ -751,23 +781,37 @@ export function ensureDockerContainerDetailed(
     if (isContainerRunning(containerName)) {
       const containerId = getContainerId(containerName)
       if (containerId) {
-        console.debug(`[runners:docker] Reusing running container ${containerName} (${containerId}), skipping setup`)
-        // PRLT-1322: Even for reused containers, verify /workspace is populated.
-        // A container may be running with an empty mount if the previous spawn
-        // attempt leaked it. Bail out with a clear error rather than silently
-        // handing the agent an empty workspace.
-        const mountError = verifyWorkspaceMount(containerId)
-        if (mountError) {
-          return { containerId: null, error: mountError }
+        // PRLT-1362: Verify credential mount exists before reusing.
+        // Containers created before the mount was added lack /home/node/.claude
+        // and Claude Code will prompt for login. Force recreation.
+        if (!verifyCredentialMount(containerId, executor)) {
+          console.debug(`[runners:docker] Reused container ${containerName} is missing credential mount, recreating`)
+          try {
+            execSync(`docker rm -f ${containerName}`, { stdio: 'pipe', timeout: 10000 })
+          } catch {
+            // Ignore removal errors
+          }
+          // Fall through to create a new container below
+        } else {
+          console.debug(`[runners:docker] Reusing running container ${containerName} (${containerId}), skipping setup`)
+          // PRLT-1322: Even for reused containers, verify /workspace is populated.
+          // A container may be running with an empty mount if the previous spawn
+          // attempt leaked it. Bail out with a clear error rather than silently
+          // handing the agent an empty workspace.
+          const mountError = verifyWorkspaceMount(containerId)
+          if (mountError) {
+            return { containerId: null, error: mountError }
+          }
+          return { containerId }
         }
-        return { containerId }
       }
-    }
-    console.debug(`[runners:docker] Removing stopped container ${containerName} to create fresh one`)
-    try {
-      execSync(`docker rm -f ${containerName}`, { stdio: 'pipe', timeout: 10000 })
-    } catch {
-      // Ignore removal errors
+    } else {
+      console.debug(`[runners:docker] Removing stopped container ${containerName} to create fresh one`)
+      try {
+        execSync(`docker rm -f ${containerName}`, { stdio: 'pipe', timeout: 10000 })
+      } catch {
+        // Ignore removal errors
+      }
     }
   }
 

--- a/apps/cli/src/lib/execution/runners/orchestrator.ts
+++ b/apps/cli/src/lib/execution/runners/orchestrator.ts
@@ -35,6 +35,7 @@ import {
 } from '../cc-version.js'
 
 import { getMachineId } from '../../telemetry/analytics.js'
+import { CLAUDE_CREDENTIALS_VOLUME } from './docker-credentials.js'
 
 /**
  * Run orchestrator in a Docker container using the sibling container pattern.
@@ -139,7 +140,7 @@ export async function runOrchestratorInDocker(
       // Docker socket for sibling container pattern
       `-v /var/run/docker.sock:/var/run/docker.sock`,
       // Claude credentials volume (shared with agent containers)
-      ...(executor === 'claude-code' ? ['-v "claude-credentials:/home/node/.claude"'] : []),
+      ...(executor === 'claude-code' ? [`-v "${CLAUDE_CREDENTIALS_VOLUME}:/home/node/.claude"`] : []),
       // Persistent bash history
       '-v "claude-bash-history:/commandhistory"',
     ]

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -374,6 +374,7 @@ export {
   ensureDockerContainer,
   ensureDockerContainerDetailed,
   verifyWorkspaceMount,
+  verifyCredentialMount,
   seedClaudeOnboarding,
   checkDockerMemoryCapacity,
 } from './docker-management.js'

--- a/apps/cli/src/lib/execution/runners/shared.ts
+++ b/apps/cli/src/lib/execution/runners/shared.ts
@@ -343,6 +343,7 @@ export {
   ensureTmuxServerHasKeychainAccess,
   copyClaudeCredentials,
   refreshCredentialVolume,
+  CREDENTIAL_SYNC_FILES,
 } from './docker-credentials.js'
 
 export {

--- a/apps/cli/test/unit/docker-credential-mount.test.ts
+++ b/apps/cli/test/unit/docker-credential-mount.test.ts
@@ -1,0 +1,325 @@
+/**
+ * PRLT-1362: Docker agent credential mount and freshness tests
+ *
+ * Ensures:
+ * 1. refreshCredentialVolume() syncs ALL credential files (not just .credentials.json)
+ * 2. CREDENTIAL_SYNC_FILES includes .credentials.json and settings.json
+ * 3. buildContainerMounts() includes credential volume mount for claude-code executor
+ * 4. Reused containers are verified for credential mount presence
+ * 5. verifyCredentialMount() function exists and inspects container mounts
+ * 6. Orchestrator also uses CLAUDE_CREDENTIALS_VOLUME constant
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { CREDENTIAL_SYNC_FILES } from '../../src/lib/execution/runners/docker-credentials.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+describe('Docker Credential Mount & Freshness (PRLT-1362)', () => {
+  // =========================================================================
+  // 1. CREDENTIAL_SYNC_FILES includes all required files
+  // =========================================================================
+  describe('CREDENTIAL_SYNC_FILES', () => {
+    it('should include .credentials.json', () => {
+      expect(CREDENTIAL_SYNC_FILES).to.include('.credentials.json')
+    })
+
+    it('should include settings.json', () => {
+      expect(CREDENTIAL_SYNC_FILES).to.include('settings.json')
+    })
+
+    it('should be an array with at least 2 entries', () => {
+      expect(CREDENTIAL_SYNC_FILES).to.be.an('array')
+      expect(CREDENTIAL_SYNC_FILES.length).to.be.at.least(2)
+    })
+  })
+
+  // =========================================================================
+  // 2. refreshCredentialVolume() syncs ALL files, not just .credentials.json
+  // =========================================================================
+  describe('refreshCredentialVolume() — full directory sync', () => {
+    const credentialsFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-credentials.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(credentialsFile, 'utf-8')
+    })
+
+    it('should reference CREDENTIAL_SYNC_FILES for determining which files to copy', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('CREDENTIAL_SYNC_FILES')
+    })
+
+    it('should filter files based on host filesystem existence', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should check existence of each file before attempting copy
+      expect(fnBody).to.include('existsSync')
+      expect(fnBody).to.include('filter')
+    })
+
+    it('should build copy commands for all sync files (not hardcoded to one file)', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should dynamically build copy commands from the file list
+      expect(fnBody).to.include('copyCommands')
+      expect(fnBody).to.include('.map')
+    })
+
+    it('should set ownership to UID 1000 for each copied file', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('chown 1000:1000')
+    })
+
+    it('should check for ~/.claude directory existence (not just .credentials.json)', () => {
+      const fnMatch = content.match(
+        /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
+      )
+      expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should check the directory, not a specific file
+      expect(fnBody).to.include("hostClaudeDir")
+    })
+  })
+
+  // =========================================================================
+  // 3. buildContainerMounts() includes credential mount
+  // =========================================================================
+  describe('buildContainerMounts() — credential volume mount', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should include credential volume mount for Claude executor', () => {
+      const fnMatch = content.match(
+        /export function buildContainerMounts\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'buildContainerMounts function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('CLAUDE_CREDENTIALS_VOLUME')
+      expect(fnBody).to.include('/home/node/.claude')
+      expect(fnBody).to.include('isClaudeExecutor')
+    })
+
+    it('should use CLAUDE_CREDENTIALS_VOLUME constant (not hardcoded string)', () => {
+      const fnMatch = content.match(
+        /export function buildContainerMounts\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'buildContainerMounts function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should use the constant, not the literal string 'claude-credentials'
+      expect(fnBody).to.include('CLAUDE_CREDENTIALS_VOLUME')
+    })
+
+    it('should import CLAUDE_CREDENTIALS_VOLUME from docker-credentials', () => {
+      expect(content).to.include("import { CLAUDE_CREDENTIALS_VOLUME } from './docker-credentials.js'")
+    })
+  })
+
+  // =========================================================================
+  // 4. verifyCredentialMount() exists and works correctly
+  // =========================================================================
+  describe('verifyCredentialMount()', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should exist as an exported function', () => {
+      expect(content).to.include('export function verifyCredentialMount(')
+    })
+
+    it('should accept containerId and executor parameters', () => {
+      const fnMatch = content.match(
+        /export function verifyCredentialMount\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'verifyCredentialMount function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('containerId')
+      expect(fnBody).to.include('executor')
+    })
+
+    it('should skip verification for non-Claude executors', () => {
+      const fnMatch = content.match(
+        /export function verifyCredentialMount\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'verifyCredentialMount function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('isClaudeExecutor')
+      // Should return true early for non-Claude executors
+      expect(fnBody).to.include('return true')
+    })
+
+    it('should use docker inspect to check mounts', () => {
+      const fnMatch = content.match(
+        /export function verifyCredentialMount\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'verifyCredentialMount function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('docker inspect')
+      expect(fnBody).to.include('Mounts')
+    })
+
+    it('should check for /home/node/.claude destination or credential volume name', () => {
+      const fnMatch = content.match(
+        /export function verifyCredentialMount\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'verifyCredentialMount function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('/home/node/.claude')
+      expect(fnBody).to.include('CLAUDE_CREDENTIALS_VOLUME')
+    })
+
+    it('should return false when inspect fails (safe default)', () => {
+      const fnMatch = content.match(
+        /export function verifyCredentialMount\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'verifyCredentialMount function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // On failure, should assume mount is missing
+      expect(fnBody).to.include('return false')
+    })
+  })
+
+  // =========================================================================
+  // 5. ensureDockerContainerDetailed() checks credential mount on reuse
+  // =========================================================================
+  describe('ensureDockerContainerDetailed() — credential mount verification on reuse', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should call verifyCredentialMount when reusing a running container', () => {
+      const fnMatch = content.match(
+        /export function ensureDockerContainerDetailed\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'ensureDockerContainerDetailed function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('verifyCredentialMount')
+    })
+
+    it('should force container recreation when credential mount is missing', () => {
+      const fnMatch = content.match(
+        /export function ensureDockerContainerDetailed\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'ensureDockerContainerDetailed function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Should contain logic to remove container when mount is missing
+      // Look for the pattern: if (!verifyCredentialMount...) { ... docker rm ...}
+      const verifyIdx = fnBody.indexOf('verifyCredentialMount')
+      expect(verifyIdx).to.be.greaterThan(-1)
+
+      // After the verify check, there should be a docker rm -f
+      const afterVerify = fnBody.substring(verifyIdx, verifyIdx + 500)
+      expect(afterVerify).to.include('docker rm -f')
+    })
+
+    it('should log a debug message when recreating due to missing mount', () => {
+      const fnMatch = content.match(
+        /export function ensureDockerContainerDetailed\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'ensureDockerContainerDetailed function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      expect(fnBody).to.include('missing credential mount')
+    })
+  })
+
+  // =========================================================================
+  // 6. Orchestrator uses CLAUDE_CREDENTIALS_VOLUME constant
+  // =========================================================================
+  describe('Orchestrator — credential volume mount', () => {
+    const orchestratorFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/orchestrator.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(orchestratorFile, 'utf-8')
+    })
+
+    it('should import CLAUDE_CREDENTIALS_VOLUME', () => {
+      expect(content).to.include('CLAUDE_CREDENTIALS_VOLUME')
+    })
+
+    it('should use CLAUDE_CREDENTIALS_VOLUME constant for mount (not hardcoded)', () => {
+      // Find the mount definition in the orchestrator
+      expect(content).to.include('CLAUDE_CREDENTIALS_VOLUME')
+      expect(content).to.include('/home/node/.claude')
+    })
+  })
+
+  // =========================================================================
+  // 7. shared.ts re-exports
+  // =========================================================================
+  describe('shared.ts — new re-exports', () => {
+    const sharedFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/shared.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(sharedFile, 'utf-8')
+    })
+
+    it('should re-export verifyCredentialMount from docker-management', () => {
+      expect(content).to.include('verifyCredentialMount')
+    })
+
+    it('should re-export CREDENTIAL_SYNC_FILES from docker-credentials', () => {
+      expect(content).to.include('CREDENTIAL_SYNC_FILES')
+    })
+  })
+})

--- a/apps/cli/test/unit/docker-version-pin-credentials.test.ts
+++ b/apps/cli/test/unit/docker-version-pin-credentials.test.ts
@@ -164,16 +164,17 @@ describe('Docker Version Pinning & Credential Refresh (PRLT-1296)', () => {
       expect(content).to.include('export function refreshCredentialVolume()')
     })
 
-    it('should check for host credentials before attempting copy', () => {
+    it('should check for host credential directory before attempting copy', () => {
       const fnMatch = content.match(
         /export function refreshCredentialVolume\(\)[\s\S]*?^}/m
       )
       expect(fnMatch, 'refreshCredentialVolume function not found').to.exist
       const fnBody = fnMatch![0]
 
-      // Should check if host credentials exist
-      expect(fnBody).to.include('.credentials.json')
+      // PRLT-1362: Should check ~/.claude directory (not just a single file)
+      // and use CREDENTIAL_SYNC_FILES to determine which files to sync
       expect(fnBody).to.include('existsSync')
+      expect(fnBody).to.include('CREDENTIAL_SYNC_FILES')
     })
 
     it('should use --pull never to avoid Docker Hub auth issues', () => {


### PR DESCRIPTION
## Summary

- Fix `refreshCredentialVolume()` to sync ALL credential files from host `~/.claude/` (not just `.credentials.json`), ensuring settings.json and other config are always fresh
- Add `verifyCredentialMount()` — when reusing a running container, verify the credential volume is mounted at `/home/node/.claude`; if missing, force container recreation
- Use `CLAUDE_CREDENTIALS_VOLUME` constant everywhere instead of hardcoded strings (docker-management.ts, orchestrator.ts)

## Problem

Docker agent containers started but Claude Code had no auth because:
1. Reused containers created before the credential mount was added lacked the `/home/node/.claude` mount entirely
2. `refreshCredentialVolume()` only copied `.credentials.json`, leaving settings.json and other needed files stale/missing
3. The credential volume contained files from weeks ago that were never refreshed

## Test plan

- [x] 24 new regression tests in `docker-credential-mount.test.ts` covering credential sync, mount verification, container reuse detection, and re-exports
- [x] Updated existing PRLT-1296 test to match new credential check pattern
- [x] Build passes cleanly