### PR TITLE
fix(PRLT-1363): bind-mount host ~/.claude for Docker agent credentials

### DIFF
--- a/apps/cli/src/lib/execution/runners/docker-management.ts
+++ b/apps/cli/src/lib/execution/runners/docker-management.ts
@@ -7,6 +7,7 @@
 
 import { execSync } from 'node:child_process'
 import * as fs from 'node:fs'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import {
   PermissionMode,
@@ -299,6 +300,8 @@ export function buildContainerMounts(
   context: ExecutionContext,
   executor: ExecutorType = 'claude-code',
 ): string[] {
+  const homeDir = process.env.HOME || os.homedir()
+  const hostClaudeDir = path.join(homeDir, '.claude')
   return [
     `-v "${context.agentDir}:/workspace:cached"`,
     ...(context.hqPath ? [`-v "${context.hqPath}/.proletariat:/hq/.proletariat:ro"`] : []),
@@ -306,7 +309,12 @@ export function buildContainerMounts(
     ...(context.repoWorktrees || []).map(
       repoName => `-v "${context.hqPath}/repos/${repoName}:/hq/repos/${repoName}:cached"`
     ),
-    ...(isClaudeExecutor(executor) ? [`-v "${CLAUDE_CREDENTIALS_VOLUME}:/home/node/.claude"`] : []),
+    // PRLT-1363: Bind-mount the host's live ~/.claude directory read-only.
+    // The previous Docker volume (claude-credentials) was a stale snapshot —
+    // tokens expire every ~24h but the volume was never refreshed automatically.
+    // The host's Claude Code keeps tokens fresh, so mounting the live directory
+    // ensures the container always has valid credentials.
+    ...(isClaudeExecutor(executor) ? [`-v "${hostClaudeDir}:/home/node/.claude:ro"`] : []),
     // PRLT-1130: Mount pnpm store cache read-only for fast installs.
     // If the cache volume doesn't exist, Docker creates an empty one (harmless).
     ...(pnpmStoreCacheExists() ? [`-v "${PNPM_STORE_CACHE_VOLUME}:/tmp/pnpm-store-cache:ro"`] : []),
@@ -427,9 +435,12 @@ export function verifyWorkspaceMount(containerId: string): SpawnStageError | nul
 }
 
 /**
- * PRLT-1362: Verify that a reused container has the claude-credentials volume
- * mounted at /home/node/.claude. Containers created before the mount was added
- * (or with a different executor) will lack this mount and need recreation.
+ * PRLT-1362 / PRLT-1363: Verify that a reused container has the host's ~/.claude
+ * bind-mounted at /home/node/.claude. Containers created before this mount was
+ * added (or with the old Docker volume approach) will lack it and need recreation.
+ *
+ * Accepts both bind-mounts (Type=bind) and the legacy Docker volume
+ * (Name=claude-credentials) to avoid needless recreation during the transition.
  *
  * Returns true if the mount exists or the executor doesn't need it,
  * false if the mount is missing and the container should be recreated.
@@ -444,7 +455,7 @@ export function verifyCredentialMount(containerId: string, executor: ExecutorTyp
       `docker inspect --format '{{json .Mounts}}' ${containerId}`,
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
     )
-    const mounts = JSON.parse(inspectOutput.trim()) as Array<{ Destination?: string; Name?: string }>
+    const mounts = JSON.parse(inspectOutput.trim()) as Array<{ Destination?: string; Name?: string; Type?: string }>
     return mounts.some(m =>
       m.Destination === '/home/node/.claude' ||
       m.Name === CLAUDE_CREDENTIALS_VOLUME
@@ -619,35 +630,30 @@ export function runContainerSetup(containerId: string, _permissionMode: Permissi
     seedClaudeOnboarding(containerId)
   }
 
-  // PRLT-1240: We also still write ~/.claude/settings.json — Claude Code does
-  // not clobber that file, so permission settings and hooks are persisted.
+  // PRLT-1363: Host ~/.claude is now bind-mounted read-only at /home/node/.claude
+  // so we write agent-specific settings and hooks to the project-level path
+  // (/workspace/.claude/) which sits on the writable workspace mount. Claude Code
+  // reads settings from both user-level (~/.claude/) and project-level, so the
+  // agent gets host credentials (read-only) plus agent-specific hooks (writable).
   if (isClaudeExecutor(executor)) {
     try {
-      // Write app settings to settings.json (skipDangerousModePermissionPrompt etc.)
+      // Write app settings + lifecycle hooks to project-level settings.json
       const appPermSettings = getCCAppPermissionSettings()
-      const claudeSettings = JSON.stringify(appPermSettings)
-      execSync(
-        `docker exec -i ${containerId} bash -c 'mkdir -p /home/node/.claude && cat > /home/node/.claude/settings.json'`,
-        { input: claudeSettings, stdio: ['pipe', 'pipe', 'pipe'] }
-      )
-      console.debug(`[runners:docker] Wrote ~/.claude/settings.json to container`)
-
-      // Write Claude Code lifecycle hooks (PRLT-1224, extends PRLT-1061)
       const lifecycleHooks = buildClaudeLifecycleHooks()
-      const mergedSettings = { ...JSON.parse(claudeSettings), ...lifecycleHooks }
+      const mergedSettings = { ...appPermSettings, ...lifecycleHooks }
       execSync(
-        `docker exec -i ${containerId} bash -c 'cat > /home/node/.claude/settings.json'`,
+        `docker exec -i ${containerId} bash -c 'mkdir -p /workspace/.claude && cat > /workspace/.claude/settings.json'`,
         { input: JSON.stringify(mergedSettings), stdio: ['pipe', 'pipe', 'pipe'] }
       )
-      console.debug(`[runners:docker] Configured Claude Code lifecycle hooks for agent containers`)
+      console.debug(`[runners:docker] Wrote /workspace/.claude/settings.json with agent hooks`)
 
       // PRLT-1225: Write the enforce-tests hook script into the container
       const enforceTestsScript = buildEnforceTestsHookScript()
       execSync(
-        `docker exec -i ${containerId} bash -c 'mkdir -p /home/node/.claude/hooks && cat > /home/node/.claude/hooks/enforce-tests.sh && chmod +x /home/node/.claude/hooks/enforce-tests.sh'`,
+        `docker exec -i ${containerId} bash -c 'mkdir -p /workspace/.claude/hooks && cat > /workspace/.claude/hooks/enforce-tests.sh && chmod +x /workspace/.claude/hooks/enforce-tests.sh'`,
         { input: enforceTestsScript, stdio: ['pipe', 'pipe', 'pipe'] }
       )
-      console.debug(`[runners:docker] Wrote enforce-tests hook script to container`)
+      console.debug(`[runners:docker] Wrote enforce-tests hook script to /workspace/.claude/hooks/`)
     } catch (error) {
       console.debug('[runners:docker] Failed to write Claude settings to container:', error)
     }

--- a/apps/cli/test/unit/regression-prlt1363-claude-credential-bind-mount.test.ts
+++ b/apps/cli/test/unit/regression-prlt1363-claude-credential-bind-mount.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression test for PRLT-1363
+ *
+ * Verifies that the Docker runner bind-mounts the host's ~/.claude directory
+ * (read-only) into agent containers instead of using a stale Docker volume.
+ * The host's Claude Code keeps OAuth tokens fresh, so mounting the live
+ * directory ensures containers always have valid credentials.
+ */
+import { expect } from 'chai'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  buildContainerMounts,
+} from '../../src/lib/execution/runners/docker-management.js'
+import type { ExecutionContext } from '../../src/lib/execution/types.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+describe('PRLT-1363: Claude credential bind-mount (not Docker volume)', () => {
+  // =========================================================================
+  // buildContainerMounts — host bind-mount for credentials
+  // =========================================================================
+  describe('buildContainerMounts (docker-management)', () => {
+    function makeContext(overrides: Partial<ExecutionContext> = {}): ExecutionContext {
+      return {
+        ticketId: 'TKT-001',
+        ticketTitle: 'Test ticket',
+        agentName: 'test-agent',
+        agentDir: '/path/to/agent',
+        worktreePath: '/path/to/worktree',
+        branch: 'main',
+        hqPath: '/path/to/hq',
+        ...overrides,
+      }
+    }
+
+    it('should mount host ~/.claude at /home/node/.claude for claude-code executor', () => {
+      const mounts = buildContainerMounts(makeContext(), 'claude-code')
+      const claudeMount = mounts.find(m => m.includes('/home/node/.claude'))
+      expect(claudeMount, 'No mount found for /home/node/.claude').to.exist
+      // Must contain the host's .claude directory path
+      expect(claudeMount).to.include('.claude:/home/node/.claude')
+    })
+
+    it('should mount ~/.claude as read-only (:ro)', () => {
+      const mounts = buildContainerMounts(makeContext(), 'claude-code')
+      const claudeMount = mounts.find(m => m.includes('/home/node/.claude'))
+      expect(claudeMount, 'No mount found for /home/node/.claude').to.exist
+      expect(claudeMount).to.include(':ro')
+    })
+
+    it('should NOT use the claude-credentials Docker volume', () => {
+      const mounts = buildContainerMounts(makeContext(), 'claude-code')
+      const claudeMount = mounts.find(m => m.includes('/home/node/.claude'))
+      expect(claudeMount, 'No mount found for /home/node/.claude').to.exist
+      // Must be a host bind-mount (contains a path separator), NOT a Docker volume name
+      expect(claudeMount).to.not.include('claude-credentials:/home/node/.claude')
+    })
+
+    it('should not include credential mount for non-claude executors', () => {
+      const mounts = buildContainerMounts(makeContext(), 'custom-executor' as any)
+      const claudeMount = mounts.find(m => m.includes('/home/node/.claude'))
+      expect(claudeMount).to.not.exist
+    })
+
+    it('should still include other mounts alongside credential mount', () => {
+      const mounts = buildContainerMounts(makeContext(), 'claude-code')
+      // Workspace mount
+      const wsMount = mounts.find(m => m.includes('/workspace:'))
+      expect(wsMount).to.exist
+      // HQ mount
+      const hqMount = mounts.find(m => m.includes('.proletariat:/hq/.proletariat'))
+      expect(hqMount).to.exist
+    })
+  })
+
+  // =========================================================================
+  // Source code analysis — verifyCredentialMount accepts bind-mounts
+  // =========================================================================
+  describe('verifyCredentialMount (docker-management)', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should check for /home/node/.claude Destination in mount list', () => {
+      const fnMatch = content.match(
+        /export function verifyCredentialMount\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'verifyCredentialMount function not found').to.exist
+      const fnBody = fnMatch![0]
+      // Must check for the Destination path (works for both bind-mounts and volumes)
+      expect(fnBody).to.include('/home/node/.claude')
+    })
+  })
+
+  // =========================================================================
+  // Source code analysis — settings written to project-level path
+  // =========================================================================
+  describe('runContainerSetup — project-level settings path', () => {
+    const managementFile = path.resolve(
+      __dirname,
+      '../../src/lib/execution/runners/docker-management.ts'
+    )
+    let content: string
+
+    before(() => {
+      content = fs.readFileSync(managementFile, 'utf-8')
+    })
+
+    it('should write settings.json to /workspace/.claude/ (not /home/node/.claude/)', () => {
+      const fnMatch = content.match(
+        /export function runContainerSetup\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runContainerSetup function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Agent-specific settings must go to /workspace/.claude/ (project-level, writable)
+      // because /home/node/.claude is now a read-only bind-mount of the host
+      expect(fnBody).to.include('/workspace/.claude/settings.json')
+      // Must NOT write to /home/node/.claude/settings.json (read-only mount)
+      expect(fnBody).to.not.include('/home/node/.claude/settings.json')
+    })
+
+    it('should write enforce-tests hook to /workspace/.claude/hooks/ (not /home/node/.claude/hooks/)', () => {
+      const fnMatch = content.match(
+        /export function runContainerSetup\([\s\S]*?^}/m
+      )
+      expect(fnMatch, 'runContainerSetup function not found').to.exist
+      const fnBody = fnMatch![0]
+
+      // Hook scripts must go to project-level writable path
+      expect(fnBody).to.include('/workspace/.claude/hooks/')
+      // Must NOT write to read-only mount
+      expect(fnBody).to.not.include('/home/node/.claude/hooks/')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replace Docker volume (claude-credentials) with read-only host bind-mount (~/.claude:/home/node/.claude:ro) for agent credentials
- Redirect agent-specific settings/hooks writes to /workspace/.claude/ (project-level) since the user-level path is now read-only
- Update verifyCredentialMount() to accept both bind-mounts and legacy volumes

## Problem

PRLT-1362 added credential handling but the docker run command still mounted a stale Docker volume instead of the host's live ~/.claude directory. The host's Claude Code keeps OAuth tokens fresh, but the Docker volume snapshot went stale after ~24h, causing containers to prompt for OAuth login.

## Fix

Mount the host's ~/.claude directory directly as a read-only bind-mount. This ensures containers always have valid credentials without needing a separate refresh step.

## Test plan

- [x] Unit tests verify bind-mount is used (not Docker volume)
- [x] Unit tests verify mount is read-only (:ro)
- [x] Unit tests verify settings/hooks write to project-level path
- [x] All existing Docker tests still pass