### PR TITLE
fix(PRLT-1370): isClaudeExecutor accepts legacy 'claude' value

### DIFF
--- a/apps/cli/src/lib/execution/runners/executor.ts
+++ b/apps/cli/src/lib/execution/runners/executor.ts
@@ -38,9 +38,13 @@ export function getExecutorCommand(executor: ExecutorType, prompt: string, skipP
 
 /**
  * Check if an executor is Claude Code.
+ *
+ * Accepts both 'claude-code' (current canonical value) and 'claude' (legacy
+ * value seeded by migration 0023 into workspace_settings.execution.default_executor).
+ * Without this, the credential bind mount is skipped for workspaces seeded with 'claude'.
  */
 export function isClaudeExecutor(executor: ExecutorType): boolean {
-  return executor === 'claude-code'
+  return executor === 'claude-code' || (executor as string) === 'claude'
 }
 
 /**

--- a/apps/cli/test/unit/execution-utils.test.ts
+++ b/apps/cli/test/unit/execution-utils.test.ts
@@ -367,6 +367,12 @@ describe('Execution Utils', () => {
       expect(isClaudeExecutor('claude-code')).to.be.true
     })
 
+    it('should return true for legacy claude value (PRLT-1370)', () => {
+      // Migration 0023 seeds workspace_settings with 'claude', so the credential
+      // mount must still be applied when the DB returns this legacy value.
+      expect(isClaudeExecutor('claude' as ExecutorType)).to.be.true
+    })
+
     it('should return false for codex', () => {
       expect(isClaudeExecutor('codex')).to.be.false
     })


### PR DESCRIPTION
## Summary

`workspace_settings.execution.default_executor` is seeded as `'claude'` by migration 0023, but `isClaudeExecutor()` only matched `'claude-code'`. This caused `buildContainerMounts()` to skip the credential bind mount in Docker agents, leaving them unable to authenticate.

## Fix

`isClaudeExecutor()` now also returns `true` for the legacy `'claude'` value. The cast keeps the function compatible with the strict `ExecutorType` union while accepting the runtime value the DB actually holds.

## Test plan

- [x] Added regression test in `execution-utils.test.ts` asserting `isClaudeExecutor('claude')` returns `true`
- [x] Existing `isClaudeExecutor` tests still pass
- [x] `pnpm build` clean

Linear: PRLT-1370